### PR TITLE
Handle old ClassAd literal escapes correctly

### DIFF
--- a/classad/old_escapes_test.go
+++ b/classad/old_escapes_test.go
@@ -1,0 +1,52 @@
+package classad
+
+import "testing"
+
+// TestParseOldClassAdLiteralEscapes locks in old-ClassAd string semantics matching the C++
+// Lexer::tokenizeStringOld: string literals get NO escape interpretation. An unrecognized
+// escape (the classic case: OSIssue = "\S" and the other agetty escapes /etc/issue carries)
+// must NOT fail the parse -- otherwise a single such attribute drops the whole ad, which is
+// how a Go collector silently lost every forwarded startd ad. Recognized C escapes are kept
+// literal too (backslash and all), byte-for-byte with the C++ old parser; only \" collapses
+// to a literal quote so an embedded quote does not end the string.
+func TestParseOldClassAdLiteralEscapes(t *testing.T) {
+	cases := []struct {
+		name string
+		text string
+		attr string
+		want string
+	}{
+		{"unknown escape S", `OSIssue = "\S"`, "OSIssue", `\S`},
+		{"agetty issue string", `OSIssue = "\S \r (\l)"`, "OSIssue", `\S \r (\l)`},
+		{"known escape kept literal (t)", `A = "tab\there"`, "A", `tab\there`},
+		{"known escape kept literal (n)", `A = "a\nb"`, "A", `a\nb`},
+		{"backslashes literal", `Path = "C:\Users\x"`, "Path", `C:\Users\x`},
+		{"double backslash literal", `A = "x\\y"`, "A", `x\\y`},
+		{"escaped quote is a literal quote", `A = "a\"b"`, "A", `a"b`},
+		{"plain string unchanged", `A = "hello world"`, "A", "hello world"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ad, err := ParseOld(tc.text)
+			if err != nil {
+				t.Fatalf("ParseOld(%q) errored: %v", tc.text, err)
+			}
+			got, ok := ad.EvaluateAttrString(tc.attr)
+			if !ok {
+				t.Fatalf("ParseOld(%q): attribute %s not a string", tc.text, tc.attr)
+			}
+			if got != tc.want {
+				t.Errorf("ParseOld(%q) %s = %q, want %q", tc.text, tc.attr, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestParseNewClassAdEscapesStillStrict guards the scope of the fix: NEW-ClassAd parsing is
+// unchanged -- an unrecognized escape there is still an error (leniency is only on the
+// old-ClassAd wire path, which is where C++ is lenient).
+func TestParseNewClassAdEscapesStillStrict(t *testing.T) {
+	if _, err := Parse(`[ A = "\S" ]`); err == nil {
+		t.Fatal("Parse (new ClassAd) accepted invalid escape \\S; leniency must be old-ClassAd only")
+	}
+}

--- a/collections/ingest.go
+++ b/collections/ingest.go
@@ -17,6 +17,14 @@ import (
 // re-encoded via the full parser, which dedups exactly.
 var errDuplicate = errors.New("duplicate attribute")
 
+// errDeferOld signals that a value needs the reference old-ClassAd parser (classad.ParseOld)
+// to encode correctly -- specifically a non-scalar, non-lone-string value that contains a
+// backslash, whose embedded string literals the fast expression path (ByteLexer / ParseExpr)
+// would lex with new-ClassAd escape rules and thus diverge from ParseOld. Backslash-free
+// expressions lex identically in both, so they keep the fast path. Like errDuplicate, the
+// whole ad is re-encoded via ParseOld.
+var errDeferOld = errors.New("defer to old-ClassAd parser")
+
 // OldAdUpdate is one insert-or-update whose ad is supplied in "old ClassAd"
 // serialization (newline-separated `Name = Value` lines, as sent over a TCP
 // socket), rather than as a parsed *classad.ClassAd.
@@ -63,7 +71,7 @@ func (c *Collection) encodeOld(text string, enc *wire.StreamEncoder, seen map[ui
 	enc.Reset()
 	clear(seen)
 	err := encodeOldText(text, enc, seen, unesc)
-	if err == errDuplicate {
+	if err == errDuplicate || err == errDeferOld {
 		ad, e := classad.ParseOld(text)
 		if e != nil {
 			return nil, e
@@ -98,7 +106,12 @@ func encodeOldText(text string, enc *wire.StreamEncoder, seen map[uint32]struct{
 		val := strings.TrimSpace(line[eq+1:])
 		if !isBareName(name) {
 			// Quoted/odd attribute names are rare in old-form ads; defer the whole
-			// assignment to the full parser, which unquotes the name correctly.
+			// assignment to the full parser, which unquotes the name correctly. But
+			// ParseClassAd is new-ClassAd (strict escapes), so if the line has a backslash
+			// its string lexing could diverge from ParseOld -- defer the whole ad instead.
+			if strings.IndexByte(line, '\\') >= 0 {
+				return errDeferOld
+			}
 			ad, err := parser.ParseClassAd("[" + line + "]")
 			if err != nil || ad == nil || len(ad.Attributes) != 1 {
 				return fmt.Errorf("malformed assignment %q", line)
@@ -117,6 +130,14 @@ func encodeOldText(text string, enc *wire.StreamEncoder, seen map[uint32]struct{
 		}
 		if fastString(enc, name, val, unesc) {
 			continue
+		}
+		// Not a scalar or a lone string literal. If it contains a backslash, an embedded
+		// string literal could lex differently under old-ClassAd rules (literal escapes) than
+		// the fast expression path's new-ClassAd lexer, so defer the whole ad to ParseOld.
+		// Backslash-free values (the overwhelming majority -- Requirements, Rank, etc.) lex
+		// identically, so they keep the fast path.
+		if strings.IndexByte(val, '\\') >= 0 {
+			return errDeferOld
 		}
 		// Computed value: parse the expression straight to wire (no ast.Expr). On any
 		// error -- a construct the native parser does not handle, or malformed text --
@@ -174,83 +195,55 @@ func fastScalar(enc *wire.StreamEncoder, name, val string) bool {
 	return false
 }
 
-// fastString handles a value that is exactly one double-quoted string literal
-// (with escapes), unescaping it into *unesc byte-for-byte as the lexer's scanString
-// does and emitting a string node -- avoiding the full expression parser for what,
-// on real ads, is the largest and most common non-scalar value (AddressV1 and other
-// escaped strings). It returns false, deferring to the parser, for anything it does
-// not handle identically to the lexer: a value that is not a lone string literal,
-// any non-ASCII byte (to avoid second-guessing the lexer's rune decoding), a null
-// (\0) or unknown escape (which the lexer rejects), or an unterminated string. The
-// parser therefore stays the source of truth for every uncertain case.
+// fastString handles a value that is exactly one double-quoted OLD-ClassAd string
+// literal, copying its content into *unesc byte-for-byte as the reference old-ClassAd
+// tokenizer (C++ Lexer::tokenizeStringOld, mirrored by classad.ParseOld) does, and
+// emitting a string node -- avoiding the full expression parser for what, on real ads,
+// is the largest and most common non-scalar value (AddressV1, OSIssue, and other
+// strings). Old-ClassAd string lexing does NO escape interpretation: a backslash is
+// kept literal (so OSIssue = "\S", the agetty escapes /etc/issue carries, ingests
+// instead of being rejected), EXCEPT immediately before the closing quote where it
+// escapes it (\" -> a literal quote, the string continues). It returns false, deferring
+// to the parser, only for a value that is not a lone string literal or is unterminated;
+// non-ASCII bytes are decoded to runes exactly as the lexer's scanString does (an invalid
+// byte becomes U+FFFD), so a lone string literal is ALWAYS handled here and never reaches the
+// strict expression fallback (which would octal-interpret \1 and diverge from ParseOld).
+//
+// Keeping this byte-identical to ParseOld is the invariant TestUpdateOldMatchesParseOld
+// and FuzzIngestOld enforce; the escape handling here must therefore track the lexer's
+// lenientEscapes path exactly.
 //
 // Escape-free plain-ASCII strings are already handled by fastScalar (simpleStr)
-// without a copy; this covers the with-escape case.
+// without a copy; this covers the with-backslash and non-ASCII cases.
 func fastString(enc *wire.StreamEncoder, name, val string, unesc *[]byte) bool {
 	if len(val) < 2 || val[0] != '"' {
 		return false
 	}
 	buf := (*unesc)[:0]
 	for i := 1; i < len(val); {
-		c := val[i]
-		switch {
-		case c == '"':
+		r, size := utf8.DecodeRuneInString(val[i:])
+		switch r {
+		case '"':
 			if i != len(val)-1 {
 				return false // content after the closing quote: not a lone string literal
 			}
 			*unesc = buf
 			enc.StringBytes(name, buf)
 			return true
-		case c >= 0x80:
-			return false // non-ASCII: let the parser's rune decoding handle it
-		case c == '\\':
-			i++
-			if i >= len(val) {
-				return false // unterminated escape
-			}
-			switch e := val[i]; e {
-			case 'b':
-				buf = append(buf, '\b')
-			case 't':
-				buf = append(buf, '\t')
-			case 'n':
-				buf = append(buf, '\n')
-			case 'f':
-				buf = append(buf, '\f')
-			case 'r':
-				buf = append(buf, '\r')
-			case '\\':
-				buf = append(buf, '\\')
-			case '"':
+		case '\\':
+			// Literal backslash, unless it immediately precedes the closing quote, where
+			// it escapes it (a lone trailing backslash therefore leaves the string
+			// unterminated, exactly as in tokenizeStringOld).
+			if i+1 < len(val) && val[i+1] == '"' {
 				buf = append(buf, '"')
-			case '\'':
-				buf = append(buf, '\'')
-			case '0', '1', '2', '3', '4', '5', '6', '7':
-				// \NNN: up to 3 octal digits if the first is 0-3, else up to 2.
-				maxDigits := 2
-				if e <= '3' {
-					maxDigits = 3
-				}
-				oval := int(e - '0')
-				for d := 1; d < maxDigits && i+1 < len(val); d++ {
-					n := val[i+1]
-					if n < '0' || n > '7' {
-						break
-					}
-					oval = oval*8 + int(n-'0')
-					i++
-				}
-				if oval == 0 {
-					return false // \0 (null) -- the lexer rejects it; let it produce the error
-				}
-				buf = utf8.AppendRune(buf, rune(oval))
-			default:
-				return false // unknown escape -- the lexer rejects it
+				i += 2
+			} else {
+				buf = append(buf, '\\')
+				i++
 			}
-			i++
 		default:
-			buf = append(buf, c)
-			i++
+			buf = utf8.AppendRune(buf, r) // invalid byte -> U+FFFD, matching scanString
+			i += size
 		}
 	}
 	return false // no closing quote

--- a/collections/ingest_faststring_test.go
+++ b/collections/ingest_faststring_test.go
@@ -4,31 +4,32 @@ import (
 	"testing"
 
 	"github.com/PelicanPlatform/classad/ast"
+	"github.com/PelicanPlatform/classad/classad"
 	"github.com/PelicanPlatform/classad/collections/wire"
-	"github.com/PelicanPlatform/classad/parser"
 )
 
-// TestFastStringMatchesParser verifies fastString unescapes a quoted string
-// literal byte-for-byte the same as the full parser (the lexer's scanString), and
-// defers to the parser for anything it does not handle.
-func TestFastStringMatchesParser(t *testing.T) {
+// TestFastStringMatchesParseOld verifies fastString copies a quoted OLD-ClassAd string
+// literal byte-for-byte the same as classad.ParseOld (the reference old-ClassAd tokenizer,
+// which keeps escapes literal), and defers to the parser for anything it does not handle.
+// This is the fast-path half of the TestUpdateOldMatchesParseOld / FuzzIngestOld invariant.
+func TestFastStringMatchesParseOld(t *testing.T) {
 	t.Parallel()
+	// Old-ClassAd strings keep backslashes literal, so escape sequences that the new-ClassAd
+	// lexer would interpret (\t \n) or reject (\S \0 \x) all pass through unchanged.
 	handled := []string{
 		`"hello"`, `""`, `"a\"b"`, `"a\\b"`, `"tab\tnl\nret\r"`,
 		`"\101\102"`, `"\7"`, `"\40"`, `"\377"`, `"a\'b"`, `"\b\f"`,
+		`"\S"`, `"\S \r (\l) \m"`, `"C:\Users\x"`, `"\0"`, `"\x"`,
+		"\"héllo\"", // valid non-ASCII: decoded to runes like scanString
 		`"{[ p=\"primary\"; a=\"1.2.3.4\"; port=9618; noUDP=true; ]}"`, // AddressV1-like
 		`"slot1@host.example.com"`,
 	}
 	for _, val := range handled {
-		table := wire.NewInternTable()
-		expr, err := parser.ParseExpr(val)
-		if err != nil {
-			t.Fatalf("parser %q: %v", val, err)
-		}
-		sl, ok := expr.(*ast.StringLiteral)
+		want, ok := parseOldStringValue(t, val)
 		if !ok {
-			t.Fatalf("%q did not parse to a string literal (%T)", val, expr)
+			t.Fatalf("reference ParseOld(%q) did not yield a string value", val)
 		}
+		table := wire.NewInternTable()
 		enc := wire.NewStreamEncoder(table, nil)
 		var buf []byte
 		if !fastString(enc, "A", val, &buf) {
@@ -40,16 +41,16 @@ func TestFastStringMatchesParser(t *testing.T) {
 			t.Fatalf("decode %q: %v", val, err)
 		}
 		got := ad.Attributes[0].Value.(*ast.StringLiteral).Value
-		if got != sl.Value {
-			t.Errorf("val %q: fastString %q != parser %q", val, got, sl.Value)
+		if got != want {
+			t.Errorf("val %q: fastString %q != ParseOld %q", val, got, want)
 		}
 	}
 
-	// Must defer to the parser: not lone string literals, or escapes the lexer
-	// treats specially/rejects, or non-ASCII.
+	// Must defer to the parser: not a lone string literal (expressions, non-strings), a
+	// non-ASCII byte (leave rune decoding to the parser), or an unterminated string.
 	deferred := []string{
 		`"a" + "b"`, `{1, 2}`, `x == y`, `"a" == "b"`, `5`, `true`,
-		`"\0"`, `"\00"`, `"\x"`, `"unterminated`, "\"héllo\"", `foo`,
+		`"unterminated`, `foo`,
 	}
 	for _, val := range deferred {
 		enc := wire.NewStreamEncoder(wire.NewInternTable(), nil)
@@ -58,4 +59,14 @@ func TestFastStringMatchesParser(t *testing.T) {
 			t.Errorf("fastString handled %q (expected deferred to parser)", val)
 		}
 	}
+}
+
+// parseOldStringValue returns the string value classad.ParseOld assigns to A in "A = <val>".
+func parseOldStringValue(t *testing.T, val string) (string, bool) {
+	t.Helper()
+	ad, err := classad.ParseOld("A = " + val)
+	if err != nil {
+		t.Fatalf("ParseOld(%q): %v", val, err)
+	}
+	return ad.EvaluateAttrString("A")
 }

--- a/fuzz/CPP_QUIRKS.md
+++ b/fuzz/CPP_QUIRKS.md
@@ -262,6 +262,39 @@ rejects the input. This is a libclassad leniency, not mirrored; the differential
 parser fuzzer allowlists parse disagreements whose input has a binary operator
 immediately before a ':' as CPP_QUIRKS #12.
 
+## 13. Old-ClassAd string literals do NO escape processing (backslashes are literal) — surprising
+
+The old-ClassAd wire format daemons advertise (newline-separated, unbracketed
+attributes) is lexed by `Lexer::tokenizeStringOld`, which — unlike the new-ClassAd
+string lexer (`tokenizeString` / `convert_escapes`) — performs **no** escape
+interpretation. Two consequences surprised us, and the *same bytes therefore mean
+different things to the old and new lexers*:
+
+- **Every backslash is literal.** In old-ClassAd, `OSIssue = "\S"` (the agetty
+  escapes `/etc/issue` carries: `\S \r \l \m`) is the two characters `\` and `S`.
+  The new-ClassAd parser instead *drops* an unknown-escape backslash — `[ A = "\S" ]`
+  evaluates `A` to `"S"` — and rejects yet others. `\n`, `\t`, and octal `\NNN`
+  are likewise kept literal in old-ClassAd, not interpreted.
+
+  ```
+  # new-ClassAd: unknown escape drops the backslash
+  classad_eval -quiet '[ A = "\S" ]' A          # "S"
+  # old-ClassAd (getOldClassAd / SetOldClassAd(true)): kept literal -> "\S"
+  ```
+
+- **A backslash immediately before the closing quote escapes it**, so a string
+  cannot end in a lone backslash: `"\\"` (backslash, backslash, quote) is
+  **unterminated** — the second `\` escapes the `"` and the scan runs off the end.
+  (`"a\"b"` is `a"b`; `"C:\"` is unterminated.) This is the one that caught us out.
+
+This is legacy behavior, not a bug — but a sharp edge. It bit a Go collector: its
+ingest lexed forwarded old-ClassAd string values with new-ClassAd escape rules,
+so `OSIssue = "\S"` was rejected (`invalid escape sequence \S`), the startd ad was
+dropped, and the forward connection reset (`condor_write(): Socket closed`). The
+Go engine's old-ClassAd path (`classad.ParseOld` and the `collections` ingest fast
+path) now matches `tokenizeStringOld` exactly, and `FuzzParseOldClassAdDifferential`
+guards it against regression.
+
 ## Observed (reasonable) semantics, recorded for completeness
 
 These are not bugs, but were non-obvious and are now matched by the Go engine:

--- a/fuzz/differ/differ.go
+++ b/fuzz/differ/differ.go
@@ -94,6 +94,11 @@ type Options struct {
 	// Useful when focusing purely on evaluation semantics, since the two
 	// parsers have known grammar differences that would otherwise dominate.
 	IgnoreParseDivergence bool
+	// OldClassAd compares the OLD-ClassAd parsers (classad.ParseOld vs libclassad's
+	// SetOldClassAd(true)) instead of the new-ClassAd ones -- the wire format daemons
+	// advertise, whose string literals keep escapes literal. This path was previously
+	// untested differentially, which is how the OSIssue = "\S" divergence shipped.
+	OldClassAd bool
 }
 
 // DefaultOptions is the standard comparison configuration.
@@ -101,9 +106,15 @@ func DefaultOptions() Options {
 	return Options{Tol: canon.DefaultTolerance}
 }
 
-// goEval parses and evaluates src with the native Go engine.
-func goEval(src string) (val canon.Value, raw string, parsed bool, err error) {
-	ad, perr := classad.Parse(src)
+// goEval parses and evaluates src with the native Go engine. When old is set it uses the
+// old-ClassAd parser (classad.ParseOld) instead of the new-ClassAd one, so the differ can
+// exercise the wire format daemons advertise -- whose string-escape semantics differ.
+func goEval(src string, old bool) (val canon.Value, raw string, parsed bool, err error) {
+	parse := classad.Parse
+	if old {
+		parse = classad.ParseOld
+	}
+	ad, perr := parse(src)
 	if perr != nil {
 		return canon.Value{}, "", false, perr
 	}
@@ -113,13 +124,13 @@ func goEval(src string) (val canon.Value, raw string, parsed bool, err error) {
 
 // goEvalSafe wraps goEval, converting a panic in the Go engine into a reported
 // finding rather than crashing the fuzzer.
-func goEvalSafe(src string) (val canon.Value, raw string, parsed bool, panicked string, err error) {
+func goEvalSafe(src string, old bool) (val canon.Value, raw string, parsed bool, panicked string, err error) {
 	defer func() {
 		if rec := recover(); rec != nil {
 			panicked = fmt.Sprintf("%v", rec)
 		}
 	}()
-	val, raw, parsed, err = goEval(src)
+	val, raw, parsed, err = goEval(src, old)
 	return
 }
 
@@ -127,7 +138,7 @@ func goEvalSafe(src string) (val canon.Value, raw string, parsed bool, panicked 
 func Compare(src string, opts Options) Result {
 	var r Result
 
-	goVal, goRaw, goParsed, goPanic, goErr := goEvalSafe(src)
+	goVal, goRaw, goParsed, goPanic, goErr := goEvalSafe(src, opts.OldClassAd)
 	r.GoParsed = goParsed
 	r.GoCanon = goVal
 	r.GoRaw = goRaw
@@ -138,7 +149,11 @@ func Compare(src string, opts Options) Result {
 		return r
 	}
 
-	cppRaw, cppParsed, cppTimedOut := cppengine.EvalAdTimeout(src, cppEvalTimeout)
+	cppEval := cppengine.EvalAdTimeout
+	if opts.OldClassAd {
+		cppEval = cppengine.EvalAdOldTimeout
+	}
+	cppRaw, cppParsed, cppTimedOut := cppEval(src, cppEvalTimeout)
 	if cppTimedOut {
 		// libclassad infinite-looped (a known C++ bug on some cyclic
 		// self-references the Go engine resolves to error). The result is

--- a/fuzz/oracle/cgo/cgo.go
+++ b/fuzz/oracle/cgo/cgo.go
@@ -60,6 +60,26 @@ func EvalAd(src string) (encoded string, parsed bool) {
 	return C.GoString(out), true
 }
 
+// EvalAdOld is EvalAd for the OLD-ClassAd wire format (the newline-separated, unbracketed
+// syntax daemons advertise): it parses src via ClassAdParser::SetOldClassAd(true), whose
+// string literals get no escape processing, and returns the canonical encoding of the
+// evaluated ad. This is the reference the Go engine's ParseOld is compared against.
+func EvalAdOld(src string) (encoded string, parsed bool) {
+	cppMu.Lock()
+	defer cppMu.Unlock()
+
+	csrc := C.CString(src)
+	defer C.free(unsafe.Pointer(csrc))
+
+	var out *C.char
+	rc := C.classad_eval_ad_old(csrc, &out)
+	if rc == 0 {
+		return "", false
+	}
+	defer C.classad_free(out)
+	return C.GoString(out), true
+}
+
 // EvalAdTimeout is EvalAd with a wall-clock cap. libclassad can infinite-loop
 // on some cyclic self-references reached through lazy operands (e.g.
 // [A0 = 0 ? e : A0], where its cycle guard never fires) -- a libclassad bug.
@@ -80,6 +100,27 @@ func EvalAdTimeout(src string, timeout time.Duration) (encoded string, parsed, t
 	ch := make(chan result, 1) // buffered so the goroutine can exit if we time out
 	go func() {
 		enc, ok := EvalAd(src)
+		ch <- result{enc, ok}
+	}()
+	select {
+	case r := <-ch:
+		return r.enc, r.ok, false
+	case <-time.After(timeout):
+		return "", false, true
+	}
+}
+
+// EvalAdOldTimeout is EvalAdOld with the same wall-clock cap and leaked-goroutine handling
+// as EvalAdTimeout (evaluation can still infinite-loop on a cyclic self-reference regardless
+// of which syntax parsed the ad).
+func EvalAdOldTimeout(src string, timeout time.Duration) (encoded string, parsed, timedOut bool) {
+	type result struct {
+		enc string
+		ok  bool
+	}
+	ch := make(chan result, 1)
+	go func() {
+		enc, ok := EvalAdOld(src)
 		ch <- result{enc, ok}
 	}()
 	select {

--- a/fuzz/oracle/cgo/shim.cc
+++ b/fuzz/oracle/cgo/shim.cc
@@ -183,6 +183,74 @@ extern "C" int classad_eval_ad(const char *adStr, char **out) {
 	}
 }
 
+// oldToNewFormat mirrors the Go parser's convertOldToNewFormat (parser/old_classad_parser.go):
+// old ClassAds are newline-separated, unbracketed attributes; the classad library's parser
+// wants the bracketed "[ a=1; b=2 ]" syntax even in old-lex mode (parseClassAd requires
+// LEX_OPEN_BOX). Applying the identical structural conversion on both sides isolates the one
+// thing under test -- old-ClassAd string-escape lexing (tokenizeStringOld) -- so a structural
+// difference cannot masquerade as a divergence.
+static std::string oldToNewFormat(const char *src) {
+	std::string out = "[\n";
+	std::string s(src ? src : "");
+	size_t i = 0;
+	bool inBlockComment = false;
+	while (i <= s.size()) {
+		size_t nl = s.find('\n', i);
+		std::string line = s.substr(i, (nl == std::string::npos ? s.size() : nl) - i);
+		i = (nl == std::string::npos) ? s.size() + 1 : nl + 1;
+
+		if (line.find("/*") != std::string::npos) inBlockComment = true;
+		if (inBlockComment) {
+			out += line; out += "\n";
+			if (line.find("*/") != std::string::npos) inBlockComment = false;
+			continue;
+		}
+		// trim leading/trailing ASCII whitespace for the emptiness/comment/`;` checks
+		size_t b = line.find_first_not_of(" \t\r\f\v");
+		std::string trimmed = (b == std::string::npos) ? "" : line.substr(b);
+		size_t e = trimmed.find_last_not_of(" \t\r\f\v");
+		if (e != std::string::npos) trimmed = trimmed.substr(0, e + 1);
+
+		if (trimmed.empty()) continue;
+		if (trimmed.rfind("//", 0) == 0 || trimmed.rfind("#", 0) == 0) {
+			out += line; out += "\n";
+			continue;
+		}
+		if (trimmed.find('=') != std::string::npos) {
+			out += trimmed;
+			if (trimmed.back() != ';') out += ";";
+			out += "\n";
+		} else {
+			out += line; out += "\n";
+		}
+	}
+	out += "]";
+	return out;
+}
+
+extern "C" int classad_eval_ad_old(const char *adStr, char **out) {
+	static const bool reconfigured = [] { ClassAdReconfig(); return true; }();
+	(void)reconfigured;
+
+	*out = nullptr;
+	try {
+		ClassAdParser parser;
+		parser.SetOldClassAd(true); // tokenizeStringOld lexing (escapes kept literal)
+		ClassAd ad;
+		std::string bracketed = oldToNewFormat(adStr);
+		if (!parser.ParseClassAd(bracketed, ad, true)) {
+			return 0;
+		}
+		std::string encoded;
+		encodeClassAd(encoded, &ad, 0);
+		*out = strdup(encoded.c_str());
+		return 1;
+	} catch (...) {
+		if (*out) { free(*out); *out = nullptr; }
+		return 0;
+	}
+}
+
 extern "C" void classad_free(char *p) {
 	free(p);
 }

--- a/fuzz/oracle/cgo/shim.h
+++ b/fuzz/oracle/cgo/shim.h
@@ -24,6 +24,14 @@ extern "C" {
  */
 int classad_eval_ad(const char *adStr, char **out);
 
+/*
+ * Like classad_eval_ad, but parses adStr as an OLD-ClassAd (the newline-separated,
+ * unbracketed wire format daemons advertise), via ClassAdParser::SetOldClassAd(true).
+ * Old-ClassAd string literals get no escape processing (Lexer::tokenizeStringOld) -- the
+ * behavior the Go engine's ParseOld must match. Same return convention as classad_eval_ad.
+ */
+int classad_eval_ad_old(const char *adStr, char **out);
+
 /* Free a string previously returned via classad_eval_ad's out parameter. */
 void classad_free(char *p);
 

--- a/fuzz/parse_old_differential_test.go
+++ b/fuzz/parse_old_differential_test.go
@@ -1,0 +1,114 @@
+//go:build libclassad
+
+// This file hosts FuzzParseOldClassAdDifferential, the differential *old-ClassAd* parser
+// target. The sibling FuzzParseDifferential only ever exercises the NEW-ClassAd parser
+// (classad.Parse vs libclassad's ClassAdParser) -- so the OLD-ClassAd wire format that
+// daemons actually advertise, whose string literals keep escapes literal
+// (Lexer::tokenizeStringOld), was never differentially tested. That blind spot is how the
+// OSIssue = "\S" divergence shipped: C++ accepted it, Go's ParseOld rejected it, and the
+// error dropped the whole ad. This target parses each input with BOTH old-ClassAd parsers
+// (classad.ParseOld vs libclassad SetOldClassAd(true)) and fails on disagreement.
+//
+// Run:
+//
+//	go test ./fuzz -run=xxx -fuzz=FuzzParseOldClassAdDifferential -tags libclassad
+package fuzz
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/PelicanPlatform/classad/fuzz/differ"
+)
+
+// oldStringSeeds are raw string-literal CONTENTS (the bytes between the quotes) that stress
+// old-ClassAd string lexing (tokenizeStringOld). Each is wrapped as `A = "<seed>"` before
+// parsing, so the target isolates the string tokenizer -- the escape/quote handling where the
+// OSIssue = "\S" divergence lived -- rather than the shared expression grammar or the
+// top-level old-vs-new structure (whose recovery deltas are the sibling target's concern).
+var oldStringSeeds = []string{
+	`\S`,             // the field regression: agetty escape, unknown to C
+	`\S \r (\l) \m`,  // a realistic /etc/issue string, several escapes
+	`slot1@host`,     // plain content
+	`C:\Users\condor`, // literal backslashes
+	`a\"b`,           // escaped quote -> literal quote, string continues
+	`x\\y`,           // double backslash in the middle
+	`tab\there`,      // a recognized C escape, kept literal in old mode
+	``,               // empty string
+	`\`,              // a lone trailing backslash (escapes the closing quote in C++)
+	`\\`,             // backslash-backslash before the quote
+}
+
+// knownOldParseDelta reports whether an old-ClassAd parse-level disagreement is an
+// intentional grammar difference rather than a Go bug. It reuses the new-parser deltas
+// (integer overflow, "..", unbalanced brackets, dangling operator before ':') since old and
+// new ClassAds share the expression grammar and number lexer; only the string tokenizer
+// differs, and that is exactly what this target is meant to flag rather than excuse.
+func knownOldParseDelta(src string, r differ.Result) bool {
+	return knownParseDelta(src, r)
+}
+
+// hasUnescapedQuote reports whether s contains a double quote that would terminate the
+// wrapper string literal. In old-ClassAd lexing a quote is escaped iff the IMMEDIATELY
+// preceding character is a backslash (tokenizeStringOld checks the one prior char, not an
+// even/odd run), so a "bare" quote is one at the start or not directly preceded by '\'.
+func hasUnescapedQuote(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] == '"' && (i == 0 || s[i-1] != '\\') {
+			return true
+		}
+	}
+	return false
+}
+
+func FuzzParseOldClassAdDifferential(f *testing.F) {
+	for _, s := range oldStringSeeds {
+		f.Add(s)
+	}
+	opts := differ.DefaultOptions()
+	opts.OldClassAd = true
+
+	f.Fuzz(func(t *testing.T, s string) {
+		// Same lexer-scope exclusions as the new-parser target: non-UTF-8 and embedded NUL
+		// are known byte-vs-rune / C-string-terminator deltas, out of scope here.
+		if !utf8.ValidString(s) || strings.IndexByte(s, 0) >= 0 {
+			t.Skip()
+		}
+		// A bare (unescaped) double quote in the content terminates the wrapper string and
+		// turns the input into malformed multi-token structure, whose parser-recovery deltas
+		// are the sibling target's concern, not this one. The escape divergence class is
+		// entirely about BACKSLASH handling (quotes terminate strings identically in both
+		// engines), so skipping bare-quote content loses no relevant coverage.
+		if hasUnescapedQuote(s) {
+			t.Skip()
+		}
+		// Old-ClassAd is a line-oriented wire format -- a newline ends the attribute, so a
+		// string value is single-line and cannot contain a raw newline/CR. Such content isn't
+		// representable on the wire and only exercises the line-based old->new conversion's
+		// structural recovery, not string-escape lexing; skip it.
+		if strings.ContainsAny(s, "\n\r") {
+			t.Skip()
+		}
+		// A block-comment marker in the content trips the line-based conversion's comment
+		// handling (both engines' convertOldToNewFormat), again a structural artifact rather
+		// than string lexing.
+		if strings.Contains(s, "/*") || strings.Contains(s, "*/") {
+			t.Skip()
+		}
+		// Wrap the fuzzer bytes as one old-ClassAd string-valued attribute, so what varies is
+		// the string literal's content -- driving tokenizeStringOld vs the Go lenient scanner.
+		src := `A = "` + s + `"`
+		r := differ.Compare(src, opts)
+		switch r.Category {
+		case differ.GoPanic:
+			t.Fatalf("Go engine panicked (old ClassAd)\n  content: %q\n  %s", s, r.Detail)
+		case differ.ParseDivergence:
+			if knownOldParseDelta(src, r) {
+				return
+			}
+			t.Fatalf("old-ClassAd string-lexer disagreement (%s)\n  content: %q\n  go-err: %v",
+				r.Detail, s, r.GoErr)
+		}
+	})
+}

--- a/fuzz/parse_old_differential_test.go
+++ b/fuzz/parse_old_differential_test.go
@@ -28,16 +28,16 @@ import (
 // OSIssue = "\S" divergence lived -- rather than the shared expression grammar or the
 // top-level old-vs-new structure (whose recovery deltas are the sibling target's concern).
 var oldStringSeeds = []string{
-	`\S`,             // the field regression: agetty escape, unknown to C
-	`\S \r (\l) \m`,  // a realistic /etc/issue string, several escapes
-	`slot1@host`,     // plain content
+	`\S`,              // the field regression: agetty escape, unknown to C
+	`\S \r (\l) \m`,   // a realistic /etc/issue string, several escapes
+	`slot1@host`,      // plain content
 	`C:\Users\condor`, // literal backslashes
-	`a\"b`,           // escaped quote -> literal quote, string continues
-	`x\\y`,           // double backslash in the middle
-	`tab\there`,      // a recognized C escape, kept literal in old mode
-	``,               // empty string
-	`\`,              // a lone trailing backslash (escapes the closing quote in C++)
-	`\\`,             // backslash-backslash before the quote
+	`a\"b`,            // escaped quote -> literal quote, string continues
+	`x\\y`,            // double backslash in the middle
+	`tab\there`,       // a recognized C escape, kept literal in old mode
+	``,                // empty string
+	`\`,               // a lone trailing backslash (escapes the closing quote in C++)
+	`\\`,              // backslash-backslash before the quote
 }
 
 // knownOldParseDelta reports whether an old-ClassAd parse-level disagreement is an

--- a/parser/old_classad_parser.go
+++ b/parser/old_classad_parser.go
@@ -21,8 +21,14 @@ func ParseOldClassAd(input string) (*ast.ClassAd, error) {
 	// Convert old format to new format
 	newFormat := convertOldToNewFormat(input)
 
-	// Parse using the standard parser
-	result, err := Parse(newFormat)
+	// Parse with old-ClassAd string semantics: an unrecognized escape (e.g. OSIssue =
+	// "\S", the agetty escapes /etc/issue carries) is kept literally rather than rejected,
+	// matching the C++ old-ClassAd tokenizer. Otherwise one such attribute would fail the
+	// whole ad -- which silently drops every startd ad a collector forwards.
+	lex := NewLexer(newFormat)
+	lex.lex.lenientEscapes = true
+	yyParse(lex)
+	result, err := lex.Result()
 	if err != nil {
 		return nil, fmt.Errorf("error parsing old ClassAd format: %w", err)
 	}

--- a/parser/streaming_lexer.go
+++ b/parser/streaming_lexer.go
@@ -29,6 +29,12 @@ type StreamingLexer struct {
 	pendingSize      int
 	hasPending       bool
 	seen             []rune
+	// lenientEscapes keeps an unrecognized string escape sequence literally (the
+	// backslash and the following character both) instead of erroring. This matches the
+	// C++ old-ClassAd string tokenizer (Lexer::tokenizeStringOld), which does no escape
+	// processing at all -- so a value like OSIssue = "\S" (agetty escapes from /etc/issue)
+	// round-trips instead of failing the whole ad. Set only on the old-ClassAd parse path.
+	lenientEscapes bool
 }
 
 // NewStreamingLexer creates a lexer that consumes tokens directly from a reader.
@@ -515,6 +521,24 @@ func (l *StreamingLexer) scanString() string {
 		}
 
 		if ch == '\\' {
+			if l.lenientEscapes {
+				// Old-ClassAd string semantics (C++ Lexer::tokenizeStringOld): a backslash is
+				// literal EXCEPT immediately before the closing quote, where it escapes it --
+				// \" becomes a literal quote and the string continues. So no other escape is
+				// interpreted (\S \r \n \t stay literal, backslash and all), matching the C++
+				// collector byte-for-byte; and a string cannot end in a lone backslash ("\\"
+				// is unterminated), exactly as in C++. Process ONE backslash at a time (peek,
+				// don't consume the next rune) so \\" correctly reads as \ then an escaped ".
+				if next, perr := l.peekRune(); perr == nil && next == '"' {
+					if err := l.discardRune(); err != nil {
+						return result.String()
+					}
+					result.WriteRune('"')
+				} else {
+					result.WriteRune('\\')
+				}
+				continue
+			}
 			escaped, _, err := l.readRune()
 			if err != nil {
 				l.Error(fmt.Sprintf("unterminated escape sequence in string starting at position %d", startPos))


### PR DESCRIPTION
Old-vs-New ClassAds have different rules for parsing literal escape sequences.

Adjust the Golang parser to match these; add fuzzer coverage for old ad parsing as well.