### PR TITLE
collections: mmap sealed-index substrate (v7 stats, CRC, shared readIndex parity)

### DIFF
--- a/collections/archive_index.go
+++ b/collections/archive_index.go
@@ -52,7 +52,7 @@ import (
 // simply rejected and reindexed.
 const (
 	sidecarMagic   = 0x41524358 // "ARCX"
-	sidecarVersion = 6
+	sidecarVersion = 7
 
 	// mphNDVThreshold gates the categorical minimal-perfect-hash: only an attribute with
 	// at least this many distinct values in a segment gets one. Below it, the sorted key
@@ -98,12 +98,13 @@ func writeSidecarIndex(path string, si *segIndex) error {
 		bmOffs                []uint32
 		exKeys                []string // exact-case keys (sorted) -> exBmOffs (for =?=/=!=)
 		exBmOffs              []uint32
-		bloom                 *bloomFilter // categorical membership over folded keys (built at seal)
+		stats                 *segStats // full summary (bloom, min/max, top-N, ndv, HLL)
 	}
 	type valBlk struct {
 		id, excOff, postedOff uint32
 		keys                  []float64
 		bmOffs                []uint32
+		stats                 *segStats
 	}
 	var catBlks []catBlk
 	for id, cp := range si.cat {
@@ -164,7 +165,7 @@ func writeSidecarIndex(path string, si *segIndex) error {
 		if err != nil {
 			return err
 		}
-		catBlks = append(catBlks, catBlk{id, excOff, postedOff, keys, bmOffs, exKeys, exBmOffs, cp.stats.bloom})
+		catBlks = append(catBlks, catBlk{id, excOff, postedOff, keys, bmOffs, exKeys, exBmOffs, &cp.stats})
 	}
 	sort.Slice(catBlks, func(i, j int) bool { return catBlks[i].id < catBlks[j].id })
 
@@ -189,7 +190,7 @@ func writeSidecarIndex(path string, si *segIndex) error {
 		if err != nil {
 			return err
 		}
-		valBlks = append(valBlks, valBlk{id, excOff, postedOff, keys, bmOffs})
+		valBlks = append(valBlks, valBlk{id, excOff, postedOff, keys, bmOffs, &vp.stats})
 	}
 	sort.Slice(valBlks, func(i, j int) bool { return valBlks[i].id < valBlks[j].id })
 
@@ -200,18 +201,26 @@ func writeSidecarIndex(path string, si *segIndex) error {
 	b = appendU64(b, si.specGen)
 	b = appendU32(b, allOff)
 
+	// Each directory entry is {id; attrOff; statsOff} (v7 added statsOff -> the per-attr
+	// segStats block), both offsets backpatched as the block is written.
 	b = appendU32(b, uint32(len(catBlks)))
 	catSlot := make([]int, len(catBlks))
+	catStatsSlot := make([]int, len(catBlks))
 	for i, cb := range catBlks {
 		b = appendU32(b, cb.id)
 		catSlot[i] = len(b)
 		b = appendU32(b, 0)
+		catStatsSlot[i] = len(b)
+		b = appendU32(b, 0)
 	}
 	b = appendU32(b, uint32(len(valBlks)))
 	valSlot := make([]int, len(valBlks))
+	valStatsSlot := make([]int, len(valBlks))
 	for i, vb := range valBlks {
 		b = appendU32(b, vb.id)
 		valSlot[i] = len(b)
+		b = appendU32(b, 0)
+		valStatsSlot[i] = len(b)
 		b = appendU32(b, 0)
 	}
 	for i, cb := range catBlks {
@@ -252,10 +261,10 @@ func writeSidecarIndex(path string, si *segIndex) error {
 		b = append(b, exBlob...)
 		// Categorical bloom (v5), immediately after the exact-case run: bloomK; bloomM;
 		// bloom words. bloomM==0 marks "no filter". Reuses the filter built at seal.
-		if cb.bloom != nil && cb.bloom.m > 0 {
-			b = appendU32(b, cb.bloom.k)
-			b = appendU32(b, cb.bloom.m)
-			for _, w := range cb.bloom.bits {
+		if cb.stats.bloom != nil && cb.stats.bloom.m > 0 {
+			b = appendU32(b, cb.stats.bloom.k)
+			b = appendU32(b, cb.stats.bloom.m)
+			for _, w := range cb.stats.bloom.bits {
 				b = appendU64(b, w)
 			}
 		} else {
@@ -283,6 +292,11 @@ func writeSidecarIndex(path string, si *segIndex) error {
 		} else {
 			b = appendU32(b, 0) // mphBlockLen == 0: no MPH
 		}
+		// Per-attribute stats block (v7): min/max, top-N, ndv, HLL — everything the query
+		// planner's skip/selectivity paths read (the mmap reader can't recompute it without
+		// paging every bitmap). Backpatch the directory's statsOff, then serialize.
+		binary.LittleEndian.PutUint32(b[catStatsSlot[i]:], uint32(len(b)))
+		b = appendSegStats(b, cb.stats)
 	}
 	for i, vb := range valBlks {
 		binary.LittleEndian.PutUint32(b[valSlot[i]:], uint32(len(b)))
@@ -295,6 +309,8 @@ func writeSidecarIndex(path string, si *segIndex) error {
 		for _, o := range vb.bmOffs {
 			b = appendU32(b, o)
 		}
+		binary.LittleEndian.PutUint32(b[valStatsSlot[i]:], uint32(len(b)))
+		b = appendSegStats(b, vb.stats)
 	}
 
 	binary.LittleEndian.PutUint32(b[metaOffPos:], metaOff)
@@ -310,6 +326,61 @@ func appendU64(b []byte, v uint64) []byte { return binary.LittleEndian.AppendUin
 func appendBytes(b, p []byte) []byte {
 	b = appendU32(b, uint32(len(p)))
 	return append(b, p...)
+}
+
+// appendSegStats serializes a segment's per-attribute summary (v7). The bloom is NOT here
+// (categorical blocks already carry it since v5, and the mmap reader consults it in place);
+// everything the query planner's skip/selectivity paths need that cannot be recomputed
+// without paging every bitmap is: covered/exc/ndv, the numeric range, the top-N heavy
+// hitters, and the HLL registers.
+func appendSegStats(b []byte, s *segStats) []byte {
+	b = appendU64(b, s.covered)
+	b = appendU64(b, s.exc)
+	b = appendU64(b, s.ndv)
+	var hasRange uint32
+	if s.hasRange {
+		hasRange = 1
+	}
+	b = appendU32(b, hasRange)
+	b = appendU64(b, math.Float64bits(s.min))
+	b = appendU64(b, math.Float64bits(s.max))
+	b = appendU32(b, uint32(len(s.top)))
+	for _, e := range s.top {
+		b = appendBytes(b, []byte(e.skey))
+		b = appendU64(b, math.Float64bits(e.fkey))
+		b = appendU32(b, e.count)
+	}
+	if s.hll != nil {
+		b = appendBytes(b, s.hll.reg)
+	} else {
+		b = appendBytes(b, nil)
+	}
+	return b
+}
+
+// readSegStats reconstructs a segStats from the block at off. The bloom stays nil (the mmap
+// reader consults the on-disk bloom directly); the rest is faithful to the build-time stats.
+func readSegStats(d []byte, off uint32) *segStats {
+	c := &cursor{b: d, i: int(off)}
+	s := &segStats{}
+	s.covered = c.u64()
+	s.exc = c.u64()
+	s.ndv = c.u64()
+	s.hasRange = c.u32() != 0
+	s.min = math.Float64frombits(c.u64())
+	s.max = math.Float64frombits(c.u64())
+	if n := c.u32(); n > 0 && n < 1<<20 {
+		s.top = make([]topEntry, n)
+		for i := range s.top {
+			s.top[i].skey = string(c.bytes())
+			s.top[i].fkey = math.Float64frombits(c.u64())
+			s.top[i].count = c.u32()
+		}
+	}
+	if reg := c.bytes(); len(reg) > 0 {
+		s.hll = &hyperLogLog{reg: append([]uint8(nil), reg...)}
+	}
+	return s
 }
 
 // cursor reads little-endian fields from a byte slice, latching the first error so

--- a/collections/archive_index.go
+++ b/collections/archive_index.go
@@ -3,6 +3,7 @@ package collections
 import (
 	"encoding/binary"
 	"fmt"
+	"hash/crc32"
 	"math"
 	"os"
 	"sort"
@@ -52,7 +53,7 @@ import (
 // simply rejected and reindexed.
 const (
 	sidecarMagic   = 0x41524358 // "ARCX"
-	sidecarVersion = 7
+	sidecarVersion = 8          // v8 appended a CRC-32C footer over the whole sidecar
 
 	// mphNDVThreshold gates the categorical minimal-perfect-hash: only an attribute with
 	// at least this many distinct values in a segment gets one. Below it, the sorted key
@@ -326,7 +327,23 @@ func buildSidecarIndex(si *segIndex) ([]byte, error) {
 	}
 
 	binary.LittleEndian.PutUint32(b[metaOffPos:], metaOff)
+	// CRC-32C footer over all preceding bytes (v8). The sidecar is derived state, so a
+	// mismatch on load is a rebuild trigger, never fatal. parseMmapSidecar reads via metaOff
+	// and never touches this tail, so the footer is transparent to the lazy mmap reader.
+	b = appendU32(b, crc32.Checksum(b, crcTable))
 	return b, nil
+}
+
+// sidecarCRCValid recomputes the CRC-32C footer and reports whether it matches. A false
+// result means the sidecar is corrupt (bit-rot or a torn write) and must be rebuilt from the
+// data. The live tier checks this on load; the archive's lazy reader does not (a full verify
+// would page the whole sidecar and defeat its >RAM design).
+func sidecarCRCValid(data []byte) bool {
+	if len(data) < 4 {
+		return false
+	}
+	want := binary.LittleEndian.Uint32(data[len(data)-4:])
+	return crc32.Checksum(data[:len(data)-4], crcTable) == want
 }
 
 // --- little-endian append helpers ---

--- a/collections/archive_index.go
+++ b/collections/archive_index.go
@@ -66,6 +66,18 @@ const (
 // built transiently at seal and discarded after — the archive never retains an
 // in-RAM index; queries mmap the sidecar (mmapSegIndex).
 func writeSidecarIndex(path string, si *segIndex) error {
+	b, err := buildSidecarIndex(si)
+	if err != nil {
+		return err
+	}
+	return writeFileSync(path, b)
+}
+
+// buildSidecarIndex serializes si to the sidecar byte layout (documented on
+// writeSidecarIndex). The bytes back either a file mmap (a persistent sealed segment) or an
+// anonymous region (an in-memory one), so the same immutable index representation serves
+// both tiers.
+func buildSidecarIndex(si *segIndex) ([]byte, error) {
 	b := make([]byte, 0, 256)
 	b = appendU32(b, sidecarMagic)
 	b = appendU16(b, sidecarVersion)
@@ -89,7 +101,7 @@ func writeSidecarIndex(path string, si *segIndex) error {
 
 	allOff, err := emit(si.all)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	type catBlk struct {
@@ -117,7 +129,7 @@ func writeSidecarIndex(path string, si *segIndex) error {
 		foldedOff := make(map[string]uint32, len(keys))
 		for i, k := range keys {
 			if bmOffs[i], err = emit(cp.post[k]); err != nil {
-				return err
+				return nil, err
 			}
 			foldedOff[k] = bmOffs[i]
 		}
@@ -146,7 +158,7 @@ func writeSidecarIndex(path string, si *segIndex) error {
 			for _, e := range exByFold[f] {
 				off, emitErr := emit(cp.exact[e])
 				if emitErr != nil {
-					return emitErr
+					return nil, emitErr
 				}
 				exPairs = append(exPairs, exPair{e, off})
 			}
@@ -159,11 +171,11 @@ func writeSidecarIndex(path string, si *segIndex) error {
 		}
 		excOff, err := emit(cp.exc)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		postedOff, err := emit(cp.posted)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		catBlks = append(catBlks, catBlk{id, excOff, postedOff, keys, bmOffs, exKeys, exBmOffs, &cp.stats})
 	}
@@ -179,16 +191,16 @@ func writeSidecarIndex(path string, si *segIndex) error {
 		bmOffs := make([]uint32, len(keys))
 		for i, k := range keys {
 			if bmOffs[i], err = emit(vp.post[k]); err != nil {
-				return err
+				return nil, err
 			}
 		}
 		excOff, err := emit(vp.exc)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		postedOff, err := emit(vp.posted)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		valBlks = append(valBlks, valBlk{id, excOff, postedOff, keys, bmOffs, &vp.stats})
 	}
@@ -314,7 +326,7 @@ func writeSidecarIndex(path string, si *segIndex) error {
 	}
 
 	binary.LittleEndian.PutUint32(b[metaOffPos:], metaOff)
-	return writeFileSync(path, b)
+	return b, nil
 }
 
 // --- little-endian append helpers ---

--- a/collections/archive_index.go
+++ b/collections/archive_index.go
@@ -35,7 +35,13 @@ import (
 //	         bloomK uint32; bloomM uint32; bloom [bloomM/64] uint64  (v5) -- categorical
 //	         membership filter over the folded keys. A miss on every probe value lets a
 //	         query skip binary-searching (and paging) the sorted key blob for that probe;
-//	         bloomM==0 means no filter (empty index).
+//	         bloomM==0 means no filter (empty index);
+//	         mphBlockLen uint32; [MPH bytes]; slotSortedIdx [nAssigned] uint32  (v6) --
+//	         a minimal perfect hash over the folded keys for O(1) equality on a
+//	         high-cardinality attr (built only when NDV >= mphNDVThreshold; mphBlockLen==0
+//	         means none). mphLookupBytes -> slot -> slotSortedIdx[slot] indexes the folded
+//	         keyOff/bmOff arrays; the caller verifies the key and falls back to binary
+//	         search, so the MPH is a fast path, never authoritative.
 //	  val attr block @attrOff: excOff uint32; postedOff uint32; n uint32;
 //	         key [n] float64 (sorted asc); bmOff [n] uint32
 //
@@ -46,7 +52,14 @@ import (
 // simply rejected and reindexed.
 const (
 	sidecarMagic   = 0x41524358 // "ARCX"
-	sidecarVersion = 5
+	sidecarVersion = 6
+
+	// mphNDVThreshold gates the categorical minimal-perfect-hash: only an attribute with
+	// at least this many distinct values in a segment gets one. Below it, the sorted key
+	// blob is small enough that binary search (two or three comparisons, one or two pages)
+	// plus the bloom already resolve equality cheaply, and the MPH's per-key overhead would
+	// not pay for itself.
+	mphNDVThreshold = 4096
 )
 
 // writeSidecarIndex serializes si to path (v2 sorted runs) and fsyncs it. si is
@@ -248,6 +261,27 @@ func writeSidecarIndex(path string, si *segIndex) error {
 		} else {
 			b = appendU32(b, 0) // bloomK
 			b = appendU32(b, 0) // bloomM == 0: no filter
+		}
+		// Categorical MPH (v6), immediately after the bloom. Gated on NDV: a high-cardinality
+		// attribute gets O(1) equality; a small one keeps bloom + binary search. mphBlockLen==0
+		// marks "no MPH". slotSortedIdx maps an MPH slot to the sorted index, so the reader
+		// reuses the folded keyOff/bmOff arrays (no key or bitmap-offset duplication).
+		if len(cb.keys) >= mphNDVThreshold {
+			m, slots := buildMPH(cb.keys)
+			mphBytes := appendMPH(nil, m)
+			b = appendU32(b, uint32(len(mphBytes)))
+			b = append(b, mphBytes...)
+			slotIdx := make([]uint32, m.nAssigned)
+			for sortedIdx, s := range slots {
+				if s >= 0 {
+					slotIdx[s] = uint32(sortedIdx)
+				}
+			}
+			for _, idx := range slotIdx {
+				b = appendU32(b, idx)
+			}
+		} else {
+			b = appendU32(b, 0) // mphBlockLen == 0: no MPH
 		}
 	}
 	for i, vb := range valBlks {

--- a/collections/archive_mmap.go
+++ b/collections/archive_mmap.go
@@ -33,3 +33,21 @@ func mapFile(path string) ([]byte, func() error, error) {
 	}
 	return data, func() error { return unix.Munmap(data) }, nil
 }
+
+// mapAnon copies b into a fresh anonymous (file-less) mapping and returns it plus an unmap
+// closer. Used for an in-memory collection's sealed-segment sidecar: the index bytes live
+// OFF the Go heap, so they neither add to GC mark work (a mapping is not scanned) nor to the
+// GOGC-paced heap, and the kernel can MADV_FREE them under pressure -- while the query path
+// reads them exactly as a file-backed sidecar. On munmap the pages are gone (no writeback:
+// an in-memory index is never persisted).
+func mapAnon(b []byte) ([]byte, func() error, error) {
+	if len(b) == 0 {
+		return nil, func() error { return nil }, nil
+	}
+	data, err := unix.Mmap(-1, 0, len(b), unix.PROT_READ|unix.PROT_WRITE, unix.MAP_ANON|unix.MAP_PRIVATE)
+	if err != nil {
+		return nil, nil, err
+	}
+	copy(data, b)
+	return data, func() error { return unix.Munmap(data) }, nil
+}

--- a/collections/archive_mmap_stub.go
+++ b/collections/archive_mmap_stub.go
@@ -15,3 +15,10 @@ func mapFile(path string) ([]byte, func() error, error) {
 	}
 	return b, func() error { return nil }, nil
 }
+
+// mapAnon falls back to the heap slice itself on platforms without mmap: the sidecar bytes
+// are then GC-cheap (a single pointer-free object, not a map of pointers) but heap-resident
+// rather than off-heap/evictable. Behavior is otherwise identical.
+func mapAnon(b []byte) ([]byte, func() error, error) {
+	return b, func() error { return nil }, nil
+}

--- a/collections/archive_mmapindex.go
+++ b/collections/archive_mmapindex.go
@@ -79,9 +79,6 @@ func parseMmapSidecar(data []byte) (*mmapSegIndex, error) {
 	if m.err != nil {
 		return nil, fmt.Errorf("archive: corrupt sidecar directory: %w", m.err)
 	}
-	if m.err != nil {
-		return nil, fmt.Errorf("archive: corrupt sidecar meta: %w", m.err)
-	}
 	return si, nil
 }
 
@@ -111,6 +108,8 @@ func (si *mmapSegIndex) candidateOffsetsGroups(groups [][]usableProbe) *roaring.
 	return indexCandidateOffsetsGroups(si, groups)
 }
 func (si *mmapSegIndex) skipsPrefix(usable []usableProbe) bool { return indexSkipsPrefix(si, usable) }
+func (si *mmapSegIndex) estCandidates(up usableProbe) float64  { return indexEstCandidates(si, up) }
+func (si *mmapSegIndex) coveredUpto() uint32                   { return si.upto }
 
 // coversProbe reports whether this segment indexes one probe's attribute.
 func (si *mmapSegIndex) coversProbe(up usableProbe) bool {

--- a/collections/archive_mmapindex.go
+++ b/collections/archive_mmapindex.go
@@ -134,7 +134,7 @@ func (si *mmapSegIndex) probeOffsets(up usableProbe) *roaring.Bitmap {
 			// the exceptional records can still match and are re-verified upstream.
 			if !si.catBloomAllAbsent(attrOff, up.svals) {
 				for _, s := range up.svals {
-					if off, ok := si.catFind(attrOff, s); ok {
+					if off, ok := si.catFindEq(attrOff, s); ok {
 						bm.Or(si.bitmapAt(off))
 					}
 				}
@@ -143,7 +143,7 @@ func (si *mmapSegIndex) probeOffsets(up usableProbe) *roaring.Bitmap {
 			return bm
 		case "!=":
 			bm := si.allBitmap().Clone()
-			if off, ok := si.catFind(attrOff, up.svals[0]); ok {
+			if off, ok := si.catFindEq(attrOff, up.svals[0]); ok {
 				bm.AndNot(si.bitmapAt(off))
 			}
 			return bm
@@ -312,6 +312,57 @@ func (si *mmapSegIndex) catBloomAllAbsent(attrOff uint32, keys []string) bool {
 		}
 	}
 	return true
+}
+
+// catMPHOff returns the file offset of the categorical MPH block (mphBlockLen), which sits
+// immediately after the bloom: bloomK u32; bloomM u32; bloom [bloomM/64] u64.
+func (si *mmapSegIndex) catMPHOff(attrOff uint32) uint32 {
+	bloomOff := si.catBloomOff(attrOff)
+	bloomM := le32(si.data, bloomOff+4)
+	return bloomOff + 8 + (bloomM/64)*8
+}
+
+// catFindEq resolves a categorical equality probe, using the MPH fast path when present and
+// falling back to the sorted-run binary search otherwise (or on an MPH miss / false hit).
+// The binary search is authoritative, so the MPH can only make a hit faster, never wrong.
+func (si *mmapSegIndex) catFindEq(attrOff uint32, key string) (bmOff uint32, ok bool) {
+	if off, hit := si.catFindMPH(attrOff, key); hit {
+		return off, true
+	}
+	return si.catFind(attrOff, key)
+}
+
+// catFindMPH probes the categorical MPH (v6). It returns (bmOff, true) only for a key that
+// the MPH resolves AND whose folded spelling verifies at the resolved slot; any other case
+// -- no MPH, an unresolved key (unassigned member or non-member), or a verify mismatch (an
+// MPH false hit) -- returns ok=false so catFindEq falls back to binary search.
+func (si *mmapSegIndex) catFindMPH(attrOff uint32, key string) (bmOff uint32, ok bool) {
+	d := si.data
+	mphOff := si.catMPHOff(attrOff)
+	mphLen := le32(d, mphOff)
+	if mphLen == 0 {
+		return 0, false
+	}
+	mphStart := mphOff + 4
+	nAssigned := le32(d, mphStart)
+	slot, resolved := mphLookupBytes(d, mphStart, key)
+	if !resolved || slot >= nAssigned {
+		return 0, false
+	}
+	j := le32(d, mphStart+mphLen+slot*4) // slotSortedIdx[slot]: index into the folded run
+	n := le32(d, attrOff+8)
+	if j >= n {
+		return 0, false // defensive: corrupt permutation -> binary search
+	}
+	keyOffBase := attrOff + 12
+	bmOffBase := keyOffBase + (n+1)*4
+	blobBase := bmOffBase + n*4
+	ks := blobBase + le32(d, keyOffBase+j*4)
+	ke := blobBase + le32(d, keyOffBase+(j+1)*4)
+	if cmpStrBytes(key, d[ks:ke]) != 0 {
+		return 0, false // MPH false hit: the slot holds a different key
+	}
+	return le32(d, bmOffBase+j*4), true
 }
 
 // --- value attr block: excOff u32; postedOff u32; n u32; key[n] f64; bmOff[n] u32 ---

--- a/collections/archive_mmapindex.go
+++ b/collections/archive_mmapindex.go
@@ -101,43 +101,44 @@ func (si *mmapSegIndex) bitmapAt(off uint32) *roaring.Bitmap {
 
 func (si *mmapSegIndex) allBitmap() *roaring.Bitmap { return si.bitmapAt(si.allOff) }
 
-// covers reports whether every usable probe's attribute is present in this index.
-func (si *mmapSegIndex) covers(usable []usableProbe) bool {
-	for _, up := range usable {
-		if up.cat {
-			if _, ok := si.catDir[up.attrID]; !ok {
-				return false
-			}
-		} else if _, ok := si.valDir[up.attrID]; !ok {
-			return false
-		}
+// The readIndex surface: thin delegates to the shared planner logic (readindex.go), so this
+// tier cannot diverge from the in-RAM segIndex.
+func (si *mmapSegIndex) covers(usable []usableProbe) bool { return indexCovers(si, usable) }
+func (si *mmapSegIndex) coversGroups(groups [][]usableProbe) bool {
+	return indexCoversGroups(si, groups)
+}
+func (si *mmapSegIndex) candidateOffsetsGroups(groups [][]usableProbe) *roaring.Bitmap {
+	return indexCandidateOffsetsGroups(si, groups)
+}
+func (si *mmapSegIndex) skipsPrefix(usable []usableProbe) bool { return indexSkipsPrefix(si, usable) }
+
+// coversProbe reports whether this segment indexes one probe's attribute.
+func (si *mmapSegIndex) coversProbe(up usableProbe) bool {
+	if up.cat {
+		_, ok := si.catDir[up.attrID]
+		return ok
 	}
-	return true
+	_, ok := si.valDir[up.attrID]
+	return ok
 }
 
-// candidateOffsets mirrors segIndex.candidateOffsets: intersect every usable probe's
-// offset set (categoricals first — cheaper), returning a superset the caller
-// re-verifies. nil means no usable probe.
-func (si *mmapSegIndex) candidateOffsets(usable []usableProbe) *roaring.Bitmap {
-	var acc *roaring.Bitmap
-	for pass := 0; pass < 2; pass++ {
-		wantCat := pass == 0
-		for _, up := range usable {
-			if up.cat != wantCat {
-				continue
-			}
-			bm := si.probeOffsets(up)
-			if acc == nil {
-				acc = bm
-			} else {
-				acc.And(bm)
-			}
-			if acc.IsEmpty() {
-				return acc
-			}
-		}
+// bloomAbsent consults the on-disk categorical bloom (v5) for a ==/in probe: true iff every
+// probe value is definitely absent.
+func (si *mmapSegIndex) bloomAbsent(up usableProbe) bool {
+	if !up.cat || (up.op != "==" && up.op != "in") {
+		return false
 	}
-	return acc
+	attrOff, ok := si.catDir[up.attrID]
+	if !ok {
+		return false
+	}
+	return si.catBloomAllAbsent(attrOff, up.svals)
+}
+
+// candidateOffsets returns the offsets satisfying every usable probe (a superset the caller
+// re-verifies), most-selective probe first via the shared planner logic. nil = no probe.
+func (si *mmapSegIndex) candidateOffsets(usable []usableProbe) *roaring.Bitmap {
+	return indexCandidateOffsets(si, usable)
 }
 
 // probeOffsets returns a fresh, mutable offset bitmap for one probe, reading only the

--- a/collections/archive_mmapindex.go
+++ b/collections/archive_mmapindex.go
@@ -23,6 +23,19 @@ type mmapSegIndex struct {
 	allOff  uint32
 	catDir  map[uint32]uint32 // attr id -> file offset of its cat attr block
 	valDir  map[uint32]uint32 // attr id -> file offset of its val attr block
+	// Per-attribute summaries, parsed eagerly (O(#attrs), resident) so the query planner's
+	// skip/selectivity paths can read them without paging the postings (v7).
+	catStats map[uint32]*segStats
+	valStats map[uint32]*segStats
+}
+
+// statsFor returns the parsed per-segment summary for a probe's attribute (nil if the
+// attribute is not indexed in this segment).
+func (si *mmapSegIndex) statsFor(up usableProbe) *segStats {
+	if up.cat {
+		return si.catStats[up.attrID]
+	}
+	return si.valStats[up.attrID]
 }
 
 // parseMmapSidecar reads a v2 sidecar's fixed header and meta directory (a few
@@ -41,7 +54,13 @@ func parseMmapSidecar(data []byte) (*mmapSegIndex, error) {
 		return nil, c.err
 	}
 	m := &cursor{b: data, i: int(metaOff)}
-	si := &mmapSegIndex{data: data, catDir: map[uint32]uint32{}, valDir: map[uint32]uint32{}}
+	si := &mmapSegIndex{
+		data:     data,
+		catDir:   map[uint32]uint32{},
+		valDir:   map[uint32]uint32{},
+		catStats: map[uint32]*segStats{},
+		valStats: map[uint32]*segStats{},
+	}
 	si.upto = m.u32()
 	si.specGen = m.u64()
 	si.allOff = m.u32()
@@ -49,11 +68,16 @@ func parseMmapSidecar(data []byte) (*mmapSegIndex, error) {
 	for i := uint32(0); i < catN; i++ {
 		id := m.u32()
 		si.catDir[id] = m.u32()
+		si.catStats[id] = readSegStats(data, m.u32())
 	}
 	valN := m.u32()
 	for i := uint32(0); i < valN; i++ {
 		id := m.u32()
 		si.valDir[id] = m.u32()
+		si.valStats[id] = readSegStats(data, m.u32())
+	}
+	if m.err != nil {
+		return nil, fmt.Errorf("archive: corrupt sidecar directory: %w", m.err)
 	}
 	if m.err != nil {
 		return nil, fmt.Errorf("archive: corrupt sidecar meta: %w", m.err)

--- a/collections/archive_mmapindex.go
+++ b/collections/archive_mmapindex.go
@@ -356,6 +356,35 @@ func (si *mmapSegIndex) catFindEq(attrOff uint32, key string) (bmOff uint32, ok 
 	return si.catFind(attrOff, key)
 }
 
+// catCanonicalValues emits each distinct canonical spelling of categorical attribute id by
+// iterating the sidecar's exact-case run, which writeSidecarIndex populated with exactly the
+// canonical spellings (a case-uniform bucket contributes its spelling; a mixed-case bucket
+// contributes each exact spelling) -- the same set segIndex.catCanonicalValues produces.
+func (si *mmapSegIndex) catCanonicalValues(id uint32, add func(string) bool) bool {
+	d := si.data
+	attrOff, ok := si.catDir[id]
+	if !ok {
+		return true
+	}
+	n := le32(d, attrOff+8)
+	keyOffBase := attrOff + 12
+	bmOffBase := keyOffBase + (n+1)*4
+	blobBase := bmOffBase + n*4
+	exOff := blobBase + le32(d, keyOffBase+n*4) // + folded blob length
+	exN := le32(d, exOff)
+	exKeyOffBase := exOff + 4
+	exBmOffBase := exKeyOffBase + (exN+1)*4
+	exBlobBase := exBmOffBase + exN*4
+	for i := uint32(0); i < exN; i++ {
+		ks := exBlobBase + le32(d, exKeyOffBase+i*4)
+		ke := exBlobBase + le32(d, exKeyOffBase+(i+1)*4)
+		if !add(string(d[ks:ke])) {
+			return false
+		}
+	}
+	return true
+}
+
 // catFindMPH probes the categorical MPH (v6). It returns (bmOff, true) only for a key that
 // the MPH resolves AND whose folded spelling verifies at the resolved slot; any other case
 // -- no MPH, an unresolved key (unassigned member or non-member), or a verify mismatch (an

--- a/collections/archive_test.go
+++ b/collections/archive_test.go
@@ -96,9 +96,102 @@ func TestArchiveCategoricalBloom(t *testing.T) {
 		}
 	}
 
-	// The sidecar must be the bloom-carrying version.
-	if sidecarVersion != 5 {
-		t.Fatalf("expected sidecar v5, got %d", sidecarVersion)
+	// The sidecar must be at least the bloom-carrying version.
+	if sidecarVersion < 5 {
+		t.Fatalf("expected sidecar >= v5, got %d", sidecarVersion)
+	}
+}
+
+// TestArchiveMPHEquality exercises the v6 categorical minimal-perfect-hash: a
+// high-cardinality attribute (NDV above the gate) gets an MPH, and equality probes -- both
+// present (exact one record) and absent (empty) -- return results identical to the
+// authoritative data. Uses a large segment so a single sealed segment's NDV trips the gate.
+func TestArchiveMPHEquality(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	a, err := CreateArchive(ArchiveOptions{
+		Dir:              dir,
+		SegmentSize:      8 << 20, // large: keep the high-NDV keys in one sealed segment
+		CategoricalAttrs: []string{"GlobalJobId"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer a.Close()
+	const n = 6000 // > mphNDVThreshold (4096) so the sealed segment builds an MPH
+	for i := 0; i < n; i++ {
+		ad, err := classad.Parse(fmt.Sprintf(`[ Id=%d; GlobalJobId="sched.example.org#%d.0" ]`, i, i))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := a.Append(ad); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := a.Flush(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Present values across the gate boundary resolve to exactly their one record.
+	for _, i := range []int{0, 1, 100, 4095, 4096, 4097, 5999} {
+		ids := archiveQueryIDs(t, a, fmt.Sprintf(`GlobalJobId == "sched.example.org#%d.0"`, i))
+		if len(ids) != 1 || ids[0] != i {
+			t.Fatalf(`GlobalJobId==#%d.0: got %v, want [%d]`, i, ids, i)
+		}
+	}
+	// Absent values (that could be MPH false hits) return nothing.
+	for _, s := range []string{"sched.example.org#999999.0", "nope", "sched.example.org#0.1"} {
+		if ids := archiveQueryIDs(t, a, fmt.Sprintf(`GlobalJobId == %q`, s)); len(ids) != 0 {
+			t.Fatalf("absent %q: got %v, want none", s, ids)
+		}
+	}
+}
+
+// TestArchiveSidecarSizes checks the evictable-bytes accounting: a high-cardinality
+// attribute builds an MPH so MPHBytes is a real fraction of the mapped sidecar bytes, while
+// a low-cardinality one builds none (only the per-attr marker), and neither is folded into
+// a heap figure.
+func TestArchiveSidecarSizes(t *testing.T) {
+	t.Parallel()
+
+	// High cardinality -> MPH built.
+	hi, err := CreateArchive(ArchiveOptions{Dir: t.TempDir(), SegmentSize: 8 << 20, CategoricalAttrs: []string{"GlobalJobId"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer hi.Close()
+	for i := 0; i < 6000; i++ {
+		ad, _ := classad.Parse(fmt.Sprintf(`[ Id=%d; GlobalJobId="s#%d.0" ]`, i, i))
+		if err := hi.Append(ad); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := hi.Flush(); err != nil {
+		t.Fatal(err)
+	}
+	sz := hi.SidecarSizes()
+	if sz.Segments == 0 || sz.MappedBytes == 0 {
+		t.Fatalf("expected sealed sidecars with mapped bytes, got %+v", sz)
+	}
+	if sz.MPHBytes < 6000*4 { // the slotSortedIdx array alone is ~4 bytes/key
+		t.Errorf("MPHBytes=%d too small for a 6000-key MPH", sz.MPHBytes)
+	}
+	if sz.MPHBytes >= sz.MappedBytes {
+		t.Errorf("MPHBytes (%d) should be a fraction of MappedBytes (%d)", sz.MPHBytes, sz.MappedBytes)
+	}
+
+	// Low cardinality -> no MPH, just the per-cat-attr marker (4 bytes each).
+	lo, _ := buildArchive(t, t.TempDir(), 500, ArchiveOptions{CategoricalAttrs: []string{"Owner"}})
+	defer lo.Close()
+	if err := lo.Flush(); err != nil {
+		t.Fatal(err)
+	}
+	lsz := lo.SidecarSizes()
+	if lsz.MappedBytes == 0 {
+		t.Fatal("expected mapped sidecar bytes for the low-NDV archive")
+	}
+	if lsz.MPHBytes > int64(lsz.Segments*8) { // 1 cat attr -> ~4 bytes/segment of markers
+		t.Errorf("low-NDV archive should build no MPH; MPHBytes=%d over %d segments", lsz.MPHBytes, lsz.Segments)
 	}
 }
 

--- a/collections/docs/design/README.md
+++ b/collections/docs/design/README.md
@@ -766,8 +766,32 @@ The design that follows:
   entirely — the win for a large, mostly-categorical history table, where an equality lookup
   for a value not in a segment would otherwise page and binary-search that segment's whole
   sorted key run. (Zone maps already give the numeric analogue; the Bloom is the categorical
-  one.) The sidecar is versioned and rebuilt at seal, so a format bump needs no migration —
-  an older sidecar is rejected and the segment reindexed.
+  one.) A high-cardinality categorical block additionally carries a **minimal perfect hash**
+  (BBHash, sidecar v6, built only when the segment's NDV for that attribute clears a
+  threshold): equality then probes the MPH — a bit-test plus a popcount-rank, ~1 page — to a
+  slot, verifies the key, and reads the bitmap offset, replacing the O(log n) scattered-page
+  binary search for present values (the point-lookup case a bloom cannot help, e.g. find a
+  job by `GlobalJobId`). The MPH is a **pure fast path**: a member resolves to its own slot,
+  a non-member is caught by the key verify, and any miss falls back to the still-present
+  sorted-run binary search, which stays authoritative — so a build bug can only cost a
+  redundant search, never a wrong answer. The sidecar is versioned and rebuilt at seal, so a
+  format bump needs no migration — an older sidecar is rejected and the segment reindexed.
+- **Residency — what stays mapped vs. what is reconstructed.** The two persistent tiers make
+  opposite choices, and it is worth being explicit about what each holds resident:
+  - *Archive sidecar (this chapter):* **nothing is reconstructed into the heap.** `Open`/query
+    parse only the fixed header and the few-entry attribute directory (O(#indexed attributes))
+    and then read keys, offsets, bloom, MPH, and bitmaps **in place over the mmap** — bitmaps
+    materialize lazily via copy-on-write `FromBuffer` for only the postings a probe touches.
+    So the resident cost is the directory plus whatever pages a query faults in; everything
+    else is demand-paged and evictable. These bytes are reported by `SidecarSizes` (mapped
+    total, with the MPH and bloom portions broken out) **separately** from the live tier's
+    heap figure, so the memory watermark isn't inflated by evictable page-cache bytes.
+  - *Live persistent Collection (Chapter 8/10):* the opposite — it **restores the full in-RAM
+    `segIndex`** from a snapshot. Only the postings are serialized; on load the value index's
+    sorted keys and **all** per-segment sketches — min/max, the categorical bloom, the HLL,
+    and the top-N heavy hitters — are **recomputed by `finishStats`** from the restored
+    postings (a decode reproduces a byte-identical index). Nothing else is reconstructed: the
+    directory (key→location) still comes from the max-seq record replay, not the snapshot.
 - **Newest-first + LIMIT pushdown.** Segments (and records within the active tail) are
   visited in reverse chronological order, and a `Limit(K)` stops the scan once K matches are
   yielded — essential when the constraint is broad but the caller wants one page.

--- a/collections/docs/design/mmap-sealed-indexes.md
+++ b/collections/docs/design/mmap-sealed-indexes.md
@@ -1,0 +1,115 @@
+# Design note: mmap-backed indexes for sealed segments (live + in-memory)
+
+Status: plan. Stacked on the MPH work (sidecar v6, PR #27).
+
+## Motivation
+
+A live `Collection` (persistent or purely in-memory, e.g. the htc-collector) keeps each
+segment's index as an in-RAM `segIndex`: `map[string]*roaring.Bitmap` and friends. That is
+fast (O(1) hash equality, no page faults) but has three costs that grow with the store:
+
+1. **Non-reclaimable heap.** The index is committed Go heap. As the store grows the index
+   grows with it, and there is a hard cliff: exceed RAM and the process OOMs. Nothing about
+   it is evictable.
+2. **GC tax.** The index is millions of pointers (map buckets, per-value bitmaps, roaring
+   containers) that the collector traverses every cycle. Mark cost and pause pressure scale
+   with index size. (The *data* arenas are large pointer-free byte slices — cheap to mark;
+   the index is where the traversal cost lives.)
+3. **Slow start.** Rebuilding (or, post-#26, CLIX-deserializing) the index on `Open` is
+   O(records or bitmaps).
+
+A sealed segment is immutable until compacted, exactly like an archive segment. The archive
+already stores an immutable index as a **sidecar read zero-copy over an mmap**
+(`mmapSegIndex`): O(#attributes) resident, demand-paged, GC-invisible (one `[]byte`), and
+O(1) to "load" (just map it). Adopting that representation for sealed live segments fixes all
+three costs. The MPH (v6) closes the one historical gap (binary-search equality), so a
+sealed sidecar's equality is now competitive with the hash map.
+
+## The representation matrix
+
+One reader (`mmapSegIndex`), three backings; the active (mutable) segment stays in-RAM.
+
+| segment | index |
+|---|---|
+| active (write frontier, mutable) | in-RAM `segIndex` (heap) — small, bounded |
+| sealed, persistent | sidecar bytes = **file** mmap (reclaimable from disk) |
+| sealed, in-memory (collector) | sidecar bytes = **anonymous** mmap (off-heap, `MADV_FREE`-able) |
+
+The reader is identical; only the byte source differs. For the in-memory case the anonymous
+mapping takes the index **off the Go heap** — out of GOGC pacing and RSS, zero mark cost —
+which is the GC win the collector wants. (Reclaim is weaker for a pure-memory DB: eviction
+means swap, usually undesirable; the GC benefit is the point.)
+
+**Pinning:** we do NOT need a separate in-RAM "pinned" mode. A file-backed sidecar can be
+`mlock`'d to hold it resident. So there is one representation, optionally pinned, rather than
+two.
+
+## The discovery: the sidecar must carry segStats (v7)
+
+The live query planner uses a richer index surface than the archive query does:
+
+- archive: `covers`, `candidateOffsets`, `probeOffsets` (+ external zone-map prune).
+- live: the above **plus** `selectivityOrder`, `estCandidates`, `canSkip`, `skipsPrefix`,
+  and DNF `coversGroups` / `candidateOffsetsGroups`.
+
+Every one of the extra methods reads `segStats` — min/max (value range skip), top-N + ndv
+(selectivity estimate), bloom (categorical skip). The sidecar (v6) serializes postings +
+bloom + MPH but **not** min/max/top-N/ndv/HLL; the live tier recomputes those with
+`finishStats`, which for a mmap index would page in every bitmap on load — defeating the
+pageable design.
+
+So a `mmapSegIndex` cannot answer `canSkip`/`estCandidates`/`selectivityOrder` today.
+Swapping sealed segments to it without fixing this would silently drop segment-skip and
+selectivity ordering for sealed data (e.g. a range query could no longer skip out-of-range
+sealed segments) — a real regression.
+
+**Fix:** serialize a per-attribute stats block into the sidecar (**v7**): `covered`, `exc`,
+`ndv`, `hasRange`, `min`, `max`, the top-N heavy hitters, and the HLL registers (the bloom is
+already there since v5). It is tiny and bounded (a few scalars + top-N + ~1 KiB HLL per attr)
+and lets `mmapSegIndex` reconstruct a faithful `segStats` cheaply, without touching postings.
+
+## Interface
+
+Extract the live planner's index surface into an interface both `*segIndex` and
+`*mmapSegIndex` satisfy (they mostly mirror already; `mmapSegIndex` gains the stats-backed
+methods from v7 and the DNF-group variants). The segment holds it atomically; the active
+segment stores a `*segIndex`, a sealed segment a `*mmapSegIndex`. The query path dispatches
+through the interface with no per-segment special-casing (it already tolerates heterogeneous
+segments).
+
+## Correctness
+
+Unchanged invariants: a sealed segment is immutable until compacted (compaction produces a
+new file → new sidecar); MVCC supersession is re-checked from record bytes, not the index;
+the query re-verifies every candidate, so any index only affects selectivity, never the
+answer. The MPH already falls back to the authoritative sorted run. So this is a
+representation change, not a semantics change.
+
+## Supersedes CLIX
+
+The CLIX snapshot (#26) restores an in-RAM `segIndex` on `Open`. With sealed segments mapping
+their sidecar instead, the CLIX write/restore path is removed: `Open` maps sidecars (O(1))
+rather than deserializing. `writeSidecarIndex` (the archive format, now v7) is written at
+seal for live segments too.
+
+## Incremental steps
+
+1. **Sidecar v7 — segStats block.** Serialize per-attr stats; add `mmapSegIndex` readers +
+   `statsFor`. Round-trip test: mmap stats == in-RAM `finishStats` stats. *(Self-contained.)*
+2. **mmapSegIndex full surface.** Implement `canSkip`, `skipsPrefix`, `estCandidates`,
+   `selectivityOrder`, DNF group variants on top of the v7 stats. Parity tests vs `segIndex`.
+3. **Read-index interface + dispatch.** Extract the interface; segment holds either; planner
+   dispatches. No behavior change yet (all segments still in-RAM).
+4. **Backing store.** `mapFile` (exists) + an anonymous `mmapAnon` variant; unmap/`MADV_FREE`
+   on reap (extend the archive's `onReap`).
+5. **Seal path.** On seal, write the sidecar, back it (file/anon by store kind), swap the
+   segment's index to the `mmapSegIndex`. Active stays in-RAM.
+6. **Open path + CLIX removal.** Map sidecars for sealed segments; drop CLIX.
+7. **Accounting + doc.** Extend `SidecarSizes` to the live store (mapped/evictable, per the
+   heap-vs-mapped split #26 introduced); update design README §8/§10.
+
+## Follow-ups (not in this work)
+
+- **Data arenas off-heap for the in-memory DB.** A separate, smaller GC win (the arenas are
+  pointer-free → pacing/RSS, not mark cost). Anonymous-mmap the RAM segment backing.
+- **`mlock` knob** for latency-critical stores that want the sidecar pinned resident.

--- a/collections/index_query.go
+++ b/collections/index_query.go
@@ -378,47 +378,25 @@ func numericFloat(v classad.Value) (float64, bool) {
 // coversGroups reports whether a segment index covers every probe of every group. If
 // it does not cover some group, that disjunct is unconstrained for this segment, so
 // the caller must full-scan the window rather than use the (incomplete) union.
-func (si *segIndex) coversGroups(groups [][]usableProbe) bool {
-	for _, g := range groups {
-		if !si.covers(g) {
-			return false
-		}
-	}
-	return true
-}
+func (si *segIndex) coversGroups(groups [][]usableProbe) bool { return indexCoversGroups(si, groups) }
 
 // candidateOffsetsGroups returns the union over groups of each group's candidate
 // intersection -- the DNF `OR of (AND of probes)`. Callers pass only prunable plans
 // (every group has at least one usable probe), so no group widens to everything.
 func (si *segIndex) candidateOffsetsGroups(groups [][]usableProbe) *roaring.Bitmap {
-	var acc *roaring.Bitmap
-	for _, g := range groups {
-		gb := si.candidateOffsets(g)
-		if gb == nil {
-			gb = roaring.New()
-		}
-		if acc == nil {
-			acc = gb
-		} else {
-			acc.Or(gb)
-		}
-	}
-	return acc
+	return indexCandidateOffsetsGroups(si, groups)
 }
 
 // covers reports whether a segment index has postings for every usable probe's
 // attribute (a segment indexed before an attribute was added would not).
-func (si *segIndex) covers(usable []usableProbe) bool {
-	for _, up := range usable {
-		if up.cat {
-			if si.cat[up.attrID] == nil {
-				return false
-			}
-		} else if si.val[up.attrID] == nil {
-			return false
-		}
+func (si *segIndex) covers(usable []usableProbe) bool { return indexCovers(si, usable) }
+
+// coversProbe reports whether this segment indexes one probe's attribute.
+func (si *segIndex) coversProbe(up usableProbe) bool {
+	if up.cat {
+		return si.cat[up.attrID] != nil
 	}
-	return true
+	return si.val[up.attrID] != nil
 }
 
 // candidateOffsets returns the segment-record offsets satisfying every usable
@@ -427,28 +405,7 @@ func (si *segIndex) covers(usable []usableProbe) bool {
 // fastest and the widest probes touch the smallest accumulator. nil means "no
 // candidates".
 func (si *segIndex) candidateOffsets(usable []usableProbe) *roaring.Bitmap {
-	// Fast path: 0/1 probe needs no ordering (and allocates no order/est slices),
-	// which is the common single-constraint query.
-	switch len(usable) {
-	case 0:
-		return nil
-	case 1:
-		return si.probeOffsets(usable[0])
-	}
-	order := si.selectivityOrder(usable)
-	var acc *roaring.Bitmap
-	for _, i := range order {
-		bm := si.probeOffsets(usable[i])
-		if acc == nil {
-			acc = bm
-		} else {
-			acc.And(bm)
-		}
-		if acc.IsEmpty() {
-			return acc
-		}
-	}
-	return acc
+	return indexCandidateOffsets(si, usable)
 }
 
 // selectivityOrder returns indices into usable ordered by ascending estimated
@@ -456,16 +413,7 @@ func (si *segIndex) candidateOffsets(usable []usableProbe) *roaring.Bitmap {
 // AND is commutative, so this never changes the result, only the work. Ties and
 // missing stats fall back to input order for a deterministic plan.
 func (si *segIndex) selectivityOrder(usable []usableProbe) []int {
-	order := make([]int, len(usable))
-	est := make([]float64, len(usable))
-	for i, up := range usable {
-		order[i] = i
-		est[i] = si.estCandidates(up)
-	}
-	sort.SliceStable(order, func(a, b int) bool {
-		return est[order[a]] < est[order[b]]
-	})
-	return order
+	return indexSelectivityOrder(si, usable)
 }
 
 // statsFor returns the segStats for a probe's attribute, or nil if that segment
@@ -490,97 +438,30 @@ func (si *segIndex) statsFor(up usableProbe) *segStats {
 // it must return true only when certain. Exceptional records (value present but
 // not the indexed literal type) are re-verified candidates, so any exception
 // forbids a skip. Equality/range/membership can skip; `!=` never does.
-func (si *segIndex) canSkip(up usableProbe) bool {
-	s := si.statsFor(up)
-	if s == nil || s.exc > 0 {
+func (si *segIndex) canSkip(up usableProbe) bool { return indexCanSkip(si, up) }
+
+// bloomAbsent reports whether a categorical ==/in probe's values are all provably absent
+// via the in-RAM per-segment bloom.
+func (si *segIndex) bloomAbsent(up usableProbe) bool {
+	if !up.cat || (up.op != "==" && up.op != "in") {
 		return false
 	}
-	if up.op == "present" || up.op == "absent" {
-		return false // presence spans posted + exc + absent; never provably empty here
+	s := si.statsFor(up)
+	if s == nil || s.bloom == nil {
+		return false
 	}
-	if up.cat {
-		if up.op != "==" && up.op != "in" {
-			return false
+	for _, v := range up.svals {
+		if s.bloom.mayContain(hashString(v)) {
+			return false // a value might be present: cannot prove absent
 		}
-		if s.bloom == nil {
-			return false
-		}
-		for _, v := range up.svals {
-			if s.bloom.mayContain(hashString(v)) {
-				return false // a value might be present: cannot skip
-			}
-		}
-		return true
 	}
-	if !s.hasRange {
-		// No numeric record in the prefix (and exc==0): nothing an equality/range
-		// probe could match. A `!=` still matches every non-exc record, so keep it.
-		return up.op != "!="
-	}
-	switch up.op {
-	case "==", "in":
-		for _, t := range up.fvals {
-			if t >= s.min && t <= s.max {
-				return false
-			}
-		}
-		return true
-	case "<":
-		return s.min >= up.fvals[0]
-	case "<=":
-		return s.min > up.fvals[0]
-	case ">":
-		return s.max <= up.fvals[0]
-	case ">=":
-		return s.max < up.fvals[0]
-	}
-	return false
+	return true
 }
 
 // estCandidates estimates how many records in the indexed prefix this probe would
 // admit (its candidate-bitmap cardinality). Used only to order probes, so a rough
 // estimate is fine; it never affects correctness.
-func (si *segIndex) estCandidates(up usableProbe) float64 {
-	s := si.statsFor(up)
-	if s == nil {
-		return math.MaxFloat64 // unknown: apply last
-	}
-	indexable := float64(s.covered - s.exc)
-	switch up.op {
-	case "==", "in":
-		var sum float64
-		if up.cat {
-			for _, v := range up.svals {
-				sum += s.estEqualStr(v)
-			}
-		} else {
-			for _, v := range up.fvals {
-				sum += s.estEqualFloat(v)
-			}
-		}
-		return sum + float64(s.exc)
-	case "!=":
-		// Everything except the single excluded value (plus absent/exc rows that the
-		// re-verify handles): close to the full prefix, so it sorts late.
-		if up.cat {
-			return indexable - s.estEqualStr(up.svals[0]) + float64(s.exc)
-		}
-		return indexable - s.estEqualFloat(up.fvals[0]) + float64(s.exc)
-	case "isnt":
-		// =!= (categorical): everything but the exact-case value. Estimate like != using
-		// the value's count (folded -- the top-N heavy hitters are folded keys); for a
-		// case-uniform bucket the exact and folded counts coincide. Without this branch
-		// the switch fell through to `return indexable` (~the whole prefix), so a selective
-		// `State =!= "Claimed"` looked ~100% and sorted last instead of first.
-		if up.cat {
-			return indexable - s.estEqualStr(strings.ToLower(up.svals[0])) + float64(s.exc)
-		}
-		return indexable
-	case "<", "<=", ">", ">=":
-		return s.estRange(up.op, up.fvals[0])*indexable + float64(s.exc)
-	}
-	return indexable
-}
+func (si *segIndex) estCandidates(up usableProbe) float64 { return indexEstCandidates(si, up) }
 
 // estEqualStr / estEqualFloat estimate the record count for one equality value:
 // its exact top-N count if it is a heavy hitter, else the average tail count (0 if
@@ -636,14 +517,7 @@ func (s *segStats) estRange(op string, t float64) float64 {
 // if any single probe provably has no candidate (canSkip), the intersection is
 // empty. Cheaper than candidateOffsets for range probes (no key iteration) and the
 // only skip path once postings are dropped from an immutable segment.
-func (si *segIndex) skipsPrefix(usable []usableProbe) bool {
-	for _, up := range usable {
-		if si.canSkip(up) {
-			return true
-		}
-	}
-	return false
-}
+func (si *segIndex) skipsPrefix(usable []usableProbe) bool { return indexSkipsPrefix(si, usable) }
 
 // probeOffsets returns a fresh, mutable offset bitmap for one probe.
 func (si *segIndex) probeOffsets(up usableProbe) *roaring.Bitmap {

--- a/collections/index_query.go
+++ b/collections/index_query.go
@@ -205,7 +205,7 @@ func (c *Collection) estimateCandidates(up usableProbe) (cand float64, covered b
 	for _, sh := range c.shards {
 		s0, wins := sh.snapshot()
 		for _, w := range wins {
-			if si := w.seg.idx.Load(); si != nil && si.covers(single) {
+			if si := w.seg.readIdx(); si != nil && si.covers(single) {
 				cand += si.estCandidates(up)
 				covered = true
 			}
@@ -518,6 +518,7 @@ func (s *segStats) estRange(op string, t float64) float64 {
 // empty. Cheaper than candidateOffsets for range probes (no key iteration) and the
 // only skip path once postings are dropped from an immutable segment.
 func (si *segIndex) skipsPrefix(usable []usableProbe) bool { return indexSkipsPrefix(si, usable) }
+func (si *segIndex) coveredUpto() uint32                   { return si.upto }
 
 // probeOffsets returns a fresh, mutable offset bitmap for one probe.
 func (si *segIndex) probeOffsets(up usableProbe) *roaring.Bitmap {
@@ -693,7 +694,7 @@ func (c *Collection) scanShardCandidates(sh *shard, usable []usableProbe, onCand
 	}
 
 	for _, w := range wins {
-		si := w.seg.idx.Load()
+		si := w.seg.readIdx()
 		if si == nil || !si.covers(usable) {
 			if !scanRange(w, 0, w.used) { // no usable index: full-scan the window
 				return false
@@ -704,8 +705,8 @@ func (c *Collection) scanShardCandidates(sh *shard, usable []usableProbe, onCand
 		// (min/max out of range, bloom miss), the conjunction is empty there — skip
 		// the prefix and only full-scan the tail written after the index was built.
 		if si.skipsPrefix(usable) {
-			if int(si.upto) < w.used {
-				if !scanRange(w, int(si.upto), w.used) {
+			if int(si.coveredUpto()) < w.used {
+				if !scanRange(w, int(si.coveredUpto()), w.used) {
 					return false
 				}
 			}
@@ -721,8 +722,8 @@ func (c *Collection) scanShardCandidates(sh *shard, usable []usableProbe, onCand
 			}
 		}
 		// Tail [upto, used): written after the index was built — full-scan it.
-		if int(si.upto) < w.used {
-			if !scanRange(w, int(si.upto), w.used) {
+		if int(si.coveredUpto()) < w.used {
+			if !scanRange(w, int(si.coveredUpto()), w.used) {
 				return false
 			}
 		}

--- a/collections/index_size.go
+++ b/collections/index_size.go
@@ -46,6 +46,67 @@ func (vp *valPostings) sizeBytes() int64 {
 	return n
 }
 
+// SidecarSizes reports the on-disk index bytes of an Archive's sealed sidecars, broken out
+// so the minimal-perfect-hash and bloom overhead is visible. These are distinct from the
+// live Collection's IndexSizes: those measure HEAP-resident postings + sketches, whereas
+// sidecar bytes live in the page cache -- demand-paged and evictable under memory pressure.
+// They are reported as a separate budget, never folded into a heap figure, so the
+// "index is N% of data" watermark stays an honest measure of resident memory.
+type SidecarSizes struct {
+	Segments    int   `json:"segments"`    // sealed segments with a sidecar
+	MappedBytes int64 `json:"mappedBytes"` // total sidecar bytes (mmap-backed, evictable)
+	MPHBytes    int64 `json:"mphBytes"`    // of MappedBytes, minimal-perfect-hash structures
+	BloomBytes  int64 `json:"bloomBytes"`  // of MappedBytes, bloom filters
+}
+
+// SidecarSizes sums each sealed segment's sidecar size and its MPH/bloom portions. It maps
+// each sidecar briefly and closes it immediately, so it is an operator diagnostic, not a
+// hot path. The active (unsealed) segment has no sidecar and is skipped.
+func (a *Archive) SidecarSizes() SidecarSizes {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	var out SidecarSizes
+	for _, as := range a.segs {
+		if !as.sealed {
+			continue
+		}
+		data, closer, err := mapFile(a.idxPath(as.seg.id))
+		if err != nil {
+			continue
+		}
+		out.Segments++
+		out.MappedBytes += int64(len(data))
+		mph, bloom := sidecarSketchBreakdown(data)
+		out.MPHBytes += mph
+		out.BloomBytes += bloom
+		_ = closer()
+	}
+	return out
+}
+
+// sidecarSketchBreakdown sums the MPH and bloom block bytes across a v6 sidecar's
+// categorical attributes. Returns (0,0) for a sidecar that does not parse (e.g. an older
+// version), since only a current sidecar carries these blocks.
+func sidecarSketchBreakdown(data []byte) (mph, bloom int64) {
+	si, err := parseMmapSidecar(data)
+	if err != nil {
+		return 0, 0
+	}
+	for _, attrOff := range si.catDir {
+		bloomOff := si.catBloomOff(attrOff)
+		bloomM := le32(data, bloomOff+4)
+		bloom += 8 + int64(bloomM/64)*8
+		mphOff := si.catMPHOff(attrOff)
+		if mphLen := le32(data, mphOff); mphLen > 0 {
+			nAssigned := le32(data, mphOff+4)
+			mph += 4 + int64(mphLen) + int64(nAssigned)*4
+		} else {
+			mph += 4 // just the mphBlockLen==0 marker
+		}
+	}
+	return mph, bloom
+}
+
 // IndexSize is the measured memory footprint of one attribute's index.
 type IndexSize struct {
 	Attr  string `json:"attr"`

--- a/collections/match_index.go
+++ b/collections/match_index.go
@@ -562,36 +562,45 @@ func (c *Collection) distinctCatValues(attr string, max int) []string {
 	for _, sh := range c.shards {
 		_, wins := sh.snapshot()
 		for _, w := range wins {
-			si := w.seg.idx.Load()
+			si := w.seg.readIdx()
 			if si == nil {
 				continue
 			}
-			cp := si.cat[id]
-			if cp == nil {
-				continue
-			}
-			for f := range cp.post { // case-uniform buckets: canonical spelling
-				if ec, has := cp.exactCase[f]; has {
-					v := f
-					if ec != "" {
-						v = ec
-					}
-					if !add(v) {
-						releaseWindows(wins)
-						return nil
-					}
-				}
-			}
-			for e := range cp.exact { // mixed-case buckets: each exact spelling
-				if !add(e) {
-					releaseWindows(wins)
-					return nil
-				}
+			if !si.catCanonicalValues(id, add) {
+				releaseWindows(wins)
+				return nil
 			}
 		}
 		releaseWindows(wins)
 	}
 	return out
+}
+
+// catCanonicalValues emits each distinct canonical spelling of categorical attribute id:
+// the canonical form of every case-uniform bucket (from post + exactCase) plus every
+// mixed-case exact spelling (from exact). Mirrors what the sidecar's exact-case run stores.
+func (si *segIndex) catCanonicalValues(id uint32, add func(string) bool) bool {
+	cp := si.cat[id]
+	if cp == nil {
+		return true
+	}
+	for f := range cp.post {
+		if ec, has := cp.exactCase[f]; has {
+			v := f
+			if ec != "" {
+				v = ec
+			}
+			if !add(v) {
+				return false
+			}
+		}
+	}
+	for e := range cp.exact {
+		if !add(e) {
+			return false
+		}
+	}
+	return true
 }
 
 // materializeFinite walks the boolean tree of a slot predicate and replaces each opaque

--- a/collections/mph.go
+++ b/collections/mph.go
@@ -1,0 +1,191 @@
+package collections
+
+import "math/bits"
+
+// Minimal perfect hash (BBHash) over an immutable, distinct key set, for O(1) equality on
+// the mmap index tier. On a cold, high-cardinality sidecar an equality probe otherwise
+// binary-searches the sorted key blob -- O(log n) comparisons, each a potential page fault
+// into a scattered part of the mapping. The MPH resolves a member to its slot in ~1 probe.
+//
+// BBHash is a cascade of bit arrays ("levels"): at each level a key hashes to a bit; a bit
+// that exactly one still-unplaced key lands on is "assigned" (set), and colliding keys fall
+// through to the next level. A key's slot is the rank (count of set bits before its bit)
+// across the levels, giving a dense [0, nAssigned) numbering. Lookups are a bit test plus a
+// popcount-rank, so the serialized form probes zero-copy over the mmap.
+//
+// SAFETY: the MPH is a pure fast path, never authoritative. A member always resolves to its
+// own slot; a non-member may resolve to some slot (a false hit) -- so the caller MUST verify
+// the key stored at that slot and, on any miss (unassigned member, verify mismatch,
+// non-member), fall back to the sorted-run binary search. A build bug can therefore only
+// cost a redundant binary search, never a wrong answer.
+
+const (
+	mphGamma          = 2 // bits per still-unplaced key at each level (load factor 1/gamma)
+	mphMaxLevels      = 7 // after this, any leftover keys are simply unassigned (caller falls back)
+	mphRankBlockWords = 8 // one cumulative-popcount checkpoint per 512 bits
+	mphSeed           = 0x9e3779b97f4a7c15
+)
+
+// mphLevel is one BBHash level: a bit array (m bits, m a multiple of 64), a per-block
+// cumulative popcount index for O(1) rank, and the slot base (set bits in all prior levels).
+type mphLevel struct {
+	bits []uint64
+	m    uint32
+	rank []uint32 // rank[i] = popcount of bits[0 : i*mphRankBlockWords]
+	base uint32
+}
+
+type mph struct {
+	levels    []mphLevel
+	nAssigned uint32
+}
+
+// mphLevelHash derives a level's hash from the key's base hash, decorrelating levels.
+func mphLevelHash(h uint64, level int) uint64 {
+	return mix64(h ^ (mphSeed * uint64(level+1)))
+}
+
+// buildMPH constructs an MPH over keys (which must be distinct). It returns the structure
+// and slots, where slots[i] is key i's assigned slot or -1 if it fell through all levels
+// unassigned (the caller resolves those via the sorted run). nAssigned == len(keys) unless
+// some keys are unassigned.
+func buildMPH(keys []string) (*mph, []int32) {
+	n := len(keys)
+	slots := make([]int32, n)
+	for i := range slots {
+		slots[i] = -1
+	}
+
+	m := &mph{}
+	// hashes[i] is the base hash of the key still at index i in `remaining`.
+	remaining := make([]int, n)
+	for i := range remaining {
+		remaining[i] = i
+	}
+	var slotBase uint32
+	for level := 0; level < mphMaxLevels && len(remaining) > 0; level++ {
+		mbits := uint32(len(remaining) * mphGamma)
+		mbits = (mbits + 63) &^ 63 // round up to a whole word
+		if mbits == 0 {
+			mbits = 64
+		}
+		// Count collisions per bit (saturating at 2), then keep only singletons.
+		count := make([]uint8, mbits)
+		pos := make([]uint32, len(remaining))
+		for i, ki := range remaining {
+			p := uint32(mphLevelHash(hashString(keys[ki]), level) % uint64(mbits))
+			pos[i] = p
+			if count[p] < 2 {
+				count[p]++
+			}
+		}
+		levelBits := make([]uint64, mbits/64)
+		next := remaining[:0:0] // fresh slice; do not alias remaining while reading it
+		for i, ki := range remaining {
+			if count[pos[i]] == 1 {
+				levelBits[pos[i]>>6] |= 1 << (pos[i] & 63)
+			} else {
+				next = append(next, ki)
+			}
+		}
+		rank, set := buildRankIndex(levelBits)
+		// Assign slots for the singletons of this level, in bit order.
+		for i, ki := range remaining {
+			if count[pos[i]] == 1 {
+				slots[ki] = int32(slotBase + rankAt(levelBits, rank, pos[i]))
+			}
+		}
+		m.levels = append(m.levels, mphLevel{bits: levelBits, m: mbits, rank: rank, base: slotBase})
+		slotBase += set
+		remaining = next
+	}
+	m.nAssigned = slotBase
+	return m, slots
+}
+
+// buildRankIndex returns cumulative popcount checkpoints (one per mphRankBlockWords words)
+// and the total set-bit count.
+func buildRankIndex(words []uint64) (rank []uint32, total uint32) {
+	nblocks := (len(words) + mphRankBlockWords - 1) / mphRankBlockWords
+	rank = make([]uint32, nblocks+1)
+	var acc uint32
+	for i, w := range words {
+		if i%mphRankBlockWords == 0 {
+			rank[i/mphRankBlockWords] = acc
+		}
+		acc += uint32(bits.OnesCount64(w))
+	}
+	rank[nblocks] = acc
+	return rank, acc
+}
+
+// rankAt returns the number of set bits in words[0:p] (p is a bit index), using the
+// checkpoint index for O(1) block skip plus a partial popcount.
+func rankAt(words []uint64, rank []uint32, p uint32) uint32 {
+	wordIdx := p >> 6
+	block := wordIdx / mphRankBlockWords
+	r := rank[block]
+	for w := block * mphRankBlockWords; w < wordIdx; w++ {
+		r += uint32(bits.OnesCount64(words[w]))
+	}
+	r += uint32(bits.OnesCount64(words[wordIdx] & ((1 << (p & 63)) - 1)))
+	return r
+}
+
+// --- serialization + zero-copy probe (for the mmap sidecar) ---
+//
+// Layout, appended contiguously into the sidecar so it pages from the one mapping:
+//
+//	nAssigned u32; nLevels u32;
+//	per level: m u32; base u32; nWords u32; nRank u32; bits [nWords]u64; rank [nRank]u32
+
+// appendMPH serializes m (bloomM==0-style empty is represented by nLevels==0).
+func appendMPH(b []byte, m *mph) []byte {
+	b = appendU32(b, m.nAssigned)
+	b = appendU32(b, uint32(len(m.levels)))
+	for _, lv := range m.levels {
+		b = appendU32(b, lv.m)
+		b = appendU32(b, lv.base)
+		b = appendU32(b, uint32(len(lv.bits)))
+		b = appendU32(b, uint32(len(lv.rank)))
+		for _, w := range lv.bits {
+			b = appendU64(b, w)
+		}
+		for _, r := range lv.rank {
+			b = appendU32(b, r)
+		}
+	}
+	return b
+}
+
+// mphLookupBytes probes a serialized MPH at file offset off directly over the mapping,
+// returning the key's slot in [0, nAssigned) if some level resolves it. A returned slot is
+// only a candidate: the caller MUST verify the key stored at that slot (a non-member can
+// resolve to another key's slot) and fall back to the sorted run on a miss. ok=false means
+// no level resolved the key (an unassigned member or a non-member): fall back.
+func mphLookupBytes(d []byte, off uint32, key string) (slot uint32, ok bool) {
+	nLevels := le32(d, off+4)
+	p := off + 8
+	h := hashString(key)
+	for lvl := 0; lvl < int(nLevels); lvl++ {
+		m := le32(d, p)
+		base := le32(d, p+4)
+		nWords := le32(d, p+8)
+		nRank := le32(d, p+12)
+		bitsOff := p + 16
+		rankOff := bitsOff + nWords*8
+		bit := uint32(mphLevelHash(h, lvl) % uint64(m))
+		wordIdx := bit >> 6
+		if le64(d, bitsOff+wordIdx*8)&(1<<(bit&63)) != 0 {
+			block := wordIdx / mphRankBlockWords
+			r := le32(d, rankOff+block*4)
+			for w := block * mphRankBlockWords; w < wordIdx; w++ {
+				r += uint32(bits.OnesCount64(le64(d, bitsOff+w*8)))
+			}
+			r += uint32(bits.OnesCount64(le64(d, bitsOff+wordIdx*8) & ((1 << (bit & 63)) - 1)))
+			return base + r, true
+		}
+		p = rankOff + nRank*4
+	}
+	return 0, false
+}

--- a/collections/mph_test.go
+++ b/collections/mph_test.go
@@ -1,0 +1,89 @@
+package collections
+
+import (
+	"fmt"
+	"testing"
+)
+
+// TestMPHRoundTrip is the correctness anchor: for a range of sizes, every assigned member
+// probes (over the serialized bytes) back to its own slot, assigned slots are a bijection
+// onto [0, nAssigned), and the vast majority of keys are assigned (the geometric tail falls
+// back to the sorted-run binary search, which is correct, just not the fast path).
+func TestMPHRoundTrip(t *testing.T) {
+	t.Parallel()
+	for _, n := range []int{1, 2, 3, 63, 64, 65, 127, 1000, 50000} {
+		keys := make([]string, n)
+		for i := range keys {
+			keys[i] = fmt.Sprintf("GlobalJobId=host%d.example.org#%d.%d", i%97, i, i*2654435761)
+		}
+		m, slots := buildMPH(keys)
+		blob := appendMPH(nil, m)
+
+		// slot -> key, and bijection check.
+		slotKey := make([]string, m.nAssigned)
+		seen := make([]bool, m.nAssigned)
+		assigned := 0
+		for i, s := range slots {
+			if s < 0 {
+				continue
+			}
+			if uint32(s) >= m.nAssigned {
+				t.Fatalf("n=%d: slot %d out of range [0,%d)", n, s, m.nAssigned)
+			}
+			if seen[s] {
+				t.Fatalf("n=%d: slot %d assigned twice", n, s)
+			}
+			seen[s] = true
+			slotKey[s] = keys[i]
+			assigned++
+		}
+
+		// Every assigned member resolves (via the serialized probe) to its slot.
+		for i, k := range keys {
+			if slots[i] < 0 {
+				continue // unassigned: caller falls back to binary search
+			}
+			slot, ok := mphLookupBytes(blob, 0, k)
+			if !ok || slot != uint32(slots[i]) {
+				t.Fatalf("n=%d member %q: probe=(slot=%d ok=%v), want slot=%d", n, k, slot, ok, slots[i])
+			}
+			if slotKey[slot] != k {
+				t.Fatalf("n=%d: slot %d holds %q, want %q", n, slot, slotKey[slot], k)
+			}
+		}
+		if n >= 1000 && assigned < n*95/100 {
+			t.Errorf("n=%d: only %d/%d keys assigned (<95%%); level cap or gamma too low", n, assigned, n)
+		}
+	}
+}
+
+// TestMPHNonMembersNeverFalselyVerify: a non-member may resolve to some slot (a false hit),
+// but the key stored at that slot is a real member, never the non-member -- so the caller's
+// verify always rejects it. This is what makes the MPH safe without an authoritative role.
+func TestMPHNonMembersNeverFalselyVerify(t *testing.T) {
+	t.Parallel()
+	const n = 8000
+	keys := make([]string, n)
+	set := make(map[string]bool, n)
+	for i := range keys {
+		keys[i] = fmt.Sprintf("member-%d-%x", i, i*40503)
+		set[keys[i]] = true
+	}
+	m, slots := buildMPH(keys)
+	blob := appendMPH(nil, m)
+	slotKey := make([]string, m.nAssigned)
+	for i, s := range slots {
+		if s >= 0 {
+			slotKey[s] = keys[i]
+		}
+	}
+	for j := 0; j < 40000; j++ {
+		nk := fmt.Sprintf("absent-%d-%x", j, j*2246822519)
+		if set[nk] {
+			continue
+		}
+		if slot, ok := mphLookupBytes(blob, 0, nk); ok && slot < m.nAssigned && slotKey[slot] == nk {
+			t.Fatalf("non-member %q verified as a member at slot %d", nk, slot)
+		}
+	}
+}

--- a/collections/readindex.go
+++ b/collections/readindex.go
@@ -20,6 +20,10 @@ type readIndex interface {
 	skipsPrefix(usable []usableProbe) bool
 	estCandidates(up usableProbe) float64 // selectivity estimate (ordering/tuning only)
 	coveredUpto() uint32                  // the index covers offsets [0, coveredUpto); the tail is scanned
+	// catCanonicalValues emits each distinct canonical spelling of categorical attribute id
+	// (for MATCH's finite-value materialization). add returns false to stop early;
+	// catCanonicalValues then returns false too. Returns true when all values were emitted.
+	catCanonicalValues(id uint32, add func(string) bool) bool
 }
 
 // indexPrimitives are the per-tier operations the shared planner logic (below) is built on.

--- a/collections/readindex.go
+++ b/collections/readindex.go
@@ -18,6 +18,8 @@ type readIndex interface {
 	candidateOffsets(usable []usableProbe) *roaring.Bitmap
 	candidateOffsetsGroups(groups [][]usableProbe) *roaring.Bitmap
 	skipsPrefix(usable []usableProbe) bool
+	estCandidates(up usableProbe) float64 // selectivity estimate (ordering/tuning only)
+	coveredUpto() uint32                  // the index covers offsets [0, coveredUpto); the tail is scanned
 }
 
 // indexPrimitives are the per-tier operations the shared planner logic (below) is built on.

--- a/collections/readindex.go
+++ b/collections/readindex.go
@@ -1,0 +1,209 @@
+package collections
+
+import (
+	"math"
+	"sort"
+	"strings"
+
+	"github.com/RoaringBitmap/roaring/v2"
+)
+
+// readIndex is a built segment index the query planner reads: an in-RAM segIndex (the
+// active/hot representation) or a mmapSegIndex (a sealed segment's pageable sidecar). Both
+// answer the same questions, so the planner can hold this interface and let a segment use
+// either representation without special-casing.
+type readIndex interface {
+	covers(usable []usableProbe) bool
+	coversGroups(groups [][]usableProbe) bool
+	candidateOffsets(usable []usableProbe) *roaring.Bitmap
+	candidateOffsetsGroups(groups [][]usableProbe) *roaring.Bitmap
+	skipsPrefix(usable []usableProbe) bool
+}
+
+// indexPrimitives are the per-tier operations the shared planner logic (below) is built on.
+// The skip/selectivity/candidate logic is written ONCE against these primitives so the two
+// index representations cannot diverge; each type's readIndex methods are thin delegates.
+type indexPrimitives interface {
+	// statsFor returns the attribute's per-segment summary, or nil if not indexed here.
+	statsFor(up usableProbe) *segStats
+	// probeOffsets returns a fresh, mutable superset of record offsets matching one probe.
+	probeOffsets(up usableProbe) *roaring.Bitmap
+	// coversProbe reports whether this segment indexes the probe's attribute.
+	coversProbe(up usableProbe) bool
+	// bloomAbsent reports whether a categorical ==/in probe's values are ALL provably absent
+	// (via the per-segment bloom). false when undeterminable: no bloom, a value might be
+	// present, or the probe is not a categorical equality. The tiers differ only here (the
+	// in-RAM stats hold the bloom; the mmap tier consults it on disk), which is why it is a
+	// primitive rather than shared logic.
+	bloomAbsent(up usableProbe) bool
+}
+
+func indexCovers(ix indexPrimitives, usable []usableProbe) bool {
+	for _, up := range usable {
+		if !ix.coversProbe(up) {
+			return false
+		}
+	}
+	return true
+}
+
+func indexCoversGroups(ix indexPrimitives, groups [][]usableProbe) bool {
+	for _, g := range groups {
+		if !indexCovers(ix, g) {
+			return false
+		}
+	}
+	return true
+}
+
+// indexCanSkip reports whether the indexed prefix provably holds no record satisfying the
+// probe, so the query can skip it (and full-scan only the un-indexed tail). Correctness-
+// critical: true only when certain. An exceptional record forbids a skip; `!=` never skips.
+func indexCanSkip(ix indexPrimitives, up usableProbe) bool {
+	s := ix.statsFor(up)
+	if s == nil || s.exc > 0 {
+		return false
+	}
+	if up.op == "present" || up.op == "absent" {
+		return false // presence spans posted + exc + absent; never provably empty here
+	}
+	if up.cat {
+		if up.op != "==" && up.op != "in" {
+			return false
+		}
+		return ix.bloomAbsent(up) // every probe value definitely absent
+	}
+	if !s.hasRange {
+		// No numeric record in the prefix (and exc==0): nothing an equality/range probe can
+		// match. A `!=` still matches every non-exc record, so keep it.
+		return up.op != "!="
+	}
+	switch up.op {
+	case "==", "in":
+		for _, t := range up.fvals {
+			if t >= s.min && t <= s.max {
+				return false
+			}
+		}
+		return true
+	case "<":
+		return s.min >= up.fvals[0]
+	case "<=":
+		return s.min > up.fvals[0]
+	case ">":
+		return s.max <= up.fvals[0]
+	case ">=":
+		return s.max < up.fvals[0]
+	}
+	return false
+}
+
+// indexSkipsPrefix reports whether the whole indexed prefix can be skipped: the candidate
+// set is the intersection of per-probe candidate sets, so any single provably-empty probe
+// empties it. Cheaper than candidateOffsets for range probes (no key iteration).
+func indexSkipsPrefix(ix indexPrimitives, usable []usableProbe) bool {
+	for _, up := range usable {
+		if indexCanSkip(ix, up) {
+			return true
+		}
+	}
+	return false
+}
+
+// indexEstCandidates estimates how many records a probe admits, for ordering only (never
+// correctness). estCandidatesFromStats holds the logic so it is testable on a bare segStats.
+func indexEstCandidates(ix indexPrimitives, up usableProbe) float64 {
+	return estCandidatesFromStats(ix.statsFor(up), up)
+}
+
+func estCandidatesFromStats(s *segStats, up usableProbe) float64 {
+	if s == nil {
+		return math.MaxFloat64 // unknown: apply last
+	}
+	indexable := float64(s.covered - s.exc)
+	switch up.op {
+	case "==", "in":
+		var sum float64
+		if up.cat {
+			for _, v := range up.svals {
+				sum += s.estEqualStr(v)
+			}
+		} else {
+			for _, v := range up.fvals {
+				sum += s.estEqualFloat(v)
+			}
+		}
+		return sum + float64(s.exc)
+	case "!=":
+		if up.cat {
+			return indexable - s.estEqualStr(up.svals[0]) + float64(s.exc)
+		}
+		return indexable - s.estEqualFloat(up.fvals[0]) + float64(s.exc)
+	case "isnt":
+		if up.cat {
+			return indexable - s.estEqualStr(strings.ToLower(up.svals[0])) + float64(s.exc)
+		}
+		return indexable
+	case "<", "<=", ">", ">=":
+		return s.estRange(up.op, up.fvals[0])*indexable + float64(s.exc)
+	}
+	return indexable
+}
+
+// indexSelectivityOrder returns indices into usable ordered by ascending estimated candidate
+// count (most selective first). Pure ordering heuristic: the AND is commutative, so it never
+// changes the result, only the work. Deterministic (stable, ties keep input order).
+func indexSelectivityOrder(ix indexPrimitives, usable []usableProbe) []int {
+	order := make([]int, len(usable))
+	est := make([]float64, len(usable))
+	for i, up := range usable {
+		order[i] = i
+		est[i] = indexEstCandidates(ix, up)
+	}
+	sort.SliceStable(order, func(a, b int) bool { return est[order[a]] < est[order[b]] })
+	return order
+}
+
+// indexCandidateOffsets returns the offsets satisfying every usable probe (a superset the
+// store re-verifies), applying the most-selective probe first so the roaring intersection
+// shrinks fastest. nil means "no candidates".
+func indexCandidateOffsets(ix indexPrimitives, usable []usableProbe) *roaring.Bitmap {
+	switch len(usable) {
+	case 0:
+		return nil
+	case 1:
+		return ix.probeOffsets(usable[0])
+	}
+	order := indexSelectivityOrder(ix, usable)
+	var acc *roaring.Bitmap
+	for _, i := range order {
+		bm := ix.probeOffsets(usable[i])
+		if acc == nil {
+			acc = bm
+		} else {
+			acc.And(bm)
+		}
+		if acc.IsEmpty() {
+			return acc
+		}
+	}
+	return acc
+}
+
+// indexCandidateOffsetsGroups returns the DNF union over groups of each group's candidate
+// intersection. Callers pass only prunable plans (every group has a usable probe).
+func indexCandidateOffsetsGroups(ix indexPrimitives, groups [][]usableProbe) *roaring.Bitmap {
+	var acc *roaring.Bitmap
+	for _, g := range groups {
+		gb := indexCandidateOffsets(ix, g)
+		if gb == nil {
+			gb = roaring.New()
+		}
+		if acc == nil {
+			acc = gb
+		} else {
+			acc.Or(gb)
+		}
+	}
+	return acc
+}

--- a/collections/readindex_test.go
+++ b/collections/readindex_test.go
@@ -3,6 +3,7 @@ package collections
 import (
 	"fmt"
 	"path/filepath"
+	"sort"
 	"testing"
 
 	"github.com/PelicanPlatform/classad/collections/vm"
@@ -95,6 +96,30 @@ func TestReadIndexParity(t *testing.T) {
 				}
 				if !bmEqual(live.candidateOffsets(usable), mm.candidateOffsets(usable)) {
 					t.Errorf("seg %d %q: candidateOffsets mismatch", seg.id, qs)
+				}
+			}
+
+			// catCanonicalValues must emit the same set from both tiers (matchmaking relies
+			// on the complete distinct-value set per segment).
+			for _, attr := range []string{"Owner", "State", "JobId"} {
+				id, ok := c.intern.LookupID(attr)
+				if !ok {
+					continue
+				}
+				collect := func(ix readIndex) []string {
+					var vs []string
+					ix.catCanonicalValues(id, func(v string) bool { vs = append(vs, v); return true })
+					sort.Strings(vs)
+					return vs
+				}
+				lv, mv := collect(live), collect(mm)
+				if len(lv) != len(mv) {
+					t.Fatalf("seg %d %s: canonical count %d vs %d", seg.id, attr, len(lv), len(mv))
+				}
+				for i := range lv {
+					if lv[i] != mv[i] {
+						t.Errorf("seg %d %s: canonical[%d] %q vs %q", seg.id, attr, i, lv[i], mv[i])
+					}
 				}
 			}
 

--- a/collections/readindex_test.go
+++ b/collections/readindex_test.go
@@ -1,0 +1,134 @@
+package collections
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/collections/vm"
+	"github.com/RoaringBitmap/roaring/v2"
+)
+
+// TestReadIndexParity is the anchor for the shared planner logic: for every built segment,
+// its in-RAM *segIndex and the *mmapSegIndex parsed from the sidecar it writes must return
+// IDENTICAL covers / candidateOffsets / skipsPrefix / DNF-group results across a broad probe
+// battery. If the two representations ever diverged (a skip the mmap tier got wrong, a
+// candidate it missed), a sealed segment on the mmap tier would answer queries differently
+// from the same data in RAM.
+func TestReadIndexParity(t *testing.T) {
+	t.Parallel()
+	c := New(Options{
+		Shards:           1,
+		CategoricalAttrs: []string{"Owner", "State", "JobId"},
+		ValueAttrs:       []string{"Memory", "Cpus"},
+	})
+	owners := []string{"alice", "bob", "carol", "dave"}
+	states := []string{"Idle", "Running", "Held"}
+	for i := 0; i < 8000; i++ { // JobId is unique -> high NDV -> trips the MPH in sealed segments
+		ad := fmt.Sprintf(`[ Id=%d; Owner=%q; State=%q; JobId=%q; Memory=%d; Cpus=%d ]`,
+			i, owners[i%len(owners)], states[i%len(states)], fmt.Sprintf("job-%d", i), (i%16+1)*512, i%8)
+		if i%29 == 0 { // a Memory type exception
+			ad = fmt.Sprintf(`[ Id=%d; Owner=%q; State=%q; JobId=%q; Memory="x"; Cpus=%d ]`,
+				i, owners[i%len(owners)], states[i%len(states)], fmt.Sprintf("job-%d", i), i%8)
+		}
+		if err := c.Put([]byte(fmt.Sprintf("m%d", i)), mustAd(t, ad)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	c.Reindex()
+
+	conj := []string{
+		`Owner == "alice"`,
+		`Owner != "bob"`,
+		`Owner == "alice" || Owner == "carol"`,
+		`Owner == "nobody"`, // bloom-absent -> skip
+		`State == "Running" && Memory >= 4096`,
+		`Memory > 2048 && Memory <= 6144`,
+		`Memory >= 999999`, // out of range -> skip
+		`Cpus == 4`,
+		`JobId == "job-100"`,    // MPH path (present)
+		`JobId == "job-999999"`, // MPH/absent
+		`Owner isnt undefined`,
+		`Owner is undefined`,
+		`State == "Held" && Owner == "dave" && Cpus < 4`,
+	}
+	dnf := []string{
+		`(Owner == "alice" && Memory >= 4096) || (State == "Held" && Cpus == 2)`,
+		`(JobId == "job-1") || (JobId == "job-2") || (State == "Idle" && Memory < 1024)`,
+	}
+
+	segs := 0
+	for _, sh := range c.shards {
+		for _, seg := range sh.segs {
+			if seg == nil {
+				continue
+			}
+			live := seg.idx.Load()
+			if live == nil {
+				continue
+			}
+			path := filepath.Join(t.TempDir(), fmt.Sprintf("seg-%d.idx", seg.id))
+			if err := writeSidecarIndex(path, live); err != nil {
+				t.Fatalf("write sidecar: %v", err)
+			}
+			data, closer, err := mapFile(path)
+			if err != nil {
+				t.Fatalf("map sidecar: %v", err)
+			}
+			mm, err := parseMmapSidecar(data)
+			if err != nil {
+				t.Fatalf("parse sidecar: %v", err)
+			}
+			segs++
+
+			for _, qs := range conj {
+				q, err := vm.Parse(qs)
+				if err != nil {
+					t.Fatalf("parse %q: %v", qs, err)
+				}
+				usable := c.planIndex(q.Probes())
+				if live.covers(usable) != mm.covers(usable) {
+					t.Errorf("seg %d %q: covers mismatch (live %v, mmap %v)", seg.id, qs, live.covers(usable), mm.covers(usable))
+				}
+				if live.skipsPrefix(usable) != mm.skipsPrefix(usable) {
+					t.Errorf("seg %d %q: skipsPrefix mismatch (live %v, mmap %v)", seg.id, qs, live.skipsPrefix(usable), mm.skipsPrefix(usable))
+				}
+				if !bmEqual(live.candidateOffsets(usable), mm.candidateOffsets(usable)) {
+					t.Errorf("seg %d %q: candidateOffsets mismatch", seg.id, qs)
+				}
+			}
+
+			for _, qs := range dnf {
+				q, err := vm.Parse(qs)
+				if err != nil {
+					t.Fatalf("parse %q: %v", qs, err)
+				}
+				plan := q.ProbePlan()
+				groups, prunable := c.planIndexGroups(plan)
+				if !prunable {
+					continue
+				}
+				if live.coversGroups(groups) != mm.coversGroups(groups) {
+					t.Errorf("seg %d %q: coversGroups mismatch", seg.id, qs)
+				}
+				if !bmEqual(live.candidateOffsetsGroups(groups), mm.candidateOffsetsGroups(groups)) {
+					t.Errorf("seg %d %q: candidateOffsetsGroups mismatch", seg.id, qs)
+				}
+			}
+			_ = closer()
+		}
+	}
+	if segs == 0 {
+		t.Fatal("no segments compared")
+	}
+}
+
+func bmEqual(a, b *roaring.Bitmap) bool {
+	if a == nil {
+		a = roaring.New()
+	}
+	if b == nil {
+		b = roaring.New()
+	}
+	return a.Equals(b)
+}

--- a/collections/readindex_test.go
+++ b/collections/readindex_test.go
@@ -123,6 +123,58 @@ func TestReadIndexParity(t *testing.T) {
 	}
 }
 
+// TestSealedIndexBackings checks that both sealed-segment backings -- a file mmap and an
+// anonymous mapping -- produce an index whose query results match the in-RAM segIndex. This
+// is the step-4 substrate for flipping sealed segments to the mmap representation.
+func TestSealedIndexBackings(t *testing.T) {
+	t.Parallel()
+	c := New(Options{Shards: 1, CategoricalAttrs: []string{"Owner"}, ValueAttrs: []string{"Memory"}})
+	for i := 0; i < 3000; i++ {
+		if err := c.Put([]byte(fmt.Sprintf("m%d", i)),
+			mustAd(t, fmt.Sprintf(`[ Id=%d; Owner="u%d"; Memory=%d ]`, i, i%40, (i%16+1)*512))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	c.Reindex()
+	queries := []string{`Owner == "u3"`, `Owner != "u3"`, `Memory >= 4096`, `Owner == "nope"`, `Memory >= 999999`}
+
+	check := func(name string, mk func(si *segIndex) (*mmapSegIndex, func() error, error)) {
+		segs := 0
+		for _, sh := range c.shards {
+			for _, seg := range sh.segs {
+				if seg == nil {
+					continue
+				}
+				live := seg.idx.Load()
+				if live == nil {
+					continue
+				}
+				mm, closer, err := mk(live)
+				if err != nil {
+					t.Fatalf("%s: %v", name, err)
+				}
+				for _, qs := range queries {
+					q, _ := vm.Parse(qs)
+					u := c.planIndex(q.Probes())
+					if !bmEqual(live.candidateOffsets(u), mm.candidateOffsets(u)) {
+						t.Errorf("%s seg %d %q: candidate mismatch", name, seg.id, qs)
+					}
+				}
+				_ = closer()
+				segs++
+			}
+		}
+		if segs == 0 {
+			t.Fatalf("%s: no segments", name)
+		}
+	}
+
+	check("file", func(si *segIndex) (*mmapSegIndex, func() error, error) {
+		return sealedIndexFromFile(filepath.Join(t.TempDir(), "s.idx"), si)
+	})
+	check("anon", sealedIndexAnon)
+}
+
 func bmEqual(a, b *roaring.Bitmap) bool {
 	if a == nil {
 		a = roaring.New()

--- a/collections/sealed_index.go
+++ b/collections/sealed_index.go
@@ -1,0 +1,49 @@
+package collections
+
+// A sealed segment's index is the immutable sidecar read over an mmap (mmapSegIndex), not
+// the in-RAM segIndex the active segment uses. Two backings, one reader:
+//
+//   - persistent: the sidecar is a file beside the segment (reclaimable from disk);
+//   - in-memory:  the sidecar bytes live in an anonymous mapping (off the Go heap, not
+//     persisted, MADV_FREE-able).
+//
+// Both return an unmap closer the segment reaps with its data, so a rotation/compaction that
+// drops a segment tears down its index mapping at the same pin-drained moment (no scan reads
+// a torn mapping). The active segment keeps its mutable in-RAM segIndex.
+
+// sealedIndexFromFile writes si's sidecar to path, maps the file, and returns the read-only
+// mmap view plus an unmap closer (persistent sealed segment).
+func sealedIndexFromFile(path string, si *segIndex) (*mmapSegIndex, func() error, error) {
+	if err := writeSidecarIndex(path, si); err != nil {
+		return nil, nil, err
+	}
+	data, closer, err := mapFile(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	mm, err := parseMmapSidecar(data)
+	if err != nil {
+		_ = closer()
+		return nil, nil, err
+	}
+	return mm, closer, nil
+}
+
+// sealedIndexAnon builds si's sidecar bytes into an anonymous mapping and returns the view
+// plus an unmap closer (in-memory sealed segment).
+func sealedIndexAnon(si *segIndex) (*mmapSegIndex, func() error, error) {
+	b, err := buildSidecarIndex(si)
+	if err != nil {
+		return nil, nil, err
+	}
+	data, closer, err := mapAnon(b)
+	if err != nil {
+		return nil, nil, err
+	}
+	mm, err := parseMmapSidecar(data)
+	if err != nil {
+		_ = closer()
+		return nil, nil, err
+	}
+	return mm, closer, nil
+}

--- a/collections/segment.go
+++ b/collections/segment.go
@@ -81,6 +81,11 @@ type segment struct {
 	// segIndex is immutable once published, so query readers load it lock-free.
 	idx atomic.Pointer[segIndex]
 
+	// msidx is a sealed segment's index in its pageable mmap form (the sidecar). When set
+	// it supersedes idx (which is then cleared to free the heap copy): readIdx prefers it.
+	// Its backing mapping is released via onReap when the segment's scan pins drain.
+	msidx atomic.Pointer[mmapSegIndex]
+
 	// Persistent (mmap) segments only; nil/zero for RAM segments. See mmapseg.go.
 	// The file name is independent of the logical id (id == array index, reassigned
 	// at compaction install and on recovery), so no rename is needed when id changes.
@@ -102,6 +107,20 @@ type segment struct {
 	// segment's mmap'd sidecar index at the same pin-drained moment its data is
 	// reaped, so a query scanning a rotating segment never reads a torn index mapping.
 	onReap func()
+}
+
+// readIdx returns the segment's queryable index behind the readIndex interface: the mmap'd
+// sidecar (msidx) once the segment is sealed and converted, else the in-RAM segIndex, else
+// nil. A sealed segment's msidx supersedes its (cleared) in-RAM idx; both satisfy readIndex,
+// so the query planner dispatches through it without caring which representation it is.
+func (s *segment) readIdx() readIndex {
+	if m := s.msidx.Load(); m != nil {
+		return m
+	}
+	if i := s.idx.Load(); i != nil {
+		return i
+	}
+	return nil
 }
 
 // pin marks the start of a scan's use of a segment (mmap only; RAM segments rely on

--- a/collections/sidecar_stats_test.go
+++ b/collections/sidecar_stats_test.go
@@ -66,6 +66,48 @@ func TestSidecarStatsRoundTrip(t *testing.T) {
 	}
 }
 
+// TestSidecarCRC checks the v8 footer: an intact sidecar validates, and any corruption
+// (a flipped byte, a truncation) is detected so the caller rebuilds from the data.
+func TestSidecarCRC(t *testing.T) {
+	t.Parallel()
+	c := New(Options{Shards: 1, CategoricalAttrs: []string{"Owner"}, ValueAttrs: []string{"Memory"}})
+	for i := 0; i < 1000; i++ {
+		if err := c.Put([]byte(fmt.Sprintf("m%d", i)),
+			mustAd(t, fmt.Sprintf(`[ Id=%d; Owner="u%d"; Memory=%d ]`, i, i%20, (i%8+1)*512))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	c.Reindex()
+	var si *segIndex
+	for _, sh := range c.shards {
+		for _, seg := range sh.segs {
+			if seg != nil && seg.idx.Load() != nil {
+				si = seg.idx.Load()
+			}
+		}
+	}
+	if si == nil {
+		t.Fatal("no index built")
+	}
+	b, err := buildSidecarIndex(si)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !sidecarCRCValid(b) {
+		t.Fatal("intact sidecar failed CRC")
+	}
+	// Flip a byte in the body.
+	bad := append([]byte(nil), b...)
+	bad[len(bad)/2] ^= 0x40
+	if sidecarCRCValid(bad) {
+		t.Error("corrupted sidecar passed CRC")
+	}
+	// Truncated tail.
+	if sidecarCRCValid(b[:len(b)-8]) {
+		t.Error("truncated sidecar passed CRC")
+	}
+}
+
 func assertStatsEqual(t *testing.T, kind string, want, got *segStats) {
 	t.Helper()
 	if got == nil {

--- a/collections/sidecar_stats_test.go
+++ b/collections/sidecar_stats_test.go
@@ -1,0 +1,97 @@
+package collections
+
+import (
+	"bytes"
+	"fmt"
+	"path/filepath"
+	"testing"
+)
+
+// TestSidecarStatsRoundTrip verifies the v7 per-attribute stats block: the summary a
+// mmapSegIndex reads back (statsFor) is identical to the in-RAM segIndex's build-time stats.
+// This is what lets a sealed segment answer canSkip/estCandidates/selectivityOrder over the
+// mmap without paging its postings to recompute finishStats.
+func TestSidecarStatsRoundTrip(t *testing.T) {
+	t.Parallel()
+	c := New(Options{Shards: 1, CategoricalAttrs: []string{"Owner", "State"}, ValueAttrs: []string{"Memory", "Cpus"}})
+	owners := []string{"alice", "bob", "carol", "dave"}
+	states := []string{"Idle", "Running", "Held"}
+	for i := 0; i < 3000; i++ {
+		ad := fmt.Sprintf(`[ Id=%d; Owner=%q; State=%q; Memory=%d; Cpus=%d ]`,
+			i, owners[i%len(owners)], states[i%len(states)], (i%16+1)*512, i%8)
+		if i%23 == 0 { // a type exception for Memory
+			ad = fmt.Sprintf(`[ Id=%d; Owner=%q; State=%q; Memory="lots"; Cpus=%d ]`, i, owners[i%len(owners)], states[i%len(states)], i%8)
+		}
+		if err := c.Put([]byte(fmt.Sprintf("m%d", i)), mustAd(t, ad)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	c.Reindex()
+
+	checked := 0
+	for _, sh := range c.shards {
+		for _, seg := range sh.segs {
+			if seg == nil {
+				continue
+			}
+			si := seg.idx.Load()
+			if si == nil {
+				continue
+			}
+			path := filepath.Join(t.TempDir(), fmt.Sprintf("seg-%d.idx", seg.id))
+			if err := writeSidecarIndex(path, si); err != nil {
+				t.Fatalf("write sidecar: %v", err)
+			}
+			data, closer, err := mapFile(path)
+			if err != nil {
+				t.Fatalf("map sidecar: %v", err)
+			}
+			msi, err := parseMmapSidecar(data)
+			if err != nil {
+				t.Fatalf("parse sidecar: %v", err)
+			}
+			for id, cp := range si.cat {
+				assertStatsEqual(t, "cat", &cp.stats, msi.catStats[id])
+				checked++
+			}
+			for id, vp := range si.val {
+				assertStatsEqual(t, "val", &vp.stats, msi.valStats[id])
+				checked++
+			}
+			_ = closer()
+		}
+	}
+	if checked == 0 {
+		t.Fatal("no attribute stats were compared")
+	}
+}
+
+func assertStatsEqual(t *testing.T, kind string, want, got *segStats) {
+	t.Helper()
+	if got == nil {
+		t.Fatalf("%s: no mmap stats parsed", kind)
+	}
+	if want.covered != got.covered || want.exc != got.exc || want.ndv != got.ndv {
+		t.Errorf("%s: covered/exc/ndv mismatch: want %d/%d/%d got %d/%d/%d",
+			kind, want.covered, want.exc, want.ndv, got.covered, got.exc, got.ndv)
+	}
+	if want.hasRange != got.hasRange || (want.hasRange && (want.min != got.min || want.max != got.max)) {
+		t.Errorf("%s: range mismatch: want hasRange=%v [%v,%v] got hasRange=%v [%v,%v]",
+			kind, want.hasRange, want.min, want.max, got.hasRange, got.min, got.max)
+	}
+	if len(want.top) != len(got.top) {
+		t.Fatalf("%s: top-N length mismatch: want %d got %d", kind, len(want.top), len(got.top))
+	}
+	for i := range want.top {
+		if want.top[i].skey != got.top[i].skey || want.top[i].fkey != got.top[i].fkey || want.top[i].count != got.top[i].count {
+			t.Errorf("%s: top[%d] mismatch: want %+v got %+v", kind, i, want.top[i], got.top[i])
+		}
+	}
+	switch {
+	case want.hll == nil && got.hll == nil:
+	case want.hll == nil || got.hll == nil:
+		t.Errorf("%s: HLL presence mismatch (want nil=%v, got nil=%v)", kind, want.hll == nil, got.hll == nil)
+	case !bytes.Equal(want.hll.reg, got.hll.reg):
+		t.Errorf("%s: HLL registers differ", kind)
+	}
+}


### PR DESCRIPTION
## Summary
Substrate for representing a **sealed** segment's index as the pageable mmap sidecar (`mmapSegIndex`) instead of the heap `segIndex` — reclaimable, GC-invisible, O(1) to load. This PR lands everything **up to but not including the behavior flip**: the mmap tier is brought to *proven full parity* with the in-RAM tier, with **zero behavior change** (the live query path still uses `*segIndex`; `segment.msidx` stays nil until conversion is enabled). The plan is in [`collections/docs/design/mmap-sealed-indexes.md`](collections/docs/design/mmap-sealed-indexes.md).

**Depends on #27** (MPH / sidecar v6). Until #27 merges, this diff also shows its commit; merge #27 first.

## What's here
- **v7 sidecar `segStats` block** — the live planner's skip/selectivity paths read `segStats` (min/max, top-N, ndv, HLL) that the sidecar didn't carry; a mmap index can't recompute them without paging every bitmap. Serialized now; parsed eagerly (O(#attrs), resident). Round-trip test proves mmap stats == `finishStats` stats.
- **v8 CRC-32C footer** — the sidecar is derived, but silent corruption has wrong-result paths (a bit-flipped bitmap decodes empty → dropped candidates; a corrupt min/max → wrong skip). Footer over the whole sidecar; mismatch ⇒ rebuild. Transparent to the lazy `parseMmapSidecar` (read via `metaOff`), so the archive's >RAM paging is unaffected.
- **Shared `readIndex` planner logic** — `covers`/`candidateOffsets`/`skipsPrefix`/DNF-groups/`estCandidates`/`catCanonicalValues` extracted to shared functions over an `indexPrimitives` interface; both `*segIndex` and `*mmapSegIndex` are thin delegates, so the two tiers **cannot diverge**. `TestReadIndexParity` drives both through an identical battery (equality, `!=`, ranges, presence, DNF, bloom/range skips, MPH-cardinality attrs, canonical-value enumeration) and asserts byte-identical results.
- **`catCanonicalValues`** — MATCH's finite-value materialization reached into `segIndex.cat` directly; now served on both tiers (mmap iterates the sidecar's exact-case run), so matchmaking will still see sealed segments after the flip.
- **Sealed-index backings** — `buildSidecarIndex` (returns bytes) + `mapAnon` (off-heap anonymous mapping; heap fallback on non-unix) + `sealedIndexFromFile`/`sealedIndexAnon`. `TestSealedIndexBackings` asserts both backings match the in-RAM index.
- **`segment.msidx` + `readIdx()`** — the dispatch plumbing; query sites go through `readIdx()` (returns the in-RAM idx while `msidx` is nil).

## Not here (the behavior flip — follow-on)
Enabling conversion (Reindex seals sealed persistent segments to mmap, `Open` maps sidecars, CLIX removed) plus the reap-path wiring it needs. Kept separate because that's the piece where a bug is a leak/use-after-unmap, not a slow query. See the design note.

## Tests
Full `collections` suite green. New: `TestSidecarStatsRoundTrip`, `TestSidecarCRC`, `TestReadIndexParity`, `TestSealedIndexBackings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
