### PR TITLE
collections: seal in-memory segment indexes to an anonymous mmap sidecar

### DIFF
--- a/collections/compact.go
+++ b/collections/compact.go
@@ -183,6 +183,7 @@ func (c *Collection) compactShard(sh *shard, target Codec) {
 			// compaction allocation failure durable/abortable).
 		}
 		cur = newSegment(0, size, codec)
+		cur.pinReap = sh.sealRAM // keep the compacted RAM segment pin/reap-eligible for anon sealing
 		dstSegs = append(dstSegs, cur)
 	}
 	var moved []movedRec

--- a/collections/docs/design/README.md
+++ b/collections/docs/design/README.md
@@ -590,7 +590,11 @@ generation checked); any that are missing, stale, or built under a different spe
 are rebuilt and re-sealed by the post-open `Reindex`. So an index configuration must still be
 supplied identically at reopen, but a large store reloads its sealed indexes by mmapping
 rather than re-indexing every record — and their bitmaps never occupy the Go heap. An
-in-memory collection keeps its active index in RAM. A demand tracker records which attributes
+in-memory collection (the collector's use case) does the same off-heap move with an
+**anonymous** mmap sidecar instead of a file: its sealed-segment indexes leave the Go heap
+too — out of GC mark cost and GOGC pacing — while only the active segment's index stays in
+RAM. (A RAM segment that carries such a sidecar joins the same scan-pin/reap discipline as a
+file-backed one, since an anonymous mapping is not GC-managed.) A demand tracker records which attributes
 queries filter on, so `SuggestIndexes` can recommend indexes a workload would benefit from,
 and the auto-tuner grows/trims indexes against a memory watermark. Because the sealed tail is
 off-heap, that watermark now splits across two reports: `IndexSizes` measures the heap-resident

--- a/collections/docs/design/mmap-sealed-indexes.md
+++ b/collections/docs/design/mmap-sealed-indexes.md
@@ -110,9 +110,24 @@ seal for live segments too.
 7. ✅ **Accounting + doc.** `Collection.SidecarSizes()` reports the live store's sealed
    sidecars (mapped/evictable, MPH+Bloom broken out); `IndexSizes` now measures only the
    in-RAM active segments; design README §8/§10 updated.
+8. ✅ **In-memory anon flip (the collector's GC win).** Sealed RAM segments seal their index
+   into an **anonymous** mmap sidecar (`sealSegmentIndexAnon`, off the Go heap), gated on
+   in-memory + mmap-supported + indexes configured at construction (`shard.sealRAM`). The
+   crux was **pin/reap for RAM segments**: a plain RAM segment relies on the GC and skips
+   pin/reap, but an anon mapping is not GC-managed, so a scan reading it could race a
+   compaction that unmaps it. Fix: a RAM segment that carries an anon sidecar is made
+   pin/reap-eligible **from birth** (`segment.pinReap`, set in `allocSeg`/compaction for a
+   sealing shard), so `segment.mapped()` (`file != nil || pinReap`) drives pin/unpin/retire/
+   closeUnmap uniformly — the pin at scan start unconditionally brackets any later `msidx`
+   read, exactly as `file != nil` does for a persistent segment. `Collection.Close` now
+   routes through the pin-aware `closeUnmap` so the anon sidecars unmap (and, as a bonus, the
+   persistent path stops leaking its `.idx` mapping at Close). `TestSealedSegmentsGoAnonMmap`
+   covers it; full suite + race clean.
 
 ## Follow-ups (not in this work)
 
-- **Data arenas off-heap for the in-memory DB.** A separate, smaller GC win (the arenas are
-  pointer-free → pacing/RSS, not mark cost). Anonymous-mmap the RAM segment backing.
+- **Data arenas off-heap for the in-memory DB.** A separate, larger GC win (the arenas are
+  pointer-free → pacing/RSS/mark cost across the whole record body, not just the index).
+  Anonymous-mmap the RAM segment backing itself. The pin/reap-for-RAM machinery added in
+  step 8 is a prerequisite (a scan reading anon record bytes must pin them too).
 - **`mlock` knob** for latency-critical stores that want the sidecar pinned resident.

--- a/collections/index_query.go
+++ b/collections/index_query.go
@@ -32,6 +32,7 @@ func (c *Collection) Reindex() {
 		// safe to convert to the pageable mmap sidecar; the active segment stays in-RAM.
 		sh.mu.RLock()
 		act := sh.act
+		sealRAM := sh.sealRAM
 		type target struct {
 			seg  *segment
 			used int
@@ -55,7 +56,7 @@ func (c *Collection) Reindex() {
 			if seg.used == 0 {
 				continue
 			}
-			sealable := persistent && seg != act
+			sealable := seg != act && (persistent || sealRAM)
 			// Rebuild when the index is missing, behind the write watermark, or built under
 			// an older spec generation; otherwise a current-but-unsealed sealable segment
 			// still needs converting.
@@ -76,10 +77,15 @@ func (c *Collection) Reindex() {
 				si = buildSegIndex(t.seg.data, t.used, t.seg.codec, spec)
 				t.seg.idx.Store(si)
 			}
-			// Sealed persistent segment: move its index off the heap into the mmap sidecar
-			// (reclaimable, GC-invisible). Best-effort; on failure the in-RAM index stays.
+			// Sealed segment: move its index off the heap into the mmap sidecar (reclaimable,
+			// GC-invisible) -- a file sidecar for a persistent segment, an anonymous mapping
+			// for a RAM one. Best-effort; on failure the in-RAM index stays.
 			if t.seal {
-				c.sealSegmentIndex(t.seg, si)
+				if persistent {
+					c.sealSegmentIndex(t.seg, si)
+				} else {
+					c.sealSegmentIndexAnon(t.seg, si)
+				}
 			}
 		}
 	}

--- a/collections/index_size.go
+++ b/collections/index_size.go
@@ -88,12 +88,14 @@ func (a *Archive) SidecarSizes() SidecarSizes {
 }
 
 // SidecarSizes reports the live Collection's sealed-segment sidecar bytes: the mmap-backed
-// index each sealed segment holds after the flip from the in-RAM segIndex. These bytes are
-// page-cache resident and evictable, NOT Go-heap memory, so they are reported apart from
-// IndexSizes (which now measures only the active, still-in-RAM segments' postings). Together
-// the two give the operator the full picture: heap postings on the hot active segment plus
-// evictable sidecar bytes on the sealed tail. It reads each segment's already-mapped bytes
-// under the shard read lock -- no re-mapping -- so it is cheap enough for periodic sampling.
+// index each sealed segment holds after the flip from the in-RAM segIndex -- a file mapping
+// for a persistent collection (page-cache resident, evictable to disk) or an anonymous
+// mapping for an in-memory one (off-heap, MADV_FREE-able to swap). Either way these bytes are
+// NOT Go-heap memory, so they are reported apart from IndexSizes (which now measures only the
+// active, still-in-RAM segments' postings). Together the two give the operator the full
+// picture: heap postings on the hot active segment plus off-heap sidecar bytes on the sealed
+// tail. It reads each segment's already-mapped bytes under the shard read lock -- no
+// re-mapping -- so it is cheap enough for periodic sampling.
 func (c *Collection) SidecarSizes() SidecarSizes {
 	var out SidecarSizes
 	for _, sh := range c.shards {

--- a/collections/mmap_flip_test.go
+++ b/collections/mmap_flip_test.go
@@ -115,6 +115,100 @@ func TestSealedSegmentsGoMmap(t *testing.T) {
 	}
 }
 
+// TestSealedSegmentsGoAnonMmap is the in-memory analogue of TestSealedSegmentsGoMmap: an
+// in-memory collection (no Dir) with indexes seals each sealed RAM segment's index into an
+// anonymous mmap sidecar (off the Go heap) while the active segment stays in-RAM. Queries stay
+// correct through the anon-mapped segments; a compaction that reaps a mapped RAM segment does
+// not crash (the pin/reap discipline now engages for RAM segments with an anon sidecar); and
+// Close unmaps the anon sidecars without leaking or crashing.
+func TestSealedSegmentsGoAnonMmap(t *testing.T) {
+	t.Parallel()
+	if !mmapSupported {
+		t.Skip("anonymous mmap sealing is unix-only")
+	}
+	opts := Options{Shards: 2, SegmentSize: 1 << 13, // in-memory (no Dir), small -> many segments
+		CategoricalAttrs: []string{"Owner"}, ValueAttrs: []string{"Memory"}}
+	c, err := Open(opts)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	src := map[int]bool{}
+	put := func(i int) {
+		mem := (i%16 + 1) * 512
+		if err := c.Put([]byte(fmt.Sprintf("m%d", i)),
+			mustAd(t, fmt.Sprintf(`[ Id=%d; Owner="u%d"; Memory=%d ]`, i, i%40, mem))); err != nil {
+			t.Fatal(err)
+		}
+		src[i] = (i%40 == 3) && mem >= 4096
+	}
+	for i := 0; i < 5000; i++ {
+		put(i)
+	}
+	c.Reindex()
+
+	countMmap := func() (mmapped, activeInRAM int) {
+		for _, sh := range c.shards {
+			for _, seg := range sh.segs {
+				if seg == nil {
+					continue
+				}
+				if seg == sh.act {
+					if seg.idx.Load() != nil {
+						activeInRAM++
+					}
+				} else if seg.msidx.Load() != nil && seg.idx.Load() == nil {
+					mmapped++
+				}
+			}
+		}
+		return
+	}
+	mmapped, _ := countMmap()
+	if mmapped == 0 {
+		t.Fatal("no sealed RAM segment was converted to an anon mmap sidecar")
+	}
+	if ss := c.SidecarSizes(); ss.Segments != mmapped || ss.MappedBytes == 0 {
+		t.Fatalf("SidecarSizes: segments=%d mapped=%d, want segments=%d and >0 bytes",
+			ss.Segments, ss.MappedBytes, mmapped)
+	}
+
+	q := func() *vm.Query {
+		x, err := vm.Parse(`Owner == "u3" && Memory >= 4096`)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return x
+	}
+	want := func() []int {
+		var ids []int
+		for i, ok := range src {
+			if ok {
+				ids = append(ids, i)
+			}
+		}
+		return sortedIntsOf(ids)
+	}()
+	if got := queryIDs(t, c, q()); !equalInts(got, want) {
+		t.Fatalf("through anon-mapped sealed segments: got %d ids, want %d", len(got), len(want))
+	}
+
+	// Compaction reaps mapped RAM segments; a use-after-unmap of the anon sidecar in the reap
+	// path (or a missing pin) would crash the query that follows.
+	for i := 0; i < 1500; i++ {
+		put(i)
+	}
+	c.Compact()
+	c.Reindex()
+	if got := queryIDs(t, c, q()); !equalInts(got, want) {
+		t.Fatalf("after compaction: got %d ids, want %d", len(got), len(want))
+	}
+	// Close unmaps the anon sidecars (no leak, no crash). An in-memory Close is otherwise a
+	// no-op; here it must tear the mappings down.
+	if err := c.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+}
+
 func sortedIntsOf(ids []int) []int {
 	for i := 1; i < len(ids); i++ { // insertion sort (small, test-only)
 		for j := i; j > 0 && ids[j-1] > ids[j]; j-- {

--- a/collections/persist.go
+++ b/collections/persist.go
@@ -402,9 +402,6 @@ func (c *Collection) rebuildDir(sh *shard) {
 // files. It is a no-op for an in-memory collection. The collection must not be used
 // after Close.
 func (c *Collection) Close() error {
-	if c.dir == "" {
-		return nil
-	}
 	var firstErr error
 	for _, sh := range c.shards {
 		sh.mu.Lock()
@@ -412,7 +409,13 @@ func (c *Collection) Close() error {
 			if seg == nil {
 				continue
 			}
-			if err := seg.unmap(); err != nil && firstErr == nil {
+			// closeUnmap unmaps a persistent segment's data file (without unlinking -- it
+			// persists for reopen) and, via the reap hook, its sidecar index; for an in-memory
+			// segment with an anon sidecar it unmaps that sidecar so a Close short of process
+			// exit does not leak the mapping. It is pin-aware (a live scan defers the unmap to
+			// its last unpin) and a no-op for a plain RAM segment, so this is safe and cheap
+			// for a pure key/value in-memory collection too.
+			if err := seg.closeUnmap(); err != nil && firstErr == nil {
 				firstErr = err
 			}
 		}

--- a/collections/sealed_index.go
+++ b/collections/sealed_index.go
@@ -93,6 +93,29 @@ func (c *Collection) loadSealedIndex(seg *segment, spec *indexSpec) bool {
 	return true
 }
 
+// sealSegmentIndexAnon is the in-memory analogue of sealSegmentIndex: it converts a sealed
+// RAM segment's in-RAM index (si) to an anonymous mmap sidecar (off the Go heap, GC-invisible,
+// MADV_FREE-able), publishes it as msidx via CAS, registers its unmap with reap (onReap), and
+// drops the heap copy. Best-effort -- on any error the in-RAM index stays. No-op for a segment
+// already sealed. The mapping is process-lifetime (no file); it is released when the segment is
+// reaped (compaction) or on Close. The segment must be pin/reap-eligible (pinReap set at
+// creation) so a concurrent scan reading the mapping keeps it alive until the scan's unpin.
+func (c *Collection) sealSegmentIndexAnon(seg *segment, si *segIndex) {
+	if si == nil || seg.msidx.Load() != nil {
+		return
+	}
+	mm, closer, err := sealedIndexAnon(si)
+	if err != nil {
+		return
+	}
+	if !seg.msidx.CompareAndSwap(nil, mm) {
+		_ = closer() // lost the race to a concurrent conversion; unmap our own and bail
+		return
+	}
+	seg.setOnReap(func() { _ = closer() })
+	seg.idx.Store(nil)
+}
+
 // sealedIndexAnon builds si's sidecar bytes into an anonymous mapping and returns the view
 // plus an unmap closer (in-memory sealed segment).
 func sealedIndexAnon(si *segIndex) (*mmapSegIndex, func() error, error) {

--- a/collections/segment.go
+++ b/collections/segment.go
@@ -107,7 +107,18 @@ type segment struct {
 	// segment's mmap'd sidecar index at the same pin-drained moment its data is
 	// reaped, so a query scanning a rotating segment never reads a torn index mapping.
 	onReap func()
+
+	// pinReap makes a RAM segment (file==nil) participate in pin/reap anyway, because it
+	// carries an anonymous mmap sidecar index (in-memory sealing): the anon mapping is not
+	// GC-managed, so scans must pin it and compaction/Close must unmap it via onReap, exactly
+	// as for a file-backed segment. Set at creation for an in-memory sealing shard; immutable.
+	pinReap bool
 }
+
+// mapped reports whether the segment holds a non-GC mapping that scans must pin and reap
+// must tear down: a file-backed data mmap, or (RAM store) an anon-mmap sealed sidecar. A
+// plain RAM segment (neither) relies on the GC and skips pin/reap entirely.
+func (s *segment) mapped() bool { return s.file != nil || s.pinReap }
 
 // readIdx returns the segment's queryable index behind the readIndex interface: the mmap'd
 // sidecar (msidx) once the segment is sealed and converted, else the in-RAM segIndex, else
@@ -123,10 +134,11 @@ func (s *segment) readIdx() readIndex {
 	return nil
 }
 
-// pin marks the start of a scan's use of a segment (mmap only; RAM segments rely on
-// the GC). Balanced by unpin. Called under the shard read lock.
+// pin marks the start of a scan's use of a segment. Balanced by unpin. Skipped for a
+// plain RAM segment (GC-managed); engaged for a file-backed segment or a RAM segment with
+// an anon sidecar (see mapped). Called under the shard read lock.
 func (s *segment) pin() {
-	if s.file == nil {
+	if !s.mapped() {
 		return
 	}
 	s.reapMu.Lock()
@@ -137,7 +149,7 @@ func (s *segment) pin() {
 // unpin ends a scan's use of a segment; if the segment was retired while pinned and
 // this was the last pin, it is reaped now (munmap + unlink). Called with no lock.
 func (s *segment) unpin() {
-	if s.file == nil {
+	if !s.mapped() {
 		return
 	}
 	s.reapMu.Lock()
@@ -171,9 +183,10 @@ func (s *segment) unmapAndHook() error {
 // otherwise it defers the unmap to the last unpin (so a live watch never reads a
 // mapping torn down under it -- the bug the pin count exists to prevent). Unlike
 // retire/reap it does not unlink the backing file. Idempotent; caller holds the
-// Archive mutex, so no new pin can be taken concurrently. No-op for RAM segments.
+// Archive mutex, so no new pin can be taken concurrently. No-op for a plain RAM segment;
+// a RAM segment with an anon sidecar unmaps it (via the reap hook) when its pins drain.
 func (s *segment) closeUnmap() error {
-	if s.file == nil {
+	if !s.mapped() {
 		return nil
 	}
 	s.reapMu.Lock()
@@ -223,10 +236,11 @@ func (s *segment) reapAndHook() error {
 
 // retire removes a compaction source segment from the live set. It returns true if
 // the caller should reap() it now (no scan references it); otherwise the last unpin
-// reaps it. For a RAM segment it is a no-op (the caller nils the slot; the GC frees
-// it). Called under the shard write lock.
+// reaps it. For a plain RAM segment it is a no-op (the caller nils the slot; the GC frees
+// it); a RAM segment with an anon sidecar retires like an mmap one so its sidecar unmaps.
+// Called under the shard write lock.
 func (s *segment) retire() (reapNow bool) {
-	if s.file == nil {
+	if !s.mapped() {
 		return false
 	}
 	s.reapMu.Lock()

--- a/collections/shard.go
+++ b/collections/shard.go
@@ -39,6 +39,12 @@ type shard struct {
 	// surfaced to the caller by Put/Update.
 	alloc    func(id uint32, size int, codec Codec) (*segment, error)
 	writeErr error
+	// sealRAM, when true, makes this (in-memory) shard's RAM segments seal their sealed
+	// index to an anonymous mmap sidecar rather than keep it on the Go heap. It also makes
+	// those RAM segments participate in pin/reap (see segment.mapped): the anon mapping is
+	// not GC-managed, so scans must pin it and compaction/Close must unmap it. Set once at
+	// construction (in-memory + mmap-supported + indexes configured); never mutated.
+	sealRAM bool
 	dirty    []*segment // segments with unsynced writes since the last sync (persistent)
 	// dirtySup lists supersededBySeq fields tombstoned by a delete since the last
 	// sync; their pages must be msync'd for the delete to be durable (unlike an
@@ -88,7 +94,9 @@ func newShard(segSize int, onSync func()) *shard {
 // lock.
 func (sh *shard) allocSeg(id uint32, size int, codec Codec) *segment {
 	if sh.alloc == nil {
-		return newSegment(id, size, codec)
+		s := newSegment(id, size, codec)
+		s.pinReap = sh.sealRAM // pin/reap-eligible so its anon sidecar tears down safely
+		return s
 	}
 	seg, err := sh.alloc(id, size, codec)
 	if err != nil {

--- a/collections/shard.go
+++ b/collections/shard.go
@@ -45,7 +45,7 @@ type shard struct {
 	// not GC-managed, so scans must pin it and compaction/Close must unmap it. Set once at
 	// construction (in-memory + mmap-supported + indexes configured); never mutated.
 	sealRAM bool
-	dirty    []*segment // segments with unsynced writes since the last sync (persistent)
+	dirty   []*segment // segments with unsynced writes since the last sync (persistent)
 	// dirtySup lists supersededBySeq fields tombstoned by a delete since the last
 	// sync; their pages must be msync'd for the delete to be durable (unlike an
 	// overwrite, a delete writes no new record, so recovery's max-seq rule cannot

--- a/collections/store.go
+++ b/collections/store.go
@@ -353,6 +353,17 @@ func New(opts Options) *Collection {
 		c.matchRoots = append(c.matchRoots, strings.ToLower(r))
 	}
 	c.spec.Store(newIndexSpec(c.intern, opts.CategoricalAttrs, opts.ValueAttrs))
+	// In-memory sealing: when this collection is in-memory (no Dir), mmap is supported, and
+	// indexes are configured, seal each sealed RAM segment's index into an anonymous mmap
+	// sidecar (off the Go heap: no GC scan of the sealed majority's bitmaps, RSS reclaimable
+	// under pressure). The active segment stays in-RAM. A collection with no indexes at
+	// construction keeps heap indexes (the flag is fixed here; a later AddIndex does not flip
+	// already-born segments), so pure key/value in-memory stores pay no pin/reap cost.
+	if opts.Dir == "" && mmapSupported && c.spec.Load().any() {
+		for _, sh := range c.shards {
+			sh.sealRAM = true
+		}
+	}
 	// Encryption at rest: build the DB-wide data-key sealer and the explicit encrypted-attr
 	// set. An encrypted attribute (explicit, or an always-encrypted private attribute) must
 	// not also be indexed -- its value is stored opaque, so it could never satisfy an index.


### PR DESCRIPTION
## Summary

Extends the sealed-index flip (#29) to **in-memory** collections — the collector's DB. A sealed RAM segment now seals its index into an **anonymous** mmap sidecar (`sealSegmentIndexAnon`) instead of keeping it on the Go heap, so the sealed majority's roaring bitmaps leave GC mark cost and GOGC pacing entirely. Only the active append segment stays in-RAM.

Gated on **in-memory + mmap-supported + indexes configured at construction** (`shard.sealRAM`); a pure key/value in-memory store is unaffected and pays no new cost.

## The hard part: pin/reap for RAM segments

A plain RAM segment relies on the GC and *skips* pin/reap (data is heap, GC-safe). An anonymous mapping is **not** GC-managed — a scan reading it could race a compaction that unmaps it (use-after-free). Persistent segments avoid this because `file != nil` makes their scan-pin unconditional from birth.

Fix — give RAM segments the same guarantee:
- `segment.pinReap` marks a RAM segment that carries (or will carry) an anon sidecar, stamped **at creation** (`allocSeg` + the compaction destination) for a sealing shard.
- `segment.mapped()` = `file != nil || pinReap` now drives `pin`/`unpin`/`retire`/`closeUnmap` uniformly. The unconditional pin at scan start brackets any *later* `msidx` read, exactly as `file != nil` does for a persistent segment — no late-binding hazard.

## Close

`Collection.Close` now routes through the pin-aware `closeUnmap` instead of a bare `unmap`. Previously an in-memory `Close` was a no-op, so the anon mappings would leak across create/close cycles (bad for tests / a collector that rebuilds its DB). As a bonus the persistent path stops leaking its `.idx` sidecar mapping at `Close` too, and the data unmap is now pin-deferred (a live scan during `Close` no longer races the munmap).

## Accounting

`SidecarSizes` already covers the live store, so the anon sidecars surface there (off-heap, `MADV_FREE`-able to swap) rather than in `IndexSizes` (heap, active-segment-only). Doc comments + design README §10 + design note step 8 updated.

## Testing

- `TestSealedSegmentsGoAnonMmap` (new): conversion (`msidx` set, heap freed), query correctness through anon-mapped segments, compaction-reap safety, `SidecarSizes`, clean `Close`.
- Full `collections` suite green (43s); `-race` clean (202s) across the concurrency/compaction/watch/close/query tests — the RAM pin/reap change is the race-sensitive part.

🤖 Generated with [Claude Code](https://claude.com/claude-code)