### PR TITLE
db,dbrpc: require siblings at real versions so tags are consumable

### DIFF
--- a/db/go.mod
+++ b/db/go.mod
@@ -3,8 +3,8 @@ module github.com/PelicanPlatform/classad/db
 go 1.25.0
 
 require (
-	github.com/PelicanPlatform/classad v0.0.0
-	github.com/PelicanPlatform/classad/collections v0.0.0
+	github.com/PelicanPlatform/classad v0.7.0
+	github.com/PelicanPlatform/classad/collections v0.7.0
 	github.com/klauspost/compress v1.19.0
 )
 

--- a/dbrpc/go.mod
+++ b/dbrpc/go.mod
@@ -3,13 +3,13 @@ module github.com/PelicanPlatform/classad/dbrpc
 go 1.25.0
 
 require (
-	github.com/PelicanPlatform/classad v0.4.0
-	github.com/PelicanPlatform/classad/db v0.0.0
-	github.com/bbockelm/cedar v0.0.0
+	github.com/PelicanPlatform/classad v0.7.0
+	github.com/PelicanPlatform/classad/db v0.7.1
+	github.com/bbockelm/cedar v0.5.3
 )
 
 require (
-	github.com/PelicanPlatform/classad/collections v0.0.0 // indirect
+	github.com/PelicanPlatform/classad/collections v0.7.0 // indirect
 	github.com/RoaringBitmap/roaring/v2 v2.19.0 // indirect
 	github.com/bits-and-blooms/bitset v1.24.4 // indirect
 	github.com/klauspost/compress v1.19.0 // indirect


### PR DESCRIPTION
## Problem

The nested modules (`db`, `dbrpc`) pin their intra-repo dependencies at **placeholder versions** that only resolve through the local `replace` directives:

- `db/go.mod`: `classad v0.0.0`, `collections v0.0.0`
- `dbrpc/go.mod`: `classad v0.4.0`, `db v0.0.0`, `collections v0.0.0`, `cedar v0.0.0`

`replace` directives in a dependency's go.mod are **ignored by consumers**, so an external module that does `go get github.com/PelicanPlatform/classad/dbrpc@v0.7.0` fails while building the module graph:

```
go: github.com/PelicanPlatform/classad/db@v0.0.0: reading .../db/go.mod at revision db/v0.0.0: unknown revision db/v0.0.0
```

(`cedar@v0.0.0` would fail next.) This makes the `v0.7.0` tags non-consumable — the reason htcondordb still pins classad via local `replace` instead of the tags.

## Fix

Bump the require versions to real, existing tags. The local `replace` directives stay, so in-repo development still builds against the `../` checkouts:

| module | dependency | v0.7.0 | this PR |
|---|---|---|---|
| db | classad | v0.0.0 | **v0.7.0** |
| db | collections | v0.0.0 | **v0.7.0** |
| dbrpc | classad | v0.4.0 | **v0.7.0** |
| dbrpc | db | v0.0.0 | **v0.7.1** |
| dbrpc | collections | v0.0.0 | **v0.7.0** |
| dbrpc | cedar | v0.0.0 | **v0.5.3** |

`dbrpc` requires `db v0.7.1` because `db v0.7.0`'s own go.mod still carries the placeholders — the fix ships in the *next* tag.

## Tagging (in dependency order)

`collections/v0.7.0` and root `v0.7.0` are unchanged. After merge, tag:

1. `db/v0.7.1` — requires only the existing `collections/v0.7.0` and root `v0.7.0`
2. `dbrpc/v0.7.1` — requires `db/v0.7.1`

Then a consumer can drop the classad `replace` directives and `go get` the tags directly.

## Verification

`go mod tidy`, `go build ./...`, and `go test .` pass for both `db` and `dbrpc` (the local replaces resolve the not-yet-tagged `db v0.7.1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
