### PR TITLE
Collections: parent/child chained ads + watch; classad: redact private attributes by default

### DIFF
--- a/classad/classad.go
+++ b/classad/classad.go
@@ -330,7 +330,17 @@ func unparseAttrName(name string) string {
 	return ast.QuoteAttributeName(name)
 }
 
-func (c *ClassAd) String() string {
+// String renders the ClassAd in new (bracketed) format, excluding private
+// (secret) attributes -- the default-safe form for any output that may reach a
+// client. Use StringWithPrivate where the full ad, including secrets, is required
+// (internal diagnostics, an authorized private channel).
+func (c *ClassAd) String() string { return c.unparse(false) }
+
+// StringWithPrivate is String including private attributes. Prefer String for
+// anything client-facing; see IsPrivateAttribute.
+func (c *ClassAd) StringWithPrivate() string { return c.unparse(true) }
+
+func (c *ClassAd) unparse(includePrivate bool) string {
 	if c.ad == nil {
 		return "[]"
 	}
@@ -338,10 +348,15 @@ func (c *ClassAd) String() string {
 	c.ensureSorted()
 	var b strings.Builder
 	b.WriteByte('[')
-	for i, attr := range c.ad.Attributes {
-		if i > 0 {
+	first := true
+	for _, attr := range c.ad.Attributes {
+		if !includePrivate && IsPrivateAttribute(attr.Name) {
+			continue
+		}
+		if !first {
 			b.WriteString("; ")
 		}
+		first = false
 		b.WriteString(unparseAttrName(attr.Name))
 		b.WriteString(" = ")
 		b.WriteString(attr.Value.String())
@@ -358,7 +373,15 @@ func (c *ClassAd) String() string {
 //	ad, _ := classad.Parse("[Cpus = 4; Memory = 8192]")
 //	oldFmt := ad.MarshalOld()
 //	// Returns: "Cpus = 4\nMemory = 8192"
-func (c *ClassAd) MarshalOld() string {
+// MarshalOld excludes private (secret) attributes; use MarshalOldWithPrivate for
+// the full ad. See IsPrivateAttribute.
+func (c *ClassAd) MarshalOld() string { return c.marshalOld(false) }
+
+// MarshalOldWithPrivate is MarshalOld including private attributes. Prefer
+// MarshalOld for anything client-facing.
+func (c *ClassAd) MarshalOldWithPrivate() string { return c.marshalOld(true) }
+
+func (c *ClassAd) marshalOld(includePrivate bool) string {
 	if c.ad == nil || len(c.ad.Attributes) == 0 {
 		return ""
 	}
@@ -368,10 +391,15 @@ func (c *ClassAd) MarshalOld() string {
 	// the whole accumulated string), which allocated tens of MB to render a single
 	// large (~21 KB) ad.
 	var b strings.Builder
-	for i, attr := range c.ad.Attributes {
-		if i > 0 {
+	first := true
+	for _, attr := range c.ad.Attributes {
+		if !includePrivate && IsPrivateAttribute(attr.Name) {
+			continue
+		}
+		if !first {
 			b.WriteByte('\n')
 		}
+		first = false
 		b.WriteString(unparseAttrName(attr.Name))
 		b.WriteString(" = ")
 		b.WriteString(attr.Value.String())
@@ -1481,7 +1509,17 @@ func (c *ClassAd) evaluateUnaryOp(op string, operand Value) Value {
 //	ad, _ := classad.Parse(`[x = 5; y = x + 3; name = "test"]`)
 //	jsonBytes, _ := json.Marshal(ad)
 //	// {"name":"test","x":5,"y":"\/Expr(x + 3)\/"}
-func (c *ClassAd) MarshalJSON() ([]byte, error) {
+// MarshalJSON implements json.Marshaler, excluding private (secret) attributes so
+// that any HTTP/JSON response that marshals a ClassAd is default-safe -- a job's
+// ClaimId or a slot's Capability never reaches a client through json.Marshal. Use
+// MarshalJSONWithPrivate where the full ad is required. See IsPrivateAttribute.
+func (c *ClassAd) MarshalJSON() ([]byte, error) { return c.marshalJSON(false) }
+
+// MarshalJSONWithPrivate is MarshalJSON including private attributes. Prefer
+// MarshalJSON for anything client-facing.
+func (c *ClassAd) MarshalJSONWithPrivate() ([]byte, error) { return c.marshalJSON(true) }
+
+func (c *ClassAd) marshalJSON(includePrivate bool) ([]byte, error) {
 	if c.ad == nil {
 		return []byte("{}"), nil
 	}
@@ -1489,10 +1527,15 @@ func (c *ClassAd) MarshalJSON() ([]byte, error) {
 	c.ensureSorted()
 	var buf bytes.Buffer
 	buf.WriteByte('{')
-	for i, attr := range c.ad.Attributes {
-		if i > 0 {
+	first := true
+	for _, attr := range c.ad.Attributes {
+		if !includePrivate && IsPrivateAttribute(attr.Name) {
+			continue
+		}
+		if !first {
 			buf.WriteByte(',')
 		}
+		first = false
 		keyBytes, err := json.Marshal(attr.Name)
 		if err != nil {
 			return nil, err

--- a/classad/classad.go
+++ b/classad/classad.go
@@ -373,6 +373,7 @@ func (c *ClassAd) unparse(includePrivate bool) string {
 //	ad, _ := classad.Parse("[Cpus = 4; Memory = 8192]")
 //	oldFmt := ad.MarshalOld()
 //	// Returns: "Cpus = 4\nMemory = 8192"
+//
 // MarshalOld excludes private (secret) attributes; use MarshalOldWithPrivate for
 // the full ad. See IsPrivateAttribute.
 func (c *ClassAd) MarshalOld() string { return c.marshalOld(false) }
@@ -1509,6 +1510,7 @@ func (c *ClassAd) evaluateUnaryOp(op string, operand Value) Value {
 //	ad, _ := classad.Parse(`[x = 5; y = x + 3; name = "test"]`)
 //	jsonBytes, _ := json.Marshal(ad)
 //	// {"name":"test","x":5,"y":"\/Expr(x + 3)\/"}
+//
 // MarshalJSON implements json.Marshaler, excluding private (secret) attributes so
 // that any HTTP/JSON response that marshals a ClassAd is default-safe -- a job's
 // ClaimId or a slot's Capability never reaches a client through json.Marshal. Use

--- a/classad/private.go
+++ b/classad/private.go
@@ -1,0 +1,79 @@
+package classad
+
+import (
+	"strings"
+
+	"github.com/PelicanPlatform/classad/ast"
+)
+
+// Private (secret) attributes. HTCondor treats a fixed set of attribute names --
+// claim capabilities and transfer keys -- plus any name with a reserved prefix as
+// secret: they must never be serialized to a client by default. Redaction is
+// enforced at the serialization boundary (String/MarshalOld/MarshalJSON here, and
+// CEDAR PutClassAd / the collector's raw fast path in the daemon layers), so a
+// secret cannot leak just because a call site forgot to filter. Emitting a secret
+// requires an explicit opt-in (the WithPrivate serializers, or an authorized
+// private-ad channel like the collector's StartdPvt table).
+//
+// This mirrors ClassAdPrivateAttrs and ClassAdAttributeIsPrivate* in HTCondor's
+// compat_classad.cpp. It is the single source of truth for what is secret;
+// higher layers (cedar, the collector) share this predicate rather than keeping
+// their own list, so they cannot disagree.
+
+// privateAttrsV1 is HTCondor's fixed private-attribute set (ClassAdPrivateAttrs),
+// keyed lower-case for case-insensitive matching.
+var privateAttrsV1 = map[string]struct{}{
+	"capability":    {},
+	"childclaimids": {},
+	"claimid":       {},
+	"claimidlist":   {},
+	"claimids":      {},
+	"transferkey":   {},
+}
+
+// privateV2Prefix marks the "V2" private attributes: any name beginning with
+// "_condor_priv" (case-insensitive) is secret.
+const privateV2Prefix = "_condor_priv"
+
+// IsPrivateAttributeV1 reports whether name is one of HTCondor's fixed private
+// attributes (a claim capability or transfer key).
+func IsPrivateAttributeV1(name string) bool {
+	_, ok := privateAttrsV1[strings.ToLower(name)]
+	return ok
+}
+
+// IsPrivateAttributeV2 reports whether name is a "_condor_priv"-prefixed private
+// attribute (matched case-insensitively).
+func IsPrivateAttributeV2(name string) bool {
+	return len(name) >= len(privateV2Prefix) &&
+		strings.EqualFold(name[:len(privateV2Prefix)], privateV2Prefix)
+}
+
+// IsPrivateAttribute reports whether name is a private (secret) attribute of
+// either kind, and so must not be serialized to a client by default. This is the
+// predicate every serialization layer shares.
+func IsPrivateAttribute(name string) bool {
+	return IsPrivateAttributeV1(name) || IsPrivateAttributeV2(name)
+}
+
+// Redacted returns a copy of the ClassAd with every private attribute removed
+// (see IsPrivateAttribute), leaving the original -- and its stored secrets --
+// untouched. It is the explicit form to hand to a client where a boundary does
+// not already redact. A nil ad (or one with no attributes) is returned as-is; the
+// returned copy shares attribute values with the original and must be treated as
+// read-only.
+func (c *ClassAd) Redacted() *ClassAd {
+	if c == nil || c.ad == nil {
+		return c
+	}
+	kept := make([]*ast.AttributeAssignment, 0, len(c.ad.Attributes))
+	for _, attr := range c.ad.Attributes {
+		if IsPrivateAttribute(attr.Name) {
+			continue
+		}
+		kept = append(kept, attr)
+	}
+	out := &ClassAd{ad: &ast.ClassAd{Attributes: kept}, attrsDirty: true}
+	out.rebuildIndex()
+	return out
+}

--- a/classad/private_test.go
+++ b/classad/private_test.go
@@ -1,0 +1,103 @@
+package classad
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestIsPrivateAttribute(t *testing.T) {
+	private := []string{
+		"ClaimId", "claimid", "CLAIMID", // V1, case-insensitive
+		"Capability", "ClaimIds", "ClaimIdList", "ChildClaimIds", "TransferKey",
+		"_condor_priv_foo", "_CONDOR_PRIV_bar", // V2 prefix, case-insensitive
+	}
+	for _, n := range private {
+		if !IsPrivateAttribute(n) {
+			t.Errorf("IsPrivateAttribute(%q) = false, want true", n)
+		}
+	}
+	public := []string{
+		"Owner", "JobStatus", "ClaimIdentifier", "Capabilities", // not exact matches
+		"_condor_public", "MyClaimId", "", "PublicClaimId",
+	}
+	for _, n := range public {
+		if IsPrivateAttribute(n) {
+			t.Errorf("IsPrivateAttribute(%q) = true, want false", n)
+		}
+	}
+}
+
+// TestSerializersRedactByDefault is the core regression guard: none of the
+// default serializers may emit a private attribute's name or its secret value.
+// If a future change reintroduces a leak here, this fails.
+func TestSerializersRedactByDefault(t *testing.T) {
+	ad, err := Parse(`[ Owner = "alice"; JobStatus = 2; ClaimId = "SECRET-CAP-123"; Capability = "SECRET-CAP-456"; _condor_priv_x = "SECRET-789" ]`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	outputs := map[string]string{
+		"String":     ad.String(),
+		"MarshalOld": ad.MarshalOld(),
+	}
+	jb, err := json.Marshal(ad) // exercises MarshalJSON via the json.Marshaler path
+	if err != nil {
+		t.Fatal(err)
+	}
+	outputs["MarshalJSON"] = string(jb)
+
+	secrets := []string{"ClaimId", "Capability", "_condor_priv_x", "SECRET-CAP-123", "SECRET-CAP-456", "SECRET-789"}
+	for name, out := range outputs {
+		for _, s := range secrets {
+			if strings.Contains(out, s) {
+				t.Errorf("%s leaked %q: %s", name, s, out)
+			}
+		}
+		// Public attributes must survive.
+		if !strings.Contains(out, "Owner") || !strings.Contains(out, "alice") {
+			t.Errorf("%s dropped public attribute: %s", name, out)
+		}
+	}
+}
+
+// TestWithPrivateOptIn verifies the explicit opt-in serializers DO include
+// secrets (for internal/authorized use).
+func TestWithPrivateOptIn(t *testing.T) {
+	ad, err := Parse(`[ Owner = "alice"; ClaimId = "SECRET-123" ]`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(ad.StringWithPrivate(), "SECRET-123") {
+		t.Errorf("StringWithPrivate dropped the secret: %s", ad.StringWithPrivate())
+	}
+	if !strings.Contains(ad.MarshalOldWithPrivate(), "SECRET-123") {
+		t.Errorf("MarshalOldWithPrivate dropped the secret: %s", ad.MarshalOldWithPrivate())
+	}
+	jb, err := ad.MarshalJSONWithPrivate()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(jb), "SECRET-123") {
+		t.Errorf("MarshalJSONWithPrivate dropped the secret: %s", jb)
+	}
+}
+
+// TestRedacted verifies Redacted strips secrets while leaving the original intact.
+func TestRedacted(t *testing.T) {
+	ad, err := Parse(`[ Owner = "alice"; ClaimId = "SECRET-123" ]`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	red := ad.Redacted()
+	if _, ok := red.Lookup("ClaimId"); ok {
+		t.Error("Redacted retained ClaimId")
+	}
+	if _, ok := red.Lookup("Owner"); !ok {
+		t.Error("Redacted dropped a public attribute")
+	}
+	// Original is untouched (secret still present for internal/authorized use).
+	if _, ok := ad.Lookup("ClaimId"); !ok {
+		t.Error("Redacted mutated the original ad")
+	}
+}

--- a/collections/archive.go
+++ b/collections/archive.go
@@ -44,6 +44,12 @@ type Archive struct {
 	// scanned, if set, is called with each segment id a query actually scans (i.e.
 	// not pruned by its zone map). Test seam for asserting pruning; nil in production.
 	scanned func(uint32)
+
+	// Watch (see archive_watch.go / docs/WATCH.md). hub fans appended records to live
+	// watchers; watchEpoch is a persisted per-archive identity for cursor validation.
+	hub            *archiveWatchHub
+	watchEpoch     uint64
+	watchEpochOnce sync.Once
 }
 
 // archiveSeg is one segment of the log: a reused mmap-backed segment plus the
@@ -156,6 +162,7 @@ func newArchiveShell(opts ArchiveOptions) (*Archive, error) {
 		codec:   codec,
 		intern:  wire.NewInternTable(),
 		ret:     opts.Retention,
+		hub:     newArchiveWatchHub(),
 	}, nil
 }
 
@@ -196,26 +203,41 @@ func (a *Archive) Append(ad *classad.ClassAd) error {
 	stored := a.codec.Compress(nil, wireBytes)
 
 	a.mu.Lock()
-	defer a.mu.Unlock()
+	seg, off, err := a.appendLocked(stored)
+	if err == nil {
+		// Publish under the lock so live events reach watchers in log-position order
+		// (concurrent Appends are otherwise unordered once the lock is dropped). The
+		// fan-out is non-blocking, so it does not stall other writers. stored is not
+		// reused, so it is safe to hand to the (read-only) watchers.
+		a.hub.publish(seg, off, stored, a.codec)
+	}
+	a.mu.Unlock()
+	return err
+}
+
+// appendLocked appends stored to the active segment (rolling to a fresh one when it
+// does not fit) and returns the record's segment id and offset. Caller holds a.mu.
+func (a *Archive) appendLocked(stored []byte) (seg, off uint32, err error) {
 	if a.active == nil {
 		if err := a.openActiveLocked(); err != nil {
-			return err
+			return 0, 0, err
 		}
 	}
-	if _, ok := a.active.seg.append(archiveSeq, noLoc, nil, stored); !ok {
+	o, ok := a.active.seg.append(archiveSeq, noLoc, nil, stored)
+	if !ok {
 		// Doesn't fit: seal the active segment and start a fresh one.
 		if err := a.sealActiveLocked(); err != nil {
-			return err
+			return 0, 0, err
 		}
 		if err := a.openActiveLocked(); err != nil {
-			return err
+			return 0, 0, err
 		}
-		if _, ok := a.active.seg.append(archiveSeq, noLoc, nil, stored); !ok {
-			return fmt.Errorf("archive: ad of %d bytes exceeds segment size %d", len(stored), a.segSize)
+		if o, ok = a.active.seg.append(archiveSeq, noLoc, nil, stored); !ok {
+			return 0, 0, fmt.Errorf("archive: ad of %d bytes exceeds segment size %d", len(stored), a.segSize)
 		}
 	}
 	a.active.recN++
-	return nil
+	return a.active.seg.id, o, nil
 }
 
 // openActiveLocked starts a fresh mmap-backed active segment. Caller holds mu.
@@ -348,7 +370,9 @@ func (a *Archive) Rotate(now float64) (int, error) {
 	for a.shouldDropOldest(now) {
 		as := a.segs[0]
 		a.segs = a.segs[1:]
-		if e := os.Remove(a.idxPath(as.seg.id)); e != nil && err == nil {
+		// The sidecar index only exists when the archive is indexed; ignore its
+		// absence so an index-less archive can still rotate.
+		if e := os.Remove(a.idxPath(as.seg.id)); e != nil && !os.IsNotExist(e) && err == nil {
 			err = e
 		}
 		if as.seg.retire() { // unpinned now ⇒ reap immediately; else last unpin reaps

--- a/collections/archive.go
+++ b/collections/archive.go
@@ -429,8 +429,10 @@ func (a *Archive) Close() error {
 		err = e
 	}
 	for _, as := range a.segs {
-		as.seg.runReapHook() // unmap the sidecar index if it was lazily mapped
-		if e := as.seg.unmap(); e != nil && err == nil {
+		// Unmap data + sidecar index, but only once no live watch/query still pins the
+		// segment; a pinned segment's unmap is deferred to its last unpin. Unmapping a
+		// mapping a watcher is still reading is a use-after-free that -race flagged.
+		if e := as.seg.closeUnmap(); e != nil && err == nil {
 			err = e
 		}
 	}

--- a/collections/archive_watch.go
+++ b/collections/archive_watch.go
@@ -1,0 +1,259 @@
+package collections
+
+import (
+	"context"
+	"encoding/binary"
+	"iter"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+
+	"github.com/PelicanPlatform/classad/classad"
+)
+
+// Archive Watch is a log tail. The archive is append-only (no updates, no deletes),
+// so a watcher's cursor is a durable log position (epoch, segment id, offset) rather
+// than an MVCC sequence: replay every record after the position, then stream new
+// appends. Segment ids are stable across restart (the catalog persists them), so a
+// cursor resumes incrementally even across a reopen. A cursor older than what
+// rotation still retains gets a WatchReset (a history gap: resume from the floor).
+// Events are WatchUpsert (an appended ad; Key is nil), plus WatchSynced / WatchResync
+// (see WatchEvent). See docs/WATCH.md.
+
+// --- opaque positional cursor: {epoch, seg, off} ---
+
+func encodeArchiveCursor(epoch uint64, seg, off uint32) []byte {
+	b := make([]byte, 16)
+	binary.LittleEndian.PutUint64(b[0:], epoch)
+	binary.LittleEndian.PutUint32(b[8:], seg)
+	binary.LittleEndian.PutUint32(b[12:], off)
+	return b
+}
+
+func decodeArchiveCursor(b []byte) (epoch uint64, seg, off uint32, ok bool) {
+	if len(b) != 16 {
+		return 0, 0, 0, false
+	}
+	return binary.LittleEndian.Uint64(b[0:]),
+		binary.LittleEndian.Uint32(b[8:]),
+		binary.LittleEndian.Uint32(b[12:]), true
+}
+
+// ensureWatchEpoch lazily loads (or creates) a stable per-archive identity persisted
+// at <dir>/watch.epoch, so a cursor minted against a different archive is rejected.
+func (a *Archive) ensureWatchEpoch() uint64 {
+	a.watchEpochOnce.Do(func() {
+		p := filepath.Join(a.dir, "watch.epoch")
+		if b, err := os.ReadFile(p); err == nil && len(b) == 8 {
+			a.watchEpoch = binary.LittleEndian.Uint64(b)
+			return
+		}
+		e := randomEpoch()
+		var b [8]byte
+		binary.LittleEndian.PutUint64(b[:], e)
+		_ = os.WriteFile(p, b[:], 0o644)
+		a.watchEpoch = e
+	})
+	return a.watchEpoch
+}
+
+// --- live subscription hub (append-only variant) ---
+
+// archiveWatchBuf is the per-watcher live buffer capacity.
+const archiveWatchBuf = 1024
+
+type archiveRawEvent struct {
+	seg, off uint32
+	ad       []byte // compressed stored bytes
+	codec    Codec
+}
+
+type archiveWatcher struct {
+	ch     chan archiveRawEvent
+	lagged atomic.Bool
+}
+
+type archiveWatchHub struct {
+	active   atomic.Bool
+	mu       sync.Mutex
+	watchers map[*archiveWatcher]struct{}
+}
+
+func newArchiveWatchHub() *archiveWatchHub {
+	return &archiveWatchHub{watchers: map[*archiveWatcher]struct{}{}}
+}
+
+func (h *archiveWatchHub) register(buf int) *archiveWatcher {
+	w := &archiveWatcher{ch: make(chan archiveRawEvent, buf)}
+	h.mu.Lock()
+	h.watchers[w] = struct{}{}
+	h.active.Store(true)
+	h.mu.Unlock()
+	return w
+}
+
+func (h *archiveWatchHub) deregister(w *archiveWatcher) {
+	h.mu.Lock()
+	delete(h.watchers, w)
+	if len(h.watchers) == 0 {
+		h.active.Store(false)
+	}
+	h.mu.Unlock()
+}
+
+// publish fans a newly appended record out to every active watcher, non-blocking; a
+// watcher whose buffer is full is marked lagged (told to resync) rather than stalling
+// Append.
+func (h *archiveWatchHub) publish(seg, off uint32, ad []byte, codec Codec) {
+	if !h.active.Load() {
+		return
+	}
+	h.mu.Lock()
+	if len(h.watchers) == 0 {
+		h.mu.Unlock()
+		return
+	}
+	ev := archiveRawEvent{seg, off, ad, codec}
+	for w := range h.watchers {
+		select {
+		case w.ch <- ev:
+		default:
+			w.lagged.Store(true)
+		}
+	}
+	h.mu.Unlock()
+}
+
+// --- snapshot for catch-up ---
+
+type archiveWin struct {
+	id   uint32
+	data []byte
+	used int
+	seg  *segment
+}
+
+// watchSnapshot pins every retained segment (oldest first) and reports the retention
+// floor (oldest segment id) and the tail position (just past the last record). Pins
+// keep segments alive against rotation for the duration of catch-up.
+func (a *Archive) watchSnapshot() (wins []archiveWin, floor, tailSeg, tailOff uint32) {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	for _, as := range a.segs { // sealed, oldest first
+		if as.seg.used == 0 {
+			continue
+		}
+		as.seg.pin()
+		wins = append(wins, archiveWin{as.seg.id, as.seg.data, as.seg.used, as.seg})
+	}
+	if a.active != nil && a.active.seg.used > 0 {
+		a.active.seg.pin()
+		wins = append(wins, archiveWin{a.active.seg.id, a.active.seg.data, a.active.seg.used, a.active.seg})
+	}
+	if len(wins) > 0 {
+		floor = wins[0].id
+		last := wins[len(wins)-1]
+		tailSeg, tailOff = last.id, uint32(last.used)
+	} else {
+		floor, tailSeg, tailOff = a.nextID, a.nextID, 0
+	}
+	return wins, floor, tailSeg, tailOff
+}
+
+func releaseArchiveWins(wins []archiveWin) {
+	for i := range wins {
+		wins[i].seg.unpin()
+	}
+}
+
+func (a *Archive) decodeStored(stored []byte, codec Codec) (*classad.ClassAd, error) {
+	w, err := codec.Decompress(nil, stored)
+	if err != nil {
+		return nil, err
+	}
+	node, err := a.decodeWire(w)
+	if err != nil {
+		return nil, err
+	}
+	return classad.FromAST(node), nil
+}
+
+// --- the Watch verb ---
+
+// Watch replays every archived ad after cursor (nil ⇒ from the oldest retained), then
+// streams new appends until ctx is cancelled or the consumer stops. A cursor from a
+// different archive, or older than what rotation still retains, yields a WatchReset
+// and resumes from the current floor. See WatchEvent and docs/WATCH.md.
+func (a *Archive) Watch(ctx context.Context, cursor []byte) (iter.Seq[WatchEvent], error) {
+	return func(yield func(WatchEvent) bool) {
+		epoch := a.ensureWatchEpoch()
+		w := a.hub.register(archiveWatchBuf)
+		defer a.hub.deregister(w)
+
+		wins, floor, tailSeg, tailOff := a.watchSnapshot()
+		defer releaseArchiveWins(wins)
+
+		cEpoch, cSeg, cOff, ok := decodeArchiveCursor(cursor)
+		full := !ok || cEpoch != epoch || cSeg < floor
+		startSeg, startOff := cSeg, cOff
+		if full {
+			startSeg, startOff = floor, 0
+			if !yield(WatchEvent{Kind: WatchReset}) {
+				return
+			}
+		}
+
+		// Catch-up: every record at position >= (startSeg, startOff), oldest first.
+		for _, wn := range wins {
+			if wn.id < startSeg {
+				continue
+			}
+			off := 0
+			if wn.id == startSeg {
+				off = int(startOff)
+			}
+			for off < wn.used {
+				o := uint32(off)
+				total := recTotalLen(wn.data, o)
+				if total == 0 {
+					break
+				}
+				if ad, err := a.decodeStored(recAd(wn.data, o), a.codec); err == nil {
+					if !yield(WatchEvent{Kind: WatchUpsert, Ad: ad}) {
+						return
+					}
+				}
+				off += int(total)
+			}
+		}
+		if !yield(WatchEvent{Kind: WatchSynced, Cursor: encodeArchiveCursor(epoch, tailSeg, tailOff)}) {
+			return
+		}
+
+		// Live: stream appends past the catch-up tail.
+		for {
+			if w.lagged.Load() {
+				yield(WatchEvent{Kind: WatchResync})
+				return
+			}
+			select {
+			case <-ctx.Done():
+				return
+			case raw := <-w.ch:
+				if raw.seg < tailSeg || (raw.seg == tailSeg && raw.off < tailOff) {
+					continue // already covered by catch-up
+				}
+				ad, err := a.decodeStored(raw.ad, raw.codec)
+				if err != nil {
+					continue
+				}
+				next := raw.off + uint32(recordLen(0, len(raw.ad)))
+				ev := WatchEvent{Kind: WatchUpsert, Ad: ad, Cursor: encodeArchiveCursor(epoch, raw.seg, next)}
+				if !yield(ev) {
+					return
+				}
+			}
+		}
+	}, nil
+}

--- a/collections/archive_watch_test.go
+++ b/collections/archive_watch_test.go
@@ -1,0 +1,305 @@
+package collections
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+func collectArchiveCatchUp(t *testing.T, a *Archive, cursor []byte) ([]WatchEvent, []byte) {
+	t.Helper()
+	seq, err := a.Watch(context.Background(), cursor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var events []WatchEvent
+	var synced []byte
+	for ev := range seq {
+		if ev.Kind == WatchSynced {
+			synced = ev.Cursor
+			break
+		}
+		events = append(events, ev)
+	}
+	if synced == nil {
+		t.Fatal("archive watch ended without WatchSynced")
+	}
+	return events, synced
+}
+
+// upsertIDs returns the Id attribute of every Upsert event, in order.
+func upsertIDs(t *testing.T, events []WatchEvent) []int {
+	t.Helper()
+	var ids []int
+	for _, ev := range events {
+		if ev.Kind == WatchUpsert {
+			if ev.Ad == nil {
+				t.Fatal("upsert with nil Ad")
+			}
+			id, ok := ev.Ad.EvaluateAttrInt("Id")
+			if !ok {
+				t.Fatal("upsert ad missing Id")
+			}
+			ids = append(ids, int(id))
+		}
+	}
+	return ids
+}
+
+func TestArchiveWatchFullReplay(t *testing.T) {
+	t.Parallel()
+	a, err := CreateArchive(ArchiveOptions{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer a.Close()
+	const n = 200
+	for i := 0; i < n; i++ {
+		if err := a.Append(mustAd(t, fmt.Sprintf(`[Id=%d]`, i))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	events, cursor := collectArchiveCatchUp(t, a, nil)
+	if len(events) == 0 || events[0].Kind != WatchReset {
+		t.Fatalf("first event should be Reset, got %v", events)
+	}
+	ids := upsertIDs(t, events[1:])
+	if len(ids) != n {
+		t.Fatalf("full replay yielded %d ads, want %d", len(ids), n)
+	}
+	for i, id := range ids { // archive preserves append (chronological) order
+		if id != i {
+			t.Fatalf("out-of-order replay at %d: got Id=%d", i, id)
+		}
+	}
+	if cursor == nil {
+		t.Fatal("no synced cursor")
+	}
+}
+
+func TestArchiveWatchIncremental(t *testing.T) {
+	t.Parallel()
+	a, err := CreateArchive(ArchiveOptions{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer a.Close()
+	for i := 0; i < 50; i++ {
+		_ = a.Append(mustAd(t, fmt.Sprintf(`[Id=%d]`, i)))
+	}
+	_, cursor := collectArchiveCatchUp(t, a, nil)
+	for i := 50; i < 80; i++ {
+		_ = a.Append(mustAd(t, fmt.Sprintf(`[Id=%d]`, i)))
+	}
+	events, _ := collectArchiveCatchUp(t, a, cursor)
+	for _, ev := range events {
+		if ev.Kind == WatchReset {
+			t.Fatal("unexpected Reset on an in-window incremental resume")
+		}
+	}
+	ids := upsertIDs(t, events)
+	if len(ids) != 30 {
+		t.Fatalf("incremental resume yielded %d ads, want 30 (50..79): %v", len(ids), ids)
+	}
+	for i, id := range ids {
+		if id != 50+i {
+			t.Fatalf("incremental resume out of order: %v", ids)
+		}
+	}
+}
+
+// TestArchiveWatchResumeAcrossReopen verifies the cursor survives Close/OpenArchive
+// (segment ids and the epoch are persisted), so a resume is still incremental.
+func TestArchiveWatchResumeAcrossReopen(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	opts := ArchiveOptions{Dir: dir}
+	a, err := CreateArchive(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 60; i++ {
+		_ = a.Append(mustAd(t, fmt.Sprintf(`[Id=%d]`, i)))
+	}
+	_, cursor := collectArchiveCatchUp(t, a, nil)
+	if err := a.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	b, err := OpenArchive(opts)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer b.Close()
+	for i := 60; i < 90; i++ {
+		_ = b.Append(mustAd(t, fmt.Sprintf(`[Id=%d]`, i)))
+	}
+	events, _ := collectArchiveCatchUp(t, b, cursor)
+	for _, ev := range events {
+		if ev.Kind == WatchReset {
+			t.Fatal("resume across reopen should be incremental, not a Reset")
+		}
+	}
+	ids := upsertIDs(t, events)
+	// Must include the 30 records appended after reopen; may include none from before
+	// (cursor was at the pre-close tail).
+	got := map[int]bool{}
+	for _, id := range ids {
+		got[id] = true
+	}
+	for i := 60; i < 90; i++ {
+		if !got[i] {
+			t.Fatalf("resume across reopen missed Id=%d; got %v", i, ids)
+		}
+	}
+}
+
+// TestArchiveWatchResetAfterRotation: a cursor older than what rotation retains gets
+// a full replay from the current floor.
+func TestArchiveWatchResetAfterRotation(t *testing.T) {
+	t.Parallel()
+	a, err := CreateArchive(ArchiveOptions{
+		Dir: t.TempDir(), SegmentSize: 1 << 12,
+		Retention: Retention{MaxSegments: 1},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer a.Close()
+	for i := 0; i < 20; i++ {
+		_ = a.Append(mustAd(t, fmt.Sprintf(`[Id=%d]`, i)))
+	}
+	_, oldCursor := collectArchiveCatchUp(t, a, nil) // cursor near the start
+
+	// Append enough to seal many segments; retention keeps only the newest, so the
+	// oldCursor's segment is dropped.
+	for i := 20; i < 900; i++ {
+		_ = a.Append(mustAd(t, fmt.Sprintf(`[Id=%d]`, i)))
+	}
+	if _, err := a.Rotate(0); err != nil {
+		t.Fatal(err)
+	}
+	events, _ := collectArchiveCatchUp(t, a, oldCursor)
+	if len(events) == 0 || events[0].Kind != WatchReset {
+		t.Fatalf("resume past the retention floor should Reset; first kind = %v",
+			func() any {
+				if len(events) == 0 {
+					return "none"
+				}
+				return events[0].Kind
+			}())
+	}
+}
+
+func TestArchiveWatchLive(t *testing.T) {
+	t.Parallel()
+	a, err := CreateArchive(ArchiveOptions{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer a.Close()
+	_ = a.Append(mustAd(t, `[Id=0]`))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	seq, err := a.Watch(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	events := make(chan WatchEvent, 128)
+	go func() {
+		for ev := range seq {
+			events <- ev
+		}
+		close(events)
+	}()
+	for ev := range events {
+		if ev.Kind == WatchSynced {
+			break
+		}
+	}
+	_ = a.Append(mustAd(t, `[Id=1]`))
+	_ = a.Append(mustAd(t, `[Id=2]`))
+	got := 0
+	deadline := time.After(3 * time.Second)
+	for got < 2 {
+		select {
+		case ev := <-events:
+			if ev.Kind == WatchUpsert {
+				got++
+				if ev.Cursor == nil {
+					t.Error("live archive event missing cursor")
+				}
+			}
+		case <-deadline:
+			t.Fatalf("timed out waiting for live appends, got %d", got)
+		}
+	}
+}
+
+// TestArchiveWatchConcurrent streams live while concurrent appenders run. Run -race.
+func TestArchiveWatchConcurrent(t *testing.T) {
+	t.Parallel()
+	a, err := CreateArchive(ArchiveOptions{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer a.Close()
+	const n = 400
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	seq, err := a.Watch(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var mu sync.Mutex
+	seen := 0
+	resync := false
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for ev := range seq {
+			mu.Lock()
+			if ev.Kind == WatchResync {
+				resync = true
+				mu.Unlock()
+				return
+			}
+			if ev.Kind == WatchUpsert {
+				seen++
+			}
+			mu.Unlock()
+		}
+	}()
+
+	var wg sync.WaitGroup
+	for w := 0; w < 4; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			for i := w; i < n; i += 4 {
+				_ = a.Append(mustAd(t, fmt.Sprintf(`[Id=%d]`, i)))
+			}
+		}(w)
+	}
+	wg.Wait()
+
+	deadline := time.After(3 * time.Second)
+	for {
+		mu.Lock()
+		got, r := seen, resync
+		mu.Unlock()
+		if r || got >= n {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("watcher saw %d/%d appends and no resync", got, n)
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+	cancel()
+	<-done
+}

--- a/collections/commit.go
+++ b/collections/commit.go
@@ -123,6 +123,11 @@ func (sh *shard) applyWrites(writes []pendingPut) {
 	sh.commitSeq = seq
 	sh.mu.Unlock()
 	sh.sync()
+	if sh.hub != nil {
+		for i := range writes {
+			sh.hub.publish(sh.idx, seq, writes[i].key, writes[i].ad, writes[i].codec, false)
+		}
+	}
 }
 
 // applyOne commits a single write under the shard lock at a fresh commit
@@ -134,6 +139,9 @@ func (sh *shard) applyOne(p pendingPut) {
 	sh.commitSeq = seq
 	sh.mu.Unlock()
 	sh.sync()
+	if sh.hub != nil {
+		sh.hub.publish(sh.idx, seq, p.key, p.ad, p.codec, false)
+	}
 }
 
 // applyBatch commits a coalesced batch of requests under the shard lock at a
@@ -149,6 +157,13 @@ func (sh *shard) applyBatch(batch []*commitReq) {
 	sh.commitSeq = seq
 	sh.mu.Unlock()
 	sh.sync()
+	if sh.hub != nil {
+		for _, r := range batch {
+			for i := range r.writes {
+				sh.hub.publish(sh.idx, seq, r.writes[i].key, r.writes[i].ad, r.writes[i].codec, false)
+			}
+		}
+	}
 }
 
 // sync is the durability point: where a future durable collection would fsync or

--- a/collections/docs/PARENT_CHILD.md
+++ b/collections/docs/PARENT_CHILD.md
@@ -59,13 +59,17 @@ structural ads, and flattens matches.
 - **No re-parenting** — a key's parent is fixed.
 - **Auto-delete of an empty parent** — a structural parent is removed when its
   last child leaves (HTCondor `ClusterCleanup`); direct parent delete is not a
-  normal operation. *(ref-counted lifecycle — Phase 2)*
+  normal operation. `Delete`, after removing a key, drops the key's structural
+  parent if no children remain (`hasChildren` scans the parent's co-located
+  shard).
 - **Archive flattens** — the append-only archive stores materialized standalone
-  ads (no parent link), like `condor_history`. *(Phase 4)*
+  ads (no parent link), like `condor_history`. The chained collection produces
+  the flattened form (`Get`/`Query`/`Scan`, or `Flatten` by intent); the archive
+  stays a plain standalone store, so a history record outlives its parent.
 - **Watch fan-out on parent change** — a change to an *inherited* parent attribute
   re-emits the affected children; a **parent-private** attribute set (e.g. job
   factory bookkeeping like `JobMaterialize*`, which children don't inherit) is
-  excluded, and a diff suppresses no-op fan-out. *(Phase 3)*
+  excluded, and a diff suppresses no-op fan-out.
 
 ## Current limitations
 

--- a/collections/docs/PARENT_CHILD.md
+++ b/collections/docs/PARENT_CHILD.md
@@ -1,0 +1,75 @@
+# Parent/child (chained) ads
+
+A collection can give an ad a **parent**: a child ad resolves attribute
+references it lacks by falling through to its parent. This is the primitive
+"join" the HTCondor job queue needs — a proc ad (`cluster.proc`) chains to its
+cluster ad (`cluster.-1`), so a query like `DAGManJobId == 42` sees the cluster's
+attribute even though it is stored only once, on the cluster ad.
+
+Enable it with two `Options`:
+
+- `ParentKeyFor func(key []byte) []byte` — maps a child key to its parent key
+  (`nil` for a top-level ad). Bindings are **immutable**: a key's parent must not
+  change across updates (HTCondor forbids re-parenting a proc).
+- `IsStructural func(key []byte) bool` — marks a parent-only ad (a cluster ad).
+  Structural ads are stored and used as parents but **hidden** from
+  Query/Scan/Watch results by default, like `condor_q` omitting cluster ads.
+
+Example (jobs):
+
+```go
+c := collections.New(collections.Options{
+    ParentKeyFor: func(k []byte) []byte { /* "N.M" -> "N.-1", "N.-1" -> nil */ },
+    IsStructural: func(k []byte) bool  { /* proc == -1 */ },
+})
+```
+
+## Co-location
+
+A whole **family** (a root and all its descendants) is routed to **one shard**:
+the shard is chosen by the family root (`hash(rootKey(key))`), while the key's own
+hash still keys the bucket chain within the shard. Because a parent and its
+children share a shard — and thus a single MVCC snapshot — chained evaluation is
+**consistent and lock-free**, with no cross-shard fetch (the engine's hardest
+problem, dissolved). The plain single-key routing is unchanged when chaining is
+off.
+
+## Evaluation vs. output
+
+Two different needs, handled two different ways:
+
+- **Filtering** (does this ad match the query?) chains at the *wire* level: the
+  wire-native resolver, on a miss, falls through to the co-located parent's wire
+  bytes — so the fast path stays fast and never builds a `ClassAd` for a
+  non-match. The partial- and full-decode fallbacks `SetParent` the decoded ad,
+  which the ClassAd evaluator walks for unscoped references.
+- **Output** (the ad handed to the consumer) is **flattened**: the parent's
+  attributes are materialized into the child (child overrides), so direct reads
+  (`EvaluateAttr*`, serialization) see the inherited attributes. `SetParent` alone
+  only chains *expression evaluation*, not direct lookups — a query result or a
+  watch event must carry the inherited attributes inline. This matches `condor_q`
+  showing a job's full ad and `condor_history` flattening it.
+
+The scan is two-pass over one snapshot: pass 1 collects the shard's structural
+(parent) ads; pass 2 evaluates each child with its parent chained, hides
+structural ads, and flattens matches.
+
+## Semantics (mirroring HTCondor)
+
+- **No re-parenting** — a key's parent is fixed.
+- **Auto-delete of an empty parent** — a structural parent is removed when its
+  last child leaves (HTCondor `ClusterCleanup`); direct parent delete is not a
+  normal operation. *(ref-counted lifecycle — Phase 2)*
+- **Archive flattens** — the append-only archive stores materialized standalone
+  ads (no parent link), like `condor_history`. *(Phase 4)*
+- **Watch fan-out on parent change** — a change to an *inherited* parent attribute
+  re-emits the affected children; a **parent-private** attribute set (e.g. job
+  factory bookkeeping like `JobMaterialize*`, which children don't inherit) is
+  excluded, and a diff suppresses no-op fan-out. *(Phase 3)*
+
+## Current limitations
+
+- Chained collections use a serial two-pass scan; secondary indexes and query
+  fan-out are bypassed (they don't yet understand chaining).
+- A parent must be `IsStructural` (the two-pass scan collects structural ads as
+  the parent pool). For the job model this is exactly the cluster ad.

--- a/collections/docs/WATCH.md
+++ b/collections/docs/WATCH.md
@@ -1,0 +1,236 @@
+# Watch: resumable full-ad subscriptions
+
+> Status: **implemented for the Collection** in `watch.go` (`Collection.Watch`); the
+> Archive variant is a follow-up. Enabled by `Options.WatchHistory > 0`. Reuses the
+> MVCC sequence machinery; the one real limitation is that precise *deletes* are only
+> replayable within the retention window (`WatchHistory`), and older resumes fall back
+> to a full replay the client rebuilds from. The **Event types & client model** and
+> **API** sections below are the canonical protocol for building a listener.
+
+## Goal
+
+A client subscribes and receives the **full ad** (not a delta) for every add or
+update, and a **tombstone** for every delete. It can disconnect and later resume
+from where it left off using an opaque **cursor** it persisted, and the server
+replays everything that *potentially* changed since then. Semantics are
+**at-least-once**: over-delivery (an ad the client already has) is fine; a missed
+change is not. In the worst case the server may replay *all* current ads.
+
+## The cursor (a.k.a. txn id)
+
+There is no single global transaction counter — each shard has its own monotonic
+`commitSeq`, by design (a global counter would reintroduce write contention). So the
+cursor is **opaque to the client** and internally is:
+
+```
+Collection cursor = { epoch, perShardSeq[nShards] }     // one commitSeq per shard
+Archive cursor    = { epoch, logPosition }               // an append-log offset
+```
+
+- **`perShardSeq`** — for each shard, the `commitSeq` up to which the client has
+  processed. On resume, shard *i* replays records with `seq > perShardSeq[i]`. This
+  is exact per shard, needs no global ordering, and costs nothing on the write path.
+- **`epoch`** — a per-store identity (a UUID persisted in the store dir; per-process
+  for in-memory). If it does not match, the client's sequence numbers are from a
+  different store generation (e.g. the store was rebuilt from empty and seqs reset),
+  so the server ignores the numbers and does a **full replay**.
+- **Archive `logPosition`** — the archive is append-only with a constant record
+  sequence, so its cursor is a *position* in the append log (segment id + record
+  ordinal), like a Kafka offset — not an MVCC seq.
+
+The client treats the whole thing as opaque bytes, stores the latest one it fully
+processed, and hands it back on reconnect. Cursors survive a **server** restart:
+recovery rebuilds each shard's `commitSeq` from the segments and record `seq`s are
+immutable (and preserved across compaction), so the numbers still mean the same
+thing; the epoch guards the store-was-wiped case.
+
+## Collection Watch: catch-up then live
+
+Two phases, arranged so there is no gap between them.
+
+1. **Register for live first.** Attach the watcher to the commit path (see below) and
+   snapshot the current per-shard `commitSeq` as `S_reg`. Because the watcher is
+   attached *before* the snapshot, every commit at `seq > S_reg` is captured live.
+2. **Catch-up scan** for `(cursor, S_reg]`. This is the existing exactly-once scan
+   with one added filter: emit a current record only when `seq > cursor[shard]`.
+   Reading `seq` is cheap and needs no decode, so old records (the vast majority for a
+   recent cursor) are skipped without cost. Each survivor is decoded and emitted as a
+   full ad.
+3. **Drain the live buffer**, then stream live. Events buffered during catch-up (all
+   at `seq > S_reg`) are flushed; any overlap with the catch-up tail is a harmless
+   duplicate (at-least-once). From here the watcher streams live commits.
+
+The union of (catch-up `(cursor, S_reg]`) and (live `> S_reg`) covers everything
+`> cursor` with no gap — the correctness crux.
+
+### Live notification
+
+Commits finalize under the shard lock in `applyOne`/`applyBatch` (`commit.go`), right
+where `commitSeq` is bumped. Add a hook there that, for each committed write, hands
+the watcher `{key, wireAd, codec, seq}` (deletes hand `{key, tombstone, seq}`). The
+watcher decodes to a full ad off the write path. This reuses the group-commit
+structure — one notification per coalesced batch.
+
+## The hard part: deletes across compaction
+
+A delete writes **no new record**; it only stamps `supersededBySeq` on the old record.
+Compaction then **discards superseded records** — so the evidence that "key K was
+deleted at seq S" is eventually garbage-collected. A client resuming from before S
+would never learn K is gone. This is the only part that isn't free.
+
+**Within a retention window** it is exact. Keep a bounded horizon `H` (by seq lag or
+wall-clock age) and teach compaction to *retain* superseded records whose
+`supersededBySeq > H` (they are not yet reclaimable). Then catch-up can emit
+tombstones precisely: during the scan, collect superseded records with
+`sup > cursor[shard]`; any such key with no current version emitted is a delete →
+tombstone. `H` is advertised to clients as the oldest resumable point.
+
+**Beyond the window** (cursor older than `H`, or a mismatched epoch) the server cannot
+reconstruct which keys were deleted. Fall back to **full replay** of all current ads
+and let the client **reconcile deletes itself**: it diffs the replayed key set against
+the keys it currently holds and drops the ones absent from the replay. This needs the
+client to hold its key set, which a full-state subscriber does anyway. This is the
+"replay all ads for reconnecting clients" case the design explicitly allows.
+
+(Alternative if we don't want compaction to retain tombstones: a separate append-only
+**delete journal** — `(key, seq)` per delete — retained for `H` and rotated. Cleaner
+separation, one more structure to persist. The retention-in-compaction option reuses
+existing machinery and is the recommended first cut.)
+
+## Making catch-up cheap
+
+A recent cursor should not require reading every record's `seq` across the whole
+store. Records are appended in commit order, so a *freshly written* segment's `seq`s
+are monotonic and it carries a `[minSeq, maxSeq]` range — segments with
+`maxSeq ≤ cursor` are skipped whole. Compaction, which gathers current records by key,
+breaks per-segment monotonicity, so a compacted segment just records its actual
+`[minSeq, maxSeq]` (a superset scan within it is fine — over-delivery is allowed). The
+archive already keeps per-segment zone maps; the collection would add a cheap min/max
+`seq` per segment. Fallback when ranges are unavailable: a full `seq`-filtered scan,
+which is correct, just O(records).
+
+## Archive Watch (simpler)
+
+The archive is append-only — no updates, no deletes — so Watch is a log tail:
+replay records after `logPosition`, then stream new appends. The resumable floor is
+whatever rotation still retains; a cursor older than the oldest retained segment gets
+everything currently retained (and the client learns the floor moved). No delete
+problem, no per-shard vector — just an offset.
+
+## Back-pressure
+
+Each watcher has a bounded buffer. A slow client that overflows it is **demoted**, not
+allowed to block writers: the server drops its live buffer and the client simply
+reconnects with its last acked cursor, re-entering catch-up. At-least-once holds
+because the cursor is only advanced by the client after it durably processes an event.
+
+## API (implemented)
+
+```go
+// Enable Watch by giving the collection a delete-retention journal:
+c := collections.New(collections.Options{
+    Shards:       16,
+    WatchHistory: 4096, // per-shard deletes retained; 0 ⇒ Watch disabled
+    WatchBuffer:  1024, // per-watcher live buffer (default 1024)
+})
+
+type WatchKind uint8
+const (
+    WatchUpsert WatchKind = iota // Ad set: key added or updated (full ad)
+    WatchDelete                  // Ad nil: key removed
+    WatchReset                   // discard state; a full snapshot of Upserts follows
+    WatchSynced                  // end of catch-up; now live. Cursor is a resume point
+    WatchResync                  // stream fell behind; reconnect with your last cursor
+)
+
+type WatchEvent struct {
+    Kind   WatchKind
+    Key    []byte
+    Ad     *classad.ClassAd // set for WatchUpsert
+    Cursor []byte           // opaque; persist after processing (set on live events + Synced)
+}
+
+// Watch replays everything that may have changed since cursor (nil ⇒ full replay from
+// empty), then streams live changes until ctx is cancelled or the consumer stops.
+// Returns an error only if Watch is disabled (WatchHistory == 0).
+func (c *Collection) Watch(ctx context.Context, cursor []byte) (iter.Seq[WatchEvent], error)
+```
+
+### Event types
+
+| Kind | Meaning | Carries |
+|------|---------|---------|
+| `WatchUpsert` | key added or updated | `Key`, `Ad` (full) |
+| `WatchDelete` | key removed | `Key` |
+| `WatchReset` | discard local state; an authoritative full snapshot of `Upsert`s follows | — |
+| `WatchSynced` | catch-up complete, now live | `Cursor` (durable resume point; swap the shadow here) |
+| `WatchResync` | live stream lagged — reconnect with the last cursor | — |
+
+`Upsert`/`Delete` are applied identically whether catching up or live — there is no
+separate "mode". The only control the client must honor is `Reset`, which exists
+**solely to convey deletes that fell out of the retention window**: rather than
+diffing, the client rebuilds from the following snapshot, so deleted keys simply never
+reappear. (An add/update-only store would need none of `Reset`/`Synced`.)
+
+### Client model
+
+```go
+var live map[string]*classad.ClassAd    // committed state
+var shadow map[string]*classad.ClassAd  // built during a Reset snapshot; nil otherwise
+
+seq, err := c.Watch(ctx, lastCursor)    // lastCursor persisted from a prior run (nil first time)
+for ev := range seq {
+    switch ev.Kind {
+    case WatchReset:
+        shadow = map[string]*classad.ClassAd{}          // start a fresh snapshot
+    case WatchUpsert:
+        target(shadow, live)[string(ev.Key)] = ev.Ad
+    case WatchDelete:
+        delete(target(shadow, live), string(ev.Key))
+    case WatchSynced:
+        if shadow != nil { live, shadow = shadow, nil }  // atomically adopt the snapshot
+        persist(ev.Cursor)                               // durable resume point
+    case WatchResync:
+        break // reconnect: call Watch(lastCursor) again
+    }
+    if ev.Cursor != nil { persist(ev.Cursor) }           // live events advance the cursor
+}
+// target(shadow, live) returns shadow while a snapshot is in progress, else live.
+```
+
+Only advance the persisted cursor *after* the event is durably applied — that is what
+makes resume at-least-once. On restart, call `Watch(lastCursor)`.
+
+## Limitations / non-goals
+
+- **At-least-once, not exactly-once** — duplicates are possible by design.
+- **No global order across shards** — the stream is per-shard-ordered and interleaved.
+  Fine for independent full-ad updates; not a global change log.
+- **Deletes beyond the retention horizon** cannot be replayed precisely → full replay
+  + client-side reconcile. This is the one inherent limit.
+- **Very slow clients** are demoted to a fresh catch-up rather than throttling writers.
+
+## Status of the plan
+
+Done (Collection):
+
+1. **Cursor + catch-up** — opaque `{epoch, perShardSeq[]}` cursor, `seq`-filtered
+   catch-up emitting `Upsert`s (deletes emitted first so re-adds end present).
+2. **Live streaming** — commit-path hook (`applyOne`/`applyWrites`/`applyBatch` +
+   `Delete`), per-watcher bounded buffer, register-then-snapshot handoff, non-blocking
+   publish with `Resync`-on-overflow.
+3. **Deletes** — implemented as a bounded per-shard **delete journal**
+   (`Options.WatchHistory`), not compaction-retained tombstones (simpler, self-
+   contained). Catch-up emits precise `Delete`s within the window; a cursor past the
+   journal horizon (or a mismatched epoch) gets a `Reset` + full replay.
+
+Deferred:
+
+4. **Catch-up efficiency** — currently a full `seq`-filtered scan of every segment
+   (correct, O(records)). Per-segment `[minSeq,maxSeq]` to skip old segments is a
+   follow-up.
+5. **Archive Watch** — positional cursor + log-tail; not yet built.
+6. **Epoch persistence** — the epoch is per-process, so **a persistent collection that
+   is reopened gets a new epoch and forces watchers to full-replay** (safe, but not
+   incremental across a server restart). Persisting the epoch (and, to resume
+   incrementally across restart, the delete journal) under `Dir` is a follow-up.

--- a/collections/docs/WATCH.md
+++ b/collections/docs/WATCH.md
@@ -1,11 +1,13 @@
 # Watch: resumable full-ad subscriptions
 
-> Status: **implemented for the Collection** in `watch.go` (`Collection.Watch`); the
-> Archive variant is a follow-up. Enabled by `Options.WatchHistory > 0`. Reuses the
-> MVCC sequence machinery; the one real limitation is that precise *deletes* are only
-> replayable within the retention window (`WatchHistory`), and older resumes fall back
-> to a full replay the client rebuilds from. The **Event types & client model** and
-> **API** sections below are the canonical protocol for building a listener.
+> Status: **implemented** — `Collection.Watch` (`watch.go`, enabled by
+> `Options.WatchHistory > 0`) and `Archive.Watch` (`archive_watch.go`, always
+> available). The Collection reuses the MVCC sequence machinery; its one real
+> limitation is that precise *deletes* are only replayable within the retention window
+> (`WatchHistory`), older resumes falling back to a full replay the client rebuilds
+> from. The Archive is append-only, so its Watch is a durable log tail with none of
+> that. The **Event types & client model** and **API** sections below are the
+> canonical protocol for building a listener.
 
 ## Goal
 
@@ -109,13 +111,27 @@ archive already keeps per-segment zone maps; the collection would add a cheap mi
 `seq` per segment. Fallback when ranges are unavailable: a full `seq`-filtered scan,
 which is correct, just O(records).
 
-## Archive Watch (simpler)
+## Archive Watch (`Archive.Watch`, implemented)
 
 The archive is append-only — no updates, no deletes — so Watch is a log tail:
-replay records after `logPosition`, then stream new appends. The resumable floor is
-whatever rotation still retains; a cursor older than the oldest retained segment gets
-everything currently retained (and the client learns the floor moved). No delete
-problem, no per-shard vector — just an offset.
+
+```go
+func (a *Archive) Watch(ctx context.Context, cursor []byte) (iter.Seq[WatchEvent], error)
+```
+
+- **Cursor** = `{epoch, segment id, offset}` — a durable **log position**, not an MVCC
+  sequence. Segment ids and offsets are stable once written and the catalog persists
+  them, and the epoch is persisted at `<dir>/watch.epoch`, so **a cursor resumes
+  incrementally even across a reopen** (unlike the Collection today). No per-shard
+  vector, no delete journal.
+- **Events**: only `WatchUpsert` (an appended ad; `Key` is nil, `Ad` is the payload),
+  plus `WatchSynced`/`WatchResync`. `WatchReset` here means a **history gap** — the
+  cursor is older than what rotation still retains (or from a different archive), so
+  the replay restarts from the current floor; a log consumer notes it may have missed
+  entries (there is no current state to rebuild).
+- **Catch-up** replays every retained record after the cursor, oldest-first; **live**
+  streams new appends. `Append` publishes under its lock so live events are strictly
+  in log order. Always available (no option); zero cost when no one is watching.
 
 ## Back-pressure
 
@@ -224,13 +240,22 @@ Done (Collection):
    contained). Catch-up emits precise `Delete`s within the window; a cursor past the
    journal horizon (or a mismatched epoch) gets a `Reset` + full replay.
 
+Also done:
+
+4. **Archive Watch** (`archive_watch.go`) — positional `{epoch, seg, off}` cursor,
+   oldest-first catch-up, live tail, Reset-on-rotation-gap. The epoch is persisted at
+   `<dir>/watch.epoch` and segment ids are catalog-stable, so archive resumes survive
+   a reopen incrementally. (Also fixed a `Rotate` bug it surfaced: an index-less
+   archive failed to drop segments because it tried to unlink a sidecar that was never
+   written.)
+
 Deferred:
 
-4. **Catch-up efficiency** — currently a full `seq`-filtered scan of every segment
-   (correct, O(records)). Per-segment `[minSeq,maxSeq]` to skip old segments is a
-   follow-up.
-5. **Archive Watch** — positional cursor + log-tail; not yet built.
-6. **Epoch persistence** — the epoch is per-process, so **a persistent collection that
-   is reopened gets a new epoch and forces watchers to full-replay** (safe, but not
-   incremental across a server restart). Persisting the epoch (and, to resume
-   incrementally across restart, the delete journal) under `Dir` is a follow-up.
+5. **Collection catch-up efficiency** — currently a full `seq`-filtered scan of every
+   segment (correct, O(records)). Per-segment `[minSeq,maxSeq]` to skip old segments
+   is a follow-up.
+6. **Collection epoch persistence** — the Collection's epoch is per-process, so **a
+   reopened persistent collection gets a new epoch and forces watchers to full-replay**
+   (safe, but not incremental across a server restart). Persisting the epoch and the
+   delete journal under `Dir` (as the Archive already does for its epoch) is a
+   follow-up. The Archive already resumes incrementally across a reopen.

--- a/collections/parent_child_test.go
+++ b/collections/parent_child_test.go
@@ -1,0 +1,129 @@
+package collections
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/collections/vm"
+)
+
+// jobParentKey maps a job key "cluster.proc" to its cluster ad "cluster.-1"
+// (returning nil for a cluster ad, which has no parent).
+func jobParentKey(key []byte) []byte {
+	s := string(key)
+	dot := strings.LastIndexByte(s, '.')
+	if dot < 0 {
+		return nil
+	}
+	if s[dot+1:] == "-1" {
+		return nil
+	}
+	return []byte(s[:dot] + ".-1")
+}
+
+// jobStructural marks cluster ads (proc == -1) structural.
+func jobStructural(key []byte) bool { return strings.HasSuffix(string(key), ".-1") }
+
+func chainedJobsCollection(t *testing.T) *Collection {
+	t.Helper()
+	c := New(Options{Shards: 8, ParentKeyFor: jobParentKey, IsStructural: jobStructural})
+	// Two DAGs. DAGManJobId and Owner live only on the cluster (parent) ads.
+	c.Put([]byte("1.-1"), mustAd(t, `[DAGManJobId=42; Owner="alice"; Cmd="/bin/sleep"]`))
+	c.Put([]byte("1.0"), mustAd(t, `[ProcId=0; JobStatus=1]`))
+	c.Put([]byte("1.1"), mustAd(t, `[ProcId=1; JobStatus=2]`))
+	c.Put([]byte("2.-1"), mustAd(t, `[DAGManJobId=7; Owner="bob"]`))
+	c.Put([]byte("2.0"), mustAd(t, `[ProcId=0; JobStatus=1]`))
+	return c
+}
+
+// TestChainedColocation verifies a cluster ad and its procs land in one shard.
+func TestChainedColocation(t *testing.T) {
+	c := chainedJobsCollection(t)
+	sc := c.shardOf([]byte("1.-1"), c.h.Hash([]byte("1.-1")))
+	for _, k := range []string{"1.0", "1.1"} {
+		if s := c.shardOf([]byte(k), c.h.Hash([]byte(k))); s != sc {
+			t.Errorf("job %s in shard %d, cluster in shard %d (not co-located)", k, s, sc)
+		}
+	}
+}
+
+// TestChainedQueryFilter verifies a query on a parent-only attribute resolves
+// through the chain: DAGManJobId (only on the cluster ad) selects that cluster's
+// procs, and cluster ads themselves are hidden.
+func TestChainedQueryFilter(t *testing.T) {
+	c := chainedJobsCollection(t)
+
+	q, err := vm.Parse(`DAGManJobId == 42`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got []string
+	for ad := range c.Query(q) {
+		cl, _ := ad.EvaluateAttrInt("ClusterId") // absent; use key-free identity via ProcId+DAGManJobId
+		p, _ := ad.EvaluateAttrInt("ProcId")
+		d, _ := ad.EvaluateAttrInt("DAGManJobId")
+		if d != 42 {
+			t.Errorf("matched ad has DAGManJobId=%d, want 42 (chain broken)", d)
+		}
+		_ = cl
+		got = append(got, fmt.Sprintf("proc%d", p))
+	}
+	sort.Strings(got)
+	if len(got) != 2 || got[0] != "proc0" || got[1] != "proc1" {
+		t.Errorf("DAGManJobId==42 matched %v, want the two procs of cluster 1 (no cluster ad)", got)
+	}
+}
+
+// TestChainedChildOverride verifies a child attribute overrides the parent's.
+func TestChainedChildOverride(t *testing.T) {
+	c := chainedJobsCollection(t)
+	// Give proc 1.0 its own DAGManJobId, overriding the cluster's 42.
+	c.Put([]byte("1.0"), mustAd(t, `[ProcId=0; DAGManJobId=99]`))
+
+	count := func(expr string) int {
+		q, err := vm.Parse(expr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		n := 0
+		for range c.Query(q) {
+			n++
+		}
+		return n
+	}
+	if n := count(`DAGManJobId == 99`); n != 1 {
+		t.Errorf("DAGManJobId==99 matched %d, want 1 (the overriding proc)", n)
+	}
+	if n := count(`DAGManJobId == 42`); n != 1 {
+		t.Errorf("DAGManJobId==42 matched %d, want 1 (proc 1.1 still inherits; 1.0 overrode)", n)
+	}
+}
+
+// TestChainedStructuralHidden verifies structural (cluster) ads are excluded from
+// Scan, and TestChainedGet verifies Get resolves inherited attributes.
+func TestChainedStructuralHidden(t *testing.T) {
+	c := chainedJobsCollection(t)
+	total := 0
+	for range c.Scan() {
+		total++
+	}
+	if total != 3 {
+		t.Errorf("Scan returned %d ads, want 3 jobs (cluster ads hidden)", total)
+	}
+}
+
+func TestChainedGet(t *testing.T) {
+	c := chainedJobsCollection(t)
+	ad, ok := c.Get([]byte("1.0"))
+	if !ok {
+		t.Fatal("Get 1.0 missing")
+	}
+	if d, _ := ad.EvaluateAttrInt("DAGManJobId"); d != 42 {
+		t.Errorf("Get(1.0) DAGManJobId=%d, want 42 (inherited from cluster)", d)
+	}
+	if o, _ := ad.EvaluateAttrString("Owner"); o != "alice" {
+		t.Errorf("Get(1.0) Owner=%q, want alice (inherited)", o)
+	}
+}

--- a/collections/parent_child_test.go
+++ b/collections/parent_child_test.go
@@ -195,3 +195,45 @@ func TestChainedArchiveFlatten(t *testing.T) {
 		t.Errorf("archive query on inherited attrs matched %d, want 2 (flattened procs)", n)
 	}
 }
+
+// TestChainedAutoDeleteCounter drives the in-memory child counter directly: with
+// every family co-located in a single shard, deleting one cluster's procs must
+// auto-delete only that cluster's ad (per-parent counts, no cross-contamination),
+// re-putting a proc must not double-count, and a proc deleted then re-added must
+// keep its parent alive.
+func TestChainedAutoDeleteCounter(t *testing.T) {
+	c := New(Options{Shards: 1, ParentKeyFor: jobParentKey, IsStructural: jobStructural})
+	for _, k := range []string{"1.-1", "1.0", "1.1", "2.-1", "2.0"} {
+		c.Put([]byte(k), mustAd(t, `[X=1]`))
+	}
+	// Same shard (Shards:1) => both families share one childCount map.
+	if c.shardOf([]byte("1.-1"), 0) != c.shardOf([]byte("2.-1"), 0) {
+		t.Fatal("test precondition: clusters not co-located")
+	}
+
+	// Re-put an existing proc: must not inflate the count.
+	c.Put([]byte("1.0"), mustAd(t, `[X=2]`))
+
+	// Delete/re-add a proc: parent must stay (count returns to 2).
+	c.Delete([]byte("1.0"))
+	c.Put([]byte("1.0"), mustAd(t, `[X=3]`))
+	if _, ok := c.Get([]byte("1.-1")); !ok {
+		t.Error("cluster 1 ad deleted while a proc remained (count desync)")
+	}
+
+	// Drain cluster 1: its ad goes; cluster 2 is untouched.
+	c.Delete([]byte("1.0"))
+	c.Delete([]byte("1.1"))
+	if _, ok := c.Get([]byte("1.-1")); ok {
+		t.Error("cluster 1 ad not auto-deleted after its last proc left")
+	}
+	if _, ok := c.Get([]byte("2.-1")); !ok {
+		t.Error("cluster 2 ad wrongly deleted (cross-family count contamination)")
+	}
+
+	// Drain cluster 2: now it goes too.
+	c.Delete([]byte("2.0"))
+	if _, ok := c.Get([]byte("2.-1")); ok {
+		t.Error("cluster 2 ad not auto-deleted after its last proc left")
+	}
+}

--- a/collections/parent_child_test.go
+++ b/collections/parent_child_test.go
@@ -149,3 +149,49 @@ func TestChainedAutoDeleteParent(t *testing.T) {
 		t.Error("cluster ad not auto-deleted after its last proc left")
 	}
 }
+
+// TestChainedArchiveFlatten verifies the Phase 4 composition: a job that inherits
+// attributes from its (structural) cluster ad is archived as a self-contained,
+// flattened history record -- queryable on the inherited attribute with no parent
+// present, like condor_history. The chained collection produces the flattened ad
+// (Flatten); the append-only Archive stores it standalone.
+func TestChainedArchiveFlatten(t *testing.T) {
+	c := chainedJobsCollection(t) // cluster 1.-1 has DAGManJobId=42, Owner="alice"
+
+	arch, err := CreateArchive(ArchiveOptions{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = arch.Close() }()
+
+	// Archive the flattened form of each proc (what a history writer would do when
+	// a job leaves the live queue).
+	for _, key := range []string{"1.0", "1.1"} {
+		flat, ok := c.Flatten([]byte(key))
+		if !ok {
+			t.Fatalf("Flatten(%s) missing", key)
+		}
+		// The flattened ad is standalone: the inherited attr is materialized, no
+		// parent link needed to read it.
+		if d, _ := flat.EvaluateAttrInt("DAGManJobId"); d != 42 {
+			t.Errorf("Flatten(%s) DAGManJobId=%d, want 42 (inherited)", key, d)
+		}
+		if err := arch.Append(flat); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// The archive holds no cluster ad, yet a query on the parent-only attribute
+	// still matches both procs -- proof the records are self-contained.
+	q, err := vm.Parse(`DAGManJobId == 42 && Owner == "alice"`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	n := 0
+	for range arch.Query(q) {
+		n++
+	}
+	if n != 2 {
+		t.Errorf("archive query on inherited attrs matched %d, want 2 (flattened procs)", n)
+	}
+}

--- a/collections/parent_child_test.go
+++ b/collections/parent_child_test.go
@@ -127,3 +127,25 @@ func TestChainedGet(t *testing.T) {
 		t.Errorf("Get(1.0) Owner=%q, want alice (inherited)", o)
 	}
 }
+
+// TestChainedAutoDeleteParent verifies a structural parent is auto-removed when
+// its last child leaves, but not before.
+func TestChainedAutoDeleteParent(t *testing.T) {
+	c := New(Options{Shards: 4, ParentKeyFor: jobParentKey, IsStructural: jobStructural})
+	c.Put([]byte("1.-1"), mustAd(t, `[DAGManJobId=42]`))
+	c.Put([]byte("1.0"), mustAd(t, `[ProcId=0]`))
+	c.Put([]byte("1.1"), mustAd(t, `[ProcId=1]`))
+	if _, ok := c.Get([]byte("1.-1")); !ok {
+		t.Fatal("cluster ad missing after Put")
+	}
+
+	c.Delete([]byte("1.0"))
+	if _, ok := c.Get([]byte("1.-1")); !ok {
+		t.Error("cluster ad auto-deleted too early (proc 1.1 still present)")
+	}
+
+	c.Delete([]byte("1.1"))
+	if _, ok := c.Get([]byte("1.-1")); ok {
+		t.Error("cluster ad not auto-deleted after its last proc left")
+	}
+}

--- a/collections/parent_child_watch_test.go
+++ b/collections/parent_child_watch_test.go
@@ -1,0 +1,103 @@
+package collections
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestChainedWatchFlattened verifies watch events for children carry inherited
+// (flattened) attributes and that cluster ads are hidden from the stream.
+func TestChainedWatchFlattened(t *testing.T) {
+	c := New(Options{
+		Shards: 4, WatchHistory: 1024,
+		ParentKeyFor: jobParentKey, IsStructural: jobStructural,
+	})
+	c.Put([]byte("1.-1"), mustAd(t, `[DAGManJobId=42; Owner="alice"]`))
+	c.Put([]byte("1.0"), mustAd(t, `[ProcId=0]`))
+	c.Put([]byte("1.1"), mustAd(t, `[ProcId=1]`))
+
+	events, _ := collectCatchUp(t, c, nil)
+	nUpsert := 0
+	for _, ev := range events {
+		if ev.Kind != WatchUpsert {
+			continue
+		}
+		nUpsert++
+		if d, _ := ev.Ad.EvaluateAttrInt("DAGManJobId"); d != 42 {
+			t.Errorf("catch-up upsert %s: DAGManJobId=%d, want 42 (not flattened)", ev.Key, d)
+		}
+	}
+	if nUpsert != 2 {
+		t.Errorf("catch-up upserts=%d, want 2 (two jobs; cluster ad hidden)", nUpsert)
+	}
+}
+
+// TestChainedWatchFanout verifies a change to an inherited parent attribute
+// fans out to the children (with the new value), while a change to only a
+// parent-private attribute does not.
+func TestChainedWatchFanout(t *testing.T) {
+	c := New(Options{
+		Shards: 4, WatchHistory: 1024,
+		ParentKeyFor: jobParentKey, IsStructural: jobStructural,
+		ParentPrivateAttrs: []string{"JobMaterializeNextProcId"},
+	})
+	c.Put([]byte("1.-1"), mustAd(t, `[DAGManJobId=42; JobMaterializeNextProcId=0]`))
+	c.Put([]byte("1.0"), mustAd(t, `[ProcId=0]`))
+	c.Put([]byte("1.1"), mustAd(t, `[ProcId=1]`))
+	_, cursor := collectCatchUp(t, c, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	seq, err := c.Watch(ctx, cursor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	type rec struct {
+		kind WatchKind
+		key  string
+		dag  int64
+	}
+	evs := make(chan rec, 64)
+	synced := make(chan struct{})
+	go func() {
+		for ev := range seq {
+			if ev.Kind == WatchSynced {
+				close(synced)
+				continue
+			}
+			d := int64(-1)
+			if ev.Ad != nil {
+				d, _ = ev.Ad.EvaluateAttrInt("DAGManJobId")
+			}
+			evs <- rec{ev.Kind, string(ev.Key), d}
+		}
+	}()
+	<-synced
+
+	// A change to only a parent-private attribute must NOT fan out.
+	c.Put([]byte("1.-1"), mustAd(t, `[DAGManJobId=42; JobMaterializeNextProcId=1]`))
+	select {
+	case e := <-evs:
+		t.Fatalf("private-only parent change fanned out: %v %s", e.kind, e.key)
+	case <-time.After(250 * time.Millisecond):
+	}
+
+	// A change to an inherited attribute must fan out to both children.
+	c.Put([]byte("1.-1"), mustAd(t, `[DAGManJobId=99; JobMaterializeNextProcId=2]`))
+	got := map[string]int64{}
+	deadline := time.After(2 * time.Second)
+	for len(got) < 2 {
+		select {
+		case e := <-evs:
+			if e.kind == WatchUpsert {
+				got[e.key] = e.dag
+			}
+		case <-deadline:
+			t.Fatalf("fan-out incomplete: got %v, want 1.0 and 1.1 at 99", got)
+		}
+	}
+	if got["1.0"] != 99 || got["1.1"] != 99 {
+		t.Errorf("fan-out values = %v, want both procs at DAGManJobId 99", got)
+	}
+}

--- a/collections/persist_test.go
+++ b/collections/persist_test.go
@@ -810,7 +810,7 @@ func TestDeleteTombstoneFlushPath(t *testing.T) {
 	sh.mu.Lock()
 	sh.dirtySup = nil // clear any prior state
 	seq := sh.commitSeq + 1
-	ok := sh.del(h, key, seq)
+	ok, _ := sh.del(h, key, seq)
 	nQueued := len(sh.dirtySup)
 	sh.mu.Unlock()
 	if !ok {

--- a/collections/segment.go
+++ b/collections/segment.go
@@ -95,7 +95,8 @@ type segment struct {
 	reapMu  sync.Mutex
 	refs    int  // active scan pins
 	retired bool // removed from the live set by compaction; awaiting reap
-	reaped  bool // reap() has run (guards against a double munmap/unlink)
+	reaped  bool // reap()/close-unmap has run (guards against a double munmap)
+	closing bool // Archive.Close requested; unmap (no unlink) when pins drain
 
 	// onReap, if set, runs once right after reap() — used by the Archive to unmap a
 	// segment's mmap'd sidecar index at the same pin-drained moment its data is
@@ -122,14 +123,53 @@ func (s *segment) unpin() {
 	}
 	s.reapMu.Lock()
 	s.refs--
+	// Last pin drop: reap (munmap + unlink) a compaction-retired segment, or unmap
+	// (munmap, no unlink) a segment Archive.Close deferred because we were pinning
+	// it. reap wins if both apply. Setting reaped guards against a double free.
 	doReap := s.refs == 0 && s.retired && !s.reaped
-	if doReap {
+	doUnmap := s.refs == 0 && s.closing && !s.retired && !s.reaped
+	if doReap || doUnmap {
 		s.reaped = true
 	}
 	s.reapMu.Unlock()
 	if doReap {
 		s.reapAndHook()
+	} else if doUnmap {
+		_ = s.unmapAndHook()
 	}
+}
+
+// unmapAndHook unmaps the segment's data (munmap + close file, WITHOUT unlinking
+// the file) and then runs onReap once (the sidecar-index unmap). It is the
+// close-time counterpart of reapAndHook: the archive files persist across Close.
+func (s *segment) unmapAndHook() error {
+	err := s.unmap()
+	s.runReapHook()
+	return err
+}
+
+// closeUnmap unmaps the segment for Archive.Close: immediately if no scan pins it,
+// otherwise it defers the unmap to the last unpin (so a live watch never reads a
+// mapping torn down under it -- the bug the pin count exists to prevent). Unlike
+// retire/reap it does not unlink the backing file. Idempotent; caller holds the
+// Archive mutex, so no new pin can be taken concurrently. No-op for RAM segments.
+func (s *segment) closeUnmap() error {
+	if s.file == nil {
+		return nil
+	}
+	s.reapMu.Lock()
+	if s.reaped { // already reaped by compaction or unmapped by a prior Close
+		s.reapMu.Unlock()
+		return nil
+	}
+	if s.refs > 0 {
+		s.closing = true // a live scan pins it; the last unpin will unmap it
+		s.reapMu.Unlock()
+		return nil
+	}
+	s.reaped = true
+	s.reapMu.Unlock()
+	return s.unmapAndHook()
 }
 
 // setOnReap registers a callback run once when the segment is reaped or explicitly

--- a/collections/shard.go
+++ b/collections/shard.go
@@ -45,6 +45,19 @@ type shard struct {
 	idx    int
 	hub    *watchHub
 	delLog *deleteLog
+
+	// Chained-parent child counting (see store.go). childParentHash, if set, maps a
+	// key to its parent's dir-hash and reports whether the key is a chained child;
+	// it is nil unless the collection is configured with ParentKeyFor. childCount
+	// tracks, per parent dir-hash, how many live children chain to it, so Delete can
+	// tell in O(1) when a structural parent's last child has left (auto-delete)
+	// without scanning the shard. The parent is co-located in this shard, so the
+	// count is complete here. Keyed by hash (pointer-free) rather than the parent
+	// key: a hash collision can only mask an auto-delete (a lingering empty parent),
+	// never trigger a wrong one -- childCount[h] reaching zero means every parent
+	// hashing to h has zero children, so this parent does too. Guarded by mu.
+	childParentHash func(key []byte) (uint64, bool)
+	childCount      map[uint64]int
 }
 
 // supRef identifies a supersededBySeq field (a record's tombstone) that must be
@@ -120,17 +133,29 @@ func (sh *shard) put(h uint64, key, ad []byte, seq uint64, codec Codec) {
 		seg.dead += int64(recTotalLen(seg.data, old.off))
 	} else {
 		sh.count++
+		// A newly-inserted chained child bumps its parent's live-child count. Re-puts
+		// (updates) take the branch above and do not double-count.
+		if sh.childParentHash != nil {
+			if ph, isChild := sh.childParentHash(key); isChild {
+				if sh.childCount == nil {
+					sh.childCount = make(map[uint64]int)
+				}
+				sh.childCount[ph]++
+			}
+		}
 	}
 	sh.dir[h] = newLoc
 }
 
 // del marks the current version of key superseded at seq (an MVCC tombstone: no
-// new record is written). Returns whether a live key was removed. Caller holds
-// the write lock.
-func (sh *shard) del(h uint64, key []byte, seq uint64) bool {
+// new record is written). It returns whether a live key was removed and, for a
+// chained child, whether that removal dropped its parent's live-child count to
+// zero (parentEmptied) -- the signal Delete uses to auto-delete an orphaned
+// structural parent. Caller holds the write lock.
+func (sh *shard) del(h uint64, key []byte, seq uint64) (removed, parentEmptied bool) {
 	old, ok := sh.findCurrent(sh.dirGet(h), key)
 	if !ok {
-		return false
+		return false, false
 	}
 	seg := sh.segs[old.seg]
 	setRecSuperseded(seg.data, old.off, seq)
@@ -139,7 +164,17 @@ func (sh *shard) del(h uint64, key []byte, seq uint64) bool {
 		sh.dirtySup = append(sh.dirtySup, supRef{seg, old.off}) // flush the tombstone
 	}
 	sh.count--
-	return true
+	if sh.childParentHash != nil {
+		if ph, isChild := sh.childParentHash(key); isChild {
+			if n := sh.childCount[ph] - 1; n <= 0 {
+				delete(sh.childCount, ph) // keep the map bounded by parents-with-children
+				parentEmptied = true
+			} else {
+				sh.childCount[ph] = n
+			}
+		}
+	}
+	return true, parentEmptied
 }
 
 // writeRecord appends a record to the active segment and returns its location. A

--- a/collections/shard.go
+++ b/collections/shard.go
@@ -38,6 +38,13 @@ type shard struct {
 	// overwrite, a delete writes no new record, so recovery's max-seq rule cannot
 	// re-derive it — the tombstone itself must reach disk). Guarded by mu.
 	dirtySup []supRef
+
+	// Watch support (see watch.go); nil/zero unless WatchHistory > 0. idx is the
+	// shard's index (used to tag events for the cursor). hub fans committed changes
+	// to live watchers; delLog retains recent deletes for resuming watchers.
+	idx    int
+	hub    *watchHub
+	delLog *deleteLog
 }
 
 // supRef identifies a supersededBySeq field (a record's tombstone) that must be

--- a/collections/shard.go
+++ b/collections/shard.go
@@ -248,3 +248,26 @@ func forEachVisible(s0 uint64, wins []segWindow, fn func(ad []byte, codec Codec)
 		}
 	}
 }
+
+// forEachVisibleKeyed is forEachVisible that also passes each record's key (a
+// view into the frozen window; the callback must not retain it). Used by the
+// chained scan, which needs a record's key to find its parent.
+func forEachVisibleKeyed(s0 uint64, wins []segWindow, fn func(key, ad []byte, codec Codec) bool) {
+	for _, w := range wins {
+		for off := 0; off < w.used; {
+			o := uint32(off)
+			total := recTotalLen(w.data, o)
+			if total == 0 {
+				break
+			}
+			seq := recSeq(w.data, o)
+			sup := recSuperseded(w.data, o)
+			if seq <= s0 && sup > s0 {
+				if !fn(recKey(w.data, o), recAd(w.data, o), w.codec) {
+					return
+				}
+			}
+			off += int(total)
+		}
+	}
+}

--- a/collections/store.go
+++ b/collections/store.go
@@ -82,6 +82,25 @@ type Options struct {
 	// the prior window and re-delivers (at-least-once is preserved). Catch-up is
 	// never coalesced.
 	WatchCoalesce time.Duration
+
+	// ParentKeyFor, if set, gives an ad a parent: it maps a child's key to its
+	// parent's key (return nil for a top-level ad with no parent). A child then
+	// resolves attribute references it lacks by falling through to its parent --
+	// the primitive "join" the job queue needs, where a proc ad chains to its
+	// cluster ad so a query like `DAGManJobId == 42` sees the cluster's attribute.
+	// A family (a root and all its descendants) is co-located in one shard -- the
+	// collection routes every key to the shard of its ultimate root -- so chained
+	// evaluation is consistent and lock-free. Parent bindings are immutable: a
+	// key's parent must not change across updates. Default nil disables chaining
+	// (every ad is standalone) and keeps the plain single-key routing/scan.
+	ParentKeyFor func(key []byte) []byte
+
+	// IsStructural, if set, marks a key as a structural (parent-only) ad that
+	// exists solely to be chained to -- e.g. a job cluster ad. Structural ads are
+	// stored and used as parents but are hidden from Query/Scan/Watch results by
+	// default (like condor_q omitting cluster ads). Default nil treats every ad as
+	// a normal, visible ad. Only meaningful together with ParentKeyFor.
+	IsStructural func(key []byte) bool
 }
 
 // AdUpdate is one insert-or-update in a batch.
@@ -128,6 +147,39 @@ type Collection struct {
 	hub           *watchHub
 	watchBuf      int
 	watchCoalesce time.Duration
+
+	// Parent/child chaining (see docs/PARENT_CHILD.md). parentKeyFor derives a
+	// child's parent key (nil ⇒ no chaining); isStructural marks parent-only ads
+	// hidden from results. Both nil unless configured.
+	parentKeyFor func(key []byte) []byte
+	isStructural func(key []byte) bool
+}
+
+// rootKey returns the key of the family root for key: it follows parentKeyFor to
+// the top (a key with no parent). With no chaining configured it returns key
+// unchanged. The result selects the shard, co-locating a whole family.
+func (c *Collection) rootKey(key []byte) []byte {
+	if c.parentKeyFor == nil {
+		return key
+	}
+	for {
+		p := c.parentKeyFor(key)
+		if p == nil {
+			return key
+		}
+		key = p
+	}
+}
+
+// shardOf selects the shard for key by the family root, so a parent and all its
+// descendants share one shard (enabling consistent, lock-free chained
+// evaluation). h is key's own hash (already computed by the caller for the bucket
+// chain); without chaining the shard is just h & mask, no re-hash.
+func (c *Collection) shardOf(key []byte, h uint64) int {
+	if c.parentKeyFor == nil {
+		return int(h & c.mask)
+	}
+	return int(c.h.Hash(c.rootKey(key)) & c.mask)
 }
 
 // writeError returns the first sticky segment-allocation error across shards
@@ -215,6 +267,8 @@ func New(opts Options) *Collection {
 			sh.delLog = newDeleteLog(opts.WatchHistory, 0)
 		}
 	}
+	c.parentKeyFor = opts.ParentKeyFor
+	c.isStructural = opts.IsStructural
 	c.parallelMinBytes = defaultParallelMinBytes
 	c.queryPar = resolveQueryParallelism(opts.QueryParallelism)
 	if c.queryPar >= 2 {
@@ -261,7 +315,7 @@ func (c *Collection) Update(batch []AdUpdate) error {
 	for i := range batch {
 		stored := codec.Compress(nil, c.encodeAd(batch[i].Ad.AST()))
 		h := c.h.Hash(batch[i].Key)
-		si := int(h & c.mask)
+		si := c.shardOf(batch[i].Key, h)
 		byShard[si] = append(byShard[si], pendingPut{hash: h, key: batch[i].Key, ad: stored, codec: codec})
 	}
 	for si, writes := range byShard {
@@ -277,7 +331,7 @@ func (c *Collection) Put(key []byte, ad *classad.ClassAd) error {
 	codec := c.currentCodec()
 	stored := codec.Compress(nil, c.encodeAd(ad.AST()))
 	h := c.h.Hash(key)
-	c.shards[h&c.mask].commitOne(pendingPut{hash: h, key: key, ad: stored, codec: codec})
+	c.shards[c.shardOf(key, h)].commitOne(pendingPut{hash: h, key: key, ad: stored, codec: codec})
 	return c.writeError()
 }
 
@@ -285,7 +339,7 @@ func (c *Collection) Put(key []byte, ad *classad.ClassAd) error {
 // tombstone: scans already in progress still see the pre-delete version.
 func (c *Collection) Delete(key []byte) bool {
 	h := c.h.Hash(key)
-	sh := c.shards[h&c.mask]
+	sh := c.shards[c.shardOf(key, h)]
 	sh.mu.Lock()
 	seq := sh.commitSeq + 1
 	ok := sh.del(h, key, seq)
@@ -306,7 +360,7 @@ func (c *Collection) Delete(key []byte) bool {
 // Get returns the current ad for key, decoded, or (nil, false).
 func (c *Collection) Get(key []byte) (*classad.ClassAd, bool) {
 	h := c.h.Hash(key)
-	sh := c.shards[h&c.mask]
+	sh := c.shards[c.shardOf(key, h)]
 	stored, codec, ok := sh.get(h, key)
 	if !ok {
 		return nil, false
@@ -314,6 +368,18 @@ func (c *Collection) Get(key []byte) (*classad.ClassAd, bool) {
 	ad, err := c.decodeAd(stored, codec)
 	if err != nil {
 		return nil, false
+	}
+	// Chain to the parent (same shard) so the returned ad resolves inherited
+	// attributes -- Get mirrors query semantics.
+	if c.parentKeyFor != nil {
+		if pk := c.parentKeyFor(key); pk != nil {
+			ph := c.h.Hash(pk)
+			if pad, pcodec, ok := sh.get(ph, pk); ok {
+				if parent, err := c.decodeAd(pad, pcodec); err == nil {
+					mergeParent(ad, parent)
+				}
+			}
+		}
 	}
 	return ad, true
 }
@@ -336,6 +402,15 @@ func (c *Collection) Len() int {
 // when that shard's scan started.
 func (c *Collection) Scan() iter.Seq[*classad.ClassAd] {
 	return func(yield func(*classad.ClassAd) bool) {
+		if c.parentKeyFor != nil {
+			qp := queryPlan{ws: &wireScope{ctx: c}} // q nil ⇒ no filter, just chain + hide structural
+			for _, sh := range c.shards {
+				if !c.scanShardChained(sh, qp, yield) {
+					return
+				}
+			}
+			return
+		}
 		q := queryPlan{}
 		emit := c.yieldAd(yield)
 		for _, sh := range c.shards {
@@ -377,6 +452,17 @@ func (c *Collection) Query(q *vm.Query) iter.Seq[*classad.ClassAd] {
 			wireOK:   q.Native() && plan.PartialSafe,
 			ws:       ws,
 			resolver: ws.resolve, // bound once to avoid a per-ad closure allocation
+		}
+		// Chained collection: a serial two-pass scan per shard resolves each ad's
+		// inherited (parent) attributes. Indexes and query fan-out are bypassed here
+		// (they don't yet understand chaining); correctness first.
+		if c.parentKeyFor != nil {
+			for _, sh := range c.shards {
+				if !c.scanShardChained(sh, qp, yield) {
+					return
+				}
+			}
+			return
 		}
 		// Record which attributes the query filters on (for SuggestIndexes), then,
 		// if the query has an index-usable constraint, visit only candidate ads;
@@ -437,6 +523,87 @@ func (c *Collection) scanShard(sh *shard, qp queryPlan, emit func(w []byte) bool
 	return cont
 }
 
+// mergeParent flattens into child every attribute of parent that child does not
+// already define (child overrides parent), producing a standalone ad. This is
+// needed for output because SetParent only chains expression evaluation, not
+// direct attribute reads (EvaluateAttr*, GetAttributes) or serialization -- a
+// query result or watch event must carry the inherited attributes inline, as
+// condor_q shows a job's full ad and condor_history flattens it.
+func mergeParent(child, parent *classad.ClassAd) {
+	for _, name := range parent.GetAttributes() {
+		if _, has := child.Lookup(name); has {
+			continue // child overrides
+		}
+		if expr, ok := parent.Lookup(name); ok {
+			child.InsertExpr(name, expr)
+		}
+	}
+}
+
+// scanShardChained scans a shard for a collection with parent/child chaining. It
+// first collects the shard's structural (parent) ads at the snapshot, then
+// evaluates every non-structural ad with its parent chained in -- so a query
+// resolves attributes the child inherits from its parent -- and yields matches
+// with the parent set (SetParent) so the consumer sees the inherited attributes
+// too. Structural (parent-only) ads are hidden from the output. The whole family
+// is co-located in this shard, so both passes read one consistent snapshot with
+// no cross-shard fetch.
+func (c *Collection) scanShardChained(sh *shard, qp queryPlan, yield func(*classad.ClassAd) bool) bool {
+	s0, wins := sh.snapshot()
+	defer releaseWindows(wins)
+
+	// Pass 1: collect structural (parent) ads' decompressed wire bytes. Parents
+	// are few (one per family), so this map stays small.
+	parents := map[string][]byte{}
+	forEachVisibleKeyed(s0, wins, func(key, ad []byte, codec Codec) bool {
+		if c.isStructural != nil && c.isStructural(key) {
+			if w, err := codec.Decompress(nil, ad); err == nil {
+				parents[string(key)] = w // owns its buffer (nil dst)
+			}
+		}
+		return true
+	})
+
+	// Pass 2: evaluate children (and standalone ads); skip structural ads.
+	cont := true
+	var dbuf []byte
+	forEachVisibleKeyed(s0, wins, func(key, ad []byte, codec Codec) bool {
+		if c.isStructural != nil && c.isStructural(key) {
+			return true // structural ads are hidden from results
+		}
+		w, err := codec.Decompress(dbuf[:0], ad)
+		if err != nil {
+			return true
+		}
+		dbuf = w
+		var parentW []byte
+		if pk := c.parentKeyFor(key); pk != nil {
+			parentW = parents[string(pk)]
+		}
+		qp.ws.parent = wire.Ad(parentW) // nil ⇒ no parent
+		if qp.q != nil && !matchWire(w, qp) {
+			return true
+		}
+		a, err := c.decodeWire(w)
+		if err != nil {
+			return true
+		}
+		child := classad.FromAST(a)
+		if parentW != nil {
+			if pa, err := c.decodeWire(parentW); err == nil {
+				mergeParent(child, classad.FromAST(pa))
+			}
+		}
+		if !yield(child) {
+			cont = false
+			return false
+		}
+		return true
+	})
+	qp.ws.parent = nil
+	return cont
+}
+
 // yieldAd is the emit callback for the classic Query/Scan path: decode w to a
 // *classad.ClassAd (skipping malformed records) and yield it.
 func (c *Collection) yieldAd(yield func(*classad.ClassAd) bool) func(w []byte) bool {
@@ -464,13 +631,25 @@ func matchWire(w []byte, qp queryPlan) bool {
 		// A queried attribute was a non-literal expression; fall back.
 	}
 	if qp.plan.PartialSafe {
-		return qp.m.Matches(partialDecodeWire(qp.ws.ctx, w, qp.plan.Seeds))
+		child := partialDecodeWire(qp.ws.ctx, w, qp.plan.Seeds)
+		if qp.ws.parent != nil {
+			// The child inherits any seed it lacks from the parent, so decode the
+			// same seeds from the parent and chain.
+			child.SetParent(partialDecodeWire(qp.ws.ctx, []byte(qp.ws.parent), qp.plan.Seeds))
+		}
+		return qp.m.Matches(child)
 	}
 	a, err := qp.ws.ctx.decodeWire(w)
 	if err != nil {
 		return false
 	}
-	return qp.m.Matches(classad.FromAST(a))
+	child := classad.FromAST(a)
+	if qp.ws.parent != nil {
+		if pa, err := qp.ws.ctx.decodeWire([]byte(qp.ws.parent)); err == nil {
+			child.SetParent(classad.FromAST(pa))
+		}
+	}
+	return qp.m.Matches(child)
 }
 
 // partialDecodeWire builds a ClassAd containing only the attributes named in

--- a/collections/store.go
+++ b/collections/store.go
@@ -1,6 +1,7 @@
 package collections
 
 import (
+	"bytes"
 	"iter"
 	"runtime"
 	"strings"
@@ -369,8 +370,37 @@ func (c *Collection) Delete(key []byte) bool {
 			sh.delLog.record(key, seq) // retain for resuming watchers
 			sh.hub.publish(sh.idx, seq, key, nil, nil, true)
 		}
+		// Auto-delete a structural parent whose last child just left (HTCondor
+		// ClusterCleanup): a structural ad exists only to be chained to, so once
+		// no child references it, remove it. The parent is co-located in this shard.
+		if c.parentKeyFor != nil && c.isStructural != nil {
+			if pk := c.parentKeyFor(key); pk != nil && c.isStructural(pk) && !c.hasChildren(pk) {
+				c.Delete(pk)
+			}
+		}
 	}
 	return ok
+}
+
+// hasChildren reports whether any non-structural child of parentKey is present
+// (co-located in the parent's shard). Early-exits at the first child.
+func (c *Collection) hasChildren(parentKey []byte) bool {
+	ph := c.h.Hash(parentKey)
+	sh := c.shards[c.shardOf(parentKey, ph)]
+	s0, wins := sh.snapshot()
+	defer releaseWindows(wins)
+	found := false
+	forEachVisibleKeyed(s0, wins, func(k, _ []byte, _ Codec) bool {
+		if c.isStructural != nil && c.isStructural(k) {
+			return true
+		}
+		if pk := c.parentKeyFor(k); pk != nil && bytes.Equal(pk, parentKey) {
+			found = true
+			return false // stop
+		}
+		return true
+	})
+	return found
 }
 
 // Get returns the current ad for key, decoded, or (nil, false).

--- a/collections/store.go
+++ b/collections/store.go
@@ -430,6 +430,17 @@ func (c *Collection) Get(key []byte) (*classad.ClassAd, bool) {
 	return ad, true
 }
 
+// Flatten returns a standalone, self-contained copy of the ad at key with every
+// inherited parent attribute materialized into it (the child's own values
+// winning, parent-private attributes excluded) and no residual parent link. It
+// is the form to archive as a history record: like condor_history, which stores
+// each completed job flattened rather than as a live cluster/proc pair, so the
+// record stays readable after its structural parent is gone. For a collection
+// without parent chaining this is identical to Get.
+func (c *Collection) Flatten(key []byte) (*classad.ClassAd, bool) {
+	return c.Get(key)
+}
+
 // Len returns the number of live keys across all shards.
 func (c *Collection) Len() int {
 	n := 0

--- a/collections/store.go
+++ b/collections/store.go
@@ -1,7 +1,6 @@
 package collections
 
 import (
-	"bytes"
 	"iter"
 	"runtime"
 	"strings"
@@ -280,6 +279,20 @@ func New(opts Options) *Collection {
 	}
 	c.parentKeyFor = opts.ParentKeyFor
 	c.isStructural = opts.IsStructural
+	if c.parentKeyFor != nil {
+		// Give each shard a pointer-free child counter keyed by the parent's dir-hash,
+		// so Delete detects an emptied structural parent in O(1). A key is a chained
+		// child iff parentKeyFor returns a parent for it (nil for structural/root ads).
+		for _, sh := range c.shards {
+			sh.childParentHash = func(key []byte) (uint64, bool) {
+				pk := c.parentKeyFor(key)
+				if pk == nil {
+					return 0, false
+				}
+				return c.h.Hash(pk), true
+			}
+		}
+	}
 	if len(opts.ParentPrivateAttrs) > 0 {
 		c.parentPrivate = make(map[string]struct{}, len(opts.ParentPrivateAttrs))
 		for _, a := range opts.ParentPrivateAttrs {
@@ -359,7 +372,7 @@ func (c *Collection) Delete(key []byte) bool {
 	sh := c.shards[c.shardOf(key, h)]
 	sh.mu.Lock()
 	seq := sh.commitSeq + 1
-	ok := sh.del(h, key, seq)
+	ok, parentEmptied := sh.del(h, key, seq)
 	if ok {
 		sh.commitSeq = seq
 	}
@@ -371,36 +384,17 @@ func (c *Collection) Delete(key []byte) bool {
 			sh.hub.publish(sh.idx, seq, key, nil, nil, true)
 		}
 		// Auto-delete a structural parent whose last child just left (HTCondor
-		// ClusterCleanup): a structural ad exists only to be chained to, so once
-		// no child references it, remove it. The parent is co-located in this shard.
-		if c.parentKeyFor != nil && c.isStructural != nil {
-			if pk := c.parentKeyFor(key); pk != nil && c.isStructural(pk) && !c.hasChildren(pk) {
+		// ClusterCleanup): a structural ad exists only to be chained to, so once no
+		// child references it, remove it. sh.del maintained the live-child count and
+		// flags when it hit zero, so this is O(1) -- no shard scan. The parent is
+		// co-located in this shard.
+		if parentEmptied && c.parentKeyFor != nil && c.isStructural != nil {
+			if pk := c.parentKeyFor(key); pk != nil && c.isStructural(pk) {
 				c.Delete(pk)
 			}
 		}
 	}
 	return ok
-}
-
-// hasChildren reports whether any non-structural child of parentKey is present
-// (co-located in the parent's shard). Early-exits at the first child.
-func (c *Collection) hasChildren(parentKey []byte) bool {
-	ph := c.h.Hash(parentKey)
-	sh := c.shards[c.shardOf(parentKey, ph)]
-	s0, wins := sh.snapshot()
-	defer releaseWindows(wins)
-	found := false
-	forEachVisibleKeyed(s0, wins, func(k, _ []byte, _ Codec) bool {
-		if c.isStructural != nil && c.isStructural(k) {
-			return true
-		}
-		if pk := c.parentKeyFor(k); pk != nil && bytes.Equal(pk, parentKey) {
-			found = true
-			return false // stop
-		}
-		return true
-	})
-	return found
 }
 
 // Get returns the current ad for key, decoded, or (nil, false).

--- a/collections/store.go
+++ b/collections/store.go
@@ -62,6 +62,16 @@ type Options struct {
 	// oversubscribing). Small scans and indexed queries run serial regardless.
 	// See parallel_scan.go / docs/PARALLEL_QUERY.md.
 	QueryParallelism int
+	// WatchHistory enables the Watch subscription verb (see docs/WATCH.md). It is the
+	// per-shard capacity of the delete journal — how many recent deletes are retained
+	// so a resuming watcher can be told precisely which keys were removed. 0 (default)
+	// disables Watch entirely (no journal, no live notification, zero write-path cost).
+	// A larger value lets clients resume incrementally from further back before
+	// falling to a full replay.
+	WatchHistory int
+	// WatchBuffer is the per-watcher live event-channel capacity (default 1024). A
+	// watcher that overflows it is told to resync rather than stalling writers.
+	WatchBuffer int
 }
 
 // AdUpdate is one insert-or-update in a batch.
@@ -103,6 +113,10 @@ type Collection struct {
 	queryPar         int
 	qsem             chan struct{}
 	parallelMinBytes int
+
+	// Watch (see watch.go / docs/WATCH.md). hub is nil unless WatchHistory > 0.
+	hub      *watchHub
+	watchBuf int
 }
 
 // writeError returns the first sticky segment-allocation error across shards
@@ -177,6 +191,18 @@ func New(opts Options) *Collection {
 		c.hotSet.Store(&hotSetHolder{set})
 	}
 	c.spec.Store(newIndexSpec(c.intern, opts.CategoricalAttrs, opts.ValueAttrs))
+	if opts.WatchHistory > 0 {
+		c.hub = newWatchHub()
+		c.watchBuf = opts.WatchBuffer
+		if c.watchBuf <= 0 {
+			c.watchBuf = 1024
+		}
+		for i, sh := range c.shards {
+			sh.idx = i
+			sh.hub = c.hub
+			sh.delLog = newDeleteLog(opts.WatchHistory, 0)
+		}
+	}
 	c.parallelMinBytes = defaultParallelMinBytes
 	c.queryPar = resolveQueryParallelism(opts.QueryParallelism)
 	if c.queryPar >= 2 {
@@ -257,6 +283,10 @@ func (c *Collection) Delete(key []byte) bool {
 	sh.mu.Unlock()
 	if ok {
 		sh.sync() // durability point for the tombstone (not coalesced)
+		if sh.delLog != nil {
+			sh.delLog.record(key, seq) // retain for resuming watchers
+			sh.hub.publish(sh.idx, seq, key, nil, nil, true)
+		}
 	}
 	return ok
 }

--- a/collections/store.go
+++ b/collections/store.go
@@ -101,6 +101,14 @@ type Options struct {
 	// default (like condor_q omitting cluster ads). Default nil treats every ad as
 	// a normal, visible ad. Only meaningful together with ParentKeyFor.
 	IsStructural func(key []byte) bool
+
+	// ParentPrivateAttrs are parent attributes children do NOT inherit and that do
+	// NOT trigger a watch fan-out when they change -- e.g. a job cluster ad's
+	// factory bookkeeping (JobMaterializeNextProcId, ...), which mutates per proc
+	// materialized but is meaningless to a proc. They are excluded from flattening
+	// and from the parent-change diff, so high-frequency parent-internal churn does
+	// not fan out to every child. Case-insensitive. Only meaningful with ParentKeyFor.
+	ParentPrivateAttrs []string
 }
 
 // AdUpdate is one insert-or-update in a batch.
@@ -150,9 +158,11 @@ type Collection struct {
 
 	// Parent/child chaining (see docs/PARENT_CHILD.md). parentKeyFor derives a
 	// child's parent key (nil ⇒ no chaining); isStructural marks parent-only ads
-	// hidden from results. Both nil unless configured.
-	parentKeyFor func(key []byte) []byte
-	isStructural func(key []byte) bool
+	// hidden from results; parentPrivate (case-folded) are parent attributes
+	// children don't inherit and that don't trigger fan-out. All nil unless configured.
+	parentKeyFor  func(key []byte) []byte
+	isStructural  func(key []byte) bool
+	parentPrivate map[string]struct{}
 }
 
 // rootKey returns the key of the family root for key: it follows parentKeyFor to
@@ -269,6 +279,12 @@ func New(opts Options) *Collection {
 	}
 	c.parentKeyFor = opts.ParentKeyFor
 	c.isStructural = opts.IsStructural
+	if len(opts.ParentPrivateAttrs) > 0 {
+		c.parentPrivate = make(map[string]struct{}, len(opts.ParentPrivateAttrs))
+		for _, a := range opts.ParentPrivateAttrs {
+			c.parentPrivate[strings.ToLower(a)] = struct{}{}
+		}
+	}
 	c.parallelMinBytes = defaultParallelMinBytes
 	c.queryPar = resolveQueryParallelism(opts.QueryParallelism)
 	if c.queryPar >= 2 {
@@ -376,7 +392,7 @@ func (c *Collection) Get(key []byte) (*classad.ClassAd, bool) {
 			ph := c.h.Hash(pk)
 			if pad, pcodec, ok := sh.get(ph, pk); ok {
 				if parent, err := c.decodeAd(pad, pcodec); err == nil {
-					mergeParent(ad, parent)
+					c.mergeParent(ad, parent)
 				}
 			}
 		}
@@ -523,14 +539,20 @@ func (c *Collection) scanShard(sh *shard, qp queryPlan, emit func(w []byte) bool
 	return cont
 }
 
-// mergeParent flattens into child every attribute of parent that child does not
-// already define (child overrides parent), producing a standalone ad. This is
-// needed for output because SetParent only chains expression evaluation, not
-// direct attribute reads (EvaluateAttr*, GetAttributes) or serialization -- a
-// query result or watch event must carry the inherited attributes inline, as
-// condor_q shows a job's full ad and condor_history flattens it.
-func mergeParent(child, parent *classad.ClassAd) {
+// mergeParent flattens into child every (non-private) attribute of parent that
+// child does not already define (child overrides parent), producing a standalone
+// ad. This is needed for output because SetParent only chains expression
+// evaluation, not direct attribute reads (EvaluateAttr*, GetAttributes) or
+// serialization -- a query result or watch event must carry the inherited
+// attributes inline, as condor_q shows a job's full ad and condor_history
+// flattens it. Parent-private attributes (factory bookkeeping) are not inherited.
+func (c *Collection) mergeParent(child, parent *classad.ClassAd) {
 	for _, name := range parent.GetAttributes() {
+		if c.parentPrivate != nil {
+			if _, priv := c.parentPrivate[strings.ToLower(name)]; priv {
+				continue // parent-private: not inherited
+			}
+		}
 		if _, has := child.Lookup(name); has {
 			continue // child overrides
 		}
@@ -591,7 +613,7 @@ func (c *Collection) scanShardChained(sh *shard, qp queryPlan, yield func(*class
 		child := classad.FromAST(a)
 		if parentW != nil {
 			if pa, err := c.decodeWire(parentW); err == nil {
-				mergeParent(child, classad.FromAST(pa))
+				c.mergeParent(child, classad.FromAST(pa))
 			}
 		}
 		if !yield(child) {

--- a/collections/store.go
+++ b/collections/store.go
@@ -5,6 +5,7 @@ import (
 	"runtime"
 	"strings"
 	"sync/atomic"
+	"time"
 
 	"github.com/PelicanPlatform/classad/ast"
 	"github.com/PelicanPlatform/classad/classad"
@@ -72,6 +73,15 @@ type Options struct {
 	// WatchBuffer is the per-watcher live event-channel capacity (default 1024). A
 	// watcher that overflows it is told to resync rather than stalling writers.
 	WatchBuffer int
+	// WatchCoalesce, if > 0, batches live Watch events into windows of this
+	// duration and emits only the newest event per key in each window (default 0 =
+	// off, one event per change). It smooths bursty churn -- e.g. a freshly
+	// submitted job that takes many SetAttribute updates in quick succession is
+	// delivered as a single Upsert of its settled state. Only the last event of a
+	// flushed window carries a cursor, so a mid-window consumer crash resumes from
+	// the prior window and re-delivers (at-least-once is preserved). Catch-up is
+	// never coalesced.
+	WatchCoalesce time.Duration
 }
 
 // AdUpdate is one insert-or-update in a batch.
@@ -115,8 +125,9 @@ type Collection struct {
 	parallelMinBytes int
 
 	// Watch (see watch.go / docs/WATCH.md). hub is nil unless WatchHistory > 0.
-	hub      *watchHub
-	watchBuf int
+	hub           *watchHub
+	watchBuf      int
+	watchCoalesce time.Duration
 }
 
 // writeError returns the first sticky segment-allocation error across shards
@@ -197,6 +208,7 @@ func New(opts Options) *Collection {
 		if c.watchBuf <= 0 {
 			c.watchBuf = 1024
 		}
+		c.watchCoalesce = opts.WatchCoalesce
 		for i, sh := range c.shards {
 			sh.idx = i
 			sh.hub = c.hub

--- a/collections/watch.go
+++ b/collections/watch.go
@@ -8,6 +8,7 @@ import (
 	"iter"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/PelicanPlatform/classad/classad"
 )
@@ -273,6 +274,10 @@ func (c *Collection) Watch(ctx context.Context, cursor []byte) (iter.Seq[WatchEv
 
 		// Live phase: stream buffered + new events, advancing a running cursor vector.
 		vec := append([]uint64(nil), sReg...)
+		if c.watchCoalesce > 0 {
+			c.liveCoalesced(ctx, w, sReg, vec, yield)
+			return
+		}
 		for {
 			if w.lagged.Load() {
 				yield(WatchEvent{Kind: WatchResync})
@@ -303,6 +308,83 @@ func (c *Collection) Watch(ctx context.Context, cursor []byte) (iter.Seq[WatchEv
 			}
 		}
 	}, nil
+}
+
+// liveCoalesced streams the live phase in windows of c.watchCoalesce, emitting
+// only the newest event per key in each window (a key upserted several times, or
+// upserted then deleted, collapses to a single event of its settled state). Only
+// the last event of a flushed window carries a cursor, so a consumer that crashes
+// mid-window resumes from the prior window and re-delivers -- at-least-once is
+// preserved. The running cursor vector still advances on every event received.
+func (c *Collection) liveCoalesced(ctx context.Context, w *watcher, sReg, vec []uint64, yield func(WatchEvent) bool) {
+	pending := map[string]rawEvent{}
+	order := make([]string, 0, 16) // first-seen order; keys are unique per window
+
+	ticker := time.NewTicker(c.watchCoalesce)
+	defer ticker.Stop()
+
+	// flush emits the coalesced window. Returns false if the consumer stopped.
+	flush := func() bool {
+		if len(pending) == 0 {
+			return true
+		}
+		evs := make([]WatchEvent, 0, len(order))
+		for _, ks := range order {
+			raw := pending[ks]
+			ev := WatchEvent{Key: raw.key}
+			if raw.deleted {
+				ev.Kind = WatchDelete
+			} else {
+				ad, err := c.decodeAd(raw.ad, raw.codec)
+				if err != nil {
+					continue // drop an undecodable ad; its later change will re-emit
+				}
+				ev.Kind = WatchUpsert
+				ev.Ad = ad
+			}
+			evs = append(evs, ev)
+		}
+		pending = map[string]rawEvent{}
+		order = order[:0]
+		if len(evs) == 0 {
+			return true
+		}
+		evs[len(evs)-1].Cursor = encodeCursor(c.hub.epoch, vec)
+		for i := range evs {
+			if !yield(evs[i]) {
+				return false
+			}
+		}
+		return true
+	}
+
+	for {
+		if w.lagged.Load() {
+			if !flush() {
+				return
+			}
+			yield(WatchEvent{Kind: WatchResync})
+			return
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if !flush() {
+				return
+			}
+		case raw := <-w.ch:
+			if raw.seq <= sReg[raw.shard] {
+				continue // already covered by catch-up
+			}
+			vec[raw.shard] = raw.seq
+			ks := string(raw.key)
+			if _, seen := pending[ks]; !seen {
+				order = append(order, ks)
+			}
+			pending[ks] = raw
+		}
+	}
 }
 
 // catchupUpserts emits an Upsert for every record visible at sReg whose seq is in

--- a/collections/watch.go
+++ b/collections/watch.go
@@ -310,6 +310,74 @@ func (c *Collection) Watch(ctx context.Context, cursor []byte) (iter.Seq[WatchEv
 	}, nil
 }
 
+// WatchFilter wraps a Watch event stream to deliver only events for keys whose
+// ad satisfies match. It keeps a set of the keys currently matching so a filtered
+// view stays correct as ads change:
+//
+//   - an Upsert whose ad matches is delivered (the key is marked matching);
+//   - an Upsert whose ad no longer matches, for a key that was matching, is
+//     converted to a Delete so the client drops it from its filtered view;
+//   - a Delete is delivered for a key known to be matching, and -- during
+//     catch-up (before Synced), where the prior match state of a resumed key is
+//     unknown -- forwarded conservatively (the client no-ops an unknown key);
+//   - Reset clears the matched set; Synced and Resync pass through.
+//
+// A nil match returns seq unchanged (no filtering). match is called on each
+// Upsert's ad and must be safe for concurrent-free sequential use.
+func WatchFilter(seq iter.Seq[WatchEvent], match func(*classad.ClassAd) bool) iter.Seq[WatchEvent] {
+	if match == nil {
+		return seq
+	}
+	return func(yield func(WatchEvent) bool) {
+		matched := map[string]struct{}{}
+		synced := false
+		for ev := range seq {
+			switch ev.Kind {
+			case WatchUpsert:
+				k := string(ev.Key)
+				if match(ev.Ad) {
+					matched[k] = struct{}{}
+					if !yield(ev) {
+						return
+					}
+				} else if _, was := matched[k]; was {
+					delete(matched, k)
+					if !yield(WatchEvent{Kind: WatchDelete, Key: ev.Key, Cursor: ev.Cursor}) {
+						return
+					}
+				}
+			case WatchDelete:
+				k := string(ev.Key)
+				if _, was := matched[k]; was {
+					delete(matched, k)
+					if !yield(ev) {
+						return
+					}
+				} else if !synced {
+					if !yield(ev) {
+						return
+					}
+				}
+			case WatchReset:
+				matched = map[string]struct{}{}
+				synced = false
+				if !yield(ev) {
+					return
+				}
+			case WatchSynced:
+				synced = true
+				if !yield(ev) {
+					return
+				}
+			default: // Resync (and any future kinds) pass through
+				if !yield(ev) {
+					return
+				}
+			}
+		}
+	}
+}
+
 // liveCoalesced streams the live phase in windows of c.watchCoalesce, emitting
 // only the newest event per key in each window (a key upserted several times, or
 // upserted then deleted, collapses to a single event of its settled state). Only

--- a/collections/watch.go
+++ b/collections/watch.go
@@ -1,11 +1,13 @@
 package collections
 
 import (
+	"bytes"
 	"context"
 	cryptorand "crypto/rand"
 	"encoding/binary"
 	"errors"
 	"iter"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -278,6 +280,7 @@ func (c *Collection) Watch(ctx context.Context, cursor []byte) (iter.Seq[WatchEv
 			c.liveCoalesced(ctx, w, sReg, vec, yield)
 			return
 		}
+		parentSig := c.seedParentSig() // parent -> non-private signature (fan-out diff baseline)
 		for {
 			if w.lagged.Load() {
 				yield(WatchEvent{Kind: WatchResync})
@@ -291,13 +294,30 @@ func (c *Collection) Watch(ctx context.Context, cursor []byte) (iter.Seq[WatchEv
 					continue // already covered by catch-up
 				}
 				vec[raw.shard] = raw.seq
+				if !raw.deleted && c.watchHidden(raw.key) {
+					// A structural (parent) change: fan out to its children if an
+					// inherited attribute changed; the parent itself is not emitted.
+					for _, ce := range c.fanoutChildren(raw, parentSig) {
+						ad, ok := c.watchAd(ce.key, ce.ad, ce.codec)
+						if !ok {
+							continue
+						}
+						if !yield(WatchEvent{Kind: WatchUpsert, Key: ce.key, Ad: ad, Cursor: encodeCursor(c.hub.epoch, vec)}) {
+							return
+						}
+					}
+					continue
+				}
 				ev := WatchEvent{Key: raw.key, Cursor: encodeCursor(c.hub.epoch, vec)}
 				if raw.deleted {
+					if c.watchHidden(raw.key) {
+						continue // structural delete: hidden
+					}
 					ev.Kind = WatchDelete
 				} else {
-					ad, err := c.decodeAd(raw.ad, raw.codec)
-					if err != nil {
-						continue
+					ad, ok := c.watchAd(raw.key, raw.ad, raw.codec)
+					if !ok {
+						continue // undecodable or a hidden structural ad
 					}
 					ev.Kind = WatchUpsert
 					ev.Ad = ad
@@ -387,6 +407,7 @@ func WatchFilter(seq iter.Seq[WatchEvent], match func(*classad.ClassAd) bool) it
 func (c *Collection) liveCoalesced(ctx context.Context, w *watcher, sReg, vec []uint64, yield func(WatchEvent) bool) {
 	pending := map[string]rawEvent{}
 	order := make([]string, 0, 16) // first-seen order; keys are unique per window
+	parentSig := c.seedParentSig()
 
 	ticker := time.NewTicker(c.watchCoalesce)
 	defer ticker.Stop()
@@ -401,11 +422,14 @@ func (c *Collection) liveCoalesced(ctx context.Context, w *watcher, sReg, vec []
 			raw := pending[ks]
 			ev := WatchEvent{Key: raw.key}
 			if raw.deleted {
+				if c.watchHidden(raw.key) {
+					continue // structural delete: hidden
+				}
 				ev.Kind = WatchDelete
 			} else {
-				ad, err := c.decodeAd(raw.ad, raw.codec)
-				if err != nil {
-					continue // drop an undecodable ad; its later change will re-emit
+				ad, ok := c.watchAd(raw.key, raw.ad, raw.codec)
+				if !ok {
+					continue // undecodable or a hidden structural ad
 				}
 				ev.Kind = WatchUpsert
 				ev.Ad = ad
@@ -446,6 +470,18 @@ func (c *Collection) liveCoalesced(ctx context.Context, w *watcher, sReg, vec []
 				continue // already covered by catch-up
 			}
 			vec[raw.shard] = raw.seq
+			if !raw.deleted && c.watchHidden(raw.key) {
+				// Structural parent change: coalesce its children's synthetic
+				// upserts (the parent itself is not emitted).
+				for _, ce := range c.fanoutChildren(raw, parentSig) {
+					cks := string(ce.key)
+					if _, seen := pending[cks]; !seen {
+						order = append(order, cks)
+					}
+					pending[cks] = ce
+				}
+				continue
+			}
 			ks := string(raw.key)
 			if _, seen := pending[ks]; !seen {
 				order = append(order, ks)
@@ -453,6 +489,137 @@ func (c *Collection) liveCoalesced(ctx context.Context, w *watcher, sReg, vec []
 			pending[ks] = raw
 		}
 	}
+}
+
+// watchAd decodes a watched key's stored ad for a WatchUpsert event. For a
+// chained collection it flattens the ad's parent in (so watch events, like query
+// results, carry inherited attributes) and returns ok=false for a structural
+// (parent-only) ad, which is hidden from watches. For a plain collection it just
+// decodes. ok=false also means "skip this event" (undecodable or hidden).
+func (c *Collection) watchAd(key, rawAd []byte, codec Codec) (*classad.ClassAd, bool) {
+	if c.isStructural != nil && c.isStructural(key) {
+		return nil, false // structural ads are hidden from watches
+	}
+	ad, err := c.decodeAd(rawAd, codec)
+	if err != nil {
+		return nil, false
+	}
+	if c.parentKeyFor != nil {
+		if pk := c.parentKeyFor(key); pk != nil {
+			ph := c.h.Hash(pk)
+			sh := c.shards[c.shardOf(pk, ph)]
+			if pad, pcodec, ok := sh.get(ph, pk); ok {
+				if parent, err := c.decodeAd(pad, pcodec); err == nil {
+					c.mergeParent(ad, parent)
+				}
+			}
+		}
+	}
+	return ad, true
+}
+
+// watchHidden reports whether key is a structural ad (hidden from watches),
+// used to suppress structural delete events.
+func (c *Collection) watchHidden(key []byte) bool {
+	return c.isStructural != nil && c.isStructural(key)
+}
+
+// nonPrivateSig renders a parent ad's non-private attributes to a comparable
+// signature, so a parent change that touched only parent-private attributes
+// (factory bookkeeping) is detected and does not fan out to children.
+func (c *Collection) nonPrivateSig(ad *classad.ClassAd) map[string]string {
+	sig := make(map[string]string)
+	for _, name := range ad.GetAttributes() {
+		lname := strings.ToLower(name)
+		if c.parentPrivate != nil {
+			if _, priv := c.parentPrivate[lname]; priv {
+				continue
+			}
+		}
+		if expr, ok := ad.Lookup(name); ok {
+			sig[lname] = expr.String()
+		}
+	}
+	return sig
+}
+
+func sigEqual(a, b map[string]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if b[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+// seedParentSig records the current non-private signature of every structural ad,
+// giving the live fan-out a baseline so a parent's first change is diffed (and a
+// change to only parent-private attributes does not fan out). Empty for a
+// non-chained collection.
+func (c *Collection) seedParentSig() map[string]map[string]string {
+	sig := map[string]map[string]string{}
+	if c.parentKeyFor == nil || c.isStructural == nil {
+		return sig
+	}
+	for _, sh := range c.shards {
+		s0, wins := sh.snapshot()
+		forEachVisibleKeyed(s0, wins, func(key, ad []byte, codec Codec) bool {
+			if c.isStructural(key) {
+				if pad, err := c.decodeAd(ad, codec); err == nil {
+					sig[string(key)] = c.nonPrivateSig(pad)
+				}
+			}
+			return true
+		})
+		releaseWindows(wins)
+	}
+	return sig
+}
+
+// fanoutChildren handles a structural (parent) change during a live watch. If a
+// non-private parent attribute changed since sig last recorded this parent, it
+// returns synthetic upsert events for the parent's children (whose flattened ads
+// changed); otherwise nil. sig caches parents' non-private signatures across the
+// watch so parent-private churn (bumped every proc a factory materializes) does
+// not fan out. The parent itself is never emitted.
+func (c *Collection) fanoutChildren(parent rawEvent, sig map[string]map[string]string) []rawEvent {
+	np, err := c.decodeAd(parent.ad, parent.codec)
+	if err != nil {
+		return nil
+	}
+	pkey := string(parent.key)
+	newSig := c.nonPrivateSig(np)
+	old, seen := sig[pkey]
+	sig[pkey] = newSig
+	if seen && sigEqual(old, newSig) {
+		return nil // only parent-private attributes changed: no fan-out
+	}
+	// Collect the parent's children (co-located in the parent's shard) with their
+	// current stored ads, as synthetic upserts stamped at the parent's sequence.
+	ph := c.h.Hash(parent.key)
+	sh := c.shards[c.shardOf(parent.key, ph)]
+	s0, wins := sh.snapshot()
+	defer releaseWindows(wins)
+	var out []rawEvent
+	forEachVisibleKeyed(s0, wins, func(k, ad []byte, codec Codec) bool {
+		if c.isStructural != nil && c.isStructural(k) {
+			return true
+		}
+		if pk := c.parentKeyFor(k); pk != nil && bytes.Equal(pk, parent.key) {
+			out = append(out, rawEvent{
+				shard: parent.shard,
+				seq:   parent.seq,
+				key:   append([]byte(nil), k...),
+				ad:    append([]byte(nil), ad...),
+				codec: codec,
+			})
+		}
+		return true
+	})
+	return out
 }
 
 // catchupUpserts emits an Upsert for every record visible at sReg whose seq is in
@@ -470,10 +637,9 @@ func (c *Collection) catchupUpserts(i int, cursor, sReg uint64, yield func(Watch
 			}
 			seq := recSeq(wn.data, o)
 			if seq > cursor && seq <= sReg && recSuperseded(wn.data, o) > sReg {
-				ad, err := c.decodeAd(recAd(wn.data, o), wn.codec)
-				if err == nil {
-					key := append([]byte(nil), recKey(wn.data, o)...)
-					if !yield(WatchEvent{Kind: WatchUpsert, Key: key, Ad: ad}) {
+				key := recKey(wn.data, o)
+				if ad, ok := c.watchAd(key, recAd(wn.data, o), wn.codec); ok {
+					if !yield(WatchEvent{Kind: WatchUpsert, Key: append([]byte(nil), key...), Ad: ad}) {
 						return false
 					}
 				}
@@ -487,6 +653,9 @@ func (c *Collection) catchupUpserts(i int, cursor, sReg uint64, yield func(Watch
 // catchupDeletes emits a Delete for each journaled delete with seq > cursor.
 func (c *Collection) catchupDeletes(i int, cursor uint64, yield func(WatchEvent) bool) bool {
 	for _, e := range c.shards[i].delLog.since(cursor) {
+		if c.watchHidden(e.key) {
+			continue // structural delete: hidden
+		}
 		if !yield(WatchEvent{Kind: WatchDelete, Key: e.key}) {
 			return false
 		}

--- a/collections/watch.go
+++ b/collections/watch.go
@@ -1,0 +1,345 @@
+package collections
+
+import (
+	"context"
+	cryptorand "crypto/rand"
+	"encoding/binary"
+	"errors"
+	"iter"
+	"sync"
+	"sync/atomic"
+
+	"github.com/PelicanPlatform/classad/classad"
+)
+
+// Watch lets a client subscribe to full-ad updates with a resumable, opaque cursor.
+// See docs/WATCH.md for the design. Semantics are at-least-once: over-delivery is
+// possible, a net change is never missed. Deletes are the only subtlety -- their
+// evidence (a tombstone) is retained only within a bounded window (Options.
+// WatchHistory), so a resume from before that window falls back to a full replay.
+
+// WatchKind is the type of a WatchEvent.
+type WatchKind uint8
+
+const (
+	// WatchUpsert carries the full ad for an added or updated key (Ad is set).
+	WatchUpsert WatchKind = iota
+	// WatchDelete signals a key was removed (Ad is nil).
+	WatchDelete
+	// WatchReset tells the client to discard its state (build into a shadow): an
+	// authoritative full snapshot of Upserts follows, ending at WatchSynced. Emitted
+	// when a precise incremental resume is impossible (first subscribe, cursor older
+	// than the delete-retention window, or a different store generation).
+	WatchReset
+	// WatchSynced marks the end of the initial catch-up/snapshot: the client is now
+	// live. Its Cursor is a durable resume point (and, after a Reset, the point to
+	// swap the shadow state live).
+	WatchSynced
+	// WatchResync tells the client the live stream fell behind and it must reconnect
+	// with its last persisted cursor (which re-enters catch-up). No state is implied.
+	WatchResync
+)
+
+// WatchEvent is one item in a Watch stream. Cursor, when non-nil, is an opaque token
+// the client persists after processing the event and passes back to Watch on resume.
+// Catch-up data events carry no cursor (persist at WatchSynced); live events do.
+type WatchEvent struct {
+	Kind   WatchKind
+	Key    []byte
+	Ad     *classad.ClassAd
+	Cursor []byte
+}
+
+// --- opaque cursor: {epoch, perShardSeq[]} ---
+
+func encodeCursor(epoch uint64, seqs []uint64) []byte {
+	b := make([]byte, 16+8*len(seqs))
+	binary.LittleEndian.PutUint64(b[0:], epoch)
+	binary.LittleEndian.PutUint64(b[8:], uint64(len(seqs)))
+	for i, s := range seqs {
+		binary.LittleEndian.PutUint64(b[16+8*i:], s)
+	}
+	return b
+}
+
+func decodeCursor(b []byte) (epoch uint64, seqs []uint64, ok bool) {
+	if len(b) < 16 {
+		return 0, nil, false
+	}
+	epoch = binary.LittleEndian.Uint64(b[0:])
+	n := binary.LittleEndian.Uint64(b[8:])
+	if uint64(len(b)) != 16+8*n {
+		return 0, nil, false
+	}
+	seqs = make([]uint64, n)
+	for i := range seqs {
+		seqs[i] = binary.LittleEndian.Uint64(b[16+8*i:])
+	}
+	return epoch, seqs, true
+}
+
+func randomEpoch() uint64 {
+	var b [8]byte
+	_, _ = cryptorand.Read(b[:])
+	e := binary.LittleEndian.Uint64(b[:])
+	if e == 0 {
+		e = 1 // reserve 0 as "no epoch"
+	}
+	return e
+}
+
+// --- per-shard delete journal ---
+//
+// Deletes write no record, so their evidence would vanish; the journal retains the
+// most recent deletes so a resuming watcher can be told precisely which keys went
+// away. It holds between cap and 2*cap entries; older ones are trimmed and horizon
+// advances to the newest trimmed seq -- a cursor at or below horizon may have missed
+// a trimmed delete and must fall back to a full replay.
+
+type delEntry struct {
+	key []byte
+	seq uint64
+}
+
+type deleteLog struct {
+	mu      sync.Mutex
+	entries []delEntry
+	cap     int
+	horizon uint64
+}
+
+func newDeleteLog(capacity int, start uint64) *deleteLog {
+	return &deleteLog{cap: capacity, horizon: start}
+}
+
+func (d *deleteLog) record(key []byte, seq uint64) {
+	d.mu.Lock()
+	d.entries = append(d.entries, delEntry{append([]byte(nil), key...), seq})
+	if len(d.entries) >= 2*d.cap {
+		drop := len(d.entries) - d.cap
+		d.horizon = d.entries[drop-1].seq
+		d.entries = append([]delEntry(nil), d.entries[drop:]...) // compact
+	}
+	d.mu.Unlock()
+}
+
+// since returns the deletes with seq > cursor (a copy) and the current horizon.
+func (d *deleteLog) since(cursor uint64) []delEntry {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	var out []delEntry
+	for _, e := range d.entries {
+		if e.seq > cursor {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+func (d *deleteLog) horizonSeq() uint64 {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.horizon
+}
+
+// --- live subscription hub ---
+
+type rawEvent struct {
+	shard   int
+	seq     uint64
+	key     []byte
+	ad      []byte // compressed stored bytes; nil for a delete
+	codec   Codec
+	deleted bool
+}
+
+type watcher struct {
+	ch     chan rawEvent
+	lagged atomic.Bool
+}
+
+type watchHub struct {
+	epoch    uint64
+	active   atomic.Bool // lock-free gate: any watchers?
+	mu       sync.Mutex
+	watchers map[*watcher]struct{}
+}
+
+func newWatchHub() *watchHub {
+	return &watchHub{epoch: randomEpoch(), watchers: map[*watcher]struct{}{}}
+}
+
+func (h *watchHub) register(buf int) *watcher {
+	w := &watcher{ch: make(chan rawEvent, buf)}
+	h.mu.Lock()
+	h.watchers[w] = struct{}{}
+	h.active.Store(true)
+	h.mu.Unlock()
+	return w
+}
+
+func (h *watchHub) deregister(w *watcher) {
+	h.mu.Lock()
+	delete(h.watchers, w)
+	if len(h.watchers) == 0 {
+		h.active.Store(false)
+	}
+	h.mu.Unlock()
+}
+
+// publish fans one committed change out to every active watcher, non-blocking: a
+// watcher whose buffer is full is marked lagged (it will be told to resync) rather
+// than stalling the commit path.
+func (h *watchHub) publish(shard int, seq uint64, key, ad []byte, codec Codec, deleted bool) {
+	if !h.active.Load() {
+		return
+	}
+	h.mu.Lock()
+	if len(h.watchers) == 0 {
+		h.mu.Unlock()
+		return
+	}
+	ev := rawEvent{shard, seq, append([]byte(nil), key...), ad, codec, deleted}
+	for w := range h.watchers {
+		select {
+		case w.ch <- ev:
+		default:
+			w.lagged.Store(true)
+		}
+	}
+	h.mu.Unlock()
+}
+
+// --- the Watch verb ---
+
+// Watch replays everything that may have changed since cursor (nil ⇒ a full replay
+// from empty), then streams live changes until ctx is cancelled or the consumer
+// stops. Requires Options.WatchHistory > 0. See docs/WATCH.md and WatchEvent.
+func (c *Collection) Watch(ctx context.Context, cursor []byte) (iter.Seq[WatchEvent], error) {
+	if c.hub == nil {
+		return nil, errors.New("collections: Watch requires Options.WatchHistory > 0")
+	}
+	return func(yield func(WatchEvent) bool) {
+		w := c.hub.register(c.watchBuf)
+		defer c.hub.deregister(w)
+
+		// Decide incremental vs. full replay.
+		epoch, seqs, ok := decodeCursor(cursor)
+		full := !ok || epoch != c.hub.epoch || len(seqs) != len(c.shards)
+
+		// Snapshot each shard's commit sequence: the upper bound of catch-up. The
+		// watcher is already registered, so any commit past this point is buffered.
+		sReg := make([]uint64, len(c.shards))
+		for i, sh := range c.shards {
+			sh.mu.RLock()
+			sReg[i] = sh.commitSeq
+			sh.mu.RUnlock()
+		}
+		// Retention: if a shard's cursor predates its delete horizon, a delete may have
+		// been trimmed -> full replay.
+		if !full {
+			for i, sh := range c.shards {
+				if seqs[i] < sh.delLog.horizonSeq() {
+					full = true
+					break
+				}
+			}
+		}
+
+		if full {
+			if !yield(WatchEvent{Kind: WatchReset}) {
+				return
+			}
+			for i := range c.shards {
+				if !c.catchupUpserts(i, 0, sReg[i], yield) {
+					return
+				}
+			}
+		} else {
+			for i := range c.shards {
+				// Deletes before upserts: a key deleted then re-added since the cursor
+				// must end present (Delete then Upsert), not absent.
+				if !c.catchupDeletes(i, seqs[i], yield) {
+					return
+				}
+				if !c.catchupUpserts(i, seqs[i], sReg[i], yield) {
+					return
+				}
+			}
+		}
+		if !yield(WatchEvent{Kind: WatchSynced, Cursor: encodeCursor(c.hub.epoch, sReg)}) {
+			return
+		}
+
+		// Live phase: stream buffered + new events, advancing a running cursor vector.
+		vec := append([]uint64(nil), sReg...)
+		for {
+			if w.lagged.Load() {
+				yield(WatchEvent{Kind: WatchResync})
+				return
+			}
+			select {
+			case <-ctx.Done():
+				return
+			case raw := <-w.ch:
+				if raw.seq <= sReg[raw.shard] {
+					continue // already covered by catch-up
+				}
+				vec[raw.shard] = raw.seq
+				ev := WatchEvent{Key: raw.key, Cursor: encodeCursor(c.hub.epoch, vec)}
+				if raw.deleted {
+					ev.Kind = WatchDelete
+				} else {
+					ad, err := c.decodeAd(raw.ad, raw.codec)
+					if err != nil {
+						continue
+					}
+					ev.Kind = WatchUpsert
+					ev.Ad = ad
+				}
+				if !yield(ev) {
+					return
+				}
+			}
+		}
+	}, nil
+}
+
+// catchupUpserts emits an Upsert for every record visible at sReg whose seq is in
+// (cursor, sReg] -- the keys whose current version changed since the cursor.
+func (c *Collection) catchupUpserts(i int, cursor, sReg uint64, yield func(WatchEvent) bool) bool {
+	sh := c.shards[i]
+	_, wins := sh.snapshot()
+	defer releaseWindows(wins)
+	for _, wn := range wins {
+		for off := 0; off < wn.used; {
+			o := uint32(off)
+			total := recTotalLen(wn.data, o)
+			if total == 0 {
+				break
+			}
+			seq := recSeq(wn.data, o)
+			if seq > cursor && seq <= sReg && recSuperseded(wn.data, o) > sReg {
+				ad, err := c.decodeAd(recAd(wn.data, o), wn.codec)
+				if err == nil {
+					key := append([]byte(nil), recKey(wn.data, o)...)
+					if !yield(WatchEvent{Kind: WatchUpsert, Key: key, Ad: ad}) {
+						return false
+					}
+				}
+			}
+			off += int(total)
+		}
+	}
+	return true
+}
+
+// catchupDeletes emits a Delete for each journaled delete with seq > cursor.
+func (c *Collection) catchupDeletes(i int, cursor uint64, yield func(WatchEvent) bool) bool {
+	for _, e := range c.shards[i].delLog.since(cursor) {
+		if !yield(WatchEvent{Kind: WatchDelete, Key: e.key}) {
+			return false
+		}
+	}
+	return true
+}

--- a/collections/watch_coalesce_test.go
+++ b/collections/watch_coalesce_test.go
@@ -1,0 +1,155 @@
+package collections
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestWatchCoalesce verifies that WatchCoalesce collapses a burst of rapid
+// changes to one key into a single settled event, collapses an upsert+delete
+// within a window to a Delete, and still delivers distinct keys -- while the
+// non-coalesced path (control) emits one event per change.
+func TestWatchCoalesce(t *testing.T) {
+	c := New(Options{Shards: 2, WatchHistory: 1024, WatchCoalesce: 40 * time.Millisecond})
+	c.Put(wkey(0), mustAd(t, `[V=0]`))
+	_, cursor := collectCatchUp(t, c, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	seq, err := c.Watch(ctx, cursor)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	type rec struct {
+		key       string
+		kind      WatchKind
+		v         int64
+		hasCursor bool
+	}
+	var mu sync.Mutex
+	var recs []rec
+	done := make(chan struct{})
+	synced := make(chan struct{})
+	go func() {
+		defer close(done)
+		for ev := range seq {
+			switch ev.Kind {
+			case WatchSynced:
+				close(synced) // now live: subsequent changes go through coalescing
+				continue
+			case WatchResync:
+				return
+			}
+			r := rec{key: string(ev.Key), kind: ev.Kind, hasCursor: ev.Cursor != nil}
+			if ev.Ad != nil {
+				if v, ok := ev.Ad.EvaluateAttrInt("V"); ok {
+					r.v = v
+				}
+			}
+			mu.Lock()
+			recs = append(recs, r)
+			mu.Unlock()
+		}
+	}()
+	<-synced
+
+	// Burst: ten rapid updates to k0, plus a distinct k1.
+	for i := 1; i <= 10; i++ {
+		c.Put(wkey(0), mustAd(t, fmt.Sprintf(`[V=%d]`, i)))
+	}
+	c.Put(wkey(1), mustAd(t, `[V=100]`))
+	time.Sleep(150 * time.Millisecond)
+
+	// An upsert then delete of k2 within a window collapses to a single Delete.
+	c.Put(wkey(2), mustAd(t, `[V=1]`))
+	c.Delete(wkey(2))
+	time.Sleep(150 * time.Millisecond)
+
+	cancel()
+	<-done
+
+	mu.Lock()
+	defer mu.Unlock()
+	var k0count int
+	var lastK0 int64 = -1
+	var k1seen, k2delete, anyCursor bool
+	for _, r := range recs {
+		if r.hasCursor {
+			anyCursor = true
+		}
+		switch r.key {
+		case skey(0):
+			k0count++
+			lastK0 = r.v
+		case skey(1):
+			k1seen = true
+		case skey(2):
+			if r.kind == WatchDelete {
+				k2delete = true
+			}
+		}
+	}
+	if k0count == 0 || k0count > 3 {
+		t.Errorf("k0: got %d events for 10 rapid updates, want coalesced (1-3)", k0count)
+	}
+	if lastK0 != 10 {
+		t.Errorf("k0 final value = %d, want 10 (latest)", lastK0)
+	}
+	if !k1seen {
+		t.Error("k1 upsert not delivered")
+	}
+	if !k2delete {
+		t.Error("k2 upsert+delete did not collapse to a Delete")
+	}
+	if !anyCursor {
+		t.Error("no coalesced event carried a cursor")
+	}
+}
+
+// TestWatchNoCoalesceByDefault confirms that with WatchCoalesce unset, every
+// change is delivered as its own live event (the default, un-batched behavior).
+func TestWatchNoCoalesceByDefault(t *testing.T) {
+	c := New(Options{Shards: 1, WatchHistory: 1024}) // no WatchCoalesce
+	c.Put(wkey(0), mustAd(t, `[V=0]`))
+	_, cursor := collectCatchUp(t, c, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	seq, err := c.Watch(ctx, cursor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := make(chan int, 1)
+	synced := make(chan struct{})
+	go func() {
+		n := 0
+		for ev := range seq {
+			switch ev.Kind {
+			case WatchSynced:
+				close(synced)
+			case WatchUpsert:
+				n++
+				if n == 5 {
+					got <- n
+					return
+				}
+			}
+		}
+	}()
+	<-synced // ensure live before mutating, so each change is its own live event
+	for i := 1; i <= 5; i++ {
+		c.Put(wkey(0), mustAd(t, fmt.Sprintf(`[V=%d]`, i)))
+	}
+	select {
+	case n := <-got:
+		if n != 5 {
+			t.Errorf("got %d upserts, want 5 (one per change)", n)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("did not receive 5 individual upserts without coalescing")
+	}
+}

--- a/collections/watch_filter_test.go
+++ b/collections/watch_filter_test.go
@@ -1,0 +1,95 @@
+package collections
+
+import (
+	"fmt"
+	"iter"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/classad"
+)
+
+func seqOf(evs ...WatchEvent) iter.Seq[WatchEvent] {
+	return func(yield func(WatchEvent) bool) {
+		for _, e := range evs {
+			if !yield(e) {
+				return
+			}
+		}
+	}
+}
+
+// matchM reports whether ad has M == 1.
+func matchM(ad *classad.ClassAd) bool {
+	v, ok := ad.EvaluateAttrInt("M")
+	return ok && v == 1
+}
+
+func collectKinds(t *testing.T, seq iter.Seq[WatchEvent]) []string {
+	t.Helper()
+	var got []string
+	for ev := range seq {
+		got = append(got, fmt.Sprintf("%d:%s", ev.Kind, ev.Key))
+	}
+	return got
+}
+
+// TestWatchFilterLive covers the live-phase filtering rules: matching upserts are
+// delivered, non-matching upserts are dropped, an upsert that stops matching
+// becomes a Delete, a Delete is delivered only for a matching key, Reset/Synced
+// pass through.
+func TestWatchFilterLive(t *testing.T) {
+	m := func(v int) *classad.ClassAd { return mustAd(t, fmt.Sprintf("[M=%d]", v)) }
+	in := seqOf(
+		WatchEvent{Kind: WatchReset},
+		WatchEvent{Kind: WatchUpsert, Key: []byte("a"), Ad: m(1)}, // match -> deliver
+		WatchEvent{Kind: WatchUpsert, Key: []byte("b"), Ad: m(0)}, // no match -> drop
+		WatchEvent{Kind: WatchSynced, Cursor: []byte("c1")},
+		WatchEvent{Kind: WatchUpsert, Key: []byte("a"), Ad: m(0)}, // a stops matching -> Delete
+		WatchEvent{Kind: WatchDelete, Key: []byte("b")},           // b never matched, live -> drop
+		WatchEvent{Kind: WatchUpsert, Key: []byte("d"), Ad: m(1)}, // match -> deliver
+		WatchEvent{Kind: WatchDelete, Key: []byte("d")},           // d matched -> Delete
+	)
+	got := collectKinds(t, WatchFilter(in, matchM))
+	want := []string{
+		fmt.Sprintf("%d:", WatchReset),
+		fmt.Sprintf("%d:a", WatchUpsert),
+		fmt.Sprintf("%d:", WatchSynced),
+		fmt.Sprintf("%d:a", WatchDelete),
+		fmt.Sprintf("%d:d", WatchUpsert),
+		fmt.Sprintf("%d:d", WatchDelete),
+	}
+	if fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Errorf("filtered stream:\n got  %v\n want %v", got, want)
+	}
+}
+
+// TestWatchFilterCatchupDelete covers an incremental resume (no Reset): the prior
+// match state of a resumed key is unknown, so a Delete arriving before Synced is
+// forwarded conservatively (the client no-ops an unknown key). After Synced,
+// deletes are filtered precisely.
+func TestWatchFilterCatchupDelete(t *testing.T) {
+	m := func(v int) *classad.ClassAd { return mustAd(t, fmt.Sprintf("[M=%d]", v)) }
+	in := seqOf(
+		WatchEvent{Kind: WatchDelete, Key: []byte("x")},           // catch-up delete -> forward
+		WatchEvent{Kind: WatchUpsert, Key: []byte("y"), Ad: m(1)}, // match -> deliver
+		WatchEvent{Kind: WatchSynced, Cursor: []byte("c1")},
+		WatchEvent{Kind: WatchDelete, Key: []byte("z")}, // live, never matched -> drop
+	)
+	got := collectKinds(t, WatchFilter(in, matchM))
+	want := []string{
+		fmt.Sprintf("%d:x", WatchDelete),
+		fmt.Sprintf("%d:y", WatchUpsert),
+		fmt.Sprintf("%d:", WatchSynced),
+	}
+	if fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Errorf("filtered stream:\n got  %v\n want %v", got, want)
+	}
+}
+
+// TestWatchFilterNil passes everything through when match is nil.
+func TestWatchFilterNil(t *testing.T) {
+	in := seqOf(WatchEvent{Kind: WatchReset}, WatchEvent{Kind: WatchSynced})
+	if n := len(collectKinds(t, WatchFilter(in, nil))); n != 2 {
+		t.Errorf("nil match: delivered %d events, want 2 (passthrough)", n)
+	}
+}

--- a/collections/watch_test.go
+++ b/collections/watch_test.go
@@ -1,0 +1,305 @@
+package collections
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+func wkey(i int) []byte { return []byte(fmt.Sprintf("k%d", i)) }
+func skey(i int) string { return fmt.Sprintf("k%d", i) }
+
+// collectCatchUp consumes a watch stream through WatchSynced, returning the catch-up
+// events (including a leading Reset, if any) and the synced cursor. Breaking at
+// Synced stops iteration cleanly (never enters the live phase).
+func collectCatchUp(t *testing.T, c *Collection, cursor []byte) ([]WatchEvent, []byte) {
+	t.Helper()
+	seq, err := c.Watch(context.Background(), cursor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var events []WatchEvent
+	var synced []byte
+	for ev := range seq {
+		if ev.Kind == WatchSynced {
+			synced = ev.Cursor
+			break
+		}
+		events = append(events, ev)
+	}
+	if synced == nil {
+		t.Fatal("watch stream ended without WatchSynced")
+	}
+	return events, synced
+}
+
+func TestWatchDisabled(t *testing.T) {
+	t.Parallel()
+	c := New(Options{Shards: 2}) // no WatchHistory
+	if _, err := c.Watch(context.Background(), nil); err == nil {
+		t.Fatal("expected error when WatchHistory is 0")
+	}
+}
+
+func TestWatchFullReplayFromEmpty(t *testing.T) {
+	t.Parallel()
+	c := New(Options{Shards: 4, WatchHistory: 1024})
+	const n = 300
+	for i := 0; i < n; i++ {
+		if err := c.Put(wkey(i), mustAd(t, fmt.Sprintf(`[Id=%d]`, i))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	events, cursor := collectCatchUp(t, c, nil)
+	if len(events) == 0 || events[0].Kind != WatchReset {
+		t.Fatalf("first event should be Reset, got %v", events)
+	}
+	got := map[string]bool{}
+	for _, ev := range events[1:] {
+		if ev.Kind != WatchUpsert {
+			t.Fatalf("expected Upsert in full replay, got kind %d", ev.Kind)
+		}
+		got[string(ev.Key)] = true
+	}
+	if len(got) != n {
+		t.Fatalf("full replay covered %d keys, want %d", len(got), n)
+	}
+	if cursor == nil {
+		t.Fatal("no synced cursor")
+	}
+}
+
+func TestWatchIncrementalResume(t *testing.T) {
+	t.Parallel()
+	c := New(Options{Shards: 4, WatchHistory: 1024})
+	const n = 300
+	for i := 0; i < n; i++ {
+		if err := c.Put(wkey(i), mustAd(t, fmt.Sprintf(`[Id=%d]`, i))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	_, cursor := collectCatchUp(t, c, nil) // initial full replay -> resume point
+
+	// Changes after the cursor.
+	_ = c.Put(wkey(0), mustAd(t, `[Id=0; V=1]`))  // update
+	_ = c.Put(wkey(9000), mustAd(t, `[Id=9000]`)) // insert
+	if !c.Delete(wkey(5)) {                       // delete
+		t.Fatal("delete k5 failed")
+	}
+
+	events, _ := collectCatchUp(t, c, cursor)
+	upserts, deletes := map[string]bool{}, map[string]bool{}
+	for _, ev := range events {
+		switch ev.Kind {
+		case WatchReset:
+			t.Fatal("unexpected Reset on an in-window incremental resume")
+		case WatchUpsert:
+			upserts[string(ev.Key)] = true
+		case WatchDelete:
+			deletes[string(ev.Key)] = true
+		}
+	}
+	if !upserts[skey(0)] || !upserts[skey(9000)] {
+		t.Fatalf("incremental resume missed changed upserts: %v", upserts)
+	}
+	if !deletes[skey(5)] {
+		t.Fatalf("incremental resume missed the delete: %v", deletes)
+	}
+	// Our implementation is precise, so an unchanged key should not be re-delivered
+	// (at-least-once permits it, but this guards against accidental full replay).
+	if upserts[skey(2)] {
+		t.Errorf("unchanged key k2 was re-delivered")
+	}
+}
+
+// TestWatchDeleteThenReadd checks catch-up ordering: a key deleted then re-added
+// since the cursor must end present (Delete emitted before Upsert).
+func TestWatchDeleteThenReadd(t *testing.T) {
+	t.Parallel()
+	c := New(Options{Shards: 1, WatchHistory: 1024})
+	_ = c.Put(wkey(0), mustAd(t, `[Id=0]`))
+	_, cursor := collectCatchUp(t, c, nil)
+
+	if !c.Delete(wkey(0)) {
+		t.Fatal("delete failed")
+	}
+	_ = c.Put(wkey(0), mustAd(t, `[Id=0; V=2]`)) // re-add
+
+	// Apply events into a map like a client would; the net state must have k0 present.
+	events, _ := collectCatchUp(t, c, cursor)
+	state := map[string]bool{}
+	for _, ev := range events {
+		switch ev.Kind {
+		case WatchUpsert:
+			state[string(ev.Key)] = true
+		case WatchDelete:
+			delete(state, string(ev.Key))
+		}
+	}
+	if !state[skey(0)] {
+		t.Fatalf("after delete+readd, k0 should be present; events=%v", events)
+	}
+}
+
+// TestWatchResetOnTrimmedDelete: once the delete journal trims past a cursor, that
+// cursor can no longer resume incrementally and must get a full replay.
+func TestWatchResetOnTrimmedDelete(t *testing.T) {
+	t.Parallel()
+	c := New(Options{Shards: 1, WatchHistory: 4}) // tiny journal
+	for i := 0; i < 100; i++ {
+		_ = c.Put(wkey(i), mustAd(t, fmt.Sprintf(`[Id=%d]`, i)))
+	}
+	_, oldCursor := collectCatchUp(t, c, nil)
+
+	// Delete far more than 2*cap keys so the journal trims and the horizon advances
+	// past oldCursor.
+	for i := 0; i < 40; i++ {
+		c.Delete(wkey(i))
+	}
+	events, _ := collectCatchUp(t, c, oldCursor)
+	if len(events) == 0 || events[0].Kind != WatchReset {
+		t.Fatalf("resume past the delete horizon should Reset; got %v",
+			func() []WatchKind {
+				ks := make([]WatchKind, len(events))
+				for i, e := range events {
+					ks[i] = e.Kind
+				}
+				return ks
+			}())
+	}
+}
+
+func TestWatchEpochMismatch(t *testing.T) {
+	t.Parallel()
+	c1 := New(Options{Shards: 2, WatchHistory: 64})
+	_ = c1.Put(wkey(0), mustAd(t, `[Id=0]`))
+	_, cursor := collectCatchUp(t, c1, nil)
+
+	// A different collection has a different epoch; the cursor is not valid there.
+	c2 := New(Options{Shards: 2, WatchHistory: 64})
+	_ = c2.Put(wkey(1), mustAd(t, `[Id=1]`))
+	events, _ := collectCatchUp(t, c2, cursor)
+	if len(events) == 0 || events[0].Kind != WatchReset {
+		t.Fatal("cursor from a different store generation should force Reset")
+	}
+}
+
+// TestWatchLive streams live changes after the initial sync.
+func TestWatchLive(t *testing.T) {
+	t.Parallel()
+	c := New(Options{Shards: 2, WatchHistory: 1024})
+	_ = c.Put(wkey(0), mustAd(t, `[Id=0]`))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	seq, err := c.Watch(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	events := make(chan WatchEvent, 128)
+	go func() {
+		for ev := range seq {
+			events <- ev
+		}
+		close(events)
+	}()
+	// Drain catch-up to Synced.
+	for ev := range events {
+		if ev.Kind == WatchSynced {
+			break
+		}
+	}
+	// Live changes.
+	_ = c.Put(wkey(1), mustAd(t, `[Id=1]`))
+	if !c.Delete(wkey(0)) {
+		t.Fatal("delete failed")
+	}
+	got := map[string]WatchKind{}
+	deadline := time.After(3 * time.Second)
+	for len(got) < 2 {
+		select {
+		case ev := <-events:
+			if ev.Kind == WatchUpsert || ev.Kind == WatchDelete {
+				got[string(ev.Key)] = ev.Kind
+				if ev.Cursor == nil {
+					t.Error("live event missing cursor")
+				}
+			}
+		case <-deadline:
+			t.Fatalf("timed out waiting for live events, got %v", got)
+		}
+	}
+	if got[skey(1)] != WatchUpsert {
+		t.Errorf("expected live Upsert for k1, got %d", got[skey(1)])
+	}
+	if got[skey(0)] != WatchDelete {
+		t.Errorf("expected live Delete for k0, got %d", got[skey(0)])
+	}
+}
+
+// TestWatchConcurrent runs a live watcher alongside concurrent writers; every change
+// must reach the watcher (or a Resync is signaled). Run with -race.
+func TestWatchConcurrent(t *testing.T) {
+	t.Parallel()
+	c := New(Options{Shards: 4, WatchHistory: 4096, WatchBuffer: 8192})
+	const n = 500
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	seq, err := c.Watch(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	seen := map[string]bool{}
+	var mu sync.Mutex
+	resync := false
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for ev := range seq {
+			if ev.Kind == WatchResync {
+				mu.Lock()
+				resync = true
+				mu.Unlock()
+				return
+			}
+			if ev.Kind == WatchUpsert {
+				mu.Lock()
+				seen[string(ev.Key)] = true
+				mu.Unlock()
+			}
+		}
+	}()
+
+	var wg sync.WaitGroup
+	for w := 0; w < 4; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			for i := w; i < n; i += 4 {
+				_ = c.Put(wkey(i), mustAd(t, fmt.Sprintf(`[Id=%d]`, i)))
+			}
+		}(w)
+	}
+	wg.Wait()
+
+	// Give the watcher a moment to drain, then stop it.
+	deadline := time.After(3 * time.Second)
+	for {
+		mu.Lock()
+		got, r := len(seen), resync
+		mu.Unlock()
+		if r || got >= n {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("watcher saw %d/%d keys and no resync", got, n)
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+	cancel()
+	<-done
+}

--- a/collections/wireeval.go
+++ b/collections/wireeval.go
@@ -21,34 +21,59 @@ type wireCtx interface {
 // an attribute whose value is a non-literal expression (or a list/record), it
 // sets fellBack and the caller retries the ad with a full ClassAd decode.
 //
-// One wireScope is reused across a scan (single-threaded): set ad and clear
-// fellBack before each evaluation.
+// One wireScope is reused across a scan (single-threaded): set ad (and, for a
+// chained child, parent) and clear fellBack before each evaluation.
 type wireScope struct {
 	ad       wire.Ad
+	parent   wire.Ad // the chained parent ad's wire bytes, or nil (no parent)
 	ctx      wireCtx // for mode-aware attribute lookup (interned id vs inline name)
 	fellBack bool
 }
 
 // resolve is the attribute resolver handed to vm.Matcher.EvalResolved.
 func (ws *wireScope) resolve(name string, scope ast.AttributeScope) classad.Value {
-	// A collection ad has no match target or enclosing parent, so TARGET/PARENT
-	// references are undefined — exactly as they evaluate against a stored ad.
-	if scope == ast.TargetScope || scope == ast.ParentScope {
+	switch scope {
+	case ast.TargetScope:
+		// A collection ad has no match target, so TARGET references are undefined.
+		return classad.NewUndefinedValue()
+	case ast.ParentScope:
+		// PARENT.attr reads from the chained parent ad (undefined if none).
+		if ws.parent == nil {
+			return classad.NewUndefinedValue()
+		}
+		v, _ := ws.tryResolve(ws.parent, name)
+		return v
+	default:
+		// Unscoped: this ad, then fall through to its parent (chaining), matching
+		// the ClassAd evaluator's parent walk.
+		if v, found := ws.tryResolve(ws.ad, name); found {
+			return v
+		}
+		if ws.parent != nil {
+			if v, found := ws.tryResolve(ws.parent, name); found {
+				return v
+			}
+		}
 		return classad.NewUndefinedValue()
 	}
-	node, ok := ws.ctx.wireLookup(ws.ad, name)
+}
+
+// tryResolve looks name up in ad. found reports whether ad has the attribute at
+// all (so an unscoped resolve knows whether to fall through to the parent). A
+// non-literal value sets fellBack (the caller retries with a full decode) and
+// still counts as found -- the ad has the attribute, it just can't be read from
+// wire alone.
+func (ws *wireScope) tryResolve(ad wire.Ad, name string) (classad.Value, bool) {
+	node, ok := ws.ctx.wireLookup(ad, name)
 	if !ok {
-		return classad.NewUndefinedValue() // this ad lacks it
+		return classad.NewUndefinedValue(), false
 	}
 	lit, ok := wire.LiteralValue(node)
 	if !ok {
-		// Non-literal (expression/list/record) attribute: cannot resolve without
-		// evaluating in a real scope. Flag fallback; the returned value is
-		// discarded once the caller sees fellBack.
 		ws.fellBack = true
-		return classad.NewUndefinedValue()
+		return classad.NewUndefinedValue(), true
 	}
-	return litToValue(lit)
+	return litToValue(lit), true
 }
 
 func litToValue(l wire.Literal) classad.Value {


### PR DESCRIPTION
Bundles this session's work on the `collections` engine and the base `classad` serializer. **This is the leaf of a multi-repo change** — see the tagging/merge order at the bottom.

## collections — watch + parent/child chained ads
- **Watch** (resumable, coalesced, constraint-filtered): `Watch`, `WatchCoalesce`, `WatchFilter`, and durable Archive watch.
- **Parent/child chained ads** (a primitive join, for the job queue's cluster→proc model):
  - *Phase 1* — query foundation: co-location by root key, `ParentKeyFor`/`IsStructural`, wire-native chained evaluation, structural-ad hiding, flatten-on-output.
  - *Phase 2* — auto-delete a structural parent when its last child leaves (HTCondor `ClusterCleanup`).
  - *Phase 3* — chained watch: flatten children, hide structural parents, fan out on inherited-attr change with a parent-private set + diff.
  - *Phase 4* — `Flatten` so a chained job archives as a self-contained history record.
  - *O(1) child counter*: replaces the per-delete shard scan with an in-memory, pointer-free (parent-dir-hash-keyed) live-child counter maintained under the shard lock — no write amplification, no O(shard) scan.

## classad — default-safe serialization (private attributes)
`IsPrivateAttribute` (V1 list + `_condor_priv` prefix, case-insensitive), mirroring compat_classad.cpp — the single source of truth every layer shares. `String`/`MarshalOld`/`MarshalJSON` now **exclude private attributes by default**; the `WithPrivate` variants and `Redacted()` are the explicit opt-ins. Storage is unaffected (the wire encoder is lossless). Regression tests assert no serializer leaks a secret.

## Tag/merge order (multi-repo)
This repo is the leaf and builds standalone (the `collections` module replaces `classad` via a relative `../`). After merge, **tag `classad` first**; the downstream repos (cedar → collector/htcondor/ccb) depend on the new `classad.IsPrivateAttribute*` and must bump their go.mod to that tag. Full runbook provided separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
