### PR TITLE
collections: minimal-perfect-hash equality for the mmap index tier (sidecar v6)

### DIFF
--- a/collections/archive_index.go
+++ b/collections/archive_index.go
@@ -35,7 +35,13 @@ import (
 //	         bloomK uint32; bloomM uint32; bloom [bloomM/64] uint64  (v5) -- categorical
 //	         membership filter over the folded keys. A miss on every probe value lets a
 //	         query skip binary-searching (and paging) the sorted key blob for that probe;
-//	         bloomM==0 means no filter (empty index).
+//	         bloomM==0 means no filter (empty index);
+//	         mphBlockLen uint32; [MPH bytes]; slotSortedIdx [nAssigned] uint32  (v6) --
+//	         a minimal perfect hash over the folded keys for O(1) equality on a
+//	         high-cardinality attr (built only when NDV >= mphNDVThreshold; mphBlockLen==0
+//	         means none). mphLookupBytes -> slot -> slotSortedIdx[slot] indexes the folded
+//	         keyOff/bmOff arrays; the caller verifies the key and falls back to binary
+//	         search, so the MPH is a fast path, never authoritative.
 //	  val attr block @attrOff: excOff uint32; postedOff uint32; n uint32;
 //	         key [n] float64 (sorted asc); bmOff [n] uint32
 //
@@ -46,7 +52,14 @@ import (
 // simply rejected and reindexed.
 const (
 	sidecarMagic   = 0x41524358 // "ARCX"
-	sidecarVersion = 5
+	sidecarVersion = 6
+
+	// mphNDVThreshold gates the categorical minimal-perfect-hash: only an attribute with
+	// at least this many distinct values in a segment gets one. Below it, the sorted key
+	// blob is small enough that binary search (two or three comparisons, one or two pages)
+	// plus the bloom already resolve equality cheaply, and the MPH's per-key overhead would
+	// not pay for itself.
+	mphNDVThreshold = 4096
 )
 
 // writeSidecarIndex serializes si to path (v2 sorted runs) and fsyncs it. si is
@@ -248,6 +261,27 @@ func writeSidecarIndex(path string, si *segIndex) error {
 		} else {
 			b = appendU32(b, 0) // bloomK
 			b = appendU32(b, 0) // bloomM == 0: no filter
+		}
+		// Categorical MPH (v6), immediately after the bloom. Gated on NDV: a high-cardinality
+		// attribute gets O(1) equality; a small one keeps bloom + binary search. mphBlockLen==0
+		// marks "no MPH". slotSortedIdx maps an MPH slot to the sorted index, so the reader
+		// reuses the folded keyOff/bmOff arrays (no key or bitmap-offset duplication).
+		if len(cb.keys) >= mphNDVThreshold {
+			m, slots := buildMPH(cb.keys)
+			mphBytes := appendMPH(nil, m)
+			b = appendU32(b, uint32(len(mphBytes)))
+			b = append(b, mphBytes...)
+			slotIdx := make([]uint32, m.nAssigned)
+			for sortedIdx, s := range slots {
+				if s >= 0 {
+					slotIdx[s] = uint32(sortedIdx)
+				}
+			}
+			for _, idx := range slotIdx {
+				b = appendU32(b, idx)
+			}
+		} else {
+			b = appendU32(b, 0) // mphBlockLen == 0: no MPH
 		}
 	}
 	for i, vb := range valBlks {

--- a/collections/archive_mmapindex.go
+++ b/collections/archive_mmapindex.go
@@ -134,7 +134,7 @@ func (si *mmapSegIndex) probeOffsets(up usableProbe) *roaring.Bitmap {
 			// the exceptional records can still match and are re-verified upstream.
 			if !si.catBloomAllAbsent(attrOff, up.svals) {
 				for _, s := range up.svals {
-					if off, ok := si.catFind(attrOff, s); ok {
+					if off, ok := si.catFindEq(attrOff, s); ok {
 						bm.Or(si.bitmapAt(off))
 					}
 				}
@@ -143,7 +143,7 @@ func (si *mmapSegIndex) probeOffsets(up usableProbe) *roaring.Bitmap {
 			return bm
 		case "!=":
 			bm := si.allBitmap().Clone()
-			if off, ok := si.catFind(attrOff, up.svals[0]); ok {
+			if off, ok := si.catFindEq(attrOff, up.svals[0]); ok {
 				bm.AndNot(si.bitmapAt(off))
 			}
 			return bm
@@ -312,6 +312,57 @@ func (si *mmapSegIndex) catBloomAllAbsent(attrOff uint32, keys []string) bool {
 		}
 	}
 	return true
+}
+
+// catMPHOff returns the file offset of the categorical MPH block (mphBlockLen), which sits
+// immediately after the bloom: bloomK u32; bloomM u32; bloom [bloomM/64] u64.
+func (si *mmapSegIndex) catMPHOff(attrOff uint32) uint32 {
+	bloomOff := si.catBloomOff(attrOff)
+	bloomM := le32(si.data, bloomOff+4)
+	return bloomOff + 8 + (bloomM/64)*8
+}
+
+// catFindEq resolves a categorical equality probe, using the MPH fast path when present and
+// falling back to the sorted-run binary search otherwise (or on an MPH miss / false hit).
+// The binary search is authoritative, so the MPH can only make a hit faster, never wrong.
+func (si *mmapSegIndex) catFindEq(attrOff uint32, key string) (bmOff uint32, ok bool) {
+	if off, hit := si.catFindMPH(attrOff, key); hit {
+		return off, true
+	}
+	return si.catFind(attrOff, key)
+}
+
+// catFindMPH probes the categorical MPH (v6). It returns (bmOff, true) only for a key that
+// the MPH resolves AND whose folded spelling verifies at the resolved slot; any other case
+// -- no MPH, an unresolved key (unassigned member or non-member), or a verify mismatch (an
+// MPH false hit) -- returns ok=false so catFindEq falls back to binary search.
+func (si *mmapSegIndex) catFindMPH(attrOff uint32, key string) (bmOff uint32, ok bool) {
+	d := si.data
+	mphOff := si.catMPHOff(attrOff)
+	mphLen := le32(d, mphOff)
+	if mphLen == 0 {
+		return 0, false
+	}
+	mphStart := mphOff + 4
+	nAssigned := le32(d, mphStart)
+	slot, resolved := mphLookupBytes(d, mphStart, key)
+	if !resolved || slot >= nAssigned {
+		return 0, false
+	}
+	j := le32(d, mphStart+mphLen+slot*4) // slotSortedIdx[slot]: index into the folded run
+	n := le32(d, attrOff+8)
+	if j >= n {
+		return 0, false // defensive: corrupt permutation -> binary search
+	}
+	keyOffBase := attrOff + 12
+	bmOffBase := keyOffBase + (n+1)*4
+	blobBase := bmOffBase + n*4
+	ks := blobBase + le32(d, keyOffBase+j*4)
+	ke := blobBase + le32(d, keyOffBase+(j+1)*4)
+	if cmpStrBytes(key, d[ks:ke]) != 0 {
+		return 0, false // MPH false hit: the slot holds a different key
+	}
+	return le32(d, bmOffBase+j*4), true
 }
 
 // --- value attr block: excOff u32; postedOff u32; n u32; key[n] f64; bmOff[n] u32 ---

--- a/collections/archive_test.go
+++ b/collections/archive_test.go
@@ -96,9 +96,102 @@ func TestArchiveCategoricalBloom(t *testing.T) {
 		}
 	}
 
-	// The sidecar must be the bloom-carrying version.
-	if sidecarVersion != 5 {
-		t.Fatalf("expected sidecar v5, got %d", sidecarVersion)
+	// The sidecar must be at least the bloom-carrying version.
+	if sidecarVersion < 5 {
+		t.Fatalf("expected sidecar >= v5, got %d", sidecarVersion)
+	}
+}
+
+// TestArchiveMPHEquality exercises the v6 categorical minimal-perfect-hash: a
+// high-cardinality attribute (NDV above the gate) gets an MPH, and equality probes -- both
+// present (exact one record) and absent (empty) -- return results identical to the
+// authoritative data. Uses a large segment so a single sealed segment's NDV trips the gate.
+func TestArchiveMPHEquality(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	a, err := CreateArchive(ArchiveOptions{
+		Dir:              dir,
+		SegmentSize:      8 << 20, // large: keep the high-NDV keys in one sealed segment
+		CategoricalAttrs: []string{"GlobalJobId"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer a.Close()
+	const n = 6000 // > mphNDVThreshold (4096) so the sealed segment builds an MPH
+	for i := 0; i < n; i++ {
+		ad, err := classad.Parse(fmt.Sprintf(`[ Id=%d; GlobalJobId="sched.example.org#%d.0" ]`, i, i))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := a.Append(ad); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := a.Flush(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Present values across the gate boundary resolve to exactly their one record.
+	for _, i := range []int{0, 1, 100, 4095, 4096, 4097, 5999} {
+		ids := archiveQueryIDs(t, a, fmt.Sprintf(`GlobalJobId == "sched.example.org#%d.0"`, i))
+		if len(ids) != 1 || ids[0] != i {
+			t.Fatalf(`GlobalJobId==#%d.0: got %v, want [%d]`, i, ids, i)
+		}
+	}
+	// Absent values (that could be MPH false hits) return nothing.
+	for _, s := range []string{"sched.example.org#999999.0", "nope", "sched.example.org#0.1"} {
+		if ids := archiveQueryIDs(t, a, fmt.Sprintf(`GlobalJobId == %q`, s)); len(ids) != 0 {
+			t.Fatalf("absent %q: got %v, want none", s, ids)
+		}
+	}
+}
+
+// TestArchiveSidecarSizes checks the evictable-bytes accounting: a high-cardinality
+// attribute builds an MPH so MPHBytes is a real fraction of the mapped sidecar bytes, while
+// a low-cardinality one builds none (only the per-attr marker), and neither is folded into
+// a heap figure.
+func TestArchiveSidecarSizes(t *testing.T) {
+	t.Parallel()
+
+	// High cardinality -> MPH built.
+	hi, err := CreateArchive(ArchiveOptions{Dir: t.TempDir(), SegmentSize: 8 << 20, CategoricalAttrs: []string{"GlobalJobId"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer hi.Close()
+	for i := 0; i < 6000; i++ {
+		ad, _ := classad.Parse(fmt.Sprintf(`[ Id=%d; GlobalJobId="s#%d.0" ]`, i, i))
+		if err := hi.Append(ad); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := hi.Flush(); err != nil {
+		t.Fatal(err)
+	}
+	sz := hi.SidecarSizes()
+	if sz.Segments == 0 || sz.MappedBytes == 0 {
+		t.Fatalf("expected sealed sidecars with mapped bytes, got %+v", sz)
+	}
+	if sz.MPHBytes < 6000*4 { // the slotSortedIdx array alone is ~4 bytes/key
+		t.Errorf("MPHBytes=%d too small for a 6000-key MPH", sz.MPHBytes)
+	}
+	if sz.MPHBytes >= sz.MappedBytes {
+		t.Errorf("MPHBytes (%d) should be a fraction of MappedBytes (%d)", sz.MPHBytes, sz.MappedBytes)
+	}
+
+	// Low cardinality -> no MPH, just the per-cat-attr marker (4 bytes each).
+	lo, _ := buildArchive(t, t.TempDir(), 500, ArchiveOptions{CategoricalAttrs: []string{"Owner"}})
+	defer lo.Close()
+	if err := lo.Flush(); err != nil {
+		t.Fatal(err)
+	}
+	lsz := lo.SidecarSizes()
+	if lsz.MappedBytes == 0 {
+		t.Fatal("expected mapped sidecar bytes for the low-NDV archive")
+	}
+	if lsz.MPHBytes > int64(lsz.Segments*8) { // 1 cat attr -> ~4 bytes/segment of markers
+		t.Errorf("low-NDV archive should build no MPH; MPHBytes=%d over %d segments", lsz.MPHBytes, lsz.Segments)
 	}
 }
 

--- a/collections/docs/design/README.md
+++ b/collections/docs/design/README.md
@@ -766,8 +766,32 @@ The design that follows:
   entirely — the win for a large, mostly-categorical history table, where an equality lookup
   for a value not in a segment would otherwise page and binary-search that segment's whole
   sorted key run. (Zone maps already give the numeric analogue; the Bloom is the categorical
-  one.) The sidecar is versioned and rebuilt at seal, so a format bump needs no migration —
-  an older sidecar is rejected and the segment reindexed.
+  one.) A high-cardinality categorical block additionally carries a **minimal perfect hash**
+  (BBHash, sidecar v6, built only when the segment's NDV for that attribute clears a
+  threshold): equality then probes the MPH — a bit-test plus a popcount-rank, ~1 page — to a
+  slot, verifies the key, and reads the bitmap offset, replacing the O(log n) scattered-page
+  binary search for present values (the point-lookup case a bloom cannot help, e.g. find a
+  job by `GlobalJobId`). The MPH is a **pure fast path**: a member resolves to its own slot,
+  a non-member is caught by the key verify, and any miss falls back to the still-present
+  sorted-run binary search, which stays authoritative — so a build bug can only cost a
+  redundant search, never a wrong answer. The sidecar is versioned and rebuilt at seal, so a
+  format bump needs no migration — an older sidecar is rejected and the segment reindexed.
+- **Residency — what stays mapped vs. what is reconstructed.** The two persistent tiers make
+  opposite choices, and it is worth being explicit about what each holds resident:
+  - *Archive sidecar (this chapter):* **nothing is reconstructed into the heap.** `Open`/query
+    parse only the fixed header and the few-entry attribute directory (O(#indexed attributes))
+    and then read keys, offsets, bloom, MPH, and bitmaps **in place over the mmap** — bitmaps
+    materialize lazily via copy-on-write `FromBuffer` for only the postings a probe touches.
+    So the resident cost is the directory plus whatever pages a query faults in; everything
+    else is demand-paged and evictable. These bytes are reported by `SidecarSizes` (mapped
+    total, with the MPH and bloom portions broken out) **separately** from the live tier's
+    heap figure, so the memory watermark isn't inflated by evictable page-cache bytes.
+  - *Live persistent Collection (Chapter 8/10):* the opposite — it **restores the full in-RAM
+    `segIndex`** from a snapshot. Only the postings are serialized; on load the value index's
+    sorted keys and **all** per-segment sketches — min/max, the categorical bloom, the HLL,
+    and the top-N heavy hitters — are **recomputed by `finishStats`** from the restored
+    postings (a decode reproduces a byte-identical index). Nothing else is reconstructed: the
+    directory (key→location) still comes from the max-seq record replay, not the snapshot.
 - **Newest-first + LIMIT pushdown.** Segments (and records within the active tail) are
   visited in reverse chronological order, and a `Limit(K)` stops the scan once K matches are
   yielded — essential when the constraint is broad but the caller wants one page.

--- a/collections/index_size.go
+++ b/collections/index_size.go
@@ -46,6 +46,67 @@ func (vp *valPostings) sizeBytes() int64 {
 	return n
 }
 
+// SidecarSizes reports the on-disk index bytes of an Archive's sealed sidecars, broken out
+// so the minimal-perfect-hash and bloom overhead is visible. These are distinct from the
+// live Collection's IndexSizes: those measure HEAP-resident postings + sketches, whereas
+// sidecar bytes live in the page cache -- demand-paged and evictable under memory pressure.
+// They are reported as a separate budget, never folded into a heap figure, so the
+// "index is N% of data" watermark stays an honest measure of resident memory.
+type SidecarSizes struct {
+	Segments    int   `json:"segments"`    // sealed segments with a sidecar
+	MappedBytes int64 `json:"mappedBytes"` // total sidecar bytes (mmap-backed, evictable)
+	MPHBytes    int64 `json:"mphBytes"`    // of MappedBytes, minimal-perfect-hash structures
+	BloomBytes  int64 `json:"bloomBytes"`  // of MappedBytes, bloom filters
+}
+
+// SidecarSizes sums each sealed segment's sidecar size and its MPH/bloom portions. It maps
+// each sidecar briefly and closes it immediately, so it is an operator diagnostic, not a
+// hot path. The active (unsealed) segment has no sidecar and is skipped.
+func (a *Archive) SidecarSizes() SidecarSizes {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	var out SidecarSizes
+	for _, as := range a.segs {
+		if !as.sealed {
+			continue
+		}
+		data, closer, err := mapFile(a.idxPath(as.seg.id))
+		if err != nil {
+			continue
+		}
+		out.Segments++
+		out.MappedBytes += int64(len(data))
+		mph, bloom := sidecarSketchBreakdown(data)
+		out.MPHBytes += mph
+		out.BloomBytes += bloom
+		_ = closer()
+	}
+	return out
+}
+
+// sidecarSketchBreakdown sums the MPH and bloom block bytes across a v6 sidecar's
+// categorical attributes. Returns (0,0) for a sidecar that does not parse (e.g. an older
+// version), since only a current sidecar carries these blocks.
+func sidecarSketchBreakdown(data []byte) (mph, bloom int64) {
+	si, err := parseMmapSidecar(data)
+	if err != nil {
+		return 0, 0
+	}
+	for _, attrOff := range si.catDir {
+		bloomOff := si.catBloomOff(attrOff)
+		bloomM := le32(data, bloomOff+4)
+		bloom += 8 + int64(bloomM/64)*8
+		mphOff := si.catMPHOff(attrOff)
+		if mphLen := le32(data, mphOff); mphLen > 0 {
+			nAssigned := le32(data, mphOff+4)
+			mph += 4 + int64(mphLen) + int64(nAssigned)*4
+		} else {
+			mph += 4 // just the mphBlockLen==0 marker
+		}
+	}
+	return mph, bloom
+}
+
 // IndexSize is the measured memory footprint of one attribute's index.
 type IndexSize struct {
 	Attr  string `json:"attr"`

--- a/collections/mph.go
+++ b/collections/mph.go
@@ -1,0 +1,191 @@
+package collections
+
+import "math/bits"
+
+// Minimal perfect hash (BBHash) over an immutable, distinct key set, for O(1) equality on
+// the mmap index tier. On a cold, high-cardinality sidecar an equality probe otherwise
+// binary-searches the sorted key blob -- O(log n) comparisons, each a potential page fault
+// into a scattered part of the mapping. The MPH resolves a member to its slot in ~1 probe.
+//
+// BBHash is a cascade of bit arrays ("levels"): at each level a key hashes to a bit; a bit
+// that exactly one still-unplaced key lands on is "assigned" (set), and colliding keys fall
+// through to the next level. A key's slot is the rank (count of set bits before its bit)
+// across the levels, giving a dense [0, nAssigned) numbering. Lookups are a bit test plus a
+// popcount-rank, so the serialized form probes zero-copy over the mmap.
+//
+// SAFETY: the MPH is a pure fast path, never authoritative. A member always resolves to its
+// own slot; a non-member may resolve to some slot (a false hit) -- so the caller MUST verify
+// the key stored at that slot and, on any miss (unassigned member, verify mismatch,
+// non-member), fall back to the sorted-run binary search. A build bug can therefore only
+// cost a redundant binary search, never a wrong answer.
+
+const (
+	mphGamma          = 2 // bits per still-unplaced key at each level (load factor 1/gamma)
+	mphMaxLevels      = 7 // after this, any leftover keys are simply unassigned (caller falls back)
+	mphRankBlockWords = 8 // one cumulative-popcount checkpoint per 512 bits
+	mphSeed           = 0x9e3779b97f4a7c15
+)
+
+// mphLevel is one BBHash level: a bit array (m bits, m a multiple of 64), a per-block
+// cumulative popcount index for O(1) rank, and the slot base (set bits in all prior levels).
+type mphLevel struct {
+	bits []uint64
+	m    uint32
+	rank []uint32 // rank[i] = popcount of bits[0 : i*mphRankBlockWords]
+	base uint32
+}
+
+type mph struct {
+	levels    []mphLevel
+	nAssigned uint32
+}
+
+// mphLevelHash derives a level's hash from the key's base hash, decorrelating levels.
+func mphLevelHash(h uint64, level int) uint64 {
+	return mix64(h ^ (mphSeed * uint64(level+1)))
+}
+
+// buildMPH constructs an MPH over keys (which must be distinct). It returns the structure
+// and slots, where slots[i] is key i's assigned slot or -1 if it fell through all levels
+// unassigned (the caller resolves those via the sorted run). nAssigned == len(keys) unless
+// some keys are unassigned.
+func buildMPH(keys []string) (*mph, []int32) {
+	n := len(keys)
+	slots := make([]int32, n)
+	for i := range slots {
+		slots[i] = -1
+	}
+
+	m := &mph{}
+	// hashes[i] is the base hash of the key still at index i in `remaining`.
+	remaining := make([]int, n)
+	for i := range remaining {
+		remaining[i] = i
+	}
+	var slotBase uint32
+	for level := 0; level < mphMaxLevels && len(remaining) > 0; level++ {
+		mbits := uint32(len(remaining) * mphGamma)
+		mbits = (mbits + 63) &^ 63 // round up to a whole word
+		if mbits == 0 {
+			mbits = 64
+		}
+		// Count collisions per bit (saturating at 2), then keep only singletons.
+		count := make([]uint8, mbits)
+		pos := make([]uint32, len(remaining))
+		for i, ki := range remaining {
+			p := uint32(mphLevelHash(hashString(keys[ki]), level) % uint64(mbits))
+			pos[i] = p
+			if count[p] < 2 {
+				count[p]++
+			}
+		}
+		levelBits := make([]uint64, mbits/64)
+		next := remaining[:0:0] // fresh slice; do not alias remaining while reading it
+		for i, ki := range remaining {
+			if count[pos[i]] == 1 {
+				levelBits[pos[i]>>6] |= 1 << (pos[i] & 63)
+			} else {
+				next = append(next, ki)
+			}
+		}
+		rank, set := buildRankIndex(levelBits)
+		// Assign slots for the singletons of this level, in bit order.
+		for i, ki := range remaining {
+			if count[pos[i]] == 1 {
+				slots[ki] = int32(slotBase + rankAt(levelBits, rank, pos[i]))
+			}
+		}
+		m.levels = append(m.levels, mphLevel{bits: levelBits, m: mbits, rank: rank, base: slotBase})
+		slotBase += set
+		remaining = next
+	}
+	m.nAssigned = slotBase
+	return m, slots
+}
+
+// buildRankIndex returns cumulative popcount checkpoints (one per mphRankBlockWords words)
+// and the total set-bit count.
+func buildRankIndex(words []uint64) (rank []uint32, total uint32) {
+	nblocks := (len(words) + mphRankBlockWords - 1) / mphRankBlockWords
+	rank = make([]uint32, nblocks+1)
+	var acc uint32
+	for i, w := range words {
+		if i%mphRankBlockWords == 0 {
+			rank[i/mphRankBlockWords] = acc
+		}
+		acc += uint32(bits.OnesCount64(w))
+	}
+	rank[nblocks] = acc
+	return rank, acc
+}
+
+// rankAt returns the number of set bits in words[0:p] (p is a bit index), using the
+// checkpoint index for O(1) block skip plus a partial popcount.
+func rankAt(words []uint64, rank []uint32, p uint32) uint32 {
+	wordIdx := p >> 6
+	block := wordIdx / mphRankBlockWords
+	r := rank[block]
+	for w := block * mphRankBlockWords; w < wordIdx; w++ {
+		r += uint32(bits.OnesCount64(words[w]))
+	}
+	r += uint32(bits.OnesCount64(words[wordIdx] & ((1 << (p & 63)) - 1)))
+	return r
+}
+
+// --- serialization + zero-copy probe (for the mmap sidecar) ---
+//
+// Layout, appended contiguously into the sidecar so it pages from the one mapping:
+//
+//	nAssigned u32; nLevels u32;
+//	per level: m u32; base u32; nWords u32; nRank u32; bits [nWords]u64; rank [nRank]u32
+
+// appendMPH serializes m (bloomM==0-style empty is represented by nLevels==0).
+func appendMPH(b []byte, m *mph) []byte {
+	b = appendU32(b, m.nAssigned)
+	b = appendU32(b, uint32(len(m.levels)))
+	for _, lv := range m.levels {
+		b = appendU32(b, lv.m)
+		b = appendU32(b, lv.base)
+		b = appendU32(b, uint32(len(lv.bits)))
+		b = appendU32(b, uint32(len(lv.rank)))
+		for _, w := range lv.bits {
+			b = appendU64(b, w)
+		}
+		for _, r := range lv.rank {
+			b = appendU32(b, r)
+		}
+	}
+	return b
+}
+
+// mphLookupBytes probes a serialized MPH at file offset off directly over the mapping,
+// returning the key's slot in [0, nAssigned) if some level resolves it. A returned slot is
+// only a candidate: the caller MUST verify the key stored at that slot (a non-member can
+// resolve to another key's slot) and fall back to the sorted run on a miss. ok=false means
+// no level resolved the key (an unassigned member or a non-member): fall back.
+func mphLookupBytes(d []byte, off uint32, key string) (slot uint32, ok bool) {
+	nLevels := le32(d, off+4)
+	p := off + 8
+	h := hashString(key)
+	for lvl := 0; lvl < int(nLevels); lvl++ {
+		m := le32(d, p)
+		base := le32(d, p+4)
+		nWords := le32(d, p+8)
+		nRank := le32(d, p+12)
+		bitsOff := p + 16
+		rankOff := bitsOff + nWords*8
+		bit := uint32(mphLevelHash(h, lvl) % uint64(m))
+		wordIdx := bit >> 6
+		if le64(d, bitsOff+wordIdx*8)&(1<<(bit&63)) != 0 {
+			block := wordIdx / mphRankBlockWords
+			r := le32(d, rankOff+block*4)
+			for w := block * mphRankBlockWords; w < wordIdx; w++ {
+				r += uint32(bits.OnesCount64(le64(d, bitsOff+w*8)))
+			}
+			r += uint32(bits.OnesCount64(le64(d, bitsOff+wordIdx*8) & ((1 << (bit & 63)) - 1)))
+			return base + r, true
+		}
+		p = rankOff + nRank*4
+	}
+	return 0, false
+}

--- a/collections/mph_test.go
+++ b/collections/mph_test.go
@@ -1,0 +1,89 @@
+package collections
+
+import (
+	"fmt"
+	"testing"
+)
+
+// TestMPHRoundTrip is the correctness anchor: for a range of sizes, every assigned member
+// probes (over the serialized bytes) back to its own slot, assigned slots are a bijection
+// onto [0, nAssigned), and the vast majority of keys are assigned (the geometric tail falls
+// back to the sorted-run binary search, which is correct, just not the fast path).
+func TestMPHRoundTrip(t *testing.T) {
+	t.Parallel()
+	for _, n := range []int{1, 2, 3, 63, 64, 65, 127, 1000, 50000} {
+		keys := make([]string, n)
+		for i := range keys {
+			keys[i] = fmt.Sprintf("GlobalJobId=host%d.example.org#%d.%d", i%97, i, i*2654435761)
+		}
+		m, slots := buildMPH(keys)
+		blob := appendMPH(nil, m)
+
+		// slot -> key, and bijection check.
+		slotKey := make([]string, m.nAssigned)
+		seen := make([]bool, m.nAssigned)
+		assigned := 0
+		for i, s := range slots {
+			if s < 0 {
+				continue
+			}
+			if uint32(s) >= m.nAssigned {
+				t.Fatalf("n=%d: slot %d out of range [0,%d)", n, s, m.nAssigned)
+			}
+			if seen[s] {
+				t.Fatalf("n=%d: slot %d assigned twice", n, s)
+			}
+			seen[s] = true
+			slotKey[s] = keys[i]
+			assigned++
+		}
+
+		// Every assigned member resolves (via the serialized probe) to its slot.
+		for i, k := range keys {
+			if slots[i] < 0 {
+				continue // unassigned: caller falls back to binary search
+			}
+			slot, ok := mphLookupBytes(blob, 0, k)
+			if !ok || slot != uint32(slots[i]) {
+				t.Fatalf("n=%d member %q: probe=(slot=%d ok=%v), want slot=%d", n, k, slot, ok, slots[i])
+			}
+			if slotKey[slot] != k {
+				t.Fatalf("n=%d: slot %d holds %q, want %q", n, slot, slotKey[slot], k)
+			}
+		}
+		if n >= 1000 && assigned < n*95/100 {
+			t.Errorf("n=%d: only %d/%d keys assigned (<95%%); level cap or gamma too low", n, assigned, n)
+		}
+	}
+}
+
+// TestMPHNonMembersNeverFalselyVerify: a non-member may resolve to some slot (a false hit),
+// but the key stored at that slot is a real member, never the non-member -- so the caller's
+// verify always rejects it. This is what makes the MPH safe without an authoritative role.
+func TestMPHNonMembersNeverFalselyVerify(t *testing.T) {
+	t.Parallel()
+	const n = 8000
+	keys := make([]string, n)
+	set := make(map[string]bool, n)
+	for i := range keys {
+		keys[i] = fmt.Sprintf("member-%d-%x", i, i*40503)
+		set[keys[i]] = true
+	}
+	m, slots := buildMPH(keys)
+	blob := appendMPH(nil, m)
+	slotKey := make([]string, m.nAssigned)
+	for i, s := range slots {
+		if s >= 0 {
+			slotKey[s] = keys[i]
+		}
+	}
+	for j := 0; j < 40000; j++ {
+		nk := fmt.Sprintf("absent-%d-%x", j, j*2246822519)
+		if set[nk] {
+			continue
+		}
+		if slot, ok := mphLookupBytes(blob, 0, nk); ok && slot < m.nAssigned && slotKey[slot] == nk {
+			t.Fatalf("non-member %q verified as a member at slot %d", nk, slot)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
Gives the mmap index tier **O(1) equality** instead of an O(log n) scattered-page binary search, for high-cardinality point lookups (e.g. find a job by `GlobalJobId` in the history archive — the case the bloom can't help, since the value is present).

**Depends on #26** (the v5 sidecar bloom). This branch is built on top of #26, so until #26 merges the diff here also shows #26's commits; GitHub narrows it to just the MPH commit once #26 lands. Merge #26 first.

## What it adds
- **BBHash minimal perfect hash per categorical attribute** (sidecar **v6**), built at seal, **gated on NDV** (`>= mphNDVThreshold`; small key sets keep bloom + binary search, already cheap). It lives **inside the existing per-segment sidecar** — no new files / FDs / mmaps — and drops with the segment.
- **Equality path:** probe the MPH (bit test + popcount-rank, ~1 page) → slot → `slotSortedIdx` → the existing folded `keyOff`/`bmOff` arrays → **verify the key** → bitmap. Any miss (unassigned member, verify mismatch, non-member) **falls back to the sorted-run binary search**, which stays authoritative — so the MPH is a pure fast path; a build bug can only cost a redundant search, never a wrong answer.
- **Both tiers:** it's in the shared sidecar format, so it benefits the archive now and the future mmap-backed sealed live segments.

## Constraints addressed
1. **FD/mmap discipline** — one block appended to the existing sidecar; the archive still maps one file per queried segment.
2. **Archive applicability** — yes; gated by NDV so a pure time-range archive builds none, while a `GlobalJobId`-lookup workload gets O(1).
3. **Space accounting** — new `SidecarSizes` reports mapped (evictable, page-cache) sidecar bytes with **MPH and bloom broken out**, kept *separate* from the live tier's heap-resident `IndexSizes` so the watermark isn't inflated by evictable bytes.

## Design doc
`§14` gains the MPH and an explicit **residency note**: the archive reconstructs *nothing* into the heap (all read in-place over the mmap, bitmaps lazy via `FromBuffer`), while the live persistent Collection restores postings and **recomputes** sortedKeys + all sketches (min/max, bloom, HLL, top-N) via `finishStats`.

## Tests
- `TestMPHRoundTrip` (every assigned member probes to its slot; slots are a bijection; ~all keys assigned), `TestMPHNonMembersNeverFalselyVerify`.
- `TestArchiveMPHEquality` (present → exact record, absent → empty, across the gate boundary), `TestArchiveSidecarSizes` (MPH bytes accounted for high-NDV; none for low-NDV).
- Full `collections` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
