### PR TITLE
collections: ProjectionChecksum for schedd RRL grouping

### DIFF
--- a/collections/projection_checksum.go
+++ b/collections/projection_checksum.go
@@ -1,0 +1,36 @@
+package collections
+
+import "github.com/PelicanPlatform/classad/classad"
+
+// ProjectionChecksum returns a 64-bit FNV-1a checksum over the given attributes'
+// literal expression text in ad, taken in the order given and delimited so two
+// distinct projections cannot alias. A missing attribute contributes a fixed
+// marker, so "absent" is distinguished from every present value.
+//
+// This is the standalone, caller-supplied-attrs form of an ordered index's
+// cluster Signature (OrderSpec.Cluster). Unlike that index-time signature -- whose
+// attribute set is fixed when the index is opened -- ProjectionChecksum takes the
+// projection at call time, for callers whose significant attributes vary per query
+// (e.g. a schedd whose negotiator sends the significant-attribute set in each
+// negotiation header).
+//
+// It hashes each attribute's *expression text* rather than its evaluated value,
+// matching HTCondor autocluster semantics: two job ads whose significant
+// attributes are textually identical (same Requirements expression, same
+// RequestMemory literal, ...) hash equal, so a run-length fold over a
+// priority-ordered stream folds them into one resource request with a
+// stored-value compare. A 64-bit collision could merge two adjacent runs; over
+// the projected value bytes that is negligible.
+func ProjectionChecksum(ad *classad.ClassAd, attrs []string) uint64 {
+	const off = 1469598103934665603
+	h := uint64(off)
+	for _, name := range attrs {
+		if e, ok := ad.Lookup(name); ok {
+			h = fnv1a(h, e.String())
+		} else {
+			h = fnv1aByte(h, 0xff) // absent marker (distinct from any present text)
+		}
+		h = fnv1aByte(h, 0) // field delimiter so ["a","bc"] and ["ab","c"] differ
+	}
+	return h
+}

--- a/collections/projection_checksum_test.go
+++ b/collections/projection_checksum_test.go
@@ -1,0 +1,76 @@
+package collections
+
+import (
+	"testing"
+
+	"github.com/PelicanPlatform/classad/classad"
+)
+
+func mkAd(t *testing.T, text string) *classad.ClassAd {
+	t.Helper()
+	ad, err := classad.Parse(text)
+	if err != nil {
+		t.Fatalf("parse %q: %v", text, err)
+	}
+	return ad
+}
+
+func TestProjectionChecksumEqualForSameProjection(t *testing.T) {
+	attrs := []string{"RequestCpus", "RequestMemory", "Requirements"}
+	// Two ads that differ only outside the projection must hash equal.
+	a := mkAd(t, `[ ClusterId = 5; ProcId = 0; RequestCpus = 1; RequestMemory = 128; Requirements = (OpSys == "LINUX"); ]`)
+	b := mkAd(t, `[ ClusterId = 9; ProcId = 3; RequestCpus = 1; RequestMemory = 128; Requirements = (OpSys == "LINUX"); Owner = "bob"; ]`)
+	if ProjectionChecksum(a, attrs) != ProjectionChecksum(b, attrs) {
+		t.Fatalf("ads with identical projection hashed differently")
+	}
+}
+
+func TestProjectionChecksumDiffersOnValue(t *testing.T) {
+	attrs := []string{"RequestMemory"}
+	a := mkAd(t, `[ RequestMemory = 128; ]`)
+	b := mkAd(t, `[ RequestMemory = 256; ]`)
+	if ProjectionChecksum(a, attrs) == ProjectionChecksum(b, attrs) {
+		t.Fatalf("different RequestMemory values hashed equal")
+	}
+}
+
+func TestProjectionChecksumDistinguishesAbsent(t *testing.T) {
+	attrs := []string{"RequestMemory"}
+	present := mkAd(t, `[ RequestMemory = 0; ]`)
+	absent := mkAd(t, `[ Owner = "bob"; ]`)
+	if ProjectionChecksum(present, attrs) == ProjectionChecksum(absent, attrs) {
+		t.Fatalf("absent attribute aliased a present value")
+	}
+}
+
+func TestProjectionChecksumHashesExpressionText(t *testing.T) {
+	// Requirements is an expression referencing machine attrs; the checksum must
+	// use the expression text, not attempt to evaluate it (which would collapse
+	// distinct requirements to the same undefined value).
+	attrs := []string{"Requirements"}
+	a := mkAd(t, `[ Requirements = (OpSys == "LINUX"); ]`)
+	b := mkAd(t, `[ Requirements = (OpSys == "WINDOWS"); ]`)
+	if ProjectionChecksum(a, attrs) == ProjectionChecksum(b, attrs) {
+		t.Fatalf("different Requirements expressions hashed equal")
+	}
+}
+
+func TestProjectionChecksumOrderAndDelimiter(t *testing.T) {
+	// The per-field delimiter must keep ["a","bc"] distinct from ["ab","c"].
+	x := mkAd(t, `[ A = "a"; B = "bc"; ]`)
+	y := mkAd(t, `[ A = "ab"; B = "c"; ]`)
+	if ProjectionChecksum(x, []string{"A", "B"}) == ProjectionChecksum(y, []string{"A", "B"}) {
+		t.Fatalf("delimiter failed to separate adjacent fields")
+	}
+}
+
+func TestProjectionChecksumStable(t *testing.T) {
+	attrs := []string{"RequestCpus", "RequestMemory", "Requirements", "Rank"}
+	ad := mkAd(t, `[ RequestCpus = 2; RequestMemory = 512; Requirements = (Arch == "X86_64"); Rank = 0.0; ]`)
+	first := ProjectionChecksum(ad, attrs)
+	for i := 0; i < 100; i++ {
+		if ProjectionChecksum(ad, attrs) != first {
+			t.Fatalf("checksum not stable across calls")
+		}
+	}
+}


### PR DESCRIPTION
`ProjectionChecksum(ad, attrs)` returns an FNV-1a checksum over the **expression text** of the given attributes (unevaluated, matching C++ autocluster semantics) with a distinct absent-marker.

The pure-Go schedd (golang-ap) uses it to run-length-fold consecutive idle jobs with identical significant attributes into one negotiator resource request (`SEND_RESOURCE_REQUEST_LIST`), without the full autocluster bookkeeping — the ordered cursor over the job collection yields ads in negotiator priority order, and equal consecutive checksums collapse into one request with a count.

Additive; new `collections/projection_checksum.go` (+test). Note: `collections` is a nested module — `go vet ./...` is clean run inside it (the repo's root-level go-vet hook false-positives on the submodule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
