### PR TITLE
ci: enable Dependabot for GitHub Actions + pin actions to SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# Managed by Dependabot: keep GitHub Actions current (including SHA-pinned actions,
+# whose pins are bumped when the action cuts a new release). Grouped into a single
+# weekly PR to keep the noise down.
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "ci(deps)"

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -27,13 +27,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
     - name: Build dev image (Go + HTCondor + libclassad)
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
       with:
         context: .
         file: .devcontainer/Dockerfile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
       with:
         go-version: ${{ matrix.go-version }}
 
@@ -42,7 +42,7 @@ jobs:
 
     - name: Upload coverage to Codecov
       if: matrix.go-version == '1.23'
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         file: ./coverage.out
         flags: unittests
@@ -60,10 +60,10 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
       with:
         go-version: '1.25'
 
@@ -95,10 +95,10 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
       with:
         go-version: '1.23'
 
@@ -122,7 +122,7 @@ jobs:
         fi
 
     - name: Run golangci-lint
-      uses: golangci/golangci-lint-action@v7
+      uses: golangci/golangci-lint-action@9fae48acfc02a90574d7c304a1758ef9895495fa # v7.0.1
       with:
         version: latest
         skip-cache: true


### PR DESCRIPTION
Two related CI hardening changes:

1. **Enable Dependabot** for the `github-actions` ecosystem (`.github/dependabot.yml`) — weekly, all updates grouped into one PR, `ci(deps)` commit prefix.
2. **Pin every action to an immutable commit SHA** with a `# vX.Y.Z` comment (e.g. `actions/checkout@34e1148… # v4.3.1`).

Why both: with tag pins (`@v4`), Dependabot only proposes a PR on a new *major* and never manages SHAs. With **SHA pins**, each action release becomes a reviewable Dependabot PR that bumps the SHA and rolls the version comment forward — the supply-chain-hardened style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
