### PR TITLE
collections: sketch-memory accounting, archive bloom, and persisted live indexes

### DIFF
--- a/collections/archive_index.go
+++ b/collections/archive_index.go
@@ -31,17 +31,22 @@ import (
 //	         keysBlob;
 //	         exactN uint32; exactKeyOff [exactN+1] uint32; exactBmOff [exactN] uint32;
 //	         exactKeysBlob   -- exact-case keys (sorted) for =?=/=!=; a case-uniform
-//	         bucket's exact key reuses its folded bmOff (no duplicate payload).
+//	         bucket's exact key reuses its folded bmOff (no duplicate payload);
+//	         bloomK uint32; bloomM uint32; bloom [bloomM/64] uint64  (v5) -- categorical
+//	         membership filter over the folded keys. A miss on every probe value lets a
+//	         query skip binary-searching (and paging) the sorted key blob for that probe;
+//	         bloomM==0 means no filter (empty index).
 //	  val attr block @attrOff: excOff uint32; postedOff uint32; n uint32;
 //	         key [n] float64 (sorted asc); bmOff [n] uint32
 //
 // postedOff is the bitmap of records that posted a literal value, for the presence
 // probes: present (isnt undefined) = posted OR exc, absent (is undefined) = all AND-NOT
-// posted. v3 added the exact-case run; v4 added postedOff. There is no migration
-// (indexes are rebuilt at seal), so an older sidecar is simply rejected and reindexed.
+// posted. v3 added the exact-case run; v4 added postedOff; v5 added the categorical
+// bloom. There is no migration (indexes are rebuilt at seal), so an older sidecar is
+// simply rejected and reindexed.
 const (
 	sidecarMagic   = 0x41524358 // "ARCX"
-	sidecarVersion = 4
+	sidecarVersion = 5
 )
 
 // writeSidecarIndex serializes si to path (v2 sorted runs) and fsyncs it. si is
@@ -80,6 +85,7 @@ func writeSidecarIndex(path string, si *segIndex) error {
 		bmOffs                []uint32
 		exKeys                []string // exact-case keys (sorted) -> exBmOffs (for =?=/=!=)
 		exBmOffs              []uint32
+		bloom                 *bloomFilter // categorical membership over folded keys (built at seal)
 	}
 	type valBlk struct {
 		id, excOff, postedOff uint32
@@ -145,7 +151,7 @@ func writeSidecarIndex(path string, si *segIndex) error {
 		if err != nil {
 			return err
 		}
-		catBlks = append(catBlks, catBlk{id, excOff, postedOff, keys, bmOffs, exKeys, exBmOffs})
+		catBlks = append(catBlks, catBlk{id, excOff, postedOff, keys, bmOffs, exKeys, exBmOffs, cp.stats.bloom})
 	}
 	sort.Slice(catBlks, func(i, j int) bool { return catBlks[i].id < catBlks[j].id })
 
@@ -231,6 +237,18 @@ func writeSidecarIndex(path string, si *segIndex) error {
 			b = appendU32(b, o)
 		}
 		b = append(b, exBlob...)
+		// Categorical bloom (v5), immediately after the exact-case run: bloomK; bloomM;
+		// bloom words. bloomM==0 marks "no filter". Reuses the filter built at seal.
+		if cb.bloom != nil && cb.bloom.m > 0 {
+			b = appendU32(b, cb.bloom.k)
+			b = appendU32(b, cb.bloom.m)
+			for _, w := range cb.bloom.bits {
+				b = appendU64(b, w)
+			}
+		} else {
+			b = appendU32(b, 0) // bloomK
+			b = appendU32(b, 0) // bloomM == 0: no filter
+		}
 	}
 	for i, vb := range valBlks {
 		binary.LittleEndian.PutUint32(b[valSlot[i]:], uint32(len(b)))

--- a/collections/archive_mmapindex.go
+++ b/collections/archive_mmapindex.go
@@ -129,9 +129,14 @@ func (si *mmapSegIndex) probeOffsets(up usableProbe) *roaring.Bitmap {
 		switch up.op {
 		case "==", "in":
 			bm := roaring.New()
-			for _, s := range up.svals {
-				if off, ok := si.catFind(attrOff, s); ok {
-					bm.Or(si.bitmapAt(off))
+			// Bloom fast path: if every probe value is definitely absent, skip the
+			// per-value binary search over the (paged) sorted key blob entirely; only
+			// the exceptional records can still match and are re-verified upstream.
+			if !si.catBloomAllAbsent(attrOff, up.svals) {
+				for _, s := range up.svals {
+					if off, ok := si.catFind(attrOff, s); ok {
+						bm.Or(si.bitmapAt(off))
+					}
 				}
 			}
 			bm.Or(si.bitmapAt(excOff))
@@ -259,6 +264,54 @@ func (si *mmapSegIndex) catFindExact(attrOff uint32, key string) (bmOff uint32, 
 		}
 	}
 	return 0, false
+}
+
+// catBloomOff returns the file offset of the categorical bloom block (bloomK) within a
+// cat attr block: it sits immediately after the exact-case run. Mirrors catFindExact's
+// walk to the exact run, then skips the exact blob.
+func (si *mmapSegIndex) catBloomOff(attrOff uint32) uint32 {
+	d := si.data
+	n := le32(d, attrOff+8)
+	keyOffBase := attrOff + 12
+	bmOffBase := keyOffBase + (n+1)*4
+	blobBase := bmOffBase + n*4
+	exOff := blobBase + le32(d, keyOffBase+n*4) // + folded blob length (keyOff[n])
+	exN := le32(d, exOff)
+	exKeyOffBase := exOff + 4
+	exBmOffBase := exKeyOffBase + (exN+1)*4
+	exBlobBase := exBmOffBase + exN*4
+	return exBlobBase + le32(d, exKeyOffBase+exN*4) // + exact blob length (exKeyOff[exN])
+}
+
+// catBloomAllAbsent reports whether the categorical bloom proves EVERY key definitely
+// absent (so a query can skip binary-searching the sorted key blob). Returns false when
+// there is no filter (bloomM==0), so the caller falls back to the exact lookup. Replays
+// the same double-hash probe as bloomFilter.mayContain directly over the mapped words.
+func (si *mmapSegIndex) catBloomAllAbsent(attrOff uint32, keys []string) bool {
+	d := si.data
+	bloomOff := si.catBloomOff(attrOff)
+	k := le32(d, bloomOff)
+	m := le32(d, bloomOff+4)
+	if m == 0 || k == 0 {
+		return false // no filter: cannot prove absence
+	}
+	wordsBase := bloomOff + 8
+	mayContain := func(h uint64) bool {
+		h1, h2 := uint32(h), uint32(h>>32)
+		for i := uint32(0); i < k; i++ {
+			p := (h1 + i*h2) & (m - 1)
+			if le64(d, wordsBase+(p>>6)*8)&(1<<(p&63)) == 0 {
+				return false
+			}
+		}
+		return true
+	}
+	for _, s := range keys {
+		if mayContain(hashString(s)) {
+			return false // a value might be present: cannot skip
+		}
+	}
+	return true
 }
 
 // --- value attr block: excOff u32; postedOff u32; n u32; key[n] f64; bmOff[n] u32 ---

--- a/collections/archive_test.go
+++ b/collections/archive_test.go
@@ -56,6 +56,52 @@ func archiveQueryIDs(t *testing.T, a *Archive, qs string) []int {
 	return ids
 }
 
+// TestArchiveCategoricalBloom checks the v5 categorical bloom: a query for a value that
+// is definitely absent returns nothing (the bloom fast path skips the key-blob search),
+// while a present value still returns exactly its records (the filter never drops a
+// match). Uses many small segments so several sidecar blooms are exercised.
+func TestArchiveCategoricalBloom(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	a, _ := buildArchive(t, dir, 500, ArchiveOptions{
+		CategoricalAttrs: []string{"Owner", "JobStatus"},
+		ValueAttrs:       []string{"Memory", "ClusterId"},
+	})
+	defer a.Close()
+	if err := a.Flush(); err != nil {
+		t.Fatal(err)
+	}
+	if len(a.segs) < 2 {
+		t.Fatalf("expected several segments, got %d", len(a.segs))
+	}
+
+	// Absent value: bloom proves it definitely absent across every segment -> empty.
+	if ids := archiveQueryIDs(t, a, `Owner == "nobody_zzz"`); len(ids) != 0 {
+		t.Errorf("absent value should match nothing, got %v", ids)
+	}
+	// Present value: every alice record (owners[i%5], alice at i%5==0) must still match.
+	var want []int
+	for i := 0; i < 500; i++ {
+		if i%5 == 0 {
+			want = append(want, i)
+		}
+	}
+	got := archiveQueryIDs(t, a, `Owner == "alice"`)
+	if len(got) != len(want) {
+		t.Fatalf("Owner==alice: got %d ids, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("Owner==alice mismatch at %d: got %d want %d", i, got[i], want[i])
+		}
+	}
+
+	// The sidecar must be the bloom-carrying version.
+	if sidecarVersion != 5 {
+		t.Fatalf("expected sidecar v5, got %d", sidecarVersion)
+	}
+}
+
 func TestArchiveRoundTripAndQuery(t *testing.T) {
 	t.Parallel()
 	a, src := buildArchive(t, t.TempDir(), 500, ArchiveOptions{

--- a/collections/docs/design/README.md
+++ b/collections/docs/design/README.md
@@ -467,14 +467,25 @@ file's name records the dictionary it used, so recovery reconstructs the right c
 segment. Base (identity or configured) codec is not persisted — it is reconstructed from
 `Options`.
 
-**Derived state is rebuilt, not persisted.** Secondary indexes (Chapter 10) and the
-maintained ordered index (Chapter 16) are not written to disk; they are rebuilt from the
-recovered records on `Open`. This is a recurring choice: derived structures are cheaper
-to rebuild deterministically than to persist and keep crash-consistent.
+**Derived state is rebuilt or restored from a snapshot.** The maintained ordered index
+(Chapter 16) is rebuilt from the recovered records on `Open`. Secondary indexes
+(Chapter 10) are **snapshotted**: each built segment index is serialized beside its
+segment file (`<segfile>.idx`), and `Open` restores it into the in-RAM index, rebuilding
+only the segments whose snapshot is missing, stale (a grown or still-active segment), or
+built under a different index-spec generation. A snapshot stores only the postings; the
+value index's sorted keys and every per-segment sketch (min/max, bloom, HLL, top-N) are
+recomputed on load, so a decode reproduces a byte-identical index. It is validated against
+the spec generation and the segment's write extent, and any mismatch — or a read error —
+falls back to a deterministic rebuild, so the snapshot is a startup-latency optimization
+that can never yield a wrong index. It shares the segment file name, so compaction and
+rotation drop it with the segment (a compacted segment is a new file, rebuilt and
+re-snapshotted). This turns index recovery from re-indexing every record into
+deserializing bitmaps for the sealed majority of a large store.
 
-Recovery costs about 19–27 µs per ad (50k ads recover in roughly a second). A directory
-checkpoint to make restart sub-linear is a possible future optimization; the baseline is
-a full replay.
+Recovery still replays records to rebuild the key **directory** (max-seq dedup), which
+costs about 19–27 µs per ad (50k ads recover in roughly a second); a directory checkpoint
+to make that sub-linear is a possible future optimization. The index snapshot removes the
+separate, larger re-indexing cost on top of that replay.
 
 ---
 
@@ -567,11 +578,13 @@ Two refinements make the index path do less work per query:
   Bloom + 1 KiB HLL per attribute per segment); a Bloom hit may be a false positive (only
   forgoing a skip, never dropping a match), so soundness is preserved by construction.
 
-Because indexes are derived state, they are **not persisted** in the live/normal
-collection — a persistent collection rebuilds them on `Open` (the same `Reindex` over
-recovered segments), which is why an index configuration must be supplied identically at
-reopen. (The archive is the exception: its segments are immutable once sealed, so it
-persists a write-once sidecar index — §14.) A demand tracker records which attributes
+Indexes are derived state, but a persistent collection **snapshots** each built segment
+index beside its segment file and restores it on `Open`, rebuilding only the segments
+whose snapshot is missing, stale, or built under a different spec generation (see §8) —
+so an index configuration must still be supplied identically at reopen, but a large store
+reloads its sealed indexes by deserializing bitmaps rather than re-indexing every record.
+An in-memory collection keeps its indexes in RAM only. (The archive persists its own
+write-once mmap sidecar — §14.) A demand tracker records which attributes
 queries filter on, so `SuggestIndexes` can recommend indexes a workload would benefit
 from, and the auto-tuner grows/trims indexes against a memory watermark. That watermark is
 measured by `IndexSizes`, which reports each attribute's resident **posting** bytes (the

--- a/collections/docs/design/README.md
+++ b/collections/docs/design/README.md
@@ -547,12 +547,37 @@ The query planner is the reusable heart of the index path, and it embodies tenet
   covers only part of a segment, only costs selectivity — never a wrong answer. Dropping
   a constraint can only *widen* the candidate set.
 
-Because indexes are derived state, they are **not persisted** — a persistent collection
-rebuilds them on `Open` (the same `Reindex` over recovered segments), which is why an
-index configuration must be supplied identically at reopen. A demand tracker records
-which attributes queries filter on, so `SuggestIndexes` can recommend indexes a workload
-would benefit from; auto-maintenance can refresh the hot set and retrain dictionaries on
-a timer.
+Two refinements make the index path do less work per query:
+
+- **Boundary-searched value index.** A value index keeps its distinct keys in a sorted
+  companion slice (`sortedKeys`, filled at build), so a range probe binary-searches to the
+  matching `[from, to)` key run (`sort.Search`) and ORs only those bitmaps rather than
+  scanning every distinct value; equality stays an O(1) map lookup. The persisted archive
+  index (§14) does the same over its on-disk sorted runs.
+- **Per-segment skip + selectivity (`segstats.go`).** Each built segment index carries a
+  compact, postings-free summary per indexed attribute: the numeric **min/max** range, a
+  categorical **Bloom filter** over the value set, an exact distinct-value count plus a
+  mergeable **HyperLogLog** sketch, and the top-N heavy hitters. It earns its keep twice.
+  (1) *Segment skip* — before enumerating a segment's candidates, a required equality or
+  range conjunct the summary proves unsatisfiable (a value outside `[min,max]`; every probe
+  value a Bloom miss) lets the whole indexed prefix be skipped — *provided* no exceptional
+  (present-but-wrong-type) record could still match, since those are always re-verified.
+  (2) *Probe ordering* — the planner estimates each probe's candidate cardinality from the
+  top-N and HLL and intersects the most selective first. These sketches are bounded (≤8 KiB
+  Bloom + 1 KiB HLL per attribute per segment); a Bloom hit may be a false positive (only
+  forgoing a skip, never dropping a match), so soundness is preserved by construction.
+
+Because indexes are derived state, they are **not persisted** in the live/normal
+collection — a persistent collection rebuilds them on `Open` (the same `Reindex` over
+recovered segments), which is why an index configuration must be supplied identically at
+reopen. (The archive is the exception: its segments are immutable once sealed, so it
+persists a write-once sidecar index — §14.) A demand tracker records which attributes
+queries filter on, so `SuggestIndexes` can recommend indexes a workload would benefit
+from, and the auto-tuner grows/trims indexes against a memory watermark. That watermark is
+measured by `IndexSizes`, which reports each attribute's resident **posting** bytes (the
+roaring bitmaps + keys) and, separately, its **sketch** bytes (`SketchBytes`: the Bloom +
+HLL above) so the sketch overhead is visible rather than hidden — the budget itself is
+calibrated on posting bytes.
 
 ## 11. Parallel query
 
@@ -716,14 +741,20 @@ The design that follows:
   consistent version.
 - **Pageable indexes for > RAM.** A high-cardinality attribute's per-value lookup structure
   would blow the heap long before its bitmap payloads do, so the archive **materializes no
-  map**. The v2 sidecar stores each attribute's postings as a **sorted key run** (sorted
+  map**. The sidecar stores each attribute's postings as a **sorted key run** (sorted
   values + parallel bitmap-offset array) queried *directly over the mmap*: equality is a
   binary search, range a boundary scan, and roaring bitmaps are built lazily via zero-copy
   `FromBuffer` for only the postings a probe touches. Resident memory is therefore
   O(#indexed attributes), independent of value cardinality; keys, offsets, and payloads all
   stay demand-paged. Indexes load lazily, so a zone-pruned segment never pages its index in,
   and unmapping routes through the same `pin/reap` hook so a rotation never unmaps under a
-  live scan.
+  live scan. Each categorical block also carries the **Bloom filter** built at seal (sidecar
+  v5): a query for a value the filter proves absent skips the key-blob binary search
+  entirely — the win for a large, mostly-categorical history table, where an equality lookup
+  for a value not in a segment would otherwise page and binary-search that segment's whole
+  sorted key run. (Zone maps already give the numeric analogue; the Bloom is the categorical
+  one.) The sidecar is versioned and rebuilt at seal, so a format bump needs no migration —
+  an older sidecar is rejected and the segment reindexed.
 - **Newest-first + LIMIT pushdown.** Segments (and records within the active tail) are
   visited in reverse chronological order, and a `Limit(K)` stops the scan once K matches are
   yielded — essential when the constraint is broad but the caller wants one page.

--- a/collections/index_query.go
+++ b/collections/index_query.go
@@ -59,7 +59,13 @@ func (c *Collection) Reindex() {
 				t.seg.idx.Store(nil)
 				continue
 			}
-			t.seg.idx.Store(buildSegIndex(t.seg.data, t.used, t.seg.codec, spec))
+			si := buildSegIndex(t.seg.data, t.used, t.seg.codec, spec)
+			t.seg.idx.Store(si)
+			// Persist the built index beside the segment (persistent collections only) so a
+			// reopen restores it instead of re-indexing every record. Best-effort.
+			if c.dir != "" {
+				c.writeIndexSnapshot(t.seg, si)
+			}
 		}
 	}
 }

--- a/collections/index_size.go
+++ b/collections/index_size.go
@@ -48,20 +48,29 @@ func (vp *valPostings) sizeBytes() int64 {
 
 // IndexSize is the measured memory footprint of one attribute's index.
 type IndexSize struct {
-	Attr  string  `json:"attr"`
-	Kind  string  `json:"kind"`  // "categorical" | "value"
-	Bytes int64   `json:"bytes"` // resident posting bytes across all live segments
-	Auto  bool    `json:"auto"`  // created by the auto-tuner (vs human/Options)
-	Frac  float64 `json:"frac"`  // Bytes as a fraction of the live data bytes
+	Attr  string `json:"attr"`
+	Kind  string `json:"kind"`  // "categorical" | "value"
+	Bytes int64  `json:"bytes"` // resident posting bytes (roaring bitmaps + keys) across all live segments
+	// SketchBytes is the resident memory of this attribute's per-segment sketches --
+	// the categorical bloom filter and the HyperLogLog distinct-count registers --
+	// reported apart from Bytes so it is visible rather than hidden in the posting total.
+	SketchBytes int64   `json:"sketchBytes"`
+	Auto        bool    `json:"auto"` // created by the auto-tuner (vs human/Options)
+	Frac        float64 `json:"frac"` // Bytes as a fraction of the live data bytes
 }
 
 // IndexSizes is the collection's index memory, per attribute and in total, against the
 // live data bytes -- the denominator for the "index is N% of data" watermark.
 type IndexSizes struct {
 	PerIndex   []IndexSize `json:"perIndex"`
-	TotalBytes int64       `json:"totalBytes"`
-	DataBytes  int64       `json:"dataBytes"` // live compressed record bytes
-	Frac       float64     `json:"frac"`      // TotalBytes / DataBytes
+	TotalBytes int64       `json:"totalBytes"` // posting bytes (the auto-tuner's budget denominator)
+	// TotalSketchBytes is the sum of every index's SketchBytes (bloom + HLL). It is
+	// reported separately and is NOT folded into TotalBytes/Frac, so the watermark and
+	// auto-tuner budget stay calibrated on posting bytes; sketch memory is bounded and
+	// small (<=8 KiB bloom + 1 KiB HLL per categorical attr per segment).
+	TotalSketchBytes int64   `json:"totalSketchBytes"`
+	DataBytes        int64   `json:"dataBytes"` // live compressed record bytes
+	Frac             float64 `json:"frac"`      // TotalBytes / DataBytes
 }
 
 // IndexSizes measures each configured index's resident bytes across all live segments,
@@ -70,6 +79,8 @@ type IndexSizes struct {
 func (c *Collection) IndexSizes() IndexSizes {
 	catBytes := map[uint32]int64{}
 	valBytes := map[uint32]int64{}
+	catSketch := map[uint32]int64{}
+	valSketch := map[uint32]int64{}
 	for _, sh := range c.shards {
 		sh.mu.RLock()
 		for _, seg := range sh.segs {
@@ -82,9 +93,11 @@ func (c *Collection) IndexSizes() IndexSizes {
 			}
 			for id, cp := range si.cat {
 				catBytes[id] += cp.sizeBytes()
+				catSketch[id] += cp.stats.sketchBytes()
 			}
 			for id, vp := range si.val {
 				valBytes[id] += vp.sizeBytes()
+				valSketch[id] += vp.stats.sketchBytes()
 			}
 		}
 		sh.mu.RUnlock()
@@ -100,22 +113,24 @@ func (c *Collection) IndexSizes() IndexSizes {
 	}
 	dataBytes := c.Stats().LiveBytes()
 	out := IndexSizes{DataBytes: dataBytes}
-	appendSizes := func(m map[uint32]int64, kind string) {
+	appendSizes := func(m, sketch map[uint32]int64, kind string) {
 		for id, b := range m {
 			nm, ok := name(id)
 			if !ok {
 				continue
 			}
-			sz := IndexSize{Attr: nm, Kind: kind, Bytes: b, Auto: spec.isAuto(id)}
+			sk := sketch[id]
+			sz := IndexSize{Attr: nm, Kind: kind, Bytes: b, SketchBytes: sk, Auto: spec.isAuto(id)}
 			if dataBytes > 0 {
 				sz.Frac = float64(b) / float64(dataBytes)
 			}
 			out.PerIndex = append(out.PerIndex, sz)
 			out.TotalBytes += b
+			out.TotalSketchBytes += sk
 		}
 	}
-	appendSizes(catBytes, "categorical")
-	appendSizes(valBytes, "value")
+	appendSizes(catBytes, catSketch, "categorical")
+	appendSizes(valBytes, valSketch, "value")
 	// Largest first: the indexes a memory budget would trim.
 	sort.Slice(out.PerIndex, func(i, j int) bool {
 		if out.PerIndex[i].Bytes != out.PerIndex[j].Bytes {

--- a/collections/index_size_test.go
+++ b/collections/index_size_test.go
@@ -37,6 +37,23 @@ func TestIndexSizesAndProvenance(t *testing.T) {
 	if s := byAttr["Memory"]; s.Auto {
 		t.Errorf("Memory (Options) should be human, got auto")
 	}
+
+	// Sketch accounting: categorical indexes carry a bloom + HLL, so their SketchBytes
+	// is positive and reported apart from the posting Bytes; the value index carries only
+	// an HLL (no bloom). TotalSketchBytes sums them and is not folded into TotalBytes.
+	if s := byAttr["Owner"]; s.SketchBytes <= 0 {
+		t.Errorf("Owner (categorical) should report sketch bytes (bloom+HLL); got %+v", s)
+	}
+	if s := byAttr["Memory"]; s.SketchBytes <= 0 {
+		t.Errorf("Memory (value) should report sketch bytes (HLL); got %+v", s)
+	}
+	var sumSketch int64
+	for _, s := range sz.PerIndex {
+		sumSketch += s.SketchBytes
+	}
+	if sz.TotalSketchBytes != sumSketch || sz.TotalSketchBytes <= 0 {
+		t.Errorf("TotalSketchBytes=%d should equal the per-index sum=%d and be > 0", sz.TotalSketchBytes, sumSketch)
+	}
 }
 
 // TestBudgetTrimNeverDropsHuman: with a tight memory budget, AutoTune trims auto indexes

--- a/collections/index_snapshot.go
+++ b/collections/index_snapshot.go
@@ -1,0 +1,296 @@
+package collections
+
+import (
+	"math"
+	"os"
+	"sort"
+
+	"github.com/RoaringBitmap/roaring/v2"
+)
+
+// Live index snapshot ("CLIX"): a round-trip serialization of a built in-RAM segIndex for
+// a SEALED persistent segment, so a reopened collection restores its indexes by
+// deserializing postings instead of re-decompressing and re-indexing every record (the
+// dominant cost of Open on a large store). Unlike the archive sidecar (mmap, pageable,
+// O(#attrs) resident), this restores the full in-RAM segIndex the live query path uses.
+//
+// Only the postings are serialized (the per-value roaring bitmaps, the exact-case run for
+// =?=/=!=, and the exception/posted bitmaps). All DERIVED state -- the value index's
+// sortedKeys and every segStats sketch (min/max, bloom, HLL, top-N, ndv, covered) -- is
+// recomputed on load by finishStats, which builds it purely from the postings, so a decode
+// reproduces a byte-identical segIndex to buildSegIndex. finalizeExact is NOT re-run: the
+// snapshot already holds the finalized exact/exactCase split.
+//
+// Safety: a snapshot is bound to its segment by living beside the segment file, and is
+// validated on load against the index spec generation (and, by the caller, the segment's
+// write extent). Any structural mismatch -- wrong magic/version or a different spec gen --
+// is a SOFT miss (nil, nil): the caller rebuilds from the records. A snapshot can therefore
+// only ever be a faster path to the same index, never a wrong one.
+const (
+	liveIndexMagic   = 0x434C4958 // "CLIX"
+	liveIndexVersion = 1
+)
+
+func appendStr(b []byte, s string) []byte { return appendBytes(b, []byte(s)) }
+
+func appendRoaring(b []byte, bm *roaring.Bitmap) ([]byte, error) {
+	if bm == nil {
+		bm = roaring.New()
+	}
+	p, err := bm.MarshalBinary()
+	if err != nil {
+		return nil, err
+	}
+	return appendBytes(b, p), nil
+}
+
+// encodeLiveIndex serializes a built segIndex. Attribute ids and keys are emitted in
+// sorted order so the encoding is deterministic (a rebuilt+re-encoded index is
+// byte-identical), which keeps round-trip tests and any future content hashing stable.
+func encodeLiveIndex(si *segIndex) ([]byte, error) {
+	b := make([]byte, 0, 1024)
+	b = appendU32(b, liveIndexMagic)
+	b = appendU16(b, liveIndexVersion)
+	b = appendU32(b, si.upto)
+	b = appendU64(b, si.specGen)
+	var err error
+	if b, err = appendRoaring(b, si.all); err != nil {
+		return nil, err
+	}
+
+	catIDs := sortedU32Keys(si.cat)
+	b = appendU32(b, uint32(len(catIDs)))
+	for _, id := range catIDs {
+		cp := si.cat[id]
+		b = appendU32(b, id)
+		if b, err = encodeStrPostings(b, cp.post); err != nil {
+			return nil, err
+		}
+		if b, err = encodeStrPostings(b, cp.exact); err != nil {
+			return nil, err
+		}
+		ecKeys := sortedStrMapKeys(cp.exactCase)
+		b = appendU32(b, uint32(len(ecKeys)))
+		for _, k := range ecKeys {
+			b = appendStr(b, k)
+			b = appendStr(b, cp.exactCase[k])
+		}
+		if b, err = appendRoaring(b, cp.exc); err != nil {
+			return nil, err
+		}
+		if b, err = appendRoaring(b, cp.posted); err != nil {
+			return nil, err
+		}
+	}
+
+	valIDs := sortedU32Keys(si.val)
+	b = appendU32(b, uint32(len(valIDs)))
+	for _, id := range valIDs {
+		vp := si.val[id]
+		b = appendU32(b, id)
+		fkeys := make([]float64, 0, len(vp.post))
+		for k := range vp.post {
+			fkeys = append(fkeys, k)
+		}
+		sort.Float64s(fkeys)
+		b = appendU32(b, uint32(len(fkeys)))
+		for _, k := range fkeys {
+			b = appendU64(b, math.Float64bits(k))
+			if b, err = appendRoaring(b, vp.post[k]); err != nil {
+				return nil, err
+			}
+		}
+		if b, err = appendRoaring(b, vp.exc); err != nil {
+			return nil, err
+		}
+		if b, err = appendRoaring(b, vp.posted); err != nil {
+			return nil, err
+		}
+	}
+	return b, nil
+}
+
+// encodeStrPostings emits a folded/exact string->bitmap map as n × { key; roaring }.
+func encodeStrPostings(b []byte, m map[string]*roaring.Bitmap) ([]byte, error) {
+	keys := sortedStrKeys(m)
+	b = appendU32(b, uint32(len(keys)))
+	var err error
+	for _, k := range keys {
+		b = appendStr(b, k)
+		if b, err = appendRoaring(b, m[k]); err != nil {
+			return nil, err
+		}
+	}
+	return b, nil
+}
+
+// decodeLiveIndex deserializes a segIndex snapshot and recomputes its derived stats.
+// Returns (nil, nil) -- a soft miss telling the caller to rebuild -- when the blob is not a
+// current-version snapshot or was built under a different index spec generation. Returns a
+// non-nil error only on a corrupt/truncated blob.
+func decodeLiveIndex(data []byte, spec *indexSpec) (*segIndex, error) {
+	c := &cursor{b: data}
+	if c.u32() != liveIndexMagic || c.u16() != liveIndexVersion {
+		return nil, nil // not a snapshot we understand: rebuild
+	}
+	si := &segIndex{cat: map[uint32]*catPostings{}, val: map[uint32]*valPostings{}}
+	si.upto = c.u32()
+	si.specGen = c.u64()
+	if spec != nil && si.specGen != spec.gen {
+		return nil, nil // built under a different spec (attrs added/dropped): rebuild
+	}
+	var err error
+	if si.all, err = c.bitmap(); err != nil {
+		return nil, err
+	}
+
+	catN := c.u32()
+	for i := uint32(0); i < catN; i++ {
+		id := c.u32()
+		cp := &catPostings{
+			post:      map[string]*roaring.Bitmap{},
+			exact:     map[string]*roaring.Bitmap{},
+			exactCase: map[string]string{},
+		}
+		if err = decodeStrPostings(c, cp.post); err != nil {
+			return nil, err
+		}
+		if err = decodeStrPostings(c, cp.exact); err != nil {
+			return nil, err
+		}
+		ecN := c.u32()
+		for j := uint32(0); j < ecN; j++ {
+			k := string(c.bytes())
+			cp.exactCase[k] = string(c.bytes())
+		}
+		if cp.exc, err = c.bitmap(); err != nil {
+			return nil, err
+		}
+		if cp.posted, err = c.bitmap(); err != nil {
+			return nil, err
+		}
+		cp.finishStats() // recompute stats from the restored postings (NOT finalizeExact)
+		si.cat[id] = cp
+	}
+
+	valN := c.u32()
+	for i := uint32(0); i < valN; i++ {
+		id := c.u32()
+		vp := &valPostings{post: map[float64]*roaring.Bitmap{}}
+		pn := c.u32()
+		for j := uint32(0); j < pn; j++ {
+			k := math.Float64frombits(c.u64())
+			bm, e := c.bitmap()
+			if e != nil {
+				return nil, e
+			}
+			vp.post[k] = bm
+		}
+		if vp.exc, err = c.bitmap(); err != nil {
+			return nil, err
+		}
+		if vp.posted, err = c.bitmap(); err != nil {
+			return nil, err
+		}
+		vp.finishStats() // recomputes sortedKeys + stats
+		si.val[id] = vp
+	}
+	if c.err != nil {
+		return nil, c.err
+	}
+	return si, nil
+}
+
+func decodeStrPostings(c *cursor, m map[string]*roaring.Bitmap) error {
+	n := c.u32()
+	for j := uint32(0); j < n; j++ {
+		k := string(c.bytes())
+		bm, err := c.bitmap()
+		if err != nil {
+			return err
+		}
+		m[k] = bm
+	}
+	return nil
+}
+
+// --- deterministic key ordering helpers ---
+
+func sortedStrKeys(m map[string]*roaring.Bitmap) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func sortedStrMapKeys(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func sortedU32Keys[V any](m map[uint32]V) []uint32 {
+	keys := make([]uint32, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool { return keys[i] < keys[j] })
+	return keys
+}
+
+// --- segment snapshot files (persistent collections only) ---
+
+// snapshotPath is where a persistent segment's index snapshot lives: beside the segment
+// file, sharing its name so compaction/rotation drops it with the segment (a compacted
+// segment is a new file with no snapshot, so it is rebuilt). "" for a RAM segment.
+func snapshotPath(seg *segment) string {
+	if seg.path == "" {
+		return ""
+	}
+	return seg.path + ".idx"
+}
+
+// writeIndexSnapshot persists a built segIndex beside its segment so a reopen restores it
+// without re-indexing. Best-effort: a write failure is swallowed (a missing snapshot only
+// costs a rebuild next Open). No-op for a RAM segment. The active (still-growing) segment
+// is snapshotted too, but reload validates coverage and rebuilds it if it has since grown,
+// so a stale active-segment snapshot is harmless.
+func (c *Collection) writeIndexSnapshot(seg *segment, si *segIndex) {
+	path := snapshotPath(seg)
+	if path == "" || si == nil {
+		return
+	}
+	if blob, err := encodeLiveIndex(si); err == nil {
+		_ = writeFileSync(path, blob)
+	}
+}
+
+// loadIndexSnapshot restores seg's index from its on-disk snapshot, returning true iff a
+// valid snapshot that fully covers the segment's recovered write extent was installed. Any
+// miss -- no file, unreadable, wrong version, a different index-spec generation, or a
+// coverage that does not match the recovered extent -- leaves idx nil so Reindex rebuilds
+// it. A snapshot is therefore only ever a faster path to the same index, never a wrong one.
+func (c *Collection) loadIndexSnapshot(seg *segment, spec *indexSpec) bool {
+	path := snapshotPath(seg)
+	if path == "" {
+		return false
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	si, err := decodeLiveIndex(data, spec)
+	if err != nil || si == nil {
+		return false
+	}
+	if int(si.upto) != seg.used {
+		return false // snapshot doesn't match the recovered extent: rebuild
+	}
+	seg.idx.Store(si)
+	return true
+}

--- a/collections/index_snapshot_test.go
+++ b/collections/index_snapshot_test.go
@@ -1,0 +1,228 @@
+package collections
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/collections/vm"
+)
+
+// TestIndexSnapshotPersistsAcrossOpen: a persistent collection writes an index snapshot
+// (.idx) beside each segment at Reindex, and a reopen restores the index from it. Proves
+// the write hook fires, the on-disk snapshot loads back into a working index, and reopen
+// query results are correct.
+func TestIndexSnapshotPersistsAcrossOpen(t *testing.T) {
+	t.Parallel()
+	if !mmapSupported {
+		t.Skip("persistence is unix-only")
+	}
+	dir := t.TempDir()
+	opts := Options{Shards: 2, Dir: dir, CategoricalAttrs: []string{"Owner"}, ValueAttrs: []string{"Memory"}}
+	c, err := Open(opts)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	for i := 0; i < 1200; i++ {
+		if err := c.Put([]byte(fmt.Sprintf("m%d", i)),
+			mustAd(t, fmt.Sprintf(`[ Id=%d; Owner="u%d"; Memory=%d ]`, i, i%20, (i%8+1)*1024))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	c.Reindex() // builds indexes and writes .idx snapshots
+
+	// The write hook fired: at least one snapshot exists on disk.
+	matches, _ := filepath.Glob(filepath.Join(dir, "*", "*.idx"))
+	if len(matches) == 0 {
+		t.Fatal("no .idx snapshot files were written")
+	}
+
+	// The snapshot loads back into a working index: clear a sealed segment's index and
+	// restore it from disk.
+	restored := false
+	for _, sh := range c.shards {
+		for _, seg := range sh.segs {
+			if seg == nil {
+				continue
+			}
+			si := seg.idx.Load()
+			if si == nil || int(si.upto) != seg.used {
+				continue
+			}
+			seg.idx.Store(nil)
+			if c.loadIndexSnapshot(seg, c.spec.Load()) {
+				restored = true
+			} else {
+				t.Fatal("loadIndexSnapshot failed for a segment with a fresh snapshot")
+			}
+		}
+	}
+	if !restored {
+		t.Fatal("no sealed segment was restored from its snapshot")
+	}
+	if err := c.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Reopen: recovery restores indexes from snapshots; queries are correct.
+	c2, err := Open(opts)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer c2.Close()
+	q, _ := vm.Parse(`Owner == "u3" && Memory >= 4096`)
+	got := queryIDs(t, c2, q)
+	var want []int
+	for i := 0; i < 1200; i++ {
+		if i%20 == 3 && (i%8+1)*1024 >= 4096 {
+			want = append(want, i)
+		}
+	}
+	if !equalInts(got, want) {
+		t.Errorf("after reopen: got %v, want %v", got, want)
+	}
+}
+
+// TestLiveIndexSnapshotRoundTrip is the correctness anchor for persisted live indexes: a
+// segIndex encoded and decoded back must yield IDENTICAL query results (a decode that
+// dropped postings would silently lose matches, which re-verify cannot recover). It swaps
+// every segment's index for its encode->decode image, then re-runs a battery that
+// exercises ==, !=, ranges, =?= exact-case, and presence probes.
+func TestLiveIndexSnapshotRoundTrip(t *testing.T) {
+	t.Parallel()
+	c := New(Options{
+		Shards:           4,
+		CategoricalAttrs: []string{"Owner", "State"},
+		ValueAttrs:       []string{"Memory", "Cpus"},
+	})
+	owners := []string{"alice", "Alice", "bob", "BOB", "carol"} // mixed case -> exact/exactCase
+	states := []string{"Idle", "Running", "Held"}
+	for i := 0; i < 1500; i++ {
+		var ad string
+		switch {
+		case i%17 == 0: // a type exception: Memory present but not numeric
+			ad = fmt.Sprintf(`[ Id=%d; Owner=%q; State=%q; Memory="lots"; Cpus=%d ]`,
+				i, owners[i%len(owners)], states[i%len(states)], i%16)
+		case i%13 == 0: // Owner absent (presence probe coverage)
+			ad = fmt.Sprintf(`[ Id=%d; State=%q; Memory=%d; Cpus=%d ]`,
+				i, states[i%len(states)], (i%8+1)*1024, i%16)
+		default:
+			ad = fmt.Sprintf(`[ Id=%d; Owner=%q; State=%q; Memory=%d; Cpus=%d ]`,
+				i, owners[i%len(owners)], states[i%len(states)], (i%8+1)*1024, i%16)
+		}
+		if err := c.Put([]byte(fmt.Sprintf("m%d", i)), mustAd(t, ad)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	c.Reindex()
+
+	queries := []string{
+		`Owner == "alice"`,
+		`Owner == "bob" || Owner == "carol"`,
+		`Owner != "alice"`,
+		`Owner =?= "Alice"`, // case-sensitive: must not match "alice"
+		`Owner =?= "BOB"`,
+		`Memory >= 4096`,
+		`Memory > 2048 && Memory <= 6144`,
+		`Cpus == 4`,
+		`State == "Running" && Memory >= 2048`,
+		`Owner =!= "alice"`,
+		`Owner isnt undefined`,
+		`Owner is undefined`,
+	}
+
+	before := map[string][]int{}
+	for _, qs := range queries {
+		q, err := vm.Parse(qs)
+		if err != nil {
+			t.Fatalf("parse %q: %v", qs, err)
+		}
+		before[qs] = queryIDs(t, c, q)
+	}
+
+	// Swap every segment's index for its encode->decode image.
+	spec := c.spec.Load()
+	swapped := 0
+	for _, sh := range c.shards {
+		sh.mu.RLock()
+		segs := append([]*segment(nil), sh.segs...)
+		sh.mu.RUnlock()
+		for _, seg := range segs {
+			if seg == nil {
+				continue
+			}
+			si := seg.idx.Load()
+			if si == nil {
+				continue
+			}
+			blob, err := encodeLiveIndex(si)
+			if err != nil {
+				t.Fatalf("encode: %v", err)
+			}
+			got, err := decodeLiveIndex(blob, spec)
+			if err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			if got == nil {
+				t.Fatal("decode returned a soft miss for a same-spec snapshot")
+			}
+			if got.upto != si.upto || got.specGen != si.specGen {
+				t.Fatalf("decoded meta mismatch: upto %d/%d specGen %d/%d", got.upto, si.upto, got.specGen, si.specGen)
+			}
+			seg.idx.Store(got)
+			swapped++
+		}
+	}
+	if swapped == 0 {
+		t.Fatal("no segment indexes were exercised")
+	}
+
+	for _, qs := range queries {
+		q, _ := vm.Parse(qs)
+		after := queryIDs(t, c, q)
+		if !equalInts(before[qs], after) {
+			t.Errorf("query %q: results changed after index round-trip\n before=%v\n after =%v", qs, before[qs], after)
+		}
+	}
+}
+
+// TestLiveIndexSnapshotSoftMiss: a snapshot from a different spec generation, or a
+// non-snapshot blob, decodes to a soft miss (nil, nil) so the caller rebuilds rather than
+// installing a wrong index.
+func TestLiveIndexSnapshotSoftMiss(t *testing.T) {
+	t.Parallel()
+	c := New(Options{Shards: 1, CategoricalAttrs: []string{"Owner"}})
+	for i := 0; i < 200; i++ {
+		if err := c.Put([]byte(fmt.Sprintf("m%d", i)), mustAd(t, fmt.Sprintf(`[ Id=%d; Owner="u%d" ]`, i, i%5))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	c.Reindex()
+	var blob []byte
+	for _, sh := range c.shards {
+		for _, seg := range sh.segs {
+			if seg == nil {
+				continue
+			}
+			if si := seg.idx.Load(); si != nil {
+				var err error
+				if blob, err = encodeLiveIndex(si); err != nil {
+					t.Fatal(err)
+				}
+			}
+		}
+	}
+	if blob == nil {
+		t.Fatal("no index to encode")
+	}
+
+	// A bumped spec generation must be rejected.
+	bumped := &indexSpec{gen: c.spec.Load().gen + 1}
+	if si, err := decodeLiveIndex(blob, bumped); err != nil || si != nil {
+		t.Errorf("spec-gen mismatch should soft-miss (nil,nil); got si=%v err=%v", si, err)
+	}
+	// Garbage is a soft miss too.
+	if si, err := decodeLiveIndex([]byte("not a snapshot"), c.spec.Load()); err != nil || si != nil {
+		t.Errorf("garbage should soft-miss (nil,nil); got si=%v err=%v", si, err)
+	}
+}

--- a/collections/mmapseg.go
+++ b/collections/mmapseg.go
@@ -92,6 +92,7 @@ func (s *segment) reap() error {
 		if e := os.Remove(s.path); err == nil {
 			err = e
 		}
+		os.Remove(s.path + ".idx") // best-effort: drop the index snapshot with the segment
 	}
 	s.file = nil
 	return err

--- a/collections/persist.go
+++ b/collections/persist.go
@@ -287,6 +287,12 @@ func (c *Collection) loadShard(sh *shard, shardDir string) (uint64, error) {
 		}
 		seg.used = used
 		seg.synced = used
+		// Restore this segment's index from its on-disk snapshot, if present and current,
+		// so the Reindex that follows Open rebuilds only the segments that lack a valid
+		// one (a grown/active segment or a spec change) instead of re-indexing everything.
+		if spec := c.spec.Load(); spec != nil && spec.any() {
+			c.loadIndexSnapshot(seg, spec)
+		}
 		sh.segs = append(sh.segs, seg)
 	}
 	c.rebuildDir(sh)

--- a/collections/segstats.go
+++ b/collections/segstats.go
@@ -176,6 +176,22 @@ func topEntries(entries []topEntry) []topEntry {
 	return entries
 }
 
+// sketchBytes is the resident memory of this attribute's per-segment sketches: the
+// categorical bloom filter (uint64 words) and the HyperLogLog register array (one byte
+// per register). These live alongside the postings but are NOT counted by the posting
+// sizeBytes; IndexSizes reports them as a separate SketchBytes column so the operator
+// sees the full index memory rather than only the roaring bitmaps.
+func (s *segStats) sketchBytes() int64 {
+	var n int64
+	if s.bloom != nil {
+		n += int64(len(s.bloom.bits)) * 8
+	}
+	if s.hll != nil {
+		n += int64(len(s.hll.reg))
+	}
+	return n
+}
+
 // --- bloom filter (categorical membership) -------------------------------------
 
 // bloomFilter is a compact Bloom filter over 64-bit value hashes. Built once from


### PR DESCRIPTION
## Summary

Four related index improvements to `collections/`, from an audit of the sorted-value / bloom-filter work: make index memory honest, give the archive the same categorical skip the live tier has, document the current design, and persist live indexes so a reopen doesn't re-index every record.

### 1. Account for per-segment sketch memory (`SketchBytes`)
`IndexSizes` counted only posting bitmaps + keys, so the per-segment **bloom** (≤8 KiB/attr/seg) and **HLL** (1 KiB/attr/seg, every indexed attr) were invisible — the reported index memory (and the `.indexes` diagnostic) undercounted. Adds `segStats.sketchBytes()` and reports it as a separate `SketchBytes`/`TotalSketchBytes`, kept apart from `Bytes`/`TotalBytes` so the auto-tuner budget and watermark stay calibrated on posting bytes.

### 2. Carry the categorical bloom into the archive sidecar (v5)
The live tier skips a prefix on a categorical equality miss via its bloom; the archive/mmap tier had none, so a large mostly-categorical history table binary-searched the paged key blob of every segment even for a definitely-absent value. Serializes the seal-time bloom into each cat block (sidecar **v5**); the mmap `==`/`in` path consults it first and skips the key-blob search on a definite miss. **Correctness unchanged** (a `catFind` miss already yielded empty) — it only avoids paging. Old sidecars rebuilt at seal.

### 3. Persist live segment indexes; restore on Open
A persistent collection rebuilt every index on `Open` by re-decompressing and re-indexing every record (O(records)). Now each built index is serialized beside its segment (`<segfile>.idx`, format `CLIX`) at `Reindex`, and `Open` restores it — rebuilding only segments without a valid snapshot (grown/active, or a spec-gen change). Only postings are serialized; sortedKeys + every sketch are recomputed by `finishStats` on load, so a decode reproduces a **byte-identical** index. Validated against spec generation + segment write extent; any mismatch/version/read error is a soft miss → deterministic rebuild (a snapshot is only ever a faster path to the same index). Shares the segment file name so compaction/rotation drops it with the segment.

### 4. Design doc
Updates the collection design book: §8 (index snapshot persistence + restore), §10 (boundary-searched value index, the per-segment skip/selectivity sketches, split posting/sketch accounting), §14 (archive bloom).

## Tests
- `SketchBytes`/`TotalSketchBytes` in `TestIndexSizesAndProvenance`.
- `TestArchiveCategoricalBloom` (absent → empty via fast path; present → exact records).
- `TestLiveIndexSnapshotRoundTrip` (identical query results across `==`/`!=`/range/`=?=`/presence after encode→decode), `TestLiveIndexSnapshotSoftMiss`, `TestIndexSnapshotPersistsAcrossOpen` (written, loaded back, correct after reopen).
- Full `collections` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
