### PR TITLE
db/dbrpc: bulk delete pushdown, wire-native raw ingest/query, inline RawAd

### DIFF
--- a/collections/go.mod
+++ b/collections/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/RoaringBitmap/roaring/v2 v2.19.0
 	github.com/klauspost/compress v1.19.0
 	github.com/tidwall/btree v1.8.1
-	golang.org/x/sys v0.43.0
+	golang.org/x/sys v0.46.0
 )
 
 require (

--- a/collections/go.sum
+++ b/collections/go.sum
@@ -16,5 +16,7 @@ github.com/tidwall/btree v1.8.1 h1:27ehoXvm5AG/g+1VxLS1SD3vRhp/H7LuEfwNvddEdmA=
 github.com/tidwall/btree v1.8.1/go.mod h1:jBbTdUWhSZClZWoDg54VnvV7/54modSOzDN7VXftj1A=
 golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=
 golang.org/x/sys v0.43.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
+golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/collections/rawdecode.go
+++ b/collections/rawdecode.go
@@ -30,9 +30,6 @@ type RawAd struct {
 // nothing for them; callers that must support those should use Query.
 func (c *Collection) QueryRaw(q *vm.Query) iter.Seq[RawAd] {
 	return func(yield func(RawAd) bool) {
-		if c.inline {
-			return
-		}
 		plan := q.ReadPlan()
 		ws := &wireScope{ctx: c}
 		qp := queryPlan{
@@ -64,9 +61,6 @@ func (c *Collection) QueryRaw(q *vm.Query) iter.Seq[RawAd] {
 // ScanRaw is Scan, yielding every ad as RawAd (AST-free).
 func (c *Collection) ScanRaw() iter.Seq[RawAd] {
 	return func(yield func(RawAd) bool) {
-		if c.inline {
-			return
-		}
 		q := queryPlan{}
 		emit := c.yieldRaw(yield)
 		for _, sh := range c.shards {
@@ -137,19 +131,14 @@ func (c *Collection) decodeAdRaw(stored []byte, codec Codec, dst []byte) (exprs 
 // reuses their backing, so a streaming scan allocates no per-ad expression strings.
 // Returns ok=false for inline-name ads (no intern table).
 func (c *Collection) appendWireAd(wireBytes []byte, buf []byte, offs []int) (outBuf []byte, outOffs []int, myType, targetType string, ok bool) {
-	if c.inline {
-		return buf, offs, "", "", false
-	}
 	buf = buf[:0]
 	offs = append(offs[:0], 0)
-	ad := wire.Ad(wireBytes)
+	// ForEachNamed handles both encodings: an inline (persistent) ad yields its
+	// stored names and the intern table is ignored; an interned ad resolves ids
+	// through it. Values render with the matching decoder (inline nodes carry
+	// inline names too).
 	good := true
-	ad.ForEach(func(id uint32, node []byte) bool {
-		name, nok := c.intern.Name(id)
-		if !nok {
-			good = false
-			return false
-		}
+	wire.Ad(wireBytes).ForEachNamed(c.intern, func(name string, node []byte) bool {
 		if name == "MyType" || name == "TargetType" {
 			if lit, lok := wire.LiteralValue(node); lok && lit.Kind == wire.LitString {
 				if name == "MyType" {
@@ -163,7 +152,11 @@ func (c *Collection) appendWireAd(wireBytes []byte, buf []byte, offs []int) (out
 		buf = append(buf, name...)
 		buf = append(buf, ' ', '=', ' ')
 		var aerr error
-		buf, aerr = appendWireValue(buf, node, c.intern)
+		if c.inline {
+			buf, aerr = wire.AppendNodeTextInline(buf, node)
+		} else {
+			buf, aerr = appendWireValue(buf, node, c.intern)
+		}
 		if aerr != nil {
 			good = false
 			return false

--- a/db/go.mod
+++ b/db/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/bits-and-blooms/bitset v1.24.4 // indirect
 	github.com/mschoch/smat v0.2.0 // indirect
 	github.com/tidwall/btree v1.8.1 // indirect
-	golang.org/x/sys v0.43.0 // indirect
+	golang.org/x/sys v0.46.0 // indirect
 )
 
 replace github.com/PelicanPlatform/classad => ../

--- a/db/go.sum
+++ b/db/go.sum
@@ -14,7 +14,7 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/tidwall/btree v1.8.1 h1:27ehoXvm5AG/g+1VxLS1SD3vRhp/H7LuEfwNvddEdmA=
 github.com/tidwall/btree v1.8.1/go.mod h1:jBbTdUWhSZClZWoDg54VnvV7/54modSOzDN7VXftj1A=
-golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=
-golang.org/x/sys v0.43.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
+golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/db/pushdown.go
+++ b/db/pushdown.go
@@ -1,0 +1,157 @@
+package db
+
+import (
+	"fmt"
+
+	"github.com/PelicanPlatform/classad/classad"
+	"github.com/PelicanPlatform/classad/collections/vm"
+)
+
+// These bound the optimistic-retry loops so a pathological amount of concurrent
+// churn on the same keys cannot spin forever. They are generous: a well-behaved
+// workload commits on the first attempt.
+const (
+	// deleteBatch caps how many keys one DeleteWhere transaction stages, bounding
+	// transaction size (and thus conflict blast radius) on a large match set.
+	deleteBatch = 8192
+	// maxDeleteRounds bounds DeleteWhere's scan/delete rounds. Each normal round
+	// removes up to deleteBatch ads, so this covers a very large store; it is only
+	// reached if the match set is continually refreshed out from under the sweep.
+	maxDeleteRounds = 10000
+	// maxWriteAttempts bounds a single-key write's optimistic retries.
+	maxWriteAttempts = 32
+)
+
+// Put inserts or replaces the ad at key in its own optimistic transaction,
+// retrying on a write-write conflict (another committer touched key since this
+// attempt's snapshot) until it lands or maxWriteAttempts is exhausted. A blind
+// overwrite that loses the optimistic race would otherwise be silently dropped;
+// Put is the retrying convenience for the common single-ad upsert so callers do
+// not each reimplement the loop. Equivalent to Begin + NewClassAd + Commit.
+func (db *DB) Put(key string, ad *classad.ClassAd) error {
+	return db.withWriteRetry(func(t *Txn) { t.NewClassAd(key, ad) })
+}
+
+// Delete removes the ad at key in its own optimistic transaction, retrying on a
+// write-write conflict. It reports whether an ad was present to remove.
+// Equivalent to Begin + DestroyClassAd + Commit with retry.
+func (db *DB) Delete(key string) (bool, error) {
+	present := false
+	err := db.withWriteRetry(func(t *Txn) {
+		if _, ok := t.LookupClassAd(key); ok {
+			present = true
+			t.DestroyClassAd(key)
+		} else {
+			present = false
+		}
+	})
+	return present, err
+}
+
+// withWriteRetry runs stage in a fresh transaction and commits it, retrying the
+// whole (re-snapshotted) transaction on a *ConflictError. stage must be
+// idempotent across retries (it is re-run on the new snapshot each attempt),
+// which every blind put/delete is. Non-conflict commit errors are returned
+// immediately.
+func (db *DB) withWriteRetry(stage func(*Txn)) error {
+	var last *ConflictError
+	for attempt := 0; attempt < maxWriteAttempts; attempt++ {
+		t := db.Begin()
+		stage(t)
+		err := t.Commit()
+		if err == nil {
+			return nil
+		}
+		if ce, ok := err.(*ConflictError); ok {
+			last = ce
+			continue // another committer won this key; re-snapshot and retry
+		}
+		return err
+	}
+	return fmt.Errorf("classad-db: write did not commit after %d optimistic attempts (last conflict on %v)", maxWriteAttempts, last.Keys)
+}
+
+// DeleteWhere removes every ad matching constraint, in batched optimistic
+// transactions, and returns the number removed. It is the server-side pushdown
+// for a bulk invalidation or a time-based expiry sweep (express expiry as a
+// constraint, e.g. "<now> > LastHeardFrom + Lifetime"), replacing a client's
+// per-key query-then-delete loop with one call executed where the data lives.
+//
+// Each round re-scans on a fresh snapshot and, inside the deleting transaction,
+// re-checks the constraint against the ad as of that snapshot before removing it.
+// Two properties fall out of that:
+//   - Self-healing under concurrency: an ad concurrently modified so that it no
+//     longer matches (a re-advertised ad whose expiry constraint no longer holds)
+//     is spared, not deleted; and a partial commit's conflicted keys are simply
+//     re-evaluated on the next round.
+//   - Idempotent and safe to run alongside writers or another sweep.
+//
+// It errors on a malformed constraint, a non-conflict commit failure, or if the
+// sweep fails to converge within maxDeleteRounds (only reachable under relentless
+// churn of the match set); the returned count reflects what was removed so far.
+func (db *DB) DeleteWhere(constraint string) (int, error) {
+	q, err := vm.Parse(constraint)
+	if err != nil {
+		return 0, fmt.Errorf("classad-db: bad constraint %q: %w", constraint, err)
+	}
+	total := 0
+	for round := 0; round < maxDeleteRounds; round++ {
+		keys := db.matchingKeys(q, deleteBatch)
+		if len(keys) == 0 {
+			return total, nil
+		}
+		deleted, err := db.deleteMatching(q, keys)
+		if err != nil {
+			return total, err
+		}
+		total += deleted
+	}
+	return total, fmt.Errorf("classad-db: DeleteWhere did not converge in %d rounds for %q (removed %d)", maxDeleteRounds, constraint, total)
+}
+
+// matchingKeys collects up to limit keys whose ads currently match q.
+func (db *DB) matchingKeys(q *vm.Query, limit int) []string {
+	keys := make([]string, 0, min(limit, 256))
+	db.c.ForEachAd(func(key string, ad *classad.ClassAd) bool {
+		if q.Matches(ad) {
+			keys = append(keys, key)
+		}
+		return len(keys) < limit
+	})
+	return keys
+}
+
+// deleteMatching removes, in one optimistic transaction, the given candidate keys
+// whose ads still match q as of the transaction's snapshot. Re-checking within
+// the transaction spares an ad refreshed out of the match set before the
+// snapshot; the optimistic commit spares one refreshed after it (its key
+// conflicts and is reported, not removed). Returns the number actually removed.
+func (db *DB) deleteMatching(q *vm.Query, keys []string) (int, error) {
+	t := db.Begin()
+	staged := 0
+	for _, k := range keys {
+		ad, ok := t.LookupClassAd(k)
+		if !ok {
+			continue // already gone
+		}
+		if !q.Matches(ad) {
+			continue // refreshed out of the match set since the scan: spare it
+		}
+		t.DestroyClassAd(k)
+		staged++
+	}
+	if staged == 0 {
+		t.Abort()
+		return 0, nil
+	}
+	err := t.Commit()
+	if err == nil {
+		return staged, nil
+	}
+	if ce, ok := err.(*ConflictError); ok {
+		// Partial commit: the non-conflicted deletes landed; the conflicted keys
+		// (concurrently rewritten) did not, and are re-evaluated next round.
+		return staged - len(ce.Keys), nil
+	}
+	return 0, err
+}

--- a/db/pushdown_test.go
+++ b/db/pushdown_test.go
@@ -1,0 +1,157 @@
+package db
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/classad"
+)
+
+// putAd is a test helper: store key=ad, failing on error.
+func putAd(t *testing.T, d *DB, key, text string) {
+	t.Helper()
+	ad, err := classad.ParseOld(text)
+	if err != nil {
+		t.Fatalf("parse %q: %v", text, err)
+	}
+	if err := d.Put(key, ad); err != nil {
+		t.Fatalf("put %s: %v", key, err)
+	}
+}
+
+func TestDeleteWhereConstraint(t *testing.T) {
+	d, err := Open("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = d.Close() }()
+
+	putAd(t, d, "a", `Name = "a"`+"\n"+`State = "Idle"`)
+	putAd(t, d, "b", `Name = "b"`+"\n"+`State = "Claimed"`)
+	putAd(t, d, "c", `Name = "c"`+"\n"+`State = "Idle"`)
+
+	n, err := d.DeleteWhere(`State == "Idle"`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 2 {
+		t.Fatalf("DeleteWhere removed %d, want 2", n)
+	}
+	if d.Len() != 1 {
+		t.Fatalf("Len = %d, want 1", d.Len())
+	}
+	if _, ok := d.LookupClassAd("b"); !ok {
+		t.Fatal("Claimed ad b should have survived")
+	}
+	if _, ok := d.LookupClassAd("a"); ok {
+		t.Fatal("Idle ad a should have been removed")
+	}
+}
+
+// TestDeleteWhereExpiry expresses the collector's expiry sweep as a DeleteWhere
+// constraint (now > LastHeardFrom + lifetime) and checks stale ads go while a
+// fresh one stays -- the single-primitive expiry the collector backends use.
+func TestDeleteWhereExpiry(t *testing.T) {
+	d, err := Open("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = d.Close() }()
+
+	const now = 1_000_000
+	putAd(t, d, "stale1", `Name = "stale1"`+"\n"+`LastHeardFrom = 900000`+"\n"+`ClassAdLifetime = 60`)  // 900060 < now
+	putAd(t, d, "stale2", `Name = "stale2"`+"\n"+`LastHeardFrom = 999000`)                              // no lifetime -> default 900 -> 999900 < now
+	putAd(t, d, "fresh", `Name = "fresh"`+"\n"+`LastHeardFrom = 999950`+"\n"+`ClassAdLifetime = 900`)   // 1000850 > now
+
+	// The collector builds exactly this constraint each sweep.
+	constraint := fmt.Sprintf(`%d > LastHeardFrom + ifThenElse(ClassAdLifetime =!= undefined, ClassAdLifetime, 900)`, now)
+	n, err := d.DeleteWhere(constraint)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 2 {
+		t.Fatalf("expiry removed %d, want 2 (the two stale ads)", n)
+	}
+	if _, ok := d.LookupClassAd("fresh"); !ok {
+		t.Fatal("fresh ad should have survived expiry")
+	}
+}
+
+func TestPutOverwriteAndDelete(t *testing.T) {
+	d, err := Open("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = d.Close() }()
+
+	putAd(t, d, "k", `Name = "k"`+"\n"+`V = 1`)
+	putAd(t, d, "k", `Name = "k"`+"\n"+`V = 2`) // overwrite
+	ad, ok := d.LookupClassAd("k")
+	if !ok {
+		t.Fatal("k missing after put")
+	}
+	if v, _ := ad.EvaluateAttrInt("V"); v != 2 {
+		t.Fatalf("V = %d after overwrite, want 2", v)
+	}
+
+	present, err := d.Delete("k")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !present {
+		t.Fatal("Delete reported k absent, want present")
+	}
+	if present, err := d.Delete("k"); err != nil || present {
+		t.Fatalf("second Delete: present=%v err=%v, want false,nil", present, err)
+	}
+}
+
+// TestDeleteWhereConcurrentWriters runs DeleteWhere while writers churn the match
+// set, exercising the optimistic-retry / self-healing loop. It asserts the sweep
+// converges (no error, no panic) and never removes an ad that does not match.
+func TestDeleteWhereConcurrentWriters(t *testing.T) {
+	d, err := Open("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = d.Close() }()
+
+	const nAds = 400
+	for i := 0; i < nAds; i++ {
+		putAd(t, d, fmt.Sprintf("slot%d", i), fmt.Sprintf(`Name = "slot%d"`+"\n"+`State = "Idle"`, i))
+	}
+
+	var wg sync.WaitGroup
+	// Writers flip some ads to Claimed (out of the match set) concurrently.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < nAds; i += 3 {
+			putAd(t, d, fmt.Sprintf("slot%d", i), fmt.Sprintf(`Name = "slot%d"`+"\n"+`State = "Claimed"`, i))
+		}
+	}()
+	// Concurrent sweep of the Idle ads.
+	wg.Add(1)
+	var sweepErr error
+	go func() {
+		defer wg.Done()
+		_, sweepErr = d.DeleteWhere(`State == "Idle"`)
+	}()
+	wg.Wait()
+	if sweepErr != nil {
+		t.Fatalf("concurrent DeleteWhere: %v", sweepErr)
+	}
+
+	// A final sweep removes any Idle ads still present; afterwards no Idle ad
+	// remains, and every surviving ad is Claimed (never wrongly deleted).
+	if _, err := d.DeleteWhere(`State == "Idle"`); err != nil {
+		t.Fatal(err)
+	}
+	d.ForEach(func(ad *classad.ClassAd) bool {
+		if s, _ := ad.EvaluateAttrString("State"); s != "Claimed" {
+			t.Fatalf("surviving ad has State=%q, want Claimed", s)
+		}
+		return true
+	})
+}

--- a/db/pushdown_test.go
+++ b/db/pushdown_test.go
@@ -60,9 +60,9 @@ func TestDeleteWhereExpiry(t *testing.T) {
 	defer func() { _ = d.Close() }()
 
 	const now = 1_000_000
-	putAd(t, d, "stale1", `Name = "stale1"`+"\n"+`LastHeardFrom = 900000`+"\n"+`ClassAdLifetime = 60`)  // 900060 < now
-	putAd(t, d, "stale2", `Name = "stale2"`+"\n"+`LastHeardFrom = 999000`)                              // no lifetime -> default 900 -> 999900 < now
-	putAd(t, d, "fresh", `Name = "fresh"`+"\n"+`LastHeardFrom = 999950`+"\n"+`ClassAdLifetime = 900`)   // 1000850 > now
+	putAd(t, d, "stale1", `Name = "stale1"`+"\n"+`LastHeardFrom = 900000`+"\n"+`ClassAdLifetime = 60`) // 900060 < now
+	putAd(t, d, "stale2", `Name = "stale2"`+"\n"+`LastHeardFrom = 999000`)                             // no lifetime -> default 900 -> 999900 < now
+	putAd(t, d, "fresh", `Name = "fresh"`+"\n"+`LastHeardFrom = 999950`+"\n"+`ClassAdLifetime = 900`)  // 1000850 > now
 
 	// The collector builds exactly this constraint each sweep.
 	constraint := fmt.Sprintf(`%d > LastHeardFrom + ifThenElse(ClassAdLifetime =!= undefined, ClassAdLifetime, 900)`, now)

--- a/db/rawwire.go
+++ b/db/rawwire.go
@@ -1,0 +1,52 @@
+package db
+
+import (
+	"fmt"
+	"iter"
+	"strings"
+
+	"github.com/PelicanPlatform/classad/classad"
+	"github.com/PelicanPlatform/classad/collections"
+	"github.com/PelicanPlatform/classad/collections/vm"
+)
+
+// UpdateOld ingests an ad from old-ClassAd wire text under key, skipping the AST
+// build -- the wire-native ingest path (as collections.UpdateOld). It writes
+// through the same shard storage, change log, and watch feed as a committed Put,
+// but bypasses the optimistic-concurrency layer (last-writer-wins), which suits
+// high-rate single-key upserts where per-key write-write races do not occur (a
+// collector re-advertising its own ad).
+//
+// When the database is encrypted it falls back to parse + Put: the wire-native
+// encoder does not seal, so an encrypted store must take the AST path to keep
+// data encrypted at rest.
+func (db *DB) UpdateOld(key, text string) error {
+	if db.c.EncryptionEnabled() {
+		ad, err := classad.ParseOld(text)
+		if err != nil {
+			return fmt.Errorf("classad-db: parse ad for %q: %w", key, err)
+		}
+		return db.Put(key, ad)
+	}
+	// The DB-wide lock held shared, exactly as Commit does, so a direct write is
+	// atomic against an exclusive Truncate/Restore.
+	db.snapMu.RLock()
+	defer db.snapMu.RUnlock()
+	return db.c.UpdateOld([]collections.OldAdUpdate{{Key: []byte(key), Text: text}})
+}
+
+// QueryRaw yields each matching ad as a collections.RawAd -- the wire-form
+// attribute strings decoded straight from the stored representation with no AST,
+// for a persistent (inline) store as well as an in-memory one -- so a whole-ad
+// result set can be relayed without materializing and re-encoding each ad. Errors
+// only on a malformed constraint.
+func (db *DB) QueryRaw(constraint string) (iter.Seq[collections.RawAd], error) {
+	if s := strings.TrimSpace(constraint); s == "" || strings.EqualFold(s, "true") {
+		return db.c.ScanRaw(), nil // match-all: full raw scan
+	}
+	q, err := vm.Parse(constraint)
+	if err != nil {
+		return nil, fmt.Errorf("classad-db: bad constraint %q: %w", constraint, err)
+	}
+	return db.c.QueryRaw(q), nil
+}

--- a/db/rawwire.go
+++ b/db/rawwire.go
@@ -35,6 +35,38 @@ func (db *DB) UpdateOld(key, text string) error {
 	return db.c.UpdateOld([]collections.OldAdUpdate{{Key: []byte(key), Text: text}})
 }
 
+// OldAdText is one keyed ad in old-ClassAd wire text, for UpdateOldBatch.
+type OldAdText struct {
+	Key  string
+	Text string
+}
+
+// UpdateOldBatch ingests many ads (key + old-ClassAd text) in one shard-commit
+// batch -- the wire-native bulk ingest, so a burst of upserts costs one commit
+// instead of one per ad. Bypasses the optimistic-concurrency layer
+// (last-writer-wins) like UpdateOld. Falls back to per-ad Put on an encrypted
+// store (the wire-native encoder does not seal).
+func (db *DB) UpdateOldBatch(items []OldAdText) error {
+	if len(items) == 0 {
+		return nil
+	}
+	if db.c.EncryptionEnabled() {
+		for _, it := range items {
+			if err := db.UpdateOld(it.Key, it.Text); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	batch := make([]collections.OldAdUpdate, len(items))
+	for i, it := range items {
+		batch[i] = collections.OldAdUpdate{Key: []byte(it.Key), Text: it.Text}
+	}
+	db.snapMu.RLock()
+	defer db.snapMu.RUnlock()
+	return db.c.UpdateOld(batch)
+}
+
 // QueryRaw yields each matching ad as a collections.RawAd -- the wire-form
 // attribute strings decoded straight from the stored representation with no AST,
 // for a persistent (inline) store as well as an in-memory one -- so a whole-ad

--- a/db/rawwire_test.go
+++ b/db/rawwire_test.go
@@ -1,0 +1,174 @@
+package db
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestUpdateOldVisibleInQueryRawAndWatch proves the wire-native ingest path goes
+// through the same storage, query, and change-log/watch machinery as a
+// transactional Put -- so a collector using UpdateOld still gets correct queries
+// AND a working watch feed (which HA replication rides on).
+func TestUpdateOldVisibleInQueryRawAndWatch(t *testing.T) {
+	d, err := Open("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = d.Close() }()
+
+	if err := d.UpdateOld("a", `Name = "a"`+"\n"+`State = "Idle"`); err != nil {
+		t.Fatal(err)
+	}
+	if err := d.UpdateOld("b", `Name = "b"`+"\n"+`State = "Busy"`); err != nil {
+		t.Fatal(err)
+	}
+
+	// Query sees both.
+	seq, err := d.Query("true")
+	if err != nil {
+		t.Fatal(err)
+	}
+	n := 0
+	for range seq {
+		n++
+	}
+	if n != 2 {
+		t.Fatalf("Query after UpdateOld = %d, want 2", n)
+	}
+
+	// QueryRaw yields wire-form ads (non-empty expression lines) and honors the
+	// constraint.
+	rseq, err := d.QueryRaw(`State == "Idle"`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw := 0
+	for ra := range rseq {
+		raw++
+		if len(ra.Exprs) == 0 {
+			t.Fatal("QueryRaw yielded a RawAd with no expression lines")
+		}
+	}
+	if raw != 1 {
+		t.Fatalf("QueryRaw Idle = %d, want 1", raw)
+	}
+
+	// Watch from the start replays both as upserts -- the proof UpdateOld reaches
+	// the change log (and thus the HA commit stream), not just the key directory.
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	wseq, err := d.Watch(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	upserts := 0
+	for ev := range wseq {
+		if ev.Kind == WatchUpsert {
+			upserts++
+		}
+		if upserts >= 2 {
+			break
+		}
+	}
+	if upserts < 2 {
+		t.Fatalf("Watch replayed %d upserts, want 2 (UpdateOld did not reach the change log)", upserts)
+	}
+}
+
+// TestQueryRawInline is the point of the inline-RawAd support: a PERSISTENT db
+// (inline-encoded storage) must yield wire-form RawAds from QueryRaw, decoded
+// straight from the stored records with no AST -- previously QueryRaw bailed on
+// inline collections.
+func TestQueryRawInline(t *testing.T) {
+	d, err := Open(t.TempDir()) // persistent -> inline encoding
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = d.Close() }()
+
+	if err := d.UpdateOld("a", "MyType = \"Machine\"\nName = \"slot1\"\nState = \"Idle\"\nCpus = 8"); err != nil {
+		t.Fatal(err)
+	}
+	if err := d.UpdateOld("b", "MyType = \"Machine\"\nName = \"slot2\"\nState = \"Busy\""); err != nil {
+		t.Fatal(err)
+	}
+
+	// Match-all (ScanRaw path).
+	all, err := d.QueryRaw("true")
+	if err != nil {
+		t.Fatal(err)
+	}
+	n, sawSlot1 := 0, false
+	for ra := range all {
+		n++
+		if ra.MyType != "Machine" {
+			t.Fatalf("inline RawAd MyType = %q, want Machine", ra.MyType)
+		}
+		joined := ""
+		for _, e := range ra.Exprs {
+			joined += string(e) + "\n"
+		}
+		if strings.Contains(joined, "MyType") {
+			t.Fatalf("MyType leaked into Exprs (should be the RawAd.MyType field):\n%s", joined)
+		}
+		if strings.Contains(joined, `Name = "slot1"`) {
+			sawSlot1 = true
+			if !strings.Contains(joined, "Cpus = 8") || !strings.Contains(joined, `State = "Idle"`) {
+				t.Fatalf("inline RawAd for slot1 missing rendered attrs:\n%s", joined)
+			}
+		}
+	}
+	if n != 2 {
+		t.Fatalf("inline QueryRaw(true) yielded %d, want 2", n)
+	}
+	if !sawSlot1 {
+		t.Fatal("inline QueryRaw did not render slot1's attributes")
+	}
+
+	// Constrained (indexed/scan QueryRaw path).
+	idle, err := d.QueryRaw(`State == "Idle"`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := 0
+	for range idle {
+		m++
+	}
+	if m != 1 {
+		t.Fatalf("inline QueryRaw(Idle) = %d, want 1", m)
+	}
+}
+
+// TestUpdateOldEncryptedFallback checks the encryption guard: on an encrypted DB,
+// UpdateOld must take the parse+Put path so data is sealed at rest -- not the
+// wire-native fast path, whose encoder does not seal. The reopen with a different
+// pool key must fail, proving the ad was written encrypted rather than plaintext.
+func TestUpdateOldEncryptedFallback(t *testing.T) {
+	dir := t.TempDir()
+	d, err := OpenConfig(Config{Dir: dir, PoolKeys: []KEK{poolKey("POOL")}, EncryptedAttrs: []string{"Secret"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := d.UpdateOld("a", `Name = "a"`+"\n"+`Secret = "top-secret"`); err != nil {
+		t.Fatal(err)
+	}
+	ad, ok := d.LookupClassAd("a")
+	if !ok {
+		t.Fatal("ad missing after encrypted UpdateOld")
+	}
+	if s, _ := ad.EvaluateAttrString("Secret"); s != "top-secret" {
+		t.Fatalf("Secret = %q, want top-secret (encrypted fallback failed)", s)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Reopen with the wrong pool key: must fail (the data key can't be unwrapped),
+	// which proves the store was actually encrypted.
+	if bad, err := OpenConfig(Config{Dir: dir, PoolKeys: []KEK{poolKey("WRONG")}, EncryptedAttrs: []string{"Secret"}}); err == nil {
+		_ = bad.Close()
+		t.Fatal("reopen with wrong key succeeded: the ad was stored in plaintext (UpdateOld leaked past encryption)")
+	}
+}

--- a/dbrpc/delete.go
+++ b/dbrpc/delete.go
@@ -1,0 +1,25 @@
+package dbrpc
+
+// DeleteWhere removes every ad matching constraint from the default table and
+// returns the number removed. The delete runs server-side as a single call --
+// the db.DeleteWhere pushdown (batched, optimistic-retry, self-healing) -- rather
+// than a per-key query-then-delete round trip per ad. Refused on a read-only
+// connection.
+func (c *Client) DeleteWhere(constraint string) (int, error) {
+	return c.DeleteWhereTable(DefaultTable, constraint)
+}
+
+// DeleteWhereTable is DeleteWhere against a named table. Express a time-based
+// expiry sweep as the constraint (e.g. "<now> > LastHeardFrom + Lifetime").
+func (c *Client) DeleteWhereTable(table, constraint string) (int, error) {
+	status, body, err := c.call(func(id uint64) []byte {
+		return putStr(putStr(req(id, opDeleteWhere), table), constraint)
+	})
+	if err != nil {
+		return 0, err
+	}
+	if status != stOK {
+		return 0, statusErr(status, body)
+	}
+	return int(body.i32()), nil
+}

--- a/dbrpc/delete_test.go
+++ b/dbrpc/delete_test.go
@@ -1,0 +1,57 @@
+package dbrpc
+
+import (
+	"testing"
+
+	"github.com/PelicanPlatform/classad/db"
+)
+
+func TestRPCDeleteWhere(t *testing.T) {
+	c, cleanup := testPair(t)
+	defer cleanup()
+
+	tx, err := c.Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = tx.NewClassAd("a", `Name = "a"`+"\n"+`State = "Idle"`)
+	_ = tx.NewClassAd("b", `Name = "b"`+"\n"+`State = "Claimed"`)
+	_ = tx.NewClassAd("c", `Name = "c"`+"\n"+`State = "Idle"`)
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Bulk delete-by-constraint in one server-side call.
+	n, err := c.DeleteWhere(`State == "Idle"`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 2 {
+		t.Fatalf("DeleteWhere removed %d, want 2", n)
+	}
+	rows, err := c.Query("true")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("after delete %d ads remain, want 1 (the Claimed one)", len(rows))
+	}
+}
+
+// TestRPCDeleteWhereReadOnly confirms the pushdown is a mutating op: a read-only
+// connection refuses it.
+func TestRPCDeleteWhereReadOnly(t *testing.T) {
+	d, err := db.Open("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := NewServer(d)
+	cconn, sconn := netPipe()
+	go func() { _ = s.ServeConnOpts(sconn, ServeOptions{ReadOnly: true}) }()
+	c := NewClient(cconn)
+	defer func() { c.Close(); s.Close(); d.Close() }()
+
+	if _, err := c.DeleteWhere("true"); err == nil {
+		t.Fatal("DeleteWhere on a read-only connection should be refused, got nil error")
+	}
+}

--- a/dbrpc/go.mod
+++ b/dbrpc/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/klauspost/compress v1.19.0 // indirect
 	github.com/mschoch/smat v0.2.0 // indirect
 	github.com/tidwall/btree v1.8.1 // indirect
-	golang.org/x/sys v0.43.0 // indirect
+	golang.org/x/sys v0.46.0 // indirect
 )
 
 replace github.com/PelicanPlatform/classad => ../

--- a/dbrpc/go.sum
+++ b/dbrpc/go.sum
@@ -14,7 +14,7 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/tidwall/btree v1.8.1 h1:27ehoXvm5AG/g+1VxLS1SD3vRhp/H7LuEfwNvddEdmA=
 github.com/tidwall/btree v1.8.1/go.mod h1:jBbTdUWhSZClZWoDg54VnvV7/54modSOzDN7VXftj1A=
-golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=
-golang.org/x/sys v0.43.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
+golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/dbrpc/proto.go
+++ b/dbrpc/proto.go
@@ -82,6 +82,7 @@ const (
 	opArchiveQuery  op = 31 // [name][limit i32][constraint] -> stream of [adText], newest first
 	opArchiveList   op = 32 // -> [n i32]{[name]}
 	opArchiveRotate op = 33 // [name] -> [dropped i32]; enforce retention (server clock); mutating
+	opDeleteWhere   op = 34 // [table][constraint] -> [removed i32]; bulk delete-by-constraint, mutating
 )
 
 // String names an opcode for diagnostics (e.g. the read-only rejection message).
@@ -135,6 +136,8 @@ func (o op) String() string {
 		return "ListTables"
 	case opMatchTables:
 		return "MatchTables"
+	case opDeleteWhere:
+		return "DeleteWhere"
 	}
 	return "op(unknown)"
 }

--- a/dbrpc/proto.go
+++ b/dbrpc/proto.go
@@ -83,6 +83,7 @@ const (
 	opArchiveList   op = 32 // -> [n i32]{[name]}
 	opArchiveRotate op = 33 // [name] -> [dropped i32]; enforce retention (server clock); mutating
 	opDeleteWhere   op = 34 // [table][constraint] -> [removed i32]; bulk delete-by-constraint, mutating
+	opQueryRaw      op = 35 // [table][limit i32][constraint] -> stream of [oldClassAdText]; wire-form, AST-free relay
 )
 
 // String names an opcode for diagnostics (e.g. the read-only rejection message).
@@ -138,6 +139,8 @@ func (o op) String() string {
 		return "MatchTables"
 	case opDeleteWhere:
 		return "DeleteWhere"
+	case opQueryRaw:
+		return "QueryRaw"
 	}
 	return "op(unknown)"
 }

--- a/dbrpc/queryraw.go
+++ b/dbrpc/queryraw.go
@@ -1,0 +1,98 @@
+package dbrpc
+
+import (
+	"context"
+	"strings"
+
+	"github.com/PelicanPlatform/classad/classad"
+	"github.com/PelicanPlatform/classad/collections"
+)
+
+// QueryRaw is Query but returns each ad as old-ClassAd wire text (the AST-free
+// relay form for the caller): the server renders straight from the stored
+// representation via the db QueryRaw pushdown, and the caller can forward the
+// text without building a ClassAd. Private attributes are stripped unless the
+// connection is privileged.
+func (c *Client) QueryRaw(constraint string) ([]string, error) {
+	return c.QueryRawTable(DefaultTable, constraint, 0)
+}
+
+// QueryRawTable is QueryRaw against a named table with an optional limit.
+func (c *Client) QueryRawTable(table, constraint string, limit int) ([]string, error) {
+	return c.stream(func(id uint64) []byte {
+		return putStr(putI32(putStr(req(id, opQueryRaw), table), int32(limit)), constraint)
+	})
+}
+
+// streamQueryRaw streams matching ads as old-ClassAd wire text, rendered from the
+// db QueryRaw pushdown (no AST decode), one frame per ad like streamQuery.
+func (s *Server) streamQueryRaw(ctx context.Context, reqID uint64, r *reader, includePrivate bool, write func([]byte)) {
+	table := r.str()
+	limit := int(r.i32())
+	constraint := r.str()
+	if r.err != nil {
+		write(respBad(reqID))
+		return
+	}
+	d, ok := s.tableOr(reqID, table, write)
+	if !ok {
+		return
+	}
+	seq, err := d.QueryRaw(constraint)
+	if err != nil {
+		write(respErr(reqID, err.Error()))
+		return
+	}
+	n := 0
+	for ra := range seq {
+		if cancelled(ctx) {
+			return
+		}
+		write(putStr(respHead(reqID, stStream), rawAdToOldText(ra, includePrivate)))
+		n++
+		if limit > 0 && n >= limit {
+			break
+		}
+	}
+	write(respHead(reqID, stStreamEnd))
+}
+
+// rawAdToOldText renders a RawAd as old-ClassAd wire text: the type tags as their
+// own lines followed by the attribute expression lines, dropping private
+// attributes unless includePrivate. It touches no AST -- the expression bytes are
+// copied straight from the stored form.
+func rawAdToOldText(ra collections.RawAd, includePrivate bool) string {
+	var b strings.Builder
+	if ra.MyType != "" {
+		b.WriteString("MyType = \"")
+		b.WriteString(ra.MyType)
+		b.WriteString("\"\n")
+	}
+	if ra.TargetType != "" {
+		b.WriteString("TargetType = \"")
+		b.WriteString(ra.TargetType)
+		b.WriteString("\"\n")
+	}
+	for _, e := range ra.Exprs {
+		if !includePrivate && classad.IsPrivateAttribute(rawExprName(e)) {
+			continue
+		}
+		b.Write(e)
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
+// rawExprName returns the attribute name of a rendered "Name = value" expression
+// line (leading whitespace trimmed, up to the first '=' or space).
+func rawExprName(expr []byte) string {
+	i := 0
+	for i < len(expr) && (expr[i] == ' ' || expr[i] == '\t') {
+		i++
+	}
+	start := i
+	for i < len(expr) && expr[i] != '=' && expr[i] != ' ' && expr[i] != '\t' {
+		i++
+	}
+	return string(expr[start:i])
+}

--- a/dbrpc/queryraw_test.go
+++ b/dbrpc/queryraw_test.go
@@ -1,0 +1,79 @@
+package dbrpc
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/db"
+)
+
+// TestRPCQueryRawPrivileged: a privileged connection (as the collector uses) gets
+// the full ad in old-ClassAd wire text, private attributes included.
+func TestRPCQueryRawPrivileged(t *testing.T) {
+	d, err := db.Open("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := NewServer(d)
+	cc, sc := netPipe()
+	go func() { _ = s.ServeConnOpts(sc, ServeOptions{IncludePrivate: true}) }()
+	c := NewClient(cc)
+	defer func() { c.Close(); s.Close(); d.Close() }()
+
+	tx, err := c.Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = tx.NewClassAd("a", "MyType = \"Machine\"\nState = \"Idle\"\nCapability = \"secret-claim\"")
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+
+	rows, err := c.QueryRaw("true")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("QueryRaw returned %d rows, want 1", len(rows))
+	}
+	text := rows[0]
+	for _, want := range []string{"MyType", "Machine", "State", "Capability", "secret-claim"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("privileged QueryRaw text missing %q:\n%s", want, text)
+		}
+	}
+}
+
+// TestRPCQueryRawStripsPrivate: a non-privileged connection gets the same ad in
+// wire text but with private attributes removed -- while public attributes and
+// the type tag survive.
+func TestRPCQueryRawStripsPrivate(t *testing.T) {
+	c, cleanup := testPair(t) // default ServeOptions: not privileged
+	defer cleanup()
+
+	tx, err := c.Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = tx.NewClassAd("a", "MyType = \"Machine\"\nState = \"Idle\"\nCapability = \"secret-claim\"")
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+
+	rows, err := c.QueryRaw("true")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("QueryRaw returned %d rows, want 1", len(rows))
+	}
+	text := rows[0]
+	if strings.Contains(text, "Capability") || strings.Contains(text, "secret-claim") {
+		t.Fatalf("non-privileged QueryRaw leaked a private attribute:\n%s", text)
+	}
+	for _, want := range []string{"State", "Idle", "Machine"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("non-privileged QueryRaw dropped public content %q:\n%s", want, text)
+		}
+	}
+}

--- a/dbrpc/server.go
+++ b/dbrpc/server.go
@@ -127,7 +127,7 @@ type ServeOptions struct {
 func (o op) isMutating() bool {
 	switch o {
 	case opNewAd, opDestroyAd, opSetAttr, opDeleteAttr, opAdmin, opCreateTable, opDropTable,
-		opArchiveCreate, opArchiveAppend, opArchiveRotate:
+		opArchiveCreate, opArchiveAppend, opArchiveRotate, opDeleteWhere:
 		return true
 	}
 	return false
@@ -629,6 +629,22 @@ func (s *Server) handle(reqID uint64, o op, r *reader, includePrivate, privilege
 			return respErr(reqID, err.Error())
 		}
 		return putStr(resp(reqID, stOK), string(data))
+
+	case opDeleteWhere:
+		table := r.str()
+		constraint := r.str()
+		if r.err != nil {
+			return respBad(reqID)
+		}
+		d, ok := s.cat.Table(table)
+		if !ok {
+			return respErr(reqID, "no such table: "+table)
+		}
+		removed, err := d.DeleteWhere(constraint)
+		if err != nil {
+			return respErr(reqID, err.Error())
+		}
+		return putI32(resp(reqID, stOK), int32(removed))
 
 	case opExplain:
 		table := r.str()

--- a/dbrpc/server.go
+++ b/dbrpc/server.go
@@ -275,6 +275,8 @@ func (sc *serverConn) dispatch(frame []byte) {
 	switch o {
 	case opQuery:
 		sc.s.streamQuery(sc.ctx, reqID, body, priv, sc.write)
+	case opQueryRaw:
+		sc.s.streamQueryRaw(sc.ctx, reqID, body, priv, sc.write)
 	case opMatchSorted:
 		sc.s.streamMatchSorted(sc.ctx, reqID, body, priv, sc.write)
 	case opOrdered:


### PR DESCRIPTION
Classad-side primitives that let the golang-collector persist ads in an embedded `db` or a remote `dbrpc` store without paying an AST tax or a per-key round trip. All additive; no breaking changes.

## db
- **`DeleteWhere(constraint)`** — server-side bulk delete-by-constraint in batched, optimistic-retry, self-healing transactions (re-scans each round, re-checks the constraint inside the deleting txn, so a partial commit's conflicted keys and an ad refreshed out of the match set are simply re-evaluated). Expiry is expressed as a constraint, so this one primitive covers both bulk invalidation and TTL sweeps.
- **`Put`/`Delete`** — retrying single-ad conveniences (the OCC retry the raw `Txn` API leaves to callers).
- **`UpdateOld`/`UpdateOldBatch`** — wire-native ingest from old-ClassAd text (no AST), the fast single-key and bulk upsert paths; take the DB-wide lock like `Commit`, reach the change-log/watch feed (HA-safe), and fall back to parse+`Put` on an encrypted store (the wire-native encoder does not seal).
- **`QueryRaw`** — yields matching ads as `collections.RawAd` (wire-form, no AST), for both persistent and in-memory stores.

## collections
- **inline→RawAd**: `QueryRaw`/`ScanRaw` previously bailed on inline (persistent) collections. `wire.Ad.ForEachNamed` already reads either inline names or interns and `wire.AppendNodeTextInline` already renders inline values, so `appendWireAd` just needed to use them. A persistent collection now yields RawAds straight from its stored records.
- x/sys → v0.46.0 (govulncheck), standalone commit.

## dbrpc
- **`opDeleteWhere`** + `DeleteWhere`/`DeleteWhereTable` — expose the db bulk delete over the wire (mutating, refused read-only).
- **`opQueryRaw`** + `QueryRaw`/`QueryRawTable` — stream results as old-ClassAd wire text rendered from the db raw pushdown (no server-side AST), private-stripped unless the connection is privileged.

Tests cover the delete self-healing under concurrency, read-only refusal, inline RawAd rendering, the encrypted-ingest fallback, and that `UpdateOld` reaches the watch/HA change stream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)