### PR TITLE
dbrpc: add opWatchHead so a watch can tail from now without replaying contents

### DIFF
--- a/collections/watch.go
+++ b/collections/watch.go
@@ -215,6 +215,23 @@ func (h *watchHub) publish(shard int, seq uint64, key, ad []byte, codec Codec, d
 
 // --- the Watch verb ---
 
+// WatchCursor returns an opaque cursor pointing at the current head of the change log,
+// so a subsequent Watch(ctx, cursor) streams only changes from now on -- no initial
+// replay of the current contents. Requires Options.WatchHistory > 0. It only snapshots
+// each shard's commit sequence (no registration, no replay), so it is cheap.
+func (c *Collection) WatchCursor() ([]byte, error) {
+	if c.hub == nil {
+		return nil, errors.New("collections: Watch requires Options.WatchHistory > 0")
+	}
+	seqs := make([]uint64, len(c.shards))
+	for i, sh := range c.shards {
+		sh.mu.RLock()
+		seqs[i] = sh.commitSeq
+		sh.mu.RUnlock()
+	}
+	return encodeCursor(c.hub.epoch, seqs), nil
+}
+
 // Watch replays everything that may have changed since cursor (nil ⇒ a full replay
 // from empty), then streams live changes until ctx is cancelled or the consumer
 // stops. Requires Options.WatchHistory > 0. See docs/WATCH.md and WatchEvent.

--- a/collections/watch_test.go
+++ b/collections/watch_test.go
@@ -303,3 +303,34 @@ func TestWatchConcurrent(t *testing.T) {
 	cancel()
 	<-done
 }
+
+// TestWatchCursorSkipsExisting: a watch started from WatchCursor() (the current head)
+// replays none of the existing contents -- the "tail from now" path.
+func TestWatchCursorSkipsExisting(t *testing.T) {
+	t.Parallel()
+	c := New(Options{Shards: 4, WatchHistory: 1024})
+	for i := 0; i < 200; i++ {
+		if err := c.Put(wkey(i), mustAd(t, fmt.Sprintf(`[Id=%d]`, i))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	head, err := c.WatchCursor()
+	if err != nil {
+		t.Fatal(err)
+	}
+	events, _ := collectCatchUp(t, c, head)
+	if len(events) != 0 {
+		t.Errorf("watch from the head cursor should replay nothing, got %d catch-up events", len(events))
+	}
+	// A nil cursor, by contrast, replays all 200.
+	full, _ := collectCatchUp(t, c, nil)
+	upserts := 0
+	for _, e := range full {
+		if e.Kind == WatchUpsert {
+			upserts++
+		}
+	}
+	if upserts != 200 {
+		t.Errorf("nil cursor should replay all 200 ads, got %d", upserts)
+	}
+}

--- a/db/watch.go
+++ b/db/watch.go
@@ -36,6 +36,11 @@ type WatchEvent struct {
 // Watch streams changes committed after the given cursor (nil = from now). Cancel via
 // ctx. Events arrive in commit order per key; see collections.Watch for the delivery
 // and coalescing guarantees.
+// WatchCursor returns an opaque cursor at the current head of the change log, so
+// Watch(ctx, cursor) then streams only subsequent changes (no replay of current
+// contents). Cheap; requires the store was opened with watch history.
+func (db *DB) WatchCursor() ([]byte, error) { return db.c.WatchCursor() }
+
 func (db *DB) Watch(ctx context.Context, cursor []byte) (iter.Seq[WatchEvent], error) {
 	seq, err := db.c.Watch(ctx, cursor)
 	if err != nil {

--- a/dbrpc/client.go
+++ b/dbrpc/client.go
@@ -374,6 +374,22 @@ func (c *Client) Watch(cursor []byte) (<-chan WatchEvent, func(), error) {
 	return c.WatchTable(DefaultTable, cursor)
 }
 
+// WatchHead returns an opaque cursor at the current head of table's change log, so a
+// following WatchTable(table, cursor) streams only subsequent changes (no replay of
+// current contents) -- the "tail from now" path.
+func (c *Client) WatchHead(table string) ([]byte, error) {
+	status, body, err := c.call(func(rid uint64) []byte {
+		return putStr(req(rid, opWatchHead), table)
+	})
+	if err != nil {
+		return nil, err
+	}
+	if status != stOK {
+		return nil, statusErr(status, body)
+	}
+	return append([]byte(nil), body.bytesRef()...), nil
+}
+
 // WatchTable streams changes to the named table.
 func (c *Client) WatchTable(table string, cursor []byte) (<-chan WatchEvent, func(), error) {
 	id, frames, err := c.callStream(func(rid uint64) []byte {

--- a/dbrpc/proto.go
+++ b/dbrpc/proto.go
@@ -60,6 +60,11 @@ const (
 	// it against resTable would execute (slot-side probe rewrite + index pushdown), with the
 	// resource-side filter targetWhere (WHERE TARGET / NOPREEMPT) melded into the plan.
 	opMatchExplain op = 23
+
+	// opWatchHead returns an opaque cursor at the current head of a table's change log:
+	// [table] -> [cursor]. A client uses it to start a Watch that streams only subsequent
+	// changes (no replay of current contents) -- the "tail from now" path.
+	opWatchHead op = 24
 )
 
 // String names an opcode for diagnostics (e.g. the read-only rejection message).
@@ -91,6 +96,8 @@ func (o op) String() string {
 		return "Watch"
 	case opWatchStop:
 		return "WatchStop"
+	case opWatchHead:
+		return "WatchHead"
 	case opOrdered:
 		return "Ordered"
 	case opAggregate:

--- a/dbrpc/server.go
+++ b/dbrpc/server.go
@@ -451,6 +451,21 @@ func (s *Server) handle(reqID uint64, o op, r *reader, includePrivate bool) []by
 		}
 		return b
 
+	case opWatchHead:
+		table := r.str()
+		if r.err != nil {
+			return respBad(reqID)
+		}
+		d, ok := s.cat.Table(table)
+		if !ok {
+			return respErr(reqID, "no such table: "+table)
+		}
+		cursor, err := d.WatchCursor()
+		if err != nil {
+			return respErr(reqID, err.Error())
+		}
+		return putBytes(resp(reqID, stOK), cursor)
+
 	case opCommit:
 		st, ok := s.take(r.u64())
 		if !ok {


### PR DESCRIPTION
Collection.WatchCursor() returns an opaque cursor at the current change-log head (just a per-shard commitSeq snapshot -- no registration, no replay), so Watch(ctx, cursor) then streams only subsequent changes. Exposed through db.DB.WatchCursor and a new dbrpc opWatchHead ([table] -> [cursor]) + Client.WatchHead, so a client can start a live tail without the server streaming (and the client discarding) the whole table. TestWatchCursorSkipsExisting.