### PR TITLE
dbrpc: context-native API, connection resilience, durable opt-in idempotency

### DIFF
--- a/collections/index_query.go
+++ b/collections/index_query.go
@@ -691,6 +691,12 @@ func (c *Collection) scanShardCandidates(sh *shard, usable []usableProbe, onCand
 		if !(recSeq(w.data, o) <= s0 && recSuperseded(w.data, o) > s0) {
 			return false
 		}
+		// Defensive: an internal system record carries no normal indexed attributes,
+		// so it can never appear as an index candidate; the tail full-scan could still
+		// reach one, and Match reuses this primitive, so skip it here too.
+		if isSystemKeyBytes(recKey(w.data, o)) {
+			return false
+		}
 		ww, err := w.codec.Decompress(dbuf[:0], recAd(w.data, o))
 		if err != nil {
 			return false
@@ -776,6 +782,11 @@ func (c *Collection) scanShardCandidatesGroups(sh *shard, groups [][]usableProbe
 	var dbuf []byte
 	visit := func(w segWindow, o uint32) (stop bool) {
 		if !(recSeq(w.data, o) <= s0 && recSuperseded(w.data, o) > s0) {
+			return false
+		}
+		// Defensive: internal system records carry no normal indexed attributes and
+		// are hidden from client results (see scanShardCandidates).
+		if isSystemKeyBytes(recKey(w.data, o)) {
 			return false
 		}
 		ww, err := w.codec.Decompress(dbuf[:0], recAd(w.data, o))

--- a/collections/parallel_scan.go
+++ b/collections/parallel_scan.go
@@ -77,6 +77,25 @@ func forEachVisibleWindow(s0 uint64, w segWindow, fn func(ad []byte, codec Codec
 	}
 }
 
+// forEachVisibleWindowKeyed is forEachVisibleWindow that also passes each record's
+// key, so the parallel query workers can filter internal system records out of the
+// client-facing result (the serial scanShard path does the same).
+func forEachVisibleWindowKeyed(s0 uint64, w segWindow, fn func(key, ad []byte, codec Codec) bool) {
+	for off := 0; off < w.used; {
+		o := uint32(off)
+		total := recTotalLen(w.data, o)
+		if total == 0 {
+			break
+		}
+		if recSeq(w.data, o) <= s0 && recSuperseded(w.data, o) > s0 {
+			if !fn(recKey(w.data, o), recAd(w.data, o), w.codec) {
+				return
+			}
+		}
+		off += int(total)
+	}
+}
+
 // tryAcquire takes up to n tokens from the worker budget without blocking, returning
 // how many it got (0..n). The taken tokens must be released by the caller. It is
 // greedy (grab whatever is free) rather than all-or-nothing: under concurrent-query
@@ -162,9 +181,12 @@ func (c *Collection) runParallelQuery(q *vm.Query, yield func(*classad.ClassAd) 
 					}
 					return
 				}
-				forEachVisibleWindow(tasks[idx].s0, tasks[idx].win, func(ad []byte, codec Codec) bool {
+				forEachVisibleWindowKeyed(tasks[idx].s0, tasks[idx].win, func(key, ad []byte, codec Codec) bool {
 					if stopped.Load() {
 						return false
+					}
+					if isSystemKeyBytes(key) {
+						return true // internal system record: hidden from client queries
 					}
 					w, err := codec.Decompress(dbuf[:0], ad)
 					if err != nil {
@@ -209,7 +231,10 @@ func (c *Collection) scanTasksSerial(tasks []scanTask, qp queryPlan, yield func(
 	var dbuf []byte
 	for _, t := range tasks {
 		stop := false
-		forEachVisibleWindow(t.s0, t.win, func(ad []byte, codec Codec) bool {
+		forEachVisibleWindowKeyed(t.s0, t.win, func(key, ad []byte, codec Codec) bool {
+			if isSystemKeyBytes(key) {
+				return true // internal system record: hidden from client queries
+			}
 			w, err := codec.Decompress(dbuf[:0], ad)
 			if err != nil {
 				return true

--- a/collections/store.go
+++ b/collections/store.go
@@ -728,7 +728,10 @@ func (c *Collection) scanShard(sh *shard, qp queryPlan, emit func(w []byte) bool
 	defer releaseWindows(wins)
 	cont := true
 	var dbuf []byte // decompression buffer reused across ads (single-threaded scan)
-	forEachVisible(s0, wins, func(ad []byte, codec Codec) bool {
+	forEachVisibleKeyed(s0, wins, func(key, ad []byte, codec Codec) bool {
+		if isSystemKeyBytes(key) {
+			return true // internal system record: hidden from client scans/queries
+		}
 		w, err := codec.Decompress(dbuf[:0], ad)
 		if err != nil {
 			return true // skip a record we cannot decode rather than abort the scan
@@ -785,6 +788,9 @@ func (c *Collection) scanShardChained(sh *shard, qp queryPlan, yield func(*class
 	// are few (one per family), so this map stays small.
 	parents := map[string][]byte{}
 	forEachVisibleKeyed(s0, wins, func(key, ad []byte, codec Codec) bool {
+		if isSystemKeyBytes(key) {
+			return true // internal system record: never a family parent
+		}
 		if c.isStructural != nil && c.isStructural(key) {
 			if w, err := codec.Decompress(nil, ad); err == nil {
 				parents[string(key)] = w // owns its buffer (nil dst)
@@ -797,6 +803,9 @@ func (c *Collection) scanShardChained(sh *shard, qp queryPlan, yield func(*class
 	cont := true
 	var dbuf []byte
 	forEachVisibleKeyed(s0, wins, func(key, ad []byte, codec Codec) bool {
+		if isSystemKeyBytes(key) {
+			return true // internal system record: hidden from client scans/queries
+		}
 		if c.isStructural != nil && c.isStructural(key) {
 			return true // structural ads are hidden from results
 		}

--- a/collections/syskey.go
+++ b/collections/syskey.go
@@ -1,0 +1,26 @@
+package collections
+
+// System keys are a reserved internal keyspace for durable bookkeeping records
+// (e.g. idempotency markers, TTL reapers) that live in the same table as data but
+// are hidden from every client-facing scan/query/iteration. They are reserved by a
+// leading NUL byte (0x00): a normal ClassAd key -- a HashKey or a user key -- is
+// printable text and never begins with NUL, so the two keyspaces cannot collide.
+//
+// A system-keyed record is stored, updated, committed, compacted, and looked up by
+// explicit key exactly like any other record (no change to writes, no change to
+// Lookup); only the client-facing enumeration paths filter it out. A dedicated
+// system-only scan (Collection.ForEachSystemAd) enumerates just these records for a
+// reaper.
+
+// IsSystemKey reports whether key is a reserved internal system key (begins with a
+// NUL byte). Exported so callers (and the db/dbrpc layers) can classify a key
+// without duplicating the sentinel.
+func IsSystemKey(key string) bool { return len(key) > 0 && key[0] == 0 }
+
+// SystemKey builds a system key from a name by prefixing the reserved NUL byte. The
+// name is otherwise opaque; callers namespace it however they like.
+func SystemKey(name string) string { return "\x00" + name }
+
+// isSystemKeyBytes is IsSystemKey over the raw record key bytes the scan primitives
+// expose (a view into a frozen segment window), avoiding a per-record string copy.
+func isSystemKeyBytes(key []byte) bool { return len(key) > 0 && key[0] == 0 }

--- a/collections/syskey_test.go
+++ b/collections/syskey_test.go
@@ -1,0 +1,196 @@
+package collections
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/classad"
+)
+
+// TestSystemKeyHiddenFromScansButRetrievable verifies that a system-keyed record is
+// stored and updated like any record, retrievable by explicit key, and preserved by
+// compaction, yet excluded from every client-facing scan/query/iteration path and
+// visible only through the dedicated ForEachSystemAd sweep.
+func TestSystemKeyHiddenFromScansButRetrievable(t *testing.T) {
+	t.Parallel()
+	c := New(Options{Shards: 4})
+
+	const n = 12
+	normalKeys := map[string]bool{}
+	for i := 0; i < n; i++ {
+		k := fmt.Sprintf("job%d", i)
+		normalKeys[k] = true
+		if err := c.Put([]byte(k), mustAd(t, fmt.Sprintf(`[Owner="alice"; Id=%d]`, i))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	sysKey := SystemKey("idem/marker-1")
+	if !IsSystemKey(sysKey) {
+		t.Fatalf("SystemKey did not produce a system key: %q", sysKey)
+	}
+	if IsSystemKey("job0") || IsSystemKey("") {
+		t.Fatal("IsSystemKey misclassified a normal/empty key")
+	}
+	if err := c.Put([]byte(sysKey), mustAd(t, `[Owner="system"; Marker=1; Ttl=100]`)); err != nil {
+		t.Fatal(err)
+	}
+
+	// Explicit lookup still finds the system record (writes/reads are unchanged).
+	if _, ok := c.Get([]byte(sysKey)); !ok {
+		t.Fatal("Get(systemKey) did not find the system record")
+	}
+	// Len counts every stored record, including the system one.
+	if got := c.Len(); got != n+1 {
+		t.Fatalf("Len = %d, want %d", got, n+1)
+	}
+
+	hasMarker := func(ad *classad.ClassAd) bool {
+		_, ok := ad.Lookup("Marker")
+		return ok
+	}
+	rawHasMarker := func(exprs [][]byte) bool {
+		for _, e := range exprs {
+			if bytes.Contains(e, []byte("Marker")) {
+				return true
+			}
+		}
+		return false
+	}
+
+	// Scan: exactly the normal ads, never the system record.
+	{
+		count := 0
+		for ad := range c.Scan() {
+			count++
+			if hasMarker(ad) {
+				t.Error("Scan yielded the system record")
+			}
+		}
+		if count != n {
+			t.Errorf("Scan returned %d ads, want %d", count, n)
+		}
+	}
+
+	// Query (match-all)
+	{
+		q := mustParseQuery(t, "true")
+		count := 0
+		for ad := range c.Query(q) {
+			count++
+			if hasMarker(ad) {
+				t.Error("Query(true) yielded the system record")
+			}
+		}
+		if count != n {
+			t.Errorf("Query(true) returned %d ads, want %d", count, n)
+		}
+	}
+
+	// ScanRaw
+	{
+		count := 0
+		for ra := range c.ScanRaw() {
+			count++
+			if rawHasMarker(ra.Exprs) {
+				t.Error("ScanRaw yielded the system record")
+			}
+		}
+		if count != n {
+			t.Errorf("ScanRaw returned %d ads, want %d", count, n)
+		}
+	}
+
+	// QueryRaw (match-all)
+	{
+		q := mustParseQuery(t, "true")
+		count := 0
+		for ra := range c.QueryRaw(q) {
+			count++
+			if rawHasMarker(ra.Exprs) {
+				t.Error("QueryRaw(true) yielded the system record")
+			}
+		}
+		if count != n {
+			t.Errorf("QueryRaw(true) returned %d ads, want %d", count, n)
+		}
+	}
+
+	// ForEachAd: yields normal keys only.
+	{
+		seen := map[string]bool{}
+		c.ForEachAd(func(key string, _ *classad.ClassAd) bool {
+			if IsSystemKey(key) {
+				t.Errorf("ForEachAd exposed system key %q", key)
+			}
+			seen[key] = true
+			return true
+		})
+		for k := range normalKeys {
+			if !seen[k] {
+				t.Errorf("ForEachAd omitted normal key %q", k)
+			}
+		}
+		if len(seen) != n {
+			t.Errorf("ForEachAd yielded %d keys, want %d", len(seen), n)
+		}
+	}
+
+	// ForEachSystemAd: yields ONLY the system record.
+	{
+		seen := map[string]bool{}
+		c.ForEachSystemAd(func(key string, ad *classad.ClassAd) bool {
+			if !IsSystemKey(key) {
+				t.Errorf("ForEachSystemAd exposed non-system key %q", key)
+			}
+			if !hasMarker(ad) {
+				t.Errorf("ForEachSystemAd yielded an ad without the Marker attr: %s", ad.String())
+			}
+			seen[key] = true
+			return true
+		})
+		if len(seen) != 1 || !seen[sysKey] {
+			t.Errorf("ForEachSystemAd yielded %v, want exactly {%q}", keysOf(seen), sysKey)
+		}
+	}
+
+	// Compaction preserves the system record: churn to build garbage, force compaction,
+	// then confirm the marker is still retrievable and still hidden from scans.
+	for round := 0; round < 30; round++ {
+		for i := 0; i < n; i++ {
+			if err := c.Put([]byte(fmt.Sprintf("job%d", i)), mustAd(t, fmt.Sprintf(`[Owner="alice"; Id=%d; R=%d]`, i, round))); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if err := c.Put([]byte(sysKey), mustAd(t, fmt.Sprintf(`[Owner="system"; Marker=1; Ttl=%d]`, round))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	c.Rewrite() // re-encode + force-compact every shard
+	if _, ok := c.Get([]byte(sysKey)); !ok {
+		t.Fatal("system record lost after compaction/Rewrite")
+	}
+	sysCount := 0
+	c.ForEachSystemAd(func(key string, _ *classad.ClassAd) bool { sysCount++; return true })
+	if sysCount != 1 {
+		t.Errorf("after compaction ForEachSystemAd yielded %d records, want 1", sysCount)
+	}
+	scanCount := 0
+	for ad := range c.Scan() {
+		scanCount++
+		if hasMarker(ad) {
+			t.Error("Scan yielded the system record after compaction")
+		}
+	}
+	if scanCount != n {
+		t.Errorf("after compaction Scan returned %d ads, want %d", scanCount, n)
+	}
+}
+
+func keysOf(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/collections/truncate.go
+++ b/collections/truncate.go
@@ -48,18 +48,53 @@ func (c *Collection) Truncate() {
 	}
 }
 
-// ForEachAd calls fn with every stored ad and its key, including structural (parent-only)
-// ads -- a complete image for a backup, unlike Scan/Keys which hide structural ads. Each
-// ad is fully decoded (decompressed and, for encrypted attributes, decrypted). Iteration
-// stops early if fn returns false. Per-shard consistent snapshot, like Scan.
+// ForEachAd calls fn with every stored (non-system) ad and its key, including structural
+// (parent-only) ads -- a client-facing image, unlike Scan/Keys which hide structural ads.
+// It is the driver for db.DeleteWhere's key matching, so it must NOT expose internal system
+// records (they are neither client-visible nor client-deletable); system records are
+// enumerated separately via ForEachSystemAd. Each ad is fully decoded (decompressed and,
+// for encrypted attributes, decrypted). Iteration stops early if fn returns false. Per-shard
+// consistent snapshot, like Scan.
 func (c *Collection) ForEachAd(fn func(key string, ad *classad.ClassAd) bool) {
 	for _, sh := range c.shards {
 		s0, wins := sh.snapshot()
 		stop := false
 		forEachVisibleKeyed(s0, wins, func(key, ad []byte, codec Codec) bool {
+			if isSystemKeyBytes(key) {
+				return true // internal system record: hidden from client iteration
+			}
 			decoded, err := c.decodeAd(ad, codec)
 			if err != nil {
 				return true // skip an undecodable record rather than abort the backup
+			}
+			if !fn(string(key), decoded) {
+				stop = true
+				return false
+			}
+			return true
+		})
+		releaseWindows(wins)
+		if stop {
+			return
+		}
+	}
+}
+
+// ForEachSystemAd calls fn with every internal system-keyed ad and its key -- the mirror
+// image of ForEachAd, which hides them. It is the enumeration path a TTL reaper uses to
+// find and expire durable bookkeeping records. Each ad is fully decoded; iteration stops
+// early if fn returns false. Per-shard consistent snapshot, like Scan.
+func (c *Collection) ForEachSystemAd(fn func(key string, ad *classad.ClassAd) bool) {
+	for _, sh := range c.shards {
+		s0, wins := sh.snapshot()
+		stop := false
+		forEachVisibleKeyed(s0, wins, func(key, ad []byte, codec Codec) bool {
+			if !isSystemKeyBytes(key) {
+				return true // only system records
+			}
+			decoded, err := c.decodeAd(ad, codec)
+			if err != nil {
+				return true // skip an undecodable record rather than abort the sweep
 			}
 			if !fn(string(key), decoded) {
 				stop = true

--- a/db/db.go
+++ b/db/db.go
@@ -389,6 +389,23 @@ func (db *DB) ForEach(fn func(ad *classad.ClassAd) bool) {
 	}
 }
 
+// ForEachSystemAd calls fn for every internal system-keyed ad and its key -- the reaper
+// enumeration path. System records are durable bookkeeping (e.g. idempotency markers)
+// stored in the same table as data but hidden from every client scan/query/DeleteWhere;
+// this is the only way to enumerate them. Reads a consistent snapshot. See SystemKey.
+func (db *DB) ForEachSystemAd(fn func(key string, ad *classad.ClassAd) bool) {
+	db.c.ForEachSystemAd(fn)
+}
+
+// IsSystemKey and SystemKey re-export the collections helpers so callers holding only a
+// *db.DB (e.g. dbrpc building marker keys) can classify or construct a reserved system
+// key without importing collections directly. A system key begins with a NUL byte and
+// names a record hidden from client reads but retrievable by explicit LookupClassAd.
+func IsSystemKey(key string) bool { return collections.IsSystemKey(key) }
+
+// SystemKey builds a reserved system key from name (prefixing the NUL sentinel).
+func SystemKey(name string) string { return collections.SystemKey(name) }
+
 // Query returns the committed ads matching the constraint expression (an "old
 // ClassAd" boolean expression over each ad, e.g. `JobStatus == 2 && Owner == "alice"`).
 // The store pushes the filter down -- indexed constraints visit only candidates -- so

--- a/db/snapshot.go
+++ b/db/snapshot.go
@@ -129,7 +129,7 @@ func (db *DB) snapshotTo(bw *bufio.Writer) ([]byte, error) {
 	}
 
 	var ferr error
-	db.c.ForEachAd(func(key string, ad *classad.ClassAd) bool {
+	appendAd := func(key string, ad *classad.ClassAd) bool {
 		batch = appendChunk(batch, []byte(key))
 		batch = appendChunk(batch, []byte(ad.MarshalOldWithPrivate()))
 		if nInBatch++; nInBatch >= snapBatchAds {
@@ -137,7 +137,15 @@ func (db *DB) snapshotTo(bw *bufio.Writer) ([]byte, error) {
 			return ferr == nil
 		}
 		return true
-	})
+	}
+	db.c.ForEachAd(appendAd)
+	if ferr != nil {
+		return nil, ferr
+	}
+	// Internal system records are hidden from client scans (ForEachAd), but the backup
+	// must still capture them so durable idempotency markers survive a snapshot/restore
+	// cycle. They Put back through the normal write path on restore and stay hidden.
+	db.c.ForEachSystemAd(appendAd)
 	if ferr != nil {
 		return nil, ferr
 	}

--- a/db/syskey_test.go
+++ b/db/syskey_test.go
@@ -1,0 +1,105 @@
+package db
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/classad"
+)
+
+// TestSystemKeyHiddenFromClientButDurable verifies the db-level guarantees for reserved
+// system keys: they are excluded from Query and are neither returned nor removed by
+// DeleteWhere, yet remain retrievable by explicit LookupClassAd, enumerable via
+// ForEachSystemAd, and durable across a snapshot/restore cycle.
+func TestSystemKeyHiddenFromClientButDurable(t *testing.T) {
+	d, err := Open("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = d.Close() }()
+
+	putAd(t, d, "a", `State = "Idle"`)
+	putAd(t, d, "b", `State = "Idle"`)
+	putAd(t, d, "c", `State = "Claimed"`)
+
+	sysKey := SystemKey("idem/op-42")
+	if !IsSystemKey(sysKey) {
+		t.Fatalf("SystemKey did not produce a system key: %q", sysKey)
+	}
+	if err := d.Put(sysKey, mustAd(t, "Marker = 1\nState = \"Idle\"")); err != nil {
+		t.Fatal(err)
+	}
+
+	// Query(true) returns only the normal ads (never the system record), even though
+	// the system record's State matches the constraint.
+	{
+		seq, err := d.Query("true")
+		if err != nil {
+			t.Fatal(err)
+		}
+		count := 0
+		for ad := range seq {
+			count++
+			if _, ok := ad.Lookup("Marker"); ok {
+				t.Error("Query(true) returned the system record")
+			}
+		}
+		if count != 3 {
+			t.Errorf("Query(true) returned %d ads, want 3", count)
+		}
+	}
+
+	// DeleteWhere(true) removes only the normal ads and spares the system record.
+	n, err := d.DeleteWhere("true")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 3 {
+		t.Errorf("DeleteWhere(true) removed %d, want 3 (the system record must be spared)", n)
+	}
+	if _, ok := d.LookupClassAd(sysKey); !ok {
+		t.Fatal("DeleteWhere(true) deleted the system record")
+	}
+	if d.Len() != 1 {
+		t.Errorf("Len = %d, want 1 (only the system record remains)", d.Len())
+	}
+
+	// ForEachSystemAd yields exactly the system record.
+	{
+		seen := 0
+		d.ForEachSystemAd(func(key string, ad *classad.ClassAd) bool {
+			if !IsSystemKey(key) {
+				t.Errorf("ForEachSystemAd exposed non-system key %q", key)
+			}
+			if key == sysKey {
+				seen++
+			}
+			return true
+		})
+		if seen != 1 {
+			t.Errorf("ForEachSystemAd yielded %d matching records, want 1", seen)
+		}
+	}
+
+	// Durability: the system record survives a snapshot/restore round-trip.
+	var snap bytes.Buffer
+	if err := d.Snapshot(&snap); err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if err := d.Restore(bytes.NewReader(snap.Bytes())); err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+	if _, ok := d.LookupClassAd(sysKey); !ok {
+		t.Fatal("system record lost across snapshot/restore")
+	}
+	sysAfter := 0
+	d.ForEachSystemAd(func(key string, _ *classad.ClassAd) bool {
+		if key == sysKey {
+			sysAfter++
+		}
+		return true
+	})
+	if sysAfter != 1 {
+		t.Errorf("after restore ForEachSystemAd yielded %d matching records, want 1", sysAfter)
+	}
+}

--- a/dbrpc/aggregate.go
+++ b/dbrpc/aggregate.go
@@ -40,12 +40,12 @@ type AggRow struct {
 // With no group columns it returns a single row aggregating the whole match. The
 // aggregation happens on the server, so only the (small) grouped result crosses
 // the wire, not every matched ad.
-func (c *Client) Aggregate(constraint string, groupBy []string, aggs []AggSpec) ([]AggRow, error) {
-	return c.AggregateTable(DefaultTable, constraint, groupBy, aggs)
+func (c *Client) Aggregate(ctx context.Context, constraint string, groupBy []string, aggs []AggSpec) ([]AggRow, error) {
+	return c.AggregateTable(ctx, DefaultTable, constraint, groupBy, aggs)
 }
 
 // AggregateTable is Aggregate on the named table.
-func (c *Client) AggregateTable(table, constraint string, groupBy []string, aggs []AggSpec) ([]AggRow, error) {
+func (c *Client) AggregateTable(ctx context.Context, table, constraint string, groupBy []string, aggs []AggSpec) ([]AggRow, error) {
 	build := func(id uint64) []byte {
 		b := putStr(putStr(req(id, opAggregate), table), constraint)
 		b = putI32(b, int32(len(groupBy)))
@@ -63,26 +63,34 @@ func (c *Client) AggregateTable(table, constraint string, groupBy []string, aggs
 		return nil, err
 	}
 	var out []AggRow
-	for frame := range frames {
-		_, status, body, ok := respHeader(frame)
-		if !ok {
-			return out, errShort
-		}
-		switch status {
-		case stStream:
-			row := AggRow{Group: make([]string, len(groupBy)), Values: make([]string, len(aggs))}
-			for i := range row.Group {
-				row.Group[i] = body.str()
+	for {
+		select {
+		case <-ctx.Done():
+			drain(frames)
+			return out, ctx.Err()
+		case frame, ok := <-frames:
+			if !ok {
+				return out, nil
 			}
-			for i := range row.Values {
-				row.Values[i] = body.str()
+			_, status, body, ok := respHeader(frame)
+			if !ok {
+				return out, errShort
 			}
-			out = append(out, row)
-		case stErr:
-			return out, statusErr(status, body)
+			switch status {
+			case stStream:
+				row := AggRow{Group: make([]string, len(groupBy)), Values: make([]string, len(aggs))}
+				for i := range row.Group {
+					row.Group[i] = body.str()
+				}
+				for i := range row.Values {
+					row.Values[i] = body.str()
+				}
+				out = append(out, row)
+			case stErr:
+				return out, statusErr(status, body)
+			}
 		}
 	}
-	return out, nil
 }
 
 // streamAggregate performs the server-side aggregation and streams one frame per

--- a/dbrpc/aggregate_bench_test.go
+++ b/dbrpc/aggregate_bench_test.go
@@ -1,6 +1,7 @@
 package dbrpc
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -79,7 +80,7 @@ func BenchmarkAggregateGroupBy(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		rows, err := c.Aggregate("RequestCpus >= 1", []string{"RequestCpus"},
+		rows, err := c.Aggregate(context.Background(), "RequestCpus >= 1", []string{"RequestCpus"},
 			[]AggSpec{{Func: AggCount, Arg: "*"}})
 		if err != nil {
 			b.Fatal(err)
@@ -129,7 +130,7 @@ func BenchmarkQueryLimit1(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		rows, err := c.QueryLimit("RequestCpus >= 1", 1) // matches every ad
+		rows, err := c.QueryLimit(context.Background(), "RequestCpus >= 1", 1) // matches every ad
 		if err != nil || len(rows) != 1 {
 			b.Fatalf("rows=%d err=%v, want 1", len(rows), err)
 		}
@@ -148,7 +149,7 @@ func BenchmarkQueryAll(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		rows, err := c.QueryLimit("RequestCpus >= 1", 0)
+		rows, err := c.QueryLimit(context.Background(), "RequestCpus >= 1", 0)
 		if err != nil || len(rows) != benchN {
 			b.Fatalf("rows=%d err=%v, want %d", len(rows), err, benchN)
 		}

--- a/dbrpc/aggregate_test.go
+++ b/dbrpc/aggregate_test.go
@@ -1,6 +1,7 @@
 package dbrpc
 
 import (
+	"context"
 	"sort"
 	"testing"
 
@@ -11,16 +12,16 @@ func TestAggregateGroupBy(t *testing.T) {
 	c, cleanup := testPair(t)
 	defer cleanup()
 
-	tx, _ := c.Begin()
-	_ = tx.NewClassAd("1", "Owner = \"alice\"\nCpus = 4")
-	_ = tx.NewClassAd("2", "Owner = \"alice\"\nCpus = 8")
-	_ = tx.NewClassAd("3", "Owner = \"bob\"\nCpus = 16")
-	if err := tx.Commit(); err != nil {
+	tx, _ := c.Begin(context.Background())
+	_ = tx.NewClassAd(context.Background(), "1", "Owner = \"alice\"\nCpus = 4")
+	_ = tx.NewClassAd(context.Background(), "2", "Owner = \"alice\"\nCpus = 8")
+	_ = tx.NewClassAd(context.Background(), "3", "Owner = \"bob\"\nCpus = 16")
+	if err := tx.Commit(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 
 	// GROUP BY Owner: COUNT(*), SUM(Cpus), MAX(Cpus).
-	rows, err := c.Aggregate("true", []string{"Owner"}, []AggSpec{
+	rows, err := c.Aggregate(context.Background(), "true", []string{"Owner"}, []AggSpec{
 		{Func: AggCount, Arg: "*"},
 		{Func: AggSum, Arg: "Cpus"},
 		{Func: AggMax, Arg: "Cpus"},
@@ -46,14 +47,14 @@ func TestAggregateGroupBy(t *testing.T) {
 func TestAggregateMultiColumnGroup(t *testing.T) {
 	c, cleanup := testPair(t)
 	defer cleanup()
-	tx, _ := c.Begin()
-	_ = tx.NewClassAd("1", "Owner = \"alice\"\nState = \"Run\"\nCpus = 4")
-	_ = tx.NewClassAd("2", "Owner = \"alice\"\nState = \"Idle\"\nCpus = 8")
-	_ = tx.NewClassAd("3", "Owner = \"alice\"\nState = \"Run\"\nCpus = 2")
-	if err := tx.Commit(); err != nil {
+	tx, _ := c.Begin(context.Background())
+	_ = tx.NewClassAd(context.Background(), "1", "Owner = \"alice\"\nState = \"Run\"\nCpus = 4")
+	_ = tx.NewClassAd(context.Background(), "2", "Owner = \"alice\"\nState = \"Idle\"\nCpus = 8")
+	_ = tx.NewClassAd(context.Background(), "3", "Owner = \"alice\"\nState = \"Run\"\nCpus = 2")
+	if err := tx.Commit(context.Background()); err != nil {
 		t.Fatal(err)
 	}
-	rows, err := c.Aggregate("true", []string{"Owner", "State"}, []AggSpec{{Func: AggCount, Arg: "*"}})
+	rows, err := c.Aggregate(context.Background(), "true", []string{"Owner", "State"}, []AggSpec{{Func: AggCount, Arg: "*"}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -70,13 +71,13 @@ func TestAggregateMultiColumnGroup(t *testing.T) {
 func TestAggregateNoGroup(t *testing.T) {
 	c, cleanup := testPair(t)
 	defer cleanup()
-	tx, _ := c.Begin()
-	_ = tx.NewClassAd("1", "Cpus = 4")
-	_ = tx.NewClassAd("2", "Cpus = 8")
-	if err := tx.Commit(); err != nil {
+	tx, _ := c.Begin(context.Background())
+	_ = tx.NewClassAd(context.Background(), "1", "Cpus = 4")
+	_ = tx.NewClassAd(context.Background(), "2", "Cpus = 8")
+	if err := tx.Commit(context.Background()); err != nil {
 		t.Fatal(err)
 	}
-	rows, err := c.Aggregate("true", nil, []AggSpec{{Func: AggCount, Arg: "*"}, {Func: AggAvg, Arg: "Cpus"}})
+	rows, err := c.Aggregate(context.Background(), "true", nil, []AggSpec{{Func: AggCount, Arg: "*"}, {Func: AggAvg, Arg: "Cpus"}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -91,13 +92,13 @@ func TestAggregateNoGroup(t *testing.T) {
 func TestAggregateCoercion(t *testing.T) {
 	c, cleanup := testPair(t)
 	defer cleanup()
-	tx, _ := c.Begin()
-	_ = tx.NewClassAd("1", "N = 4\nX = 4\nName = \"alice\"")
-	_ = tx.NewClassAd("2", "N = 8\nX = 1.5\nName = \"bob\"")
-	if err := tx.Commit(); err != nil {
+	tx, _ := c.Begin(context.Background())
+	_ = tx.NewClassAd(context.Background(), "1", "N = 4\nX = 4\nName = \"alice\"")
+	_ = tx.NewClassAd(context.Background(), "2", "N = 8\nX = 1.5\nName = \"bob\"")
+	if err := tx.Commit(context.Background()); err != nil {
 		t.Fatal(err)
 	}
-	rows, err := c.Aggregate("true", nil, []AggSpec{
+	rows, err := c.Aggregate(context.Background(), "true", nil, []AggSpec{
 		{Func: AggSum, Arg: "N"},    // 4 + 8 -> integer 12
 		{Func: AggSum, Arg: "X"},    // 4 + 1.5 -> real 5.5
 		{Func: AggMin, Arg: "Name"}, // strings are not numeric -> error
@@ -130,7 +131,7 @@ func TestAggregatePrivateRefused(t *testing.T) {
 	c := NewClient(cconn)
 	defer func() { c.Close(); s.Close(); d.Close() }()
 
-	if _, err := c.Aggregate("true", []string{"Capability"}, []AggSpec{{Func: AggCount, Arg: "*"}}); err == nil {
+	if _, err := c.Aggregate(context.Background(), "true", []string{"Capability"}, []AggSpec{{Func: AggCount, Arg: "*"}}); err == nil {
 		t.Fatal("grouping by a private attribute on a stripped connection should be refused")
 	}
 }

--- a/dbrpc/archive.go
+++ b/dbrpc/archive.go
@@ -1,6 +1,7 @@
 package dbrpc
 
 import (
+	"context"
 	"encoding/json"
 
 	"github.com/PelicanPlatform/classad/db"
@@ -42,12 +43,12 @@ func (sc *serverConn) streamArchiveQuery(reqID uint64, r *reader) {
 
 // CreateArchiveTable creates (or no-ops if present) an append-only history table. cfg
 // configures indexes / zone maps / retention on first creation.
-func (c *Client) CreateArchiveTable(name string, cfg db.ArchiveConfig) error {
+func (c *Client) CreateArchiveTable(ctx context.Context, name string, cfg db.ArchiveConfig) error {
 	data, err := json.Marshal(cfg)
 	if err != nil {
 		return err
 	}
-	status, body, err := c.call(func(id uint64) []byte {
+	status, body, err := c.callCtx(ctx, func(id uint64) []byte {
 		return putBytes(putStr(req(id, opArchiveCreate), name), data)
 	})
 	if err != nil {
@@ -60,8 +61,8 @@ func (c *Client) CreateArchiveTable(name string, cfg db.ArchiveConfig) error {
 }
 
 // ArchiveAppend appends an ad (old-ClassAd text) to the named history table.
-func (c *Client) ArchiveAppend(name, adText string) error {
-	status, body, err := c.call(func(id uint64) []byte {
+func (c *Client) ArchiveAppend(ctx context.Context, name, adText string) error {
+	status, body, err := c.callCtx(ctx, func(id uint64) []byte {
 		return putStr(putStr(req(id, opArchiveAppend), name), adText)
 	})
 	if err != nil {
@@ -75,16 +76,16 @@ func (c *Client) ArchiveAppend(name, adText string) error {
 
 // ArchiveQuery returns up to limit (<= 0 = all) newest-first matches (old-ClassAd texts)
 // from the named history table -- the condor_history "last K" pattern.
-func (c *Client) ArchiveQuery(name, constraint string, limit int) ([]string, error) {
-	return c.stream(func(id uint64) []byte {
+func (c *Client) ArchiveQuery(ctx context.Context, name, constraint string, limit int) ([]string, error) {
+	return c.streamCtx(ctx, func(id uint64) []byte {
 		return putStr(putI32(putStr(req(id, opArchiveQuery), name), int32(limit)), constraint)
 	})
 }
 
 // ArchiveRotate enforces the named archive's retention policy now (using the server's
 // clock for age-based rules), returning how many sealed segments were dropped.
-func (c *Client) ArchiveRotate(name string) (int, error) {
-	status, body, err := c.call(func(id uint64) []byte {
+func (c *Client) ArchiveRotate(ctx context.Context, name string) (int, error) {
+	status, body, err := c.callCtx(ctx, func(id uint64) []byte {
 		return putStr(req(id, opArchiveRotate), name)
 	})
 	if err != nil {
@@ -97,8 +98,8 @@ func (c *Client) ArchiveRotate(name string) (int, error) {
 }
 
 // ArchiveTables lists the history table names.
-func (c *Client) ArchiveTables() ([]string, error) {
-	status, body, err := c.call(func(id uint64) []byte { return req(id, opArchiveList) })
+func (c *Client) ArchiveTables(ctx context.Context) ([]string, error) {
+	status, body, err := c.callCtx(ctx, func(id uint64) []byte { return req(id, opArchiveList) })
 	if err != nil {
 		return nil, err
 	}

--- a/dbrpc/archive_test.go
+++ b/dbrpc/archive_test.go
@@ -1,6 +1,7 @@
 package dbrpc
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -27,17 +28,17 @@ func TestArchiveOverRPC(t *testing.T) {
 	c, cleanup := catServerPair(t, ServeOptions{})
 	defer cleanup()
 
-	if err := c.CreateArchiveTable("history", db.ArchiveConfig{ValueAttrs: []string{"ClusterId"}}); err != nil {
+	if err := c.CreateArchiveTable(context.Background(), "history", db.ArchiveConfig{ValueAttrs: []string{"ClusterId"}}); err != nil {
 		t.Fatalf("CreateArchiveTable: %v", err)
 	}
 	for i := 0; i < 100; i++ {
-		if err := c.ArchiveAppend("history", fmt.Sprintf("ClusterId = %d\nJobStatus = 4", i)); err != nil {
+		if err := c.ArchiveAppend(context.Background(), "history", fmt.Sprintf("ClusterId = %d\nJobStatus = 4", i)); err != nil {
 			t.Fatalf("ArchiveAppend: %v", err)
 		}
 	}
 
 	// Newest-first, last 3.
-	got, err := c.ArchiveQuery("history", "true", 3)
+	got, err := c.ArchiveQuery(context.Background(), "history", "true", 3)
 	if err != nil {
 		t.Fatalf("ArchiveQuery: %v", err)
 	}
@@ -45,7 +46,7 @@ func TestArchiveOverRPC(t *testing.T) {
 		t.Fatalf("ArchiveQuery(limit 3) returned %d, want 3", len(got))
 	}
 	// Constrained query.
-	one, err := c.ArchiveQuery("history", "ClusterId == 42", 0)
+	one, err := c.ArchiveQuery(context.Background(), "history", "ClusterId == 42", 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -53,7 +54,7 @@ func TestArchiveOverRPC(t *testing.T) {
 		t.Fatalf("ClusterId==42 matched %d, want 1", len(one))
 	}
 
-	names, err := c.ArchiveTables()
+	names, err := c.ArchiveTables(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -64,7 +65,7 @@ func TestArchiveOverRPC(t *testing.T) {
 	// Append is refused on a read-only connection.
 	rc, rcleanup := catServerPair(t, ServeOptions{ReadOnly: true})
 	defer rcleanup()
-	if err := rc.ArchiveAppend("history", "ClusterId = 1"); err == nil {
+	if err := rc.ArchiveAppend(context.Background(), "history", "ClusterId = 1"); err == nil {
 		t.Error("archive append should be refused on a read-only connection")
 	}
 }

--- a/dbrpc/client.go
+++ b/dbrpc/client.go
@@ -1,6 +1,7 @@
 package dbrpc
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -68,7 +69,9 @@ func (c *Client) failAll(err error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if c.closeErr == nil {
-		c.closeErr = err
+		// Wrap the transport cause as ErrConnClosed so callers classify with
+		// errors.Is (reconnect-and-replay) while retaining the specific I/O error.
+		c.closeErr = fmt.Errorf("%w: %v", ErrConnClosed, err)
 	}
 	for id, p := range c.pending {
 		close(p.ch)
@@ -79,22 +82,41 @@ func (c *Client) failAll(err error) {
 // Close closes the underlying connection; pending and future calls fail.
 func (c *Client) Close() error { return c.conn.Close() }
 
-// call sends one request (built by build with the assigned id) and waits for its
-// response, returning the status and a reader positioned at the response payload.
-func (c *Client) call(build func(reqID uint64) []byte) (int32, *reader, error) {
-	ch, err := c.send(build, false)
+// callCtx sends one request (built by build with the assigned id) and waits for its
+// response under ctx, returning the status and a reader positioned at the response
+// payload. If ctx ends first it unregisters the pending call (so the eventual
+// response is discarded, not delivered to a since-departed caller) and returns
+// ctx.Err(); the shared read loop keeps serving every other in-flight call. There
+// is no implicit timeout -- the deadline is exactly whatever ctx carries.
+func (c *Client) callCtx(ctx context.Context, build func(reqID uint64) []byte) (int32, *reader, error) {
+	id := c.nextReq.Add(1)
+	ch, err := c.sendID(id, build, false)
 	if err != nil {
 		return 0, nil, err
 	}
-	frame, ok := <-ch
-	if !ok {
-		return 0, nil, c.closeErr
+	select {
+	case <-ctx.Done():
+		c.cancelPending(id)
+		return 0, nil, ctx.Err()
+	case frame, ok := <-ch:
+		if !ok {
+			return 0, nil, c.closeErr
+		}
+		_, status, body, ok := respHeader(frame)
+		if !ok {
+			return 0, nil, errShort
+		}
+		return status, body, nil
 	}
-	_, status, body, ok := respHeader(frame)
-	if !ok {
-		return 0, nil, errShort
-	}
-	return status, body, nil
+}
+
+// cancelPending unregisters a unary call's pending entry so a late response frame is
+// discarded by the read loop. The response channel is buffered (size 1), so the read
+// loop never blocks delivering to an abandoned call.
+func (c *Client) cancelPending(id uint64) {
+	c.mu.Lock()
+	delete(c.pending, id)
+	c.mu.Unlock()
 }
 
 // callStream issues a streaming request; the returned channel yields each result
@@ -139,7 +161,7 @@ func (c *Client) sendID(id uint64, build func(reqID uint64) []byte, stream bool)
 
 func statusErr(status int32, body *reader) error {
 	if status == stErr {
-		return fmt.Errorf("dbrpc: %s", body.str())
+		return &ServerError{Msg: body.str()}
 	}
 	return fmt.Errorf("dbrpc: status %d", status)
 }
@@ -153,11 +175,11 @@ type Tx struct {
 }
 
 // Begin starts a new independent transaction on the default table ("ads").
-func (c *Client) Begin() (*Tx, error) { return c.BeginTable(DefaultTable) }
+func (c *Client) Begin(ctx context.Context) (*Tx, error) { return c.BeginTable(ctx, DefaultTable) }
 
 // BeginTable starts a new independent transaction on the named table.
-func (c *Client) BeginTable(table string) (*Tx, error) {
-	status, body, err := c.call(func(id uint64) []byte { return putStr(req(id, opBegin), table) })
+func (c *Client) BeginTable(ctx context.Context, table string) (*Tx, error) {
+	status, body, err := c.callCtx(ctx, func(id uint64) []byte { return putStr(req(id, opBegin), table) })
 	if err != nil {
 		return nil, err
 	}
@@ -169,8 +191,38 @@ func (c *Client) BeginTable(table string) (*Tx, error) {
 
 // Commit applies the transaction, returning *db.ConflictError with the conflicted
 // keys if any lost a write-write race (the rest committed), or nil.
-func (t *Tx) Commit() error {
-	status, body, err := t.c.call(func(id uint64) []byte { return putU64(req(id, opCommit), t.id) })
+func (t *Tx) Commit(ctx context.Context) error {
+	status, body, err := t.c.callCtx(ctx, func(id uint64) []byte { return putU64(req(id, opCommit), t.id) })
+	if err != nil {
+		return err
+	}
+	switch status {
+	case stOK:
+		return nil
+	case stConflict:
+		var keys []string
+		for body.err == nil && len(body.b) > 0 {
+			keys = append(keys, body.str())
+		}
+		return &db.ConflictError{Keys: keys}
+	default:
+		return statusErr(status, body)
+	}
+}
+
+// CommitIdempotent is Commit with exactly-once semantics across retries: the server
+// records a durable marker under idemKey, committed atomically with this
+// transaction's writes, so replaying the SAME unit of work (same idemKey) after an
+// ambiguous failure -- a reconnect where the original commit's fate is unknown --
+// applies it at most once. The caller must generate idemKey ONCE per unit of work
+// and reuse it verbatim on every replay. Use this for non-idempotent transactions
+// (e.g. relative updates, appends); an already-idempotent-by-key workload can use
+// the cheaper plain Commit. Returns the same results as Commit (nil, or
+// *db.ConflictError on a genuine write-write conflict).
+func (t *Tx) CommitIdempotent(ctx context.Context, idemKey string) error {
+	status, body, err := t.c.callCtx(ctx, func(id uint64) []byte {
+		return putStr(putU64(req(id, opCommitIdem), t.id), idemKey)
+	})
 	if err != nil {
 		return err
 	}
@@ -189,13 +241,13 @@ func (t *Tx) Commit() error {
 }
 
 // Abort discards the transaction.
-func (t *Tx) Abort() error {
-	_, _, err := t.c.call(func(id uint64) []byte { return putU64(req(id, opAbort), t.id) })
+func (t *Tx) Abort(ctx context.Context) error {
+	_, _, err := t.c.callCtx(ctx, func(id uint64) []byte { return putU64(req(id, opAbort), t.id) })
 	return err
 }
 
-func (t *Tx) simple(o op, fields ...string) error {
-	status, body, err := t.c.call(func(id uint64) []byte {
+func (t *Tx) simple(ctx context.Context, o op, fields ...string) error {
+	status, body, err := t.c.callCtx(ctx, func(id uint64) []byte {
 		b := putU64(req(id, o), t.id)
 		for _, f := range fields {
 			b = putStr(b, f)
@@ -212,21 +264,29 @@ func (t *Tx) simple(o op, fields ...string) error {
 }
 
 // NewClassAd stores the ad (old-ClassAd text) under key.
-func (t *Tx) NewClassAd(key, adText string) error { return t.simple(opNewAd, key, adText) }
+func (t *Tx) NewClassAd(ctx context.Context, key, adText string) error {
+	return t.simple(ctx, opNewAd, key, adText)
+}
 
 // DestroyClassAd removes key.
-func (t *Tx) DestroyClassAd(key string) error { return t.simple(opDestroyAd, key) }
+func (t *Tx) DestroyClassAd(ctx context.Context, key string) error {
+	return t.simple(ctx, opDestroyAd, key)
+}
 
 // SetAttribute sets key's attribute name to expr.
-func (t *Tx) SetAttribute(key, name, expr string) error { return t.simple(opSetAttr, key, name, expr) }
+func (t *Tx) SetAttribute(ctx context.Context, key, name, expr string) error {
+	return t.simple(ctx, opSetAttr, key, name, expr)
+}
 
 // DeleteAttribute removes key's attribute name.
-func (t *Tx) DeleteAttribute(key, name string) error { return t.simple(opDeleteAttr, key, name) }
+func (t *Tx) DeleteAttribute(ctx context.Context, key, name string) error {
+	return t.simple(ctx, opDeleteAttr, key, name)
+}
 
 // LookupAttr returns key's attribute name (unparsed expression) as the transaction
 // sees it, or ("", false).
-func (t *Tx) LookupAttr(key, name string) (string, bool, error) {
-	status, body, err := t.c.call(func(id uint64) []byte {
+func (t *Tx) LookupAttr(ctx context.Context, key, name string) (string, bool, error) {
+	status, body, err := t.c.callCtx(ctx, func(id uint64) []byte {
 		return putStr(putStr(putU64(req(id, opLookupAttr), t.id), key), name)
 	})
 	if err != nil {
@@ -243,8 +303,8 @@ func (t *Tx) LookupAttr(key, name string) (string, bool, error) {
 }
 
 // LookupClassAd returns key's ad (old-ClassAd text) as the transaction sees it.
-func (t *Tx) LookupClassAd(key string) (string, bool, error) {
-	status, body, err := t.c.call(func(id uint64) []byte {
+func (t *Tx) LookupClassAd(ctx context.Context, key string) (string, bool, error) {
+	status, body, err := t.c.callCtx(ctx, func(id uint64) []byte {
 		return putStr(putU64(req(id, opLookupAd), t.id), key)
 	})
 	if err != nil {
@@ -262,58 +322,70 @@ func (t *Tx) LookupClassAd(key string) (string, bool, error) {
 
 // --- streaming reads over the committed store (no transaction) ---
 
-// stream collects a finite streamed read into a slice of old-ClassAd texts.
-func (c *Client) stream(build func(id uint64) []byte) ([]string, error) {
+// streamCtx collects a finite streamed read into a slice of old-ClassAd texts,
+// honoring ctx. If ctx ends first it returns ctx.Err() and hands the response
+// channel to a background drain: the shared read loop must never block delivering a
+// stream frame, and the pending entry is cleaned only when the server's stream
+// terminator arrives, so we keep reading (discarding) rather than orphaning it.
+func (c *Client) streamCtx(ctx context.Context, build func(id uint64) []byte) ([]string, error) {
 	_, ch, err := c.callStream(build)
 	if err != nil {
 		return nil, err
 	}
 	var out []string
-	for frame := range ch {
-		_, status, body, ok := respHeader(frame)
-		if !ok {
-			return out, errShort
-		}
-		switch status {
-		case stStream:
-			out = append(out, body.str())
-		case stErr:
-			return out, statusErr(status, body)
+	for {
+		select {
+		case <-ctx.Done():
+			drain(ch) // backgrounds itself; keeps the read loop unblocked
+			return out, ctx.Err()
+		case frame, ok := <-ch:
+			if !ok {
+				return out, nil
+			}
+			_, status, body, ok := respHeader(frame)
+			if !ok {
+				return out, errShort
+			}
+			switch status {
+			case stStream:
+				out = append(out, body.str())
+			case stErr:
+				return out, statusErr(status, body)
+			}
 		}
 	}
-	return out, nil
 }
 
 // Query returns the committed ads (old-ClassAd texts) in the default table ("ads")
 // matching a constraint. The server streams results; a slow scan does not block
 // other calls.
-func (c *Client) Query(constraint string) ([]string, error) {
-	return c.QueryTable(DefaultTable, constraint, 0)
+func (c *Client) Query(ctx context.Context, constraint string) ([]string, error) {
+	return c.QueryTable(ctx, DefaultTable, constraint, 0)
 }
 
 // QueryLimit is Query with a row cap (<= 0 = all) on the default table.
-func (c *Client) QueryLimit(constraint string, limit int) ([]string, error) {
-	return c.QueryTable(DefaultTable, constraint, limit)
+func (c *Client) QueryLimit(ctx context.Context, constraint string, limit int) ([]string, error) {
+	return c.QueryTable(ctx, DefaultTable, constraint, limit)
 }
 
 // QueryTable returns the committed ads in the named table matching constraint,
 // stopping after at most limit matches (<= 0 = all). The limit is pushed to the
 // server, which stops the scan early.
-func (c *Client) QueryTable(table, constraint string, limit int) ([]string, error) {
-	return c.stream(func(id uint64) []byte {
+func (c *Client) QueryTable(ctx context.Context, table, constraint string, limit int) ([]string, error) {
+	return c.streamCtx(ctx, func(id uint64) []byte {
 		return putStr(putI32(putStr(req(id, opQuery), table), int32(limit)), constraint)
 	})
 }
 
 // MatchSorted returns job's matches in the default table, ranked best-first, at
 // most limit (<=0 = all).
-func (c *Client) MatchSorted(jobText string, limit int) ([]string, error) {
-	return c.MatchSortedTable(DefaultTable, jobText, limit)
+func (c *Client) MatchSorted(ctx context.Context, jobText string, limit int) ([]string, error) {
+	return c.MatchSortedTable(ctx, DefaultTable, jobText, limit)
 }
 
 // MatchSortedTable returns job's ranked matches in the named table.
-func (c *Client) MatchSortedTable(table, jobText string, limit int) ([]string, error) {
-	return c.stream(func(id uint64) []byte {
+func (c *Client) MatchSortedTable(ctx context.Context, table, jobText string, limit int) ([]string, error) {
+	return c.streamCtx(ctx, func(id uint64) []byte {
 		return putStr(putI32(putStr(req(id, opMatchSorted), table), int32(limit)), jobText)
 	})
 }
@@ -328,12 +400,12 @@ type OrderedRow struct {
 // Ordered streams one partition of the index-th configured ordered index in sort
 // order (the negotiator resource-request path). One-shot: the whole partition is
 // returned (the server-side resume cursor is not carried over the wire).
-func (c *Client) Ordered(index int, partition string) ([]OrderedRow, error) {
-	return c.OrderedTable(DefaultTable, index, partition)
+func (c *Client) Ordered(ctx context.Context, index int, partition string) ([]OrderedRow, error) {
+	return c.OrderedTable(ctx, DefaultTable, index, partition)
 }
 
 // OrderedTable streams one partition of an ordered index in the named table.
-func (c *Client) OrderedTable(table string, index int, partition string) ([]OrderedRow, error) {
+func (c *Client) OrderedTable(ctx context.Context, table string, index int, partition string) ([]OrderedRow, error) {
 	_, frames, err := c.callStream(func(id uint64) []byte {
 		return putStr(putI32(putStr(req(id, opOrdered), table), int32(index)), partition)
 	})
@@ -341,21 +413,29 @@ func (c *Client) OrderedTable(table string, index int, partition string) ([]Orde
 		return nil, err
 	}
 	var out []OrderedRow
-	for frame := range frames {
-		_, status, body, ok := respHeader(frame)
-		if !ok {
-			return out, errShort
-		}
-		switch status {
-		case stStream:
-			row := OrderedRow{Signature: body.u64()}
-			row.AdText = body.str()
-			out = append(out, row)
-		case stErr:
-			return out, statusErr(status, body)
+	for {
+		select {
+		case <-ctx.Done():
+			drain(frames)
+			return out, ctx.Err()
+		case frame, ok := <-frames:
+			if !ok {
+				return out, nil
+			}
+			_, status, body, ok := respHeader(frame)
+			if !ok {
+				return out, errShort
+			}
+			switch status {
+			case stStream:
+				row := OrderedRow{Signature: body.u64()}
+				row.AdText = body.str()
+				out = append(out, row)
+			case stErr:
+				return out, statusErr(status, body)
+			}
 		}
 	}
-	return out, nil
 }
 
 // WatchEvent is one change delivered over a Watch. AdText is the ad's old-ClassAd text
@@ -370,15 +450,15 @@ type WatchEvent struct {
 // Watch streams changes committed after cursor (nil = from now) on the channel, which
 // closes when the returned stop is called, the connection fails, or the server ends
 // the stream. A full replay leads with a reset event.
-func (c *Client) Watch(cursor []byte) (<-chan WatchEvent, func(), error) {
-	return c.WatchTable(DefaultTable, cursor)
+func (c *Client) Watch(ctx context.Context, cursor []byte) (<-chan WatchEvent, func(), error) {
+	return c.WatchTable(ctx, DefaultTable, cursor)
 }
 
 // WatchHead returns an opaque cursor at the current head of table's change log, so a
 // following WatchTable(table, cursor) streams only subsequent changes (no replay of
 // current contents) -- the "tail from now" path.
-func (c *Client) WatchHead(table string) ([]byte, error) {
-	status, body, err := c.call(func(rid uint64) []byte {
+func (c *Client) WatchHead(ctx context.Context, table string) ([]byte, error) {
+	status, body, err := c.callCtx(ctx, func(rid uint64) []byte {
 		return putStr(req(rid, opWatchHead), table)
 	})
 	if err != nil {
@@ -391,33 +471,49 @@ func (c *Client) WatchHead(table string) ([]byte, error) {
 }
 
 // WatchTable streams changes to the named table.
-func (c *Client) WatchTable(table string, cursor []byte) (<-chan WatchEvent, func(), error) {
+func (c *Client) WatchTable(ctx context.Context, table string, cursor []byte) (<-chan WatchEvent, func(), error) {
 	id, frames, err := c.callStream(func(rid uint64) []byte {
 		return putBytes(putStr(req(rid, opWatch), table), cursor)
 	})
 	if err != nil {
 		return nil, nil, err
 	}
-	events := make(chan WatchEvent, 64)
-	go func() {
-		defer close(events)
-		for frame := range frames {
-			_, status, body, ok := respHeader(frame)
-			if !ok || status != stStream {
-				continue
-			}
-			ev := WatchEvent{Kind: body.u8()}
-			ev.Key = body.str()
-			ev.AdText = body.str()
-			ev.Cursor = append([]byte(nil), body.bytesRef()...)
-			events <- ev
-		}
-	}()
 	var once sync.Once
 	stop := func() {
 		once.Do(func() {
-			_, _, _ = c.call(func(rid uint64) []byte { return putU64(req(rid, opWatchStop), id) })
+			_, _, _ = c.callCtx(context.Background(), func(rid uint64) []byte { return putU64(req(rid, opWatchStop), id) })
 		})
 	}
+	events := make(chan WatchEvent, 64)
+	go func() {
+		defer close(events)
+		for {
+			select {
+			case <-ctx.Done():
+				stop() // tell the server to end the stream; frames is drained below
+				drain(frames)
+				return
+			case frame, ok := <-frames:
+				if !ok {
+					return
+				}
+				_, status, body, ok := respHeader(frame)
+				if !ok || status != stStream {
+					continue
+				}
+				ev := WatchEvent{Kind: body.u8()}
+				ev.Key = body.str()
+				ev.AdText = body.str()
+				ev.Cursor = append([]byte(nil), body.bytesRef()...)
+				select {
+				case events <- ev:
+				case <-ctx.Done():
+					stop()
+					drain(frames)
+					return
+				}
+			}
+		}
+	}()
 	return events, stop, nil
 }

--- a/dbrpc/delete.go
+++ b/dbrpc/delete.go
@@ -1,18 +1,20 @@
 package dbrpc
 
+import "context"
+
 // DeleteWhere removes every ad matching constraint from the default table and
 // returns the number removed. The delete runs server-side as a single call --
 // the db.DeleteWhere pushdown (batched, optimistic-retry, self-healing) -- rather
 // than a per-key query-then-delete round trip per ad. Refused on a read-only
 // connection.
-func (c *Client) DeleteWhere(constraint string) (int, error) {
-	return c.DeleteWhereTable(DefaultTable, constraint)
+func (c *Client) DeleteWhere(ctx context.Context, constraint string) (int, error) {
+	return c.DeleteWhereTable(ctx, DefaultTable, constraint)
 }
 
 // DeleteWhereTable is DeleteWhere against a named table. Express a time-based
 // expiry sweep as the constraint (e.g. "<now> > LastHeardFrom + Lifetime").
-func (c *Client) DeleteWhereTable(table, constraint string) (int, error) {
-	status, body, err := c.call(func(id uint64) []byte {
+func (c *Client) DeleteWhereTable(ctx context.Context, table, constraint string) (int, error) {
+	status, body, err := c.callCtx(ctx, func(id uint64) []byte {
 		return putStr(putStr(req(id, opDeleteWhere), table), constraint)
 	})
 	if err != nil {

--- a/dbrpc/delete_test.go
+++ b/dbrpc/delete_test.go
@@ -1,6 +1,7 @@
 package dbrpc
 
 import (
+	"context"
 	"testing"
 
 	"github.com/PelicanPlatform/classad/db"
@@ -10,26 +11,26 @@ func TestRPCDeleteWhere(t *testing.T) {
 	c, cleanup := testPair(t)
 	defer cleanup()
 
-	tx, err := c.Begin()
+	tx, err := c.Begin(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
-	_ = tx.NewClassAd("a", `Name = "a"`+"\n"+`State = "Idle"`)
-	_ = tx.NewClassAd("b", `Name = "b"`+"\n"+`State = "Claimed"`)
-	_ = tx.NewClassAd("c", `Name = "c"`+"\n"+`State = "Idle"`)
-	if err := tx.Commit(); err != nil {
+	_ = tx.NewClassAd(context.Background(), "a", `Name = "a"`+"\n"+`State = "Idle"`)
+	_ = tx.NewClassAd(context.Background(), "b", `Name = "b"`+"\n"+`State = "Claimed"`)
+	_ = tx.NewClassAd(context.Background(), "c", `Name = "c"`+"\n"+`State = "Idle"`)
+	if err := tx.Commit(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 
 	// Bulk delete-by-constraint in one server-side call.
-	n, err := c.DeleteWhere(`State == "Idle"`)
+	n, err := c.DeleteWhere(context.Background(), `State == "Idle"`)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if n != 2 {
 		t.Fatalf("DeleteWhere removed %d, want 2", n)
 	}
-	rows, err := c.Query("true")
+	rows, err := c.Query(context.Background(), "true")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -51,7 +52,7 @@ func TestRPCDeleteWhereReadOnly(t *testing.T) {
 	c := NewClient(cconn)
 	defer func() { c.Close(); s.Close(); d.Close() }()
 
-	if _, err := c.DeleteWhere("true"); err == nil {
+	if _, err := c.DeleteWhere(context.Background(), "true"); err == nil {
 		t.Fatal("DeleteWhere on a read-only connection should be refused, got nil error")
 	}
 }

--- a/dbrpc/diag.go
+++ b/dbrpc/diag.go
@@ -1,6 +1,7 @@
 package dbrpc
 
 import (
+	"context"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -194,11 +195,13 @@ func join(ss []string) string {
 
 // Diagnostics fetches the default table's storage stats, hot set, indexes, and
 // tuning suggestions.
-func (c *Client) Diagnostics() (*Diagnostics, error) { return c.DiagnosticsTable(DefaultTable) }
+func (c *Client) Diagnostics(ctx context.Context) (*Diagnostics, error) {
+	return c.DiagnosticsTable(ctx, DefaultTable)
+}
 
 // DiagnosticsTable fetches the named table's diagnostics.
-func (c *Client) DiagnosticsTable(table string) (*Diagnostics, error) {
-	status, body, err := c.call(func(id uint64) []byte { return putStr(req(id, opDiag), table) })
+func (c *Client) DiagnosticsTable(ctx context.Context, table string) (*Diagnostics, error) {
+	status, body, err := c.callCtx(ctx, func(id uint64) []byte { return putStr(req(id, opDiag), table) })
 	if err != nil {
 		return nil, err
 	}
@@ -213,13 +216,13 @@ func (c *Client) DiagnosticsTable(table string) (*Diagnostics, error) {
 }
 
 // Explain reports how the default table would execute a constraint query.
-func (c *Client) Explain(constraint string) (*db.QueryExplain, error) {
-	return c.ExplainTable(DefaultTable, constraint)
+func (c *Client) Explain(ctx context.Context, constraint string) (*db.QueryExplain, error) {
+	return c.ExplainTable(ctx, DefaultTable, constraint)
 }
 
 // ExplainTable reports how the named table would execute a constraint query.
-func (c *Client) ExplainTable(table, constraint string) (*db.QueryExplain, error) {
-	status, body, err := c.call(func(id uint64) []byte {
+func (c *Client) ExplainTable(ctx context.Context, table, constraint string) (*db.QueryExplain, error) {
+	status, body, err := c.callCtx(ctx, func(id uint64) []byte {
 		return putStr(putStr(req(id, opExplain), table), constraint)
 	})
 	if err != nil {
@@ -239,8 +242,8 @@ func (c *Client) ExplainTable(table, constraint string) (*db.QueryExplain, error
 // jobSelector against resTable would execute: the job's Requirements rewritten over
 // the slot (job constants baked in) and which resulting probes prune via a resource
 // index. jobSelector is a constraint (e.g. `Key == "1.0"`) identifying the request.
-func (c *Client) MatchExplain(reqTable, jobSelector, resTable, targetWhere string) (*db.MatchExplain, error) {
-	status, body, err := c.call(func(id uint64) []byte {
+func (c *Client) MatchExplain(ctx context.Context, reqTable, jobSelector, resTable, targetWhere string) (*db.MatchExplain, error) {
+	status, body, err := c.callCtx(ctx, func(id uint64) []byte {
 		b := putStr(req(id, opMatchExplain), reqTable)
 		b = putStr(b, jobSelector)
 		b = putStr(b, resTable)
@@ -261,14 +264,14 @@ func (c *Client) MatchExplain(reqTable, jobSelector, resTable, targetWhere strin
 }
 
 // Admin runs a management action (index/hot-set) on the default table.
-func (c *Client) Admin(action string, args ...string) (string, error) {
-	return c.AdminTable(DefaultTable, action, args...)
+func (c *Client) Admin(ctx context.Context, action string, args ...string) (string, error) {
+	return c.AdminTable(ctx, DefaultTable, action, args...)
 }
 
 // AdminTable runs a management action on the named table; it returns the server's
 // human-readable result. Refused on a read-only connection.
-func (c *Client) AdminTable(table, action string, args ...string) (string, error) {
-	status, body, err := c.call(func(id uint64) []byte {
+func (c *Client) AdminTable(ctx context.Context, table, action string, args ...string) (string, error) {
+	status, body, err := c.callCtx(ctx, func(id uint64) []byte {
 		b := putStr(putStr(req(id, opAdmin), table), action)
 		b = putI32(b, int32(len(args)))
 		for _, a := range args {
@@ -289,15 +292,15 @@ func (c *Client) AdminTable(table, action string, args ...string) (string, error
 // (private attributes are always encrypted). It is a DAEMON-level action: the server
 // refuses it unless the connection is privileged. Passing no attributes clears the
 // explicit set. Returns the server's human-readable result.
-func (c *Client) SetEncryptedAttrs(table string, attrs ...string) (string, error) {
-	return c.AdminTable(table, "encrypt.set", attrs...)
+func (c *Client) SetEncryptedAttrs(ctx context.Context, table string, attrs ...string) (string, error) {
+	return c.AdminTable(ctx, table, "encrypt.set", attrs...)
 }
 
 // BackupKeyTable retrieves the named table's backup key -- the escrow key that decrypts
 // its encrypted snapshots independently of the pool keys. DAEMON-level. Errors if
 // encryption is not enabled.
-func (c *Client) BackupKeyTable(table string) ([]byte, error) {
-	s, err := c.AdminTable(table, "backup.key")
+func (c *Client) BackupKeyTable(ctx context.Context, table string) ([]byte, error) {
+	s, err := c.AdminTable(ctx, table, "backup.key")
 	if err != nil {
 		return nil, err
 	}
@@ -307,15 +310,15 @@ func (c *Client) BackupKeyTable(table string) ([]byte, error) {
 // TruncateTable removes every ad from the named table. It is a DAEMON-level action
 // (destructive, DB-wide locked): the server refuses it unless the connection is
 // privileged. Returns the server's human-readable result.
-func (c *Client) TruncateTable(table string) (string, error) {
-	return c.AdminTable(table, "truncate")
+func (c *Client) TruncateTable(ctx context.Context, table string) (string, error) {
+	return c.AdminTable(ctx, table, "truncate")
 }
 
 // --- table catalog ---
 
 // CreateTable creates (or no-ops if present) the named table.
-func (c *Client) CreateTable(name string) error {
-	status, body, err := c.call(func(id uint64) []byte { return putStr(req(id, opCreateTable), name) })
+func (c *Client) CreateTable(ctx context.Context, name string) error {
+	status, body, err := c.callCtx(ctx, func(id uint64) []byte { return putStr(req(id, opCreateTable), name) })
 	if err != nil {
 		return err
 	}
@@ -326,8 +329,8 @@ func (c *Client) CreateTable(name string) error {
 }
 
 // DropTable removes the named table and its data.
-func (c *Client) DropTable(name string) error {
-	status, body, err := c.call(func(id uint64) []byte { return putStr(req(id, opDropTable), name) })
+func (c *Client) DropTable(ctx context.Context, name string) error {
+	status, body, err := c.callCtx(ctx, func(id uint64) []byte { return putStr(req(id, opDropTable), name) })
 	if err != nil {
 		return err
 	}
@@ -338,8 +341,8 @@ func (c *Client) DropTable(name string) error {
 }
 
 // Tables lists the table names.
-func (c *Client) Tables() ([]string, error) {
-	status, body, err := c.call(func(id uint64) []byte { return req(id, opListTables) })
+func (c *Client) Tables(ctx context.Context) ([]string, error) {
+	status, body, err := c.callCtx(ctx, func(id uint64) []byte { return req(id, opListTables) })
 	if err != nil {
 		return nil, err
 	}

--- a/dbrpc/diag_test.go
+++ b/dbrpc/diag_test.go
@@ -1,6 +1,7 @@
 package dbrpc
 
 import (
+	"context"
 	"testing"
 
 	"github.com/PelicanPlatform/classad/db"
@@ -10,25 +11,25 @@ func TestDiagnosticsAndAdmin(t *testing.T) {
 	c, cleanup := testPair(t)
 	defer cleanup()
 
-	tx, _ := c.Begin()
-	_ = tx.NewClassAd("1", "Owner = \"alice\"\nCpus = 4")
-	_ = tx.NewClassAd("2", "Owner = \"bob\"\nCpus = 8")
-	if err := tx.Commit(); err != nil {
+	tx, _ := c.Begin(context.Background())
+	_ = tx.NewClassAd(context.Background(), "1", "Owner = \"alice\"\nCpus = 4")
+	_ = tx.NewClassAd(context.Background(), "2", "Owner = \"bob\"\nCpus = 8")
+	if err := tx.Commit(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 
 	// Add indexes, then confirm diagnostics reflect them.
-	if msg, err := c.Admin("index.add.categorical", "Owner"); err != nil || msg == "" {
+	if msg, err := c.Admin(context.Background(), "index.add.categorical", "Owner"); err != nil || msg == "" {
 		t.Fatalf("Admin add categorical = %q,%v", msg, err)
 	}
-	if _, err := c.Admin("index.add.value", "Cpus"); err != nil {
+	if _, err := c.Admin(context.Background(), "index.add.value", "Cpus"); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := c.Admin("hot.add", "Owner", "Cpus"); err != nil {
+	if _, err := c.Admin(context.Background(), "hot.add", "Owner", "Cpus"); err != nil {
 		t.Fatal(err)
 	}
 
-	d, err := c.Diagnostics()
+	d, err := c.Diagnostics(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -46,12 +47,12 @@ func TestDiagnosticsAndAdmin(t *testing.T) {
 	}
 
 	// Build the segment indexes over the existing ads so selectivity stats exist.
-	if _, err := c.Admin("index.reindex"); err != nil {
+	if _, err := c.Admin(context.Background(), "index.reindex"); err != nil {
 		t.Fatal(err)
 	}
 
 	// Explain: a query on the indexed categorical attribute uses the index.
-	ex, err := c.Explain(`Owner == "alice"`)
+	ex, err := c.Explain(context.Background(), `Owner == "alice"`)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -68,7 +69,7 @@ func TestDiagnosticsAndAdmin(t *testing.T) {
 	}
 
 	// A query on an un-indexed attribute falls back to a scan.
-	ex2, err := c.Explain("Memory > 1024")
+	ex2, err := c.Explain(context.Background(), "Memory > 1024")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -77,21 +78,21 @@ func TestDiagnosticsAndAdmin(t *testing.T) {
 	}
 
 	// Drop and reindex succeed.
-	if _, err := c.Admin("index.drop", "Owner"); err != nil {
+	if _, err := c.Admin(context.Background(), "index.drop", "Owner"); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := c.Admin("index.reindex"); err != nil {
+	if _, err := c.Admin(context.Background(), "index.reindex"); err != nil {
 		t.Fatal(err)
 	}
 
 	// Rewrite (re-encode with the hot set) and compact succeed, preserving data.
-	if msg, err := c.Admin("rewrite"); err != nil || msg == "" {
+	if msg, err := c.Admin(context.Background(), "rewrite"); err != nil || msg == "" {
 		t.Fatalf("Admin rewrite = %q,%v", msg, err)
 	}
-	if _, err := c.Admin("compact"); err != nil {
+	if _, err := c.Admin(context.Background(), "compact"); err != nil {
 		t.Fatal(err)
 	}
-	if rows, err := c.Query("Owner == \"alice\""); err != nil || len(rows) != 1 {
+	if rows, err := c.Query(context.Background(), "Owner == \"alice\""); err != nil || len(rows) != 1 {
 		t.Fatalf("after rewrite/compact Query = %v,%v want 1 row", rows, err)
 	}
 }
@@ -108,11 +109,11 @@ func TestAdminRefusedReadOnly(t *testing.T) {
 	c := NewClient(cconn)
 	defer func() { c.Close(); s.Close(); d.Close() }()
 
-	if _, err := c.Admin("index.add.value", "Cpus"); err == nil {
+	if _, err := c.Admin(context.Background(), "index.add.value", "Cpus"); err == nil {
 		t.Fatal("Admin on a read-only connection should be refused")
 	}
 	// But diagnostics (read-only) still work.
-	if _, err := c.Diagnostics(); err != nil {
+	if _, err := c.Diagnostics(context.Background()); err != nil {
 		t.Fatalf("Diagnostics should work read-only: %v", err)
 	}
 }

--- a/dbrpc/encrypt_test.go
+++ b/dbrpc/encrypt_test.go
@@ -2,6 +2,7 @@ package dbrpc
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"testing"
 
@@ -30,7 +31,7 @@ func encServerPair(t *testing.T, opts ServeOptions) (*Client, *db.DB, func()) {
 func TestEncryptSetRequiresDaemon(t *testing.T) {
 	// Unprivileged (WRITE-level: not read-only, but not Privileged) -> refused.
 	c, _, cleanup := encServerPair(t, ServeOptions{})
-	if _, err := c.SetEncryptedAttrs("ads", "Region"); err == nil {
+	if _, err := c.SetEncryptedAttrs(context.Background(), "ads", "Region"); err == nil {
 		t.Fatal("encrypt.set should be refused without DAEMON privilege")
 	}
 	cleanup()
@@ -38,10 +39,10 @@ func TestEncryptSetRequiresDaemon(t *testing.T) {
 	// Privileged -> accepted, and reflected in diagnostics.
 	c, _, cleanup = encServerPair(t, ServeOptions{Privileged: true})
 	defer cleanup()
-	if _, err := c.SetEncryptedAttrs("ads", "Region", "Zone"); err != nil {
+	if _, err := c.SetEncryptedAttrs(context.Background(), "ads", "Region", "Zone"); err != nil {
 		t.Fatalf("privileged encrypt.set: %v", err)
 	}
-	diag, err := c.Diagnostics()
+	diag, err := c.Diagnostics(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -61,7 +62,7 @@ func TestTruncateRequiresDaemon(t *testing.T) {
 	tx := d.Begin()
 	tx.NewClassAd("a", mustAd(t, "N = 1"))
 	tx.Commit()
-	if _, err := c.TruncateTable("ads"); err == nil {
+	if _, err := c.TruncateTable(context.Background(), "ads"); err == nil {
 		t.Fatal("truncate should be refused without DAEMON privilege")
 	}
 	if d.Len() != 1 {
@@ -76,7 +77,7 @@ func TestTruncateRequiresDaemon(t *testing.T) {
 	tx.NewClassAd("a", mustAd(t, "N = 1"))
 	tx.NewClassAd("b", mustAd(t, "N = 2"))
 	tx.Commit()
-	if _, err := c.TruncateTable("ads"); err != nil {
+	if _, err := c.TruncateTable(context.Background(), "ads"); err != nil {
 		t.Fatalf("privileged truncate: %v", err)
 	}
 	if d.Len() != 0 {
@@ -96,19 +97,19 @@ func TestSnapshotRestoreOverRPC(t *testing.T) {
 	tx.Commit()
 
 	var snap bytes.Buffer
-	if err := c.Snapshot(&snap); err != nil {
+	if err := c.Snapshot(context.Background(), &snap); err != nil {
 		t.Fatalf("Snapshot over RPC: %v", err)
 	}
 	if bytes.Contains(snap.Bytes(), []byte("top-secret-rpc")) {
 		t.Fatal("snapshot bytes leaked a private attribute over the wire")
 	}
-	if _, err := c.TruncateTable("ads"); err != nil {
+	if _, err := c.TruncateTable(context.Background(), "ads"); err != nil {
 		t.Fatal(err)
 	}
 	if d.Len() != 0 {
 		t.Fatal("truncate did not empty the table")
 	}
-	if err := c.Restore(bytes.NewReader(snap.Bytes())); err != nil {
+	if err := c.Restore(context.Background(), bytes.NewReader(snap.Bytes())); err != nil {
 		t.Fatalf("Restore over RPC: %v", err)
 	}
 	if d.Len() != 2 {
@@ -125,10 +126,10 @@ func TestSnapshotRestoreOverRPC(t *testing.T) {
 	// Unprivileged connection: both refused.
 	c2, _, cleanup2 := encServerPair(t, ServeOptions{})
 	defer cleanup2()
-	if err := c2.Snapshot(&bytes.Buffer{}); err == nil {
+	if err := c2.Snapshot(context.Background(), &bytes.Buffer{}); err == nil {
 		t.Error("snapshot should be refused without DAEMON privilege")
 	}
-	if err := c2.Restore(bytes.NewReader(snap.Bytes())); err == nil {
+	if err := c2.Restore(context.Background(), bytes.NewReader(snap.Bytes())); err == nil {
 		t.Error("restore should be refused without DAEMON privilege")
 	}
 }
@@ -148,16 +149,16 @@ func TestSnapshotRestoreStreamingLarge(t *testing.T) {
 	}
 
 	var snap bytes.Buffer
-	if err := c.Snapshot(&snap); err != nil {
+	if err := c.Snapshot(context.Background(), &snap); err != nil {
 		t.Fatalf("Snapshot: %v", err)
 	}
 	if snap.Len() < 64*1024 {
 		t.Fatalf("snapshot is %d bytes -- expected multiple chunks (>64 KiB)", snap.Len())
 	}
-	if _, err := c.TruncateTable("ads"); err != nil {
+	if _, err := c.TruncateTable(context.Background(), "ads"); err != nil {
 		t.Fatal(err)
 	}
-	if err := c.Restore(bytes.NewReader(snap.Bytes())); err != nil {
+	if err := c.Restore(context.Background(), bytes.NewReader(snap.Bytes())); err != nil {
 		t.Fatalf("Restore: %v", err)
 	}
 	if d.Len() != n {
@@ -180,7 +181,7 @@ func TestSnapshotRestoreStreamingLarge(t *testing.T) {
 func TestEncryptSetReadOnlyRejected(t *testing.T) {
 	c, _, cleanup := encServerPair(t, ServeOptions{ReadOnly: true, Privileged: true})
 	defer cleanup()
-	if _, err := c.SetEncryptedAttrs("ads", "Region"); err == nil {
+	if _, err := c.SetEncryptedAttrs(context.Background(), "ads", "Region"); err == nil {
 		t.Fatal("encrypt.set should be refused on a read-only connection")
 	}
 }

--- a/dbrpc/errors.go
+++ b/dbrpc/errors.go
@@ -1,0 +1,31 @@
+package dbrpc
+
+import "errors"
+
+// The error taxonomy a caller needs to drive reconnection policy. A dbrpc call
+// fails in one of a few distinct ways, and the right response differs for each:
+//
+//   - *db.ConflictError (from Commit): an optimistic write-write conflict. The
+//     connection is healthy; retry the transaction on the SAME connection.
+//   - ErrConnClosed: the transport failed or the Client was closed. Every in-flight
+//     and future call fails with it (wrapping the underlying cause). Redial, and --
+//     if the unit of work is idempotent -- replay it on the fresh connection.
+//   - *ServerError: the server rejected the request (bad constraint, unknown table,
+//     malformed op). Deterministic; a replay fails identically, so surface it.
+//   - context.Canceled / context.DeadlineExceeded: the caller's context ended while
+//     waiting. Surface it; do not retry against the caller's wishes.
+//
+// Callers classify with errors.Is / errors.As rather than matching message text.
+
+// ErrConnClosed reports that the dbrpc connection is no longer usable. It wraps the
+// underlying transport cause, so errors.Is(err, ErrConnClosed) identifies the class
+// while errors.Unwrap reaches the specific I/O error.
+var ErrConnClosed = errors.New("dbrpc: connection closed")
+
+// ServerError is a logical error the server returned for a request (wire status
+// stErr): a bad constraint, an unknown table, a malformed op. It is deterministic
+// -- replaying the request fails the same way -- so callers should surface it
+// rather than retry.
+type ServerError struct{ Msg string }
+
+func (e *ServerError) Error() string { return "dbrpc: " + e.Msg }

--- a/dbrpc/idempotency.go
+++ b/dbrpc/idempotency.go
@@ -1,0 +1,94 @@
+package dbrpc
+
+import (
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/PelicanPlatform/classad/classad"
+	"github.com/PelicanPlatform/classad/db"
+)
+
+// Durable idempotency (opt-in, via Tx.CommitIdempotent). A committing transaction
+// that carries an idempotency key also writes a small marker record, keyed in the
+// db's reserved "system" keyspace, inside the SAME transaction as the data. Because
+// the commit is atomic, the marker lands iff the data lands -- so it survives a
+// server restart, and a replay of the same unit of work is detected (the marker is
+// already present, or the replayed marker conflicts on its key under OCC) and
+// short-circuits to success instead of applying the writes twice.
+//
+// The marker is a system-keyed record, so it is invisible to every normal
+// scan/query/iterate (see the collections reserved-prefix support) and is
+// retrievable only by explicit key lookup and the TTL reaper below. A workload that
+// never calls CommitIdempotent writes no markers and pays nothing.
+
+const (
+	// idemMarkerPrefix namespaces idempotency markers within the reserved system
+	// keyspace, so the reaper can enumerate exactly them.
+	idemMarkerPrefix = "idem:"
+	// idemMarkerAttr holds a marker's creation time (unix seconds); the reaper uses
+	// it to expire markers older than its configured retention.
+	idemMarkerAttr = "IdemAt"
+)
+
+// idemMarkerKey is the reserved system key under which the marker for idemKey lives.
+func idemMarkerKey(idemKey string) string {
+	return db.SystemKey(idemMarkerPrefix + idemKey)
+}
+
+// reapIdemMarkers deletes idempotency markers older than maxAge from every table,
+// returning how many were removed. Markers are system-keyed, so a normal
+// DeleteWhere never touches them; the reaper enumerates them via ForEachSystemAd and
+// destroys the expired ones by key.
+func (s *Server) reapIdemMarkers(maxAge time.Duration) int {
+	cutoff := time.Now().Add(-maxAge).Unix()
+	reaped := 0
+	for _, table := range s.cat.Tables() {
+		d, ok := s.cat.Table(table)
+		if !ok {
+			continue
+		}
+		var expired []string
+		d.ForEachSystemAd(func(key string, ad *classad.ClassAd) bool {
+			if !strings.HasPrefix(key, idemMarkerKey("")) {
+				return true // a system key that is not one of our markers
+			}
+			at, ok := ad.EvaluateAttrInt(idemMarkerAttr)
+			if !ok || at <= cutoff {
+				expired = append(expired, key)
+			}
+			return true
+		})
+		for _, k := range expired {
+			tx := d.Begin()
+			tx.DestroyClassAd(k)
+			if err := tx.Commit(); err == nil {
+				reaped++
+			}
+		}
+	}
+	return reaped
+}
+
+// StartIdemReaper runs reapIdemMarkers every interval, deleting idempotency markers
+// older than maxAge, until the returned stop is called. maxAge should exceed the
+// longest window over which a client might replay a unit of work (its retry budget),
+// so a marker is never reaped while a late replay could still arrive. Servers that
+// never see CommitIdempotent need not start it (there is nothing to reap).
+func (s *Server) StartIdemReaper(interval, maxAge time.Duration) (stop func()) {
+	done := make(chan struct{})
+	go func() {
+		t := time.NewTicker(interval)
+		defer t.Stop()
+		for {
+			select {
+			case <-done:
+				return
+			case <-t.C:
+				s.reapIdemMarkers(maxAge)
+			}
+		}
+	}()
+	var once sync.Once
+	return func() { once.Do(func() { close(done) }) }
+}

--- a/dbrpc/idempotency_test.go
+++ b/dbrpc/idempotency_test.go
@@ -1,0 +1,159 @@
+package dbrpc
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/db"
+)
+
+// idemServer wires a client to a fresh server over an in-memory pipe for one db.
+func idemServer(t *testing.T, d *db.DB) (*Client, *Server, func()) {
+	t.Helper()
+	s := NewServer(d)
+	cc, sc := netPipe()
+	go func() { _ = s.ServeConn(sc) }()
+	c := NewClient(cc)
+	return c, s, func() { c.Close(); s.Close() }
+}
+
+// commitOne begins a txn, writes key=Payload, and commits it idempotently under idem.
+func commitOne(t *testing.T, c *Client, key, payload, idem string) error {
+	t.Helper()
+	ctx := context.Background()
+	tx, err := c.Begin(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.NewClassAd(ctx, key, `Name = "`+key+`"`+"\n"+`Payload = "`+payload+`"`); err != nil {
+		t.Fatal(err)
+	}
+	return tx.CommitIdempotent(ctx, idem)
+}
+
+func queryAll(t *testing.T, c *Client) []string {
+	t.Helper()
+	rows, err := c.Query(context.Background(), "true")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return rows
+}
+
+// TestCommitIdempotentExactlyOnce: replaying the same unit of work (same idem key)
+// with different data does NOT re-apply -- the marker short-circuits it -- while a
+// different idem key applies normally.
+func TestCommitIdempotentExactlyOnce(t *testing.T) {
+	d, err := db.Open("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+	c, _, cleanup := idemServer(t, d)
+	defer cleanup()
+
+	// First attempt lands.
+	if err := commitOne(t, c, "counter", "first", "unit-1"); err != nil {
+		t.Fatal(err)
+	}
+	// Replay of unit-1 with DIFFERENT data: succeeds but must not overwrite.
+	if err := commitOne(t, c, "counter", "second", "unit-1"); err != nil {
+		t.Fatalf("idempotent replay should succeed, got %v", err)
+	}
+	rows := queryAll(t, c)
+	joined := strings.Join(rows, "\n")
+	if len(rows) != 1 || !strings.Contains(joined, `"first"`) || strings.Contains(joined, `"second"`) {
+		t.Fatalf("after replay want single ad Payload=first, got:\n%s", joined)
+	}
+	// A different unit of work applies normally.
+	if err := commitOne(t, c, "counter", "third", "unit-2"); err != nil {
+		t.Fatal(err)
+	}
+	if joined := strings.Join(queryAll(t, c), "\n"); !strings.Contains(joined, `"third"`) {
+		t.Fatalf("distinct idem key should apply, got:\n%s", joined)
+	}
+}
+
+// TestCommitIdempotentMarkerInvisible: the durable marker is stored but never
+// appears in query results.
+func TestCommitIdempotentMarkerInvisible(t *testing.T) {
+	d, err := db.Open("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+	c, _, cleanup := idemServer(t, d)
+	defer cleanup()
+
+	if err := commitOne(t, c, "a", "x", "unit-1"); err != nil {
+		t.Fatal(err)
+	}
+	rows := queryAll(t, c)
+	if len(rows) != 1 {
+		t.Fatalf("query returned %d rows, want 1 (marker must be hidden): %v", len(rows), rows)
+	}
+	if strings.Contains(strings.Join(rows, "\n"), idemMarkerAttr) {
+		t.Fatalf("query leaked the idempotency marker: %v", rows)
+	}
+}
+
+// TestCommitIdempotentDurableAcrossRestart: the marker survives a server+db restart,
+// so a replay after reconnecting to a restarted server is still deduplicated.
+func TestCommitIdempotentDurableAcrossRestart(t *testing.T) {
+	dir := t.TempDir()
+	d, err := db.Open(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c, _, cleanup := idemServer(t, d)
+	if err := commitOne(t, c, "k", "first", "unit-1"); err != nil {
+		t.Fatal(err)
+	}
+	cleanup()
+	if err := d.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Restart: reopen the same directory, replay unit-1 with different data.
+	d2, err := db.Open(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d2.Close()
+	c2, _, cleanup2 := idemServer(t, d2)
+	defer cleanup2()
+	if err := commitOne(t, c2, "k", "second", "unit-1"); err != nil {
+		t.Fatalf("replay after restart should succeed, got %v", err)
+	}
+	if joined := strings.Join(queryAll(t, c2), "\n"); !strings.Contains(joined, `"first"`) || strings.Contains(joined, `"second"`) {
+		t.Fatalf("marker did not survive restart (replay re-applied), got:\n%s", joined)
+	}
+}
+
+// TestReapIdemMarkers: after the reaper expires a marker, replaying that unit of work
+// applies again (idempotency lapses past its retention, as intended).
+func TestReapIdemMarkers(t *testing.T) {
+	d, err := db.Open("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+	c, s, cleanup := idemServer(t, d)
+	defer cleanup()
+
+	if err := commitOne(t, c, "counter", "first", "unit-1"); err != nil {
+		t.Fatal(err)
+	}
+	// Reap everything (maxAge 0 => every marker is already older than the cutoff).
+	if n := s.reapIdemMarkers(0); n != 1 {
+		t.Fatalf("reaped %d markers, want 1", n)
+	}
+	// With the marker gone, the same idem key applies again.
+	if err := commitOne(t, c, "counter", "second", "unit-1"); err != nil {
+		t.Fatal(err)
+	}
+	if joined := strings.Join(queryAll(t, c), "\n"); !strings.Contains(joined, `"second"`) {
+		t.Fatalf("after reap, replay should re-apply, got:\n%s", joined)
+	}
+}

--- a/dbrpc/match.go
+++ b/dbrpc/match.go
@@ -33,7 +33,7 @@ type MatchRow struct {
 // significant-attribute autoclusters. It must list every attribute the match
 // depends on (the request's Requirements and Rank, and the request attributes the
 // resources' Requirements reference).
-func (c *Client) MatchTables(reqTable, resTable, keyAttr, reqWhere, targetWhere string, limit int, significantAttrs []string) ([]MatchRow, error) {
+func (c *Client) MatchTables(ctx context.Context, reqTable, resTable, keyAttr, reqWhere, targetWhere string, limit int, significantAttrs []string) ([]MatchRow, error) {
 	_, frames, err := c.callStream(func(id uint64) []byte {
 		b := putStr(req(id, opMatchTables), reqTable)
 		b = putStr(b, resTable)
@@ -51,19 +51,27 @@ func (c *Client) MatchTables(reqTable, resTable, keyAttr, reqWhere, targetWhere 
 		return nil, err
 	}
 	var out []MatchRow
-	for frame := range frames {
-		_, status, body, ok := respHeader(frame)
-		if !ok {
-			return out, errShort
-		}
-		switch status {
-		case stStream:
-			out = append(out, MatchRow{Request: body.str(), Resource: body.str(), Rank: body.str()})
-		case stErr:
-			return out, statusErr(status, body)
+	for {
+		select {
+		case <-ctx.Done():
+			drain(frames)
+			return out, ctx.Err()
+		case frame, ok := <-frames:
+			if !ok {
+				return out, nil
+			}
+			_, status, body, ok := respHeader(frame)
+			if !ok {
+				return out, errShort
+			}
+			switch status {
+			case stStream:
+				out = append(out, MatchRow{Request: body.str(), Resource: body.str(), Rank: body.str()})
+			case stErr:
+				return out, statusErr(status, body)
+			}
 		}
 	}
-	return out, nil
 }
 
 // matchResult is one row of a request's (or autocluster's) ranked candidates.

--- a/dbrpc/match_test.go
+++ b/dbrpc/match_test.go
@@ -1,6 +1,7 @@
 package dbrpc
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -25,25 +26,25 @@ func TestMatchTables(t *testing.T) {
 	defer func() { c.Close(); s.Close(); cat.Close() }()
 
 	// Machines accept any job; the job prefers (ranks by) more Cpus.
-	mtx, _ := c.BeginTable("machines")
-	_ = mtx.NewClassAd("slot1", "Key = \"slot1\"\nCpus = 8\nRequirements = true")
-	_ = mtx.NewClassAd("slot2", "Key = \"slot2\"\nCpus = 4\nRequirements = true")
-	_ = mtx.NewClassAd("slot3", "Key = \"slot3\"\nCpus = 16\nRequirements = true")
-	if err := mtx.Commit(); err != nil {
+	mtx, _ := c.BeginTable(context.Background(), "machines")
+	_ = mtx.NewClassAd(context.Background(), "slot1", "Key = \"slot1\"\nCpus = 8\nRequirements = true")
+	_ = mtx.NewClassAd(context.Background(), "slot2", "Key = \"slot2\"\nCpus = 4\nRequirements = true")
+	_ = mtx.NewClassAd(context.Background(), "slot3", "Key = \"slot3\"\nCpus = 16\nRequirements = true")
+	if err := mtx.Commit(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 	// Two identical jobs: assignment consumes machines, so they can't both take
 	// slot3. Each ranks by Cpus.
-	jtx, _ := c.BeginTable("jobs")
+	jtx, _ := c.BeginTable(context.Background(), "jobs")
 	job := "Key = %q\nRequestCpus = 4\nRequirements = (TARGET.Cpus >= RequestCpus)\nRank = TARGET.Cpus"
-	_ = jtx.NewClassAd("1.0", fmt.Sprintf(job, "1.0"))
-	_ = jtx.NewClassAd("2.0", fmt.Sprintf(job, "2.0"))
-	if err := jtx.Commit(); err != nil {
+	_ = jtx.NewClassAd(context.Background(), "1.0", fmt.Sprintf(job, "1.0"))
+	_ = jtx.NewClassAd(context.Background(), "2.0", fmt.Sprintf(job, "2.0"))
+	if err := jtx.Commit(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 
 	// LIMIT bounds jobs: one job assigned, taking the best machine (slot3, Cpus 16).
-	rows, err := c.MatchTables("jobs", "machines", "Key", "", "", 1, nil)
+	rows, err := c.MatchTables(context.Background(), "jobs", "machines", "Key", "", "", 1, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -54,7 +55,7 @@ func TestMatchTables(t *testing.T) {
 	// LIMIT 2: both jobs assigned distinct machines, the two best by Rank —
 	// slot3(16) and slot1(8). Order between the identical jobs is unspecified, so
 	// assert the set and each machine's rank.
-	rows, err = c.MatchTables("jobs", "machines", "Key", "", "", 2, nil)
+	rows, err = c.MatchTables(context.Background(), "jobs", "machines", "Key", "", "", 2, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -68,7 +69,7 @@ func TestMatchTables(t *testing.T) {
 
 	// Resource-side filter (pushed down): with only Cpus <= 8 eligible, the first
 	// job's best available is slot1.
-	rows, err = c.MatchTables("jobs", "machines", "Key", "", "Cpus <= 8", 1, nil)
+	rows, err = c.MatchTables(context.Background(), "jobs", "machines", "Key", "", "Cpus <= 8", 1, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -92,20 +93,20 @@ func TestMatchAutocluster(t *testing.T) {
 
 	// Two top-ranked (Cpus 16) machines and a lesser one; identical jobs must be
 	// spread across the two 16s rather than both taking one.
-	mtx, _ := c.BeginTable("machines")
-	_ = mtx.NewClassAd("slot1", "Key = \"slot1\"\nCpus = 16\nRequirements = true")
-	_ = mtx.NewClassAd("slot2", "Key = \"slot2\"\nCpus = 16\nRequirements = true")
-	_ = mtx.NewClassAd("slot3", "Key = \"slot3\"\nCpus = 8\nRequirements = true")
-	_ = mtx.Commit()
+	mtx, _ := c.BeginTable(context.Background(), "machines")
+	_ = mtx.NewClassAd(context.Background(), "slot1", "Key = \"slot1\"\nCpus = 16\nRequirements = true")
+	_ = mtx.NewClassAd(context.Background(), "slot2", "Key = \"slot2\"\nCpus = 16\nRequirements = true")
+	_ = mtx.NewClassAd(context.Background(), "slot3", "Key = \"slot3\"\nCpus = 8\nRequirements = true")
+	_ = mtx.Commit(context.Background())
 
-	jtx, _ := c.BeginTable("jobs")
+	jtx, _ := c.BeginTable(context.Background(), "jobs")
 	req := "Key = %q\nRequestCpus = 4\nRequirements = (TARGET.Cpus >= RequestCpus)\nRank = TARGET.Cpus"
-	_ = jtx.NewClassAd("a", fmt.Sprintf(req, "a"))
-	_ = jtx.NewClassAd("b", fmt.Sprintf(req, "b")) // identical to a in matchmaking terms
-	_ = jtx.Commit()
+	_ = jtx.NewClassAd(context.Background(), "a", fmt.Sprintf(req, "a"))
+	_ = jtx.NewClassAd(context.Background(), "b", fmt.Sprintf(req, "b")) // identical to a in matchmaking terms
+	_ = jtx.Commit(context.Background())
 
 	sig := []string{"RequestCpus", "Requirements", "Rank"}
-	rows, err := c.MatchTables("jobs", "machines", "Key", "", "", 5, sig)
+	rows, err := c.MatchTables(context.Background(), "jobs", "machines", "Key", "", "", 5, sig)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -134,14 +135,14 @@ func TestMatchExplain(t *testing.T) {
 	c := NewClient(cconn)
 	defer func() { c.Close(); s.Close(); cat.Close() }()
 
-	mtx, _ := c.BeginTable("machines")
-	_ = mtx.NewClassAd("slot1", "Key=\"slot1\"\nArch=\"X86_64\"\nMemory=8192\nRequirements=true")
-	_ = mtx.Commit()
-	jtx, _ := c.BeginTable("jobs")
-	_ = jtx.NewClassAd("1.0", "Key=\"1.0\"\nRequestMemory=2048\nRequirements=(TARGET.Arch==\"X86_64\") && (TARGET.Memory>=RequestMemory)")
-	_ = jtx.Commit()
+	mtx, _ := c.BeginTable(context.Background(), "machines")
+	_ = mtx.NewClassAd(context.Background(), "slot1", "Key=\"slot1\"\nArch=\"X86_64\"\nMemory=8192\nRequirements=true")
+	_ = mtx.Commit(context.Background())
+	jtx, _ := c.BeginTable(context.Background(), "jobs")
+	_ = jtx.NewClassAd(context.Background(), "1.0", "Key=\"1.0\"\nRequestMemory=2048\nRequirements=(TARGET.Arch==\"X86_64\") && (TARGET.Memory>=RequestMemory)")
+	_ = jtx.Commit(context.Background())
 
-	ex, err := c.MatchExplain("jobs", "Key == \"1.0\"", "machines", "")
+	ex, err := c.MatchExplain(context.Background(), "jobs", "Key == \"1.0\"", "machines", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -165,7 +166,7 @@ func TestMatchExplain(t *testing.T) {
 	}
 
 	// A resource-side filter (WHERE TARGET / NOPREEMPT) is melded into the explanation.
-	exT, err := c.MatchExplain("jobs", "Key == \"1.0\"", "machines", `State =!= "Claimed"`)
+	exT, err := c.MatchExplain(context.Background(), "jobs", "Key == \"1.0\"", "machines", `State =!= "Claimed"`)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/dbrpc/multitable_test.go
+++ b/dbrpc/multitable_test.go
@@ -1,6 +1,7 @@
 package dbrpc
 
 import (
+	"context"
 	"testing"
 
 	"github.com/PelicanPlatform/classad/db"
@@ -24,39 +25,39 @@ func TestMultiTable(t *testing.T) {
 	defer func() { c.Close(); s.Close(); cat.Close() }()
 
 	// Writes route by table.
-	tx, err := c.BeginTable("machines")
+	tx, err := c.BeginTable(context.Background(), "machines")
 	if err != nil {
 		t.Fatal(err)
 	}
-	_ = tx.NewClassAd("slot1", "Name = \"slot1\"\nCpus = 8")
-	if err := tx.Commit(); err != nil {
+	_ = tx.NewClassAd(context.Background(), "slot1", "Name = \"slot1\"\nCpus = 8")
+	if err := tx.Commit(context.Background()); err != nil {
 		t.Fatal(err)
 	}
-	if rows, err := c.QueryTable("machines", "true", 0); err != nil || len(rows) != 1 {
+	if rows, err := c.QueryTable(context.Background(), "machines", "true", 0); err != nil || len(rows) != 1 {
 		t.Fatalf("machines rows = %d, %v; want 1", len(rows), err)
 	}
-	if rows, err := c.QueryTable("jobs", "true", 0); err != nil || len(rows) != 0 {
+	if rows, err := c.QueryTable(context.Background(), "jobs", "true", 0); err != nil || len(rows) != 0 {
 		t.Fatalf("jobs rows = %d, %v; want 0", len(rows), err)
 	}
 
 	// List / create / drop via the client.
-	if names, err := c.Tables(); err != nil || len(names) != 2 || names[0] != "jobs" || names[1] != "machines" {
+	if names, err := c.Tables(context.Background()); err != nil || len(names) != 2 || names[0] != "jobs" || names[1] != "machines" {
 		t.Fatalf("Tables() = %v, %v; want [jobs machines]", names, err)
 	}
-	if err := c.CreateTable("submitters"); err != nil {
+	if err := c.CreateTable(context.Background(), "submitters"); err != nil {
 		t.Fatal(err)
 	}
-	if names, _ := c.Tables(); len(names) != 3 {
+	if names, _ := c.Tables(context.Background()); len(names) != 3 {
 		t.Fatalf("after create Tables() = %v, want 3", names)
 	}
 	// A query on a missing table errors.
-	if _, err := c.QueryTable("nope", "true", 0); err == nil {
+	if _, err := c.QueryTable(context.Background(), "nope", "true", 0); err == nil {
 		t.Fatal("query on a nonexistent table should error")
 	}
-	if err := c.DropTable("machines"); err != nil {
+	if err := c.DropTable(context.Background(), "machines"); err != nil {
 		t.Fatal(err)
 	}
-	if names, _ := c.Tables(); len(names) != 2 || names[0] != "jobs" || names[1] != "submitters" {
+	if names, _ := c.Tables(context.Background()); len(names) != 2 || names[0] != "jobs" || names[1] != "submitters" {
 		t.Fatalf("after drop Tables() = %v; want [jobs submitters]", names)
 	}
 }
@@ -66,10 +67,10 @@ func TestMultiTable(t *testing.T) {
 func TestSingleServerRejectsTableOps(t *testing.T) {
 	c, cleanup := testPair(t)
 	defer cleanup()
-	if names, err := c.Tables(); err != nil || len(names) != 1 || names[0] != DefaultTable {
+	if names, err := c.Tables(context.Background()); err != nil || len(names) != 1 || names[0] != DefaultTable {
 		t.Fatalf("Tables() = %v, %v; want [ads]", names, err)
 	}
-	if err := c.CreateTable("x"); err == nil {
+	if err := c.CreateTable(context.Background(), "x"); err == nil {
 		t.Fatal("single-DB server should reject CreateTable")
 	}
 }

--- a/dbrpc/pool.go
+++ b/dbrpc/pool.go
@@ -1,6 +1,9 @@
 package dbrpc
 
-import "sync/atomic"
+import (
+	"context"
+	"sync/atomic"
+)
 
 // Pool is a set of multiplexed connections to one Server, load-balanced round-robin.
 // It borrows the database/sql idea of a connection pool, but adapts it: an SQL driver
@@ -40,24 +43,26 @@ func (p *Pool) pick() *Client {
 
 // Begin starts a transaction on a pool connection; the returned Tx's operations all
 // run over that connection (server-side transaction state + op ordering).
-func (p *Pool) Begin() (*Tx, error) { return p.pick().Begin() }
+func (p *Pool) Begin(ctx context.Context) (*Tx, error) { return p.pick().Begin(ctx) }
 
 // Query runs a constraint query on a pool connection, streaming the results.
-func (p *Pool) Query(constraint string) ([]string, error) { return p.pick().Query(constraint) }
+func (p *Pool) Query(ctx context.Context, constraint string) ([]string, error) {
+	return p.pick().Query(ctx, constraint)
+}
 
 // MatchSorted runs a ranked match on a pool connection.
-func (p *Pool) MatchSorted(jobText string, limit int) ([]string, error) {
-	return p.pick().MatchSorted(jobText, limit)
+func (p *Pool) MatchSorted(ctx context.Context, jobText string, limit int) ([]string, error) {
+	return p.pick().MatchSorted(ctx, jobText, limit)
 }
 
 // Watch starts a watch on a pool connection.
-func (p *Pool) Watch(cursor []byte) (<-chan WatchEvent, func(), error) {
-	return p.pick().Watch(cursor)
+func (p *Pool) Watch(ctx context.Context, cursor []byte) (<-chan WatchEvent, func(), error) {
+	return p.pick().Watch(ctx, cursor)
 }
 
 // Ordered streams a partition of an ordered index on a pool connection.
-func (p *Pool) Ordered(index int, partition string) ([]OrderedRow, error) {
-	return p.pick().Ordered(index, partition)
+func (p *Pool) Ordered(ctx context.Context, index int, partition string) ([]OrderedRow, error) {
+	return p.pick().Ordered(ctx, index, partition)
 }
 
 // Close closes every connection. The first close error is returned.

--- a/dbrpc/pool_test.go
+++ b/dbrpc/pool_test.go
@@ -1,6 +1,7 @@
 package dbrpc
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"testing"
@@ -27,12 +28,12 @@ func TestPool(t *testing.T) {
 	}
 	defer p.Close()
 
-	tx, err := p.Begin()
+	tx, err := p.Begin(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
-	_ = tx.NewClassAd("k", "N = 1")
-	if err := tx.Commit(); err != nil {
+	_ = tx.NewClassAd(context.Background(), "k", "N = 1")
+	if err := tx.Commit(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 
@@ -45,7 +46,7 @@ func TestPool(t *testing.T) {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-			rows, err := p.Query("N == 1")
+			rows, err := p.Query(context.Background(), "N == 1")
 			switch {
 			case err != nil:
 				errs[i] = err

--- a/dbrpc/propose_test.go
+++ b/dbrpc/propose_test.go
@@ -1,6 +1,7 @@
 package dbrpc
 
 import (
+	"context"
 	"testing"
 
 	"github.com/PelicanPlatform/classad/classad"
@@ -49,21 +50,21 @@ func TestProposeHookRoutesWrites(t *testing.T) {
 	c := NewClient(cconn)
 	defer c.Close()
 
-	tx, err := c.Begin()
+	tx, err := c.Begin(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := tx.NewClassAd("1.0", "Owner = \"alice\""); err != nil {
+	if err := tx.NewClassAd(context.Background(), "1.0", "Owner = \"alice\""); err != nil {
 		t.Fatal(err)
 	}
-	if err := tx.SetAttribute("1.0", "JobStatus", "2"); err != nil {
+	if err := tx.SetAttribute(context.Background(), "1.0", "JobStatus", "2"); err != nil {
 		t.Fatal(err)
 	}
 	// Read-your-writes mid-transaction (served from the local txn buffer).
-	if v, ok, err := tx.LookupAttr("1.0", "JobStatus"); err != nil || !ok || v != "2" {
+	if v, ok, err := tx.LookupAttr(context.Background(), "1.0", "JobStatus"); err != nil || !ok || v != "2" {
 		t.Fatalf("read-your-writes JobStatus = %q,%v,%v want 2", v, ok, err)
 	}
-	if err := tx.Commit(); err != nil {
+	if err := tx.Commit(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 

--- a/dbrpc/proto.go
+++ b/dbrpc/proto.go
@@ -84,6 +84,7 @@ const (
 	opArchiveRotate op = 33 // [name] -> [dropped i32]; enforce retention (server clock); mutating
 	opDeleteWhere   op = 34 // [table][constraint] -> [removed i32]; bulk delete-by-constraint, mutating
 	opQueryRaw      op = 35 // [table][limit i32][constraint] -> stream of [oldClassAdText]; wire-form, AST-free relay
+	opCommitIdem    op = 36 // [txnID][idemKey] -> status (like opCommit) + durable idempotency marker; opt-in exactly-once, mutating
 )
 
 // String names an opcode for diagnostics (e.g. the read-only rejection message).
@@ -141,6 +142,8 @@ func (o op) String() string {
 		return "DeleteWhere"
 	case opQueryRaw:
 		return "QueryRaw"
+	case opCommitIdem:
+		return "CommitIdempotent"
 	}
 	return "op(unknown)"
 }

--- a/dbrpc/queryraw.go
+++ b/dbrpc/queryraw.go
@@ -13,13 +13,13 @@ import (
 // representation via the db QueryRaw pushdown, and the caller can forward the
 // text without building a ClassAd. Private attributes are stripped unless the
 // connection is privileged.
-func (c *Client) QueryRaw(constraint string) ([]string, error) {
-	return c.QueryRawTable(DefaultTable, constraint, 0)
+func (c *Client) QueryRaw(ctx context.Context, constraint string) ([]string, error) {
+	return c.QueryRawTable(ctx, DefaultTable, constraint, 0)
 }
 
 // QueryRawTable is QueryRaw against a named table with an optional limit.
-func (c *Client) QueryRawTable(table, constraint string, limit int) ([]string, error) {
-	return c.stream(func(id uint64) []byte {
+func (c *Client) QueryRawTable(ctx context.Context, table, constraint string, limit int) ([]string, error) {
+	return c.streamCtx(ctx, func(id uint64) []byte {
 		return putStr(putI32(putStr(req(id, opQueryRaw), table), int32(limit)), constraint)
 	})
 }

--- a/dbrpc/queryraw_test.go
+++ b/dbrpc/queryraw_test.go
@@ -1,6 +1,7 @@
 package dbrpc
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -20,16 +21,16 @@ func TestRPCQueryRawPrivileged(t *testing.T) {
 	c := NewClient(cc)
 	defer func() { c.Close(); s.Close(); d.Close() }()
 
-	tx, err := c.Begin()
+	tx, err := c.Begin(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
-	_ = tx.NewClassAd("a", "MyType = \"Machine\"\nState = \"Idle\"\nCapability = \"secret-claim\"")
-	if err := tx.Commit(); err != nil {
+	_ = tx.NewClassAd(context.Background(), "a", "MyType = \"Machine\"\nState = \"Idle\"\nCapability = \"secret-claim\"")
+	if err := tx.Commit(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 
-	rows, err := c.QueryRaw("true")
+	rows, err := c.QueryRaw(context.Background(), "true")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -51,16 +52,16 @@ func TestRPCQueryRawStripsPrivate(t *testing.T) {
 	c, cleanup := testPair(t) // default ServeOptions: not privileged
 	defer cleanup()
 
-	tx, err := c.Begin()
+	tx, err := c.Begin(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
-	_ = tx.NewClassAd("a", "MyType = \"Machine\"\nState = \"Idle\"\nCapability = \"secret-claim\"")
-	if err := tx.Commit(); err != nil {
+	_ = tx.NewClassAd(context.Background(), "a", "MyType = \"Machine\"\nState = \"Idle\"\nCapability = \"secret-claim\"")
+	if err := tx.Commit(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 
-	rows, err := c.QueryRaw("true")
+	rows, err := c.QueryRaw(context.Background(), "true")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/dbrpc/rpc_test.go
+++ b/dbrpc/rpc_test.go
@@ -1,6 +1,7 @@
 package dbrpc
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"sync"
@@ -27,51 +28,51 @@ func TestRPCRoundTrip(t *testing.T) {
 	c, cleanup := testPair(t)
 	defer cleanup()
 
-	tx, err := c.Begin()
+	tx, err := c.Begin(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := tx.NewClassAd("1.0", "ProcId = 0\nClusterId = 1"); err != nil {
+	if err := tx.NewClassAd(context.Background(), "1.0", "ProcId = 0\nClusterId = 1"); err != nil {
 		t.Fatal(err)
 	}
-	if err := tx.SetAttribute("1.0", "JobStatus", "1"); err != nil {
+	if err := tx.SetAttribute(context.Background(), "1.0", "JobStatus", "1"); err != nil {
 		t.Fatal(err)
 	}
 	// Read-your-writes over the wire.
-	if v, ok, err := tx.LookupAttr("1.0", "JobStatus"); err != nil || !ok || v != "1" {
+	if v, ok, err := tx.LookupAttr(context.Background(), "1.0", "JobStatus"); err != nil || !ok || v != "1" {
 		t.Fatalf("LookupAttr = %q,%v,%v want 1", v, ok, err)
 	}
-	if err := tx.Commit(); err != nil {
+	if err := tx.Commit(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 
 	// New transaction sees the committed state.
-	tx2, _ := c.Begin()
-	v, ok, err := tx2.LookupAttr("1.0", "JobStatus")
+	tx2, _ := c.Begin(context.Background())
+	v, ok, err := tx2.LookupAttr(context.Background(), "1.0", "JobStatus")
 	if err != nil || !ok || v != "1" {
 		t.Fatalf("committed LookupAttr = %q,%v,%v want 1", v, ok, err)
 	}
-	_ = tx2.Abort()
+	_ = tx2.Abort(context.Background())
 }
 
 func TestRPCQueryLimit(t *testing.T) {
 	c, cleanup := testPair(t)
 	defer cleanup()
-	tx, _ := c.Begin()
+	tx, _ := c.Begin(context.Background())
 	for i := 0; i < 100; i++ {
-		_ = tx.NewClassAd(fmt.Sprintf("k%d", i), "Cpus = 4")
+		_ = tx.NewClassAd(context.Background(), fmt.Sprintf("k%d", i), "Cpus = 4")
 	}
-	if err := tx.Commit(); err != nil {
+	if err := tx.Commit(context.Background()); err != nil {
 		t.Fatal(err)
 	}
-	if rows, err := c.QueryLimit("Cpus == 4", 5); err != nil || len(rows) != 5 {
+	if rows, err := c.QueryLimit(context.Background(), "Cpus == 4", 5); err != nil || len(rows) != 5 {
 		t.Fatalf("QueryLimit(5) = %d rows, %v; want 5", len(rows), err)
 	}
-	if rows, err := c.QueryLimit("Cpus == 4", 0); err != nil || len(rows) != 100 {
+	if rows, err := c.QueryLimit(context.Background(), "Cpus == 4", 0); err != nil || len(rows) != 100 {
 		t.Fatalf("QueryLimit(0) = %d rows, %v; want 100", len(rows), err)
 	}
 	// A limit larger than the match count returns all matches.
-	if rows, err := c.QueryLimit("Cpus == 4", 500); err != nil || len(rows) != 100 {
+	if rows, err := c.QueryLimit(context.Background(), "Cpus == 4", 500); err != nil || len(rows) != 100 {
 		t.Fatalf("QueryLimit(500) = %d rows, %v; want 100", len(rows), err)
 	}
 }
@@ -79,22 +80,22 @@ func TestRPCQueryLimit(t *testing.T) {
 func TestRPCConflict(t *testing.T) {
 	c, cleanup := testPair(t)
 	defer cleanup()
-	seed, _ := c.Begin()
-	_ = seed.NewClassAd("j", "JobStatus = 1")
-	if err := seed.Commit(); err != nil {
+	seed, _ := c.Begin(context.Background())
+	_ = seed.NewClassAd(context.Background(), "j", "JobStatus = 1")
+	if err := seed.Commit(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 
-	a, _ := c.Begin()
-	b, _ := c.Begin()
-	_, _, _ = a.LookupAttr("j", "JobStatus") // snapshot
-	_, _, _ = b.LookupAttr("j", "JobStatus")
-	_ = a.SetAttribute("j", "JobStatus", "2")
-	_ = b.SetAttribute("j", "JobStatus", "3")
-	if err := a.Commit(); err != nil {
+	a, _ := c.Begin(context.Background())
+	b, _ := c.Begin(context.Background())
+	_, _, _ = a.LookupAttr(context.Background(), "j", "JobStatus") // snapshot
+	_, _, _ = b.LookupAttr(context.Background(), "j", "JobStatus")
+	_ = a.SetAttribute(context.Background(), "j", "JobStatus", "2")
+	_ = b.SetAttribute(context.Background(), "j", "JobStatus", "3")
+	if err := a.Commit(context.Background()); err != nil {
 		t.Fatalf("first commit should win: %v", err)
 	}
-	err := b.Commit()
+	err := b.Commit(context.Background())
 	ce, ok := err.(*db.ConflictError)
 	if !ok || len(ce.Keys) != 1 || ce.Keys[0] != "j" {
 		t.Fatalf("second commit = %v, want ConflictError on j", err)
@@ -104,15 +105,15 @@ func TestRPCConflict(t *testing.T) {
 func TestRPCStreamQueryAndMatch(t *testing.T) {
 	c, cleanup := testPair(t)
 	defer cleanup()
-	tx, _ := c.Begin()
-	_ = tx.NewClassAd("s1", "Cpus = 4\nRequirements = true")
-	_ = tx.NewClassAd("s2", "Cpus = 16\nRequirements = true")
-	_ = tx.NewClassAd("s3", "Cpus = 8\nRequirements = true")
-	if err := tx.Commit(); err != nil {
+	tx, _ := c.Begin(context.Background())
+	_ = tx.NewClassAd(context.Background(), "s1", "Cpus = 4\nRequirements = true")
+	_ = tx.NewClassAd(context.Background(), "s2", "Cpus = 16\nRequirements = true")
+	_ = tx.NewClassAd(context.Background(), "s3", "Cpus = 8\nRequirements = true")
+	if err := tx.Commit(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 
-	rows, err := c.Query("Cpus >= 8")
+	rows, err := c.Query(context.Background(), "Cpus >= 8")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -120,7 +121,7 @@ func TestRPCStreamQueryAndMatch(t *testing.T) {
 		t.Fatalf("Query streamed %d rows, want 2", len(rows))
 	}
 
-	got, err := c.MatchSorted("Requirements = TARGET.Cpus >= 4\nRank = TARGET.Cpus", 2)
+	got, err := c.MatchSorted(context.Background(), "Requirements = TARGET.Cpus >= 4\nRank = TARGET.Cpus", 2)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -147,15 +148,15 @@ func TestRPCOrdered(t *testing.T) {
 	c := NewClient(cconn)
 	defer func() { c.Close(); s.Close(); d.Close() }()
 
-	tx, _ := c.Begin()
-	_ = tx.NewClassAd("1", "Owner = \"alice\"\nJobPrio = 5")
-	_ = tx.NewClassAd("2", "Owner = \"alice\"\nJobPrio = 10")
-	_ = tx.NewClassAd("3", "Owner = \"bob\"\nJobPrio = 1")
-	if err := tx.Commit(); err != nil {
+	tx, _ := c.Begin(context.Background())
+	_ = tx.NewClassAd(context.Background(), "1", "Owner = \"alice\"\nJobPrio = 5")
+	_ = tx.NewClassAd(context.Background(), "2", "Owner = \"alice\"\nJobPrio = 10")
+	_ = tx.NewClassAd(context.Background(), "3", "Owner = \"bob\"\nJobPrio = 1")
+	if err := tx.Commit(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 
-	rows, err := c.Ordered(0, "alice")
+	rows, err := c.Ordered(context.Background(), 0, "alice")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -171,7 +172,7 @@ func TestRPCOrdered(t *testing.T) {
 func TestRPCWatch(t *testing.T) {
 	c, cleanup := testPair(t)
 	defer cleanup()
-	events, stop, err := c.Watch(nil)
+	events, stop, err := c.Watch(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -179,9 +180,9 @@ func TestRPCWatch(t *testing.T) {
 	time.Sleep(30 * time.Millisecond) // let the server-side watch subscribe
 
 	// A commit over the SAME connection: its ops mux with the streaming watch.
-	tx, _ := c.Begin()
-	_ = tx.NewClassAd("k", "N = 1")
-	if err := tx.Commit(); err != nil {
+	tx, _ := c.Begin(context.Background())
+	_ = tx.NewClassAd(context.Background(), "k", "N = 1")
+	if err := tx.Commit(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 
@@ -207,13 +208,13 @@ func TestRPCConcurrentCalls(t *testing.T) {
 	c, cleanup := testPair(t)
 	defer cleanup()
 	const n = 200
-	tx, _ := c.Begin()
+	tx, _ := c.Begin(context.Background())
 	for i := 0; i < n; i++ {
-		if err := tx.NewClassAd(fmt.Sprintf("k%d", i), fmt.Sprintf("N = %d", i)); err != nil {
+		if err := tx.NewClassAd(context.Background(), fmt.Sprintf("k%d", i), fmt.Sprintf("N = %d", i)); err != nil {
 			t.Fatal(err)
 		}
 	}
-	if err := tx.Commit(); err != nil {
+	if err := tx.Commit(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 
@@ -223,13 +224,13 @@ func TestRPCConcurrentCalls(t *testing.T) {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-			rtx, err := c.Begin() // independent transactions, concurrent over one conn
+			rtx, err := c.Begin(context.Background()) // independent transactions, concurrent over one conn
 			if err != nil {
 				errs[i] = err
 				return
 			}
-			v, ok, err := rtx.LookupAttr(fmt.Sprintf("k%d", i), "N")
-			_ = rtx.Abort()
+			v, ok, err := rtx.LookupAttr(context.Background(), fmt.Sprintf("k%d", i), "N")
+			_ = rtx.Abort(context.Background())
 			if err != nil {
 				errs[i] = err
 			} else if !ok || v != fmt.Sprintf("%d", i) {

--- a/dbrpc/serveopts_test.go
+++ b/dbrpc/serveopts_test.go
@@ -1,6 +1,7 @@
 package dbrpc
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -54,19 +55,19 @@ func TestServeReadOnlyRejectsMutation(t *testing.T) {
 	c, cleanup := serveOptsPair(t, ServeOptions{ReadOnly: true})
 	defer cleanup()
 
-	tx, err := c.Begin()
+	tx, err := c.Begin(context.Background())
 	if err != nil {
 		t.Fatalf("Begin on a read-only conn should succeed (read snapshot): %v", err)
 	}
-	if err := tx.NewClassAd("x", "N = 1"); err == nil {
+	if err := tx.NewClassAd(context.Background(), "x", "N = 1"); err == nil {
 		t.Fatal("NewClassAd on a read-only connection should be rejected")
 	} else if !strings.Contains(err.Error(), "read-only") {
 		t.Fatalf("rejection error = %v, want a read-only message", err)
 	}
-	if err := tx.SetAttribute("x", "N", "2"); err == nil {
+	if err := tx.SetAttribute(context.Background(), "x", "N", "2"); err == nil {
 		t.Fatal("SetAttribute on a read-only connection should be rejected")
 	}
-	_ = tx.Abort()
+	_ = tx.Abort(context.Background())
 }
 
 // TestServeStripsPrivate confirms private attributes are stripped by default and
@@ -80,7 +81,7 @@ func TestServeStripsPrivate(t *testing.T) {
 	c := NewClient(cconn)
 	defer func() { c.Close(); s.Close(); d.Close() }()
 
-	rows, err := c.Query("Cpus == 4")
+	rows, err := c.Query(context.Background(), "Cpus == 4")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -96,7 +97,7 @@ func TestServeStripsPrivate(t *testing.T) {
 	go func() { _ = s.ServeConnOpts(psconn, ServeOptions{IncludePrivate: true}) }()
 	pc := NewClient(pconn)
 	defer pc.Close()
-	prows, err := pc.Query("Cpus == 4")
+	prows, err := pc.Query(context.Background(), "Cpus == 4")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/dbrpc/server.go
+++ b/dbrpc/server.go
@@ -60,6 +60,14 @@ type serverTxn struct {
 	mu    sync.Mutex
 	table string    // the transaction's table (from opBegin), for the propose hook
 	batch []WriteOp // ops accumulated for the propose hook (nil unless propose is set)
+
+	// conn owns this transaction; when that connection closes, its still-open
+	// transactions are aborted (a client that drops mid-transaction -- e.g. a
+	// transient network reset -- must not leak the server-side txn + its write-set).
+	conn *serverConn
+	// lastTouch is the unix-nano time of the last op on this txn, read by the idle
+	// reaper to abort transactions abandoned on a still-open (half-open) connection.
+	lastTouch atomic.Int64
 }
 
 // NewServer returns a single-table server over d, served as table "ads". The
@@ -127,7 +135,7 @@ type ServeOptions struct {
 func (o op) isMutating() bool {
 	switch o {
 	case opNewAd, opDestroyAd, opSetAttr, opDeleteAttr, opAdmin, opCreateTable, opDropTable,
-		opArchiveCreate, opArchiveAppend, opArchiveRotate, opDeleteWhere:
+		opArchiveCreate, opArchiveAppend, opArchiveRotate, opDeleteWhere, opCommitIdem:
 		return true
 	}
 	return false
@@ -217,7 +225,11 @@ func (s *Server) ServeConn(conn MsgConn) error {
 func (s *Server) ServeConnOpts(conn MsgConn, opts ServeOptions) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel() // stop this connection's watches when it closes
-	sc := &serverConn{s: s, ctx: ctx, opts: opts, watches: make(map[uint64]context.CancelFunc)}
+	sc := &serverConn{s: s, ctx: ctx, opts: opts, watches: make(map[uint64]context.CancelFunc), txns: make(map[uint64]struct{})}
+	// Abort any transactions still open when the connection ends, so a client that
+	// drops mid-transaction (a transient reset, a crash, a cancelled context) does
+	// not leak the server-side txn and its buffered write-set.
+	defer sc.abortTxns()
 	var wmu sync.Mutex
 	sc.write = func(b []byte) {
 		wmu.Lock()
@@ -255,6 +267,11 @@ type serverConn struct {
 
 	wmu     sync.Mutex
 	watches map[uint64]context.CancelFunc
+
+	// tmu guards txns: the ids of transactions this connection opened and has not yet
+	// committed or aborted, so they can be aborted when the connection closes.
+	tmu  sync.Mutex
+	txns map[uint64]struct{}
 
 	// restore is the in-progress restore upload for this connection (at most one), spooled
 	// to a temp file. Only touched from the single read-loop goroutine (restore frames are
@@ -295,7 +312,7 @@ func (sc *serverConn) dispatch(frame []byte) {
 		sc.stopWatch(body.u64())
 		sc.write(resp(reqID, stOK))
 	default:
-		sc.write(sc.s.handle(reqID, o, body, priv, sc.opts.Privileged))
+		sc.write(sc.s.handle(sc, reqID, o, body, priv, sc.opts.Privileged))
 	}
 }
 
@@ -456,7 +473,7 @@ func (s *Server) streamOrdered(ctx context.Context, reqID uint64, r *reader, inc
 
 // handle executes one request and returns its response frame. includePrivate
 // controls whether ads returned by lookups carry their private attributes.
-func (s *Server) handle(reqID uint64, o op, r *reader, includePrivate, privileged bool) []byte {
+func (s *Server) handle(sc *serverConn, reqID uint64, o op, r *reader, includePrivate, privileged bool) []byte {
 	switch o {
 	case opBegin:
 		table := r.str()
@@ -468,7 +485,10 @@ func (s *Server) handle(reqID uint64, o op, r *reader, includePrivate, privilege
 			return respErr(reqID, "no such table: "+table)
 		}
 		id := s.nextID.Add(1)
-		s.txns.Store(id, &serverTxn{tx: d.Begin(), table: table})
+		st := &serverTxn{tx: d.Begin(), table: table, conn: sc}
+		st.lastTouch.Store(nowNano())
+		s.txns.Store(id, st)
+		sc.addTxn(id)
 		return putU64(resp(reqID, stOK), id)
 
 	case opCreateTable:
@@ -515,10 +535,12 @@ func (s *Server) handle(reqID uint64, o op, r *reader, includePrivate, privilege
 		return putBytes(resp(reqID, stOK), cursor)
 
 	case opCommit:
-		st, ok := s.take(r.u64())
+		id := r.u64()
+		st, ok := s.take(id)
 		if !ok {
 			return respErr(reqID, "no such transaction")
 		}
+		sc.removeTxn(id)
 		// Consistent-HA routing: propose the accumulated writes through consensus (raft)
 		// instead of committing locally. The local transaction was only for read-your-
 		// writes during the session; the propose hook (via the FSM) is the real writer.
@@ -542,8 +564,68 @@ func (s *Server) handle(reqID uint64, o op, r *reader, includePrivate, privilege
 		}
 		return respErr(reqID, err.Error())
 
+	case opCommitIdem:
+		id := r.u64()
+		idemKey := r.str()
+		if r.err != nil {
+			return respBad(reqID)
+		}
+		st, ok := s.take(id)
+		if !ok {
+			return respErr(reqID, "no such transaction")
+		}
+		sc.removeTxn(id)
+		// Consensus routing has its own write path (the local txn is not the writer),
+		// so the in-txn marker does not apply; fall back to a plain proposed commit.
+		if s.propose != nil {
+			st.tx.Abort()
+			if err := s.propose(st.table, st.batch); err != nil {
+				return respErr(reqID, err.Error())
+			}
+			return resp(reqID, stOK)
+		}
+		d, ok := s.cat.Table(st.table)
+		if !ok {
+			st.tx.Abort()
+			return respErr(reqID, "no such table: "+st.table)
+		}
+		markerKey := idemMarkerKey(idemKey)
+		// Replay of an already-committed unit of work: the marker is present, so the
+		// prior attempt landed. Do not re-apply; report success.
+		if _, exists := d.LookupClassAd(markerKey); exists {
+			st.tx.Abort()
+			return resp(reqID, stOK)
+		}
+		// Add the marker to this same transaction so it commits atomically with the
+		// data (durable, survives restart) and doubles as the OCC guard: a concurrent
+		// replay of the same unit of work conflicts on the marker key.
+		marker := classad.New()
+		marker.InsertAttr(idemMarkerAttr, time.Now().Unix())
+		st.tx.NewClassAd(markerKey, marker)
+		cerr := st.tx.Commit()
+		if cerr == nil {
+			return resp(reqID, stOK)
+		}
+		if ce, isConf := cerr.(*db.ConflictError); isConf {
+			// A conflict on the marker key means a concurrent replay of the same unit
+			// of work already committed -> exactly-once success, not a data conflict.
+			for _, k := range ce.Keys {
+				if k == markerKey {
+					return resp(reqID, stOK)
+				}
+			}
+			b := respHead(reqID, stConflict)
+			for _, k := range ce.Keys {
+				b = putStr(b, k)
+			}
+			return b
+		}
+		return respErr(reqID, cerr.Error())
+
 	case opAbort:
-		if st, ok := s.take(r.u64()); ok {
+		id := r.u64()
+		if st, ok := s.take(id); ok {
+			sc.removeTxn(id)
 			st.tx.Abort()
 		}
 		return resp(reqID, stOK)
@@ -796,9 +878,97 @@ func (s *Server) withTxn(reqID uint64, r *reader, fn func(*serverTxn) []byte) []
 		return respErr(reqID, "no such transaction")
 	}
 	st := v.(*serverTxn)
+	st.lastTouch.Store(nowNano())
 	st.mu.Lock()
 	defer st.mu.Unlock()
 	return fn(st)
+}
+
+// nowNano is the current time in unix nanoseconds, stamped on a transaction at each
+// op so the idle reaper can measure inactivity.
+func nowNano() int64 { return time.Now().UnixNano() }
+
+// addTxn / removeTxn track the transactions this connection has open so they can be
+// aborted if the connection closes with them still uncommitted.
+func (sc *serverConn) addTxn(id uint64) {
+	sc.tmu.Lock()
+	sc.txns[id] = struct{}{}
+	sc.tmu.Unlock()
+}
+
+func (sc *serverConn) removeTxn(id uint64) {
+	sc.tmu.Lock()
+	delete(sc.txns, id)
+	sc.tmu.Unlock()
+}
+
+// abortTxns aborts every transaction still open on this connection. Called from the
+// serve loop's defer, so a client that disconnects mid-transaction releases its
+// server-side txn and write-set instead of leaking it. take() deduplicates against a
+// concurrently-arriving commit/abort, so exactly one side wins.
+func (sc *serverConn) abortTxns() {
+	sc.tmu.Lock()
+	ids := make([]uint64, 0, len(sc.txns))
+	for id := range sc.txns {
+		ids = append(ids, id)
+	}
+	sc.txns = make(map[uint64]struct{})
+	sc.tmu.Unlock()
+	for _, id := range ids {
+		if st, ok := sc.s.take(id); ok {
+			st.mu.Lock()
+			st.tx.Abort()
+			st.mu.Unlock()
+		}
+	}
+}
+
+// reapIdleTxns aborts transactions with no activity for at least maxIdle -- a
+// backstop for a transaction abandoned on a connection that stays open (half-open
+// TCP, a wedged client). Disconnect handles the common case; this handles the rest.
+func (s *Server) reapIdleTxns(maxIdle time.Duration) int {
+	cutoff := nowNano() - int64(maxIdle)
+	reaped := 0
+	s.txns.Range(func(k, v any) bool {
+		st := v.(*serverTxn)
+		if st.lastTouch.Load() > cutoff {
+			return true
+		}
+		id := k.(uint64)
+		if taken, ok := s.take(id); ok {
+			taken.mu.Lock()
+			taken.tx.Abort()
+			taken.mu.Unlock()
+			if taken.conn != nil {
+				taken.conn.removeTxn(id)
+			}
+			reaped++
+		}
+		return true
+	})
+	return reaped
+}
+
+// StartTxnReaper runs reapIdleTxns every interval, aborting transactions idle longer
+// than maxIdle, until the returned stop is called. Optional: disconnect cleanup is
+// automatic; a server that wants to bound transactions abandoned on still-open
+// connections starts this.
+func (s *Server) StartTxnReaper(interval, maxIdle time.Duration) (stop func()) {
+	done := make(chan struct{})
+	go func() {
+		t := time.NewTicker(interval)
+		defer t.Stop()
+		for {
+			select {
+			case <-done:
+				return
+			case <-t.C:
+				s.reapIdleTxns(maxIdle)
+			}
+		}
+	}()
+	var once sync.Once
+	return func() { once.Do(func() { close(done) }) }
 }
 
 // record appends a write op to the transaction's batch when the server routes commits

--- a/dbrpc/snapshot.go
+++ b/dbrpc/snapshot.go
@@ -1,6 +1,7 @@
 package dbrpc
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -180,36 +181,44 @@ func (sc *serverConn) abortRestore() {
 // SnapshotTable streams a consistent backup of the named table to w. DAEMON-level: a
 // snapshot carries every attribute, including private ones. The server streams it in
 // chunks, so neither side buffers the whole database.
-func (c *Client) SnapshotTable(table string, w io.Writer) error {
+func (c *Client) SnapshotTable(ctx context.Context, table string, w io.Writer) error {
 	_, ch, err := c.callStream(func(id uint64) []byte {
 		return putStr(req(id, opSnapshot), table)
 	})
 	if err != nil {
 		return err
 	}
-	for frame := range ch {
-		_, status, body, ok := respHeader(frame)
-		if !ok {
+	for {
+		select {
+		case <-ctx.Done():
 			drain(ch)
-			return errShort
-		}
-		switch status {
-		case stStream:
-			if _, err := w.Write(body.bytesRef()); err != nil {
-				drain(ch) // let the read loop finish delivering so the channel closes
-				return err
+			return ctx.Err()
+		case frame, ok := <-ch:
+			if !ok {
+				return nil
 			}
-		case stErr:
-			return statusErr(status, body)
+			_, status, body, ok := respHeader(frame)
+			if !ok {
+				drain(ch)
+				return errShort
+			}
+			switch status {
+			case stStream:
+				if _, err := w.Write(body.bytesRef()); err != nil {
+					drain(ch) // let the read loop finish delivering so the channel closes
+					return err
+				}
+			case stErr:
+				return statusErr(status, body)
+			}
 		}
 	}
-	return nil
 }
 
 // RestoreTable replaces the named table with the snapshot read from r. DAEMON-level and
 // destructive: the server spools the upload and restores under the DB-wide lock. The
 // upload streams in chunks, so the client does not buffer the whole snapshot.
-func (c *Client) RestoreTable(table string, r io.Reader) error {
+func (c *Client) RestoreTable(ctx context.Context, table string, r io.Reader) error {
 	id := c.nextReq.Add(1)
 	ch, err := c.sendID(id, func(reqID uint64) []byte {
 		return putStr(req(reqID, opRestore), table)
@@ -219,6 +228,10 @@ func (c *Client) RestoreTable(table string, r io.Reader) error {
 	}
 	buf := make([]byte, snapChunk)
 	for {
+		if err := ctx.Err(); err != nil {
+			c.cancelPending(id)
+			return err
+		}
 		n, rerr := r.Read(buf)
 		if n > 0 {
 			if werr := c.conn.WriteMsg(putBytes(req(id, opRestoreChunk), buf[:n])); werr != nil {
@@ -235,23 +248,32 @@ func (c *Client) RestoreTable(table string, r io.Reader) error {
 	if werr := c.conn.WriteMsg(req(id, opRestoreEnd)); werr != nil {
 		return werr
 	}
-	frame, ok := <-ch
-	if !ok {
-		return c.closeErr
+	select {
+	case <-ctx.Done():
+		c.cancelPending(id)
+		return ctx.Err()
+	case frame, ok := <-ch:
+		if !ok {
+			return c.closeErr
+		}
+		_, status, body, ok := respHeader(frame)
+		if !ok {
+			return errShort
+		}
+		if status != stOK {
+			return statusErr(status, body)
+		}
+		return nil
 	}
-	_, status, body, ok := respHeader(frame)
-	if !ok {
-		return errShort
-	}
-	if status != stOK {
-		return statusErr(status, body)
-	}
-	return nil
 }
 
 // Snapshot / Restore operate on the default table.
-func (c *Client) Snapshot(w io.Writer) error { return c.SnapshotTable(DefaultTable, w) }
-func (c *Client) Restore(r io.Reader) error  { return c.RestoreTable(DefaultTable, r) }
+func (c *Client) Snapshot(ctx context.Context, w io.Writer) error {
+	return c.SnapshotTable(ctx, DefaultTable, w)
+}
+func (c *Client) Restore(ctx context.Context, r io.Reader) error {
+	return c.RestoreTable(ctx, DefaultTable, r)
+}
 
 // drain discards any remaining frames until the stream channel closes, so the client's
 // read loop is never blocked writing to a channel no one is reading.

--- a/dbrpc/txn_cleanup_test.go
+++ b/dbrpc/txn_cleanup_test.go
@@ -1,0 +1,86 @@
+package dbrpc
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/PelicanPlatform/classad/db"
+)
+
+// txnCount counts the server's live transactions.
+func txnCount(s *Server) int {
+	n := 0
+	s.txns.Range(func(_, _ any) bool { n++; return true })
+	return n
+}
+
+// TestServerAbortsTxnsOnDisconnect: a client that opens a transaction and then drops
+// its connection (a transient reset, a crash) must not leak the server-side txn --
+// the serve loop aborts it when the connection closes.
+func TestServerAbortsTxnsOnDisconnect(t *testing.T) {
+	d, err := db.Open("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+	s := NewServer(d)
+	defer s.Close()
+	cc, sc := netPipe()
+	go func() { _ = s.ServeConn(sc) }()
+	c := NewClient(cc)
+
+	tx, err := c.Begin(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.NewClassAd(context.Background(), "k", `Name = "a"`); err != nil {
+		t.Fatal(err)
+	}
+	if txnCount(s) != 1 {
+		t.Fatalf("server txn count = %d before disconnect, want 1", txnCount(s))
+	}
+
+	// Drop the connection mid-transaction (no commit, no abort).
+	_ = c.Close()
+
+	// The serve loop's defer aborts the orphaned txn; poll until it drains.
+	deadline := time.Now().Add(2 * time.Second)
+	for txnCount(s) != 0 {
+		if time.Now().After(deadline) {
+			t.Fatalf("server txn count = %d 2s after disconnect, want 0 (txn leaked)", txnCount(s))
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+// TestReapIdleTxns: a transaction abandoned on a still-open connection is aborted by
+// the idle reaper.
+func TestReapIdleTxns(t *testing.T) {
+	d, err := db.Open("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+	s := NewServer(d)
+	defer s.Close()
+	cc, sc := netPipe()
+	go func() { _ = s.ServeConn(sc) }()
+	c := NewClient(cc)
+	defer c.Close()
+
+	if _, err := c.Begin(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if txnCount(s) != 1 {
+		t.Fatalf("server txn count = %d, want 1", txnCount(s))
+	}
+
+	// maxIdle 0: every txn is at least "0 ago" idle, so all are reaped.
+	if n := s.reapIdleTxns(0); n != 1 {
+		t.Fatalf("reapIdleTxns reaped %d, want 1", n)
+	}
+	if txnCount(s) != 0 {
+		t.Fatalf("server txn count = %d after reap, want 0", txnCount(s))
+	}
+}


### PR DESCRIPTION
Makes `dbrpc` production-robust for callers that hold a long-lived connection over a flaky link (motivated by the golang-collector external-database backend, which needs to ride out transient DB outages). Spans `collections`, `db`, and `dbrpc` (they build together via the existing `replace` directives).

## Context & error taxonomy (`dbrpc`)
- **Context through every `Client`/`Tx` call.** The caller's context is the deadline — no implicit timeouts. Cancellation unregisters the pending call (the shared read loop keeps serving every other in-flight call); finite streams cancel by *draining* rather than orphaning the mux; `WatchTable` stops the stream server-side (`opWatchStop`) on ctx done.
- **Typed errors** so a caller classifies without matching message text:
  - `ErrConnClosed` — transport dead/closed → reconnect and (if idempotent) replay; wraps the underlying cause.
  - `ServerError` — a logical/deterministic rejection (bad constraint, unknown table) → surface, don't retry.
  - `*db.ConflictError` unchanged → retry on the same connection.

## Server transaction lifecycle
- **Abort a connection's still-open transactions on disconnect.** Previously a client that dropped mid-transaction (a reset, a crash, a cancelled context) leaked the server-side txn and its buffered write-set — exactly what a reconnect storm produces. Now the serve loop aborts them.
- `StartTxnReaper(interval, maxIdle)` backstops transactions abandoned on a still-open (half-open) connection.
- Tests: `TestServerAbortsTxnsOnDisconnect`, `TestReapIdleTxns`.

## Durable, opt-in idempotency
- **`Tx.CommitIdempotent(ctx, idemKey)`** records a marker in the *same transaction* as the data. Because the commit is atomic, the marker lands iff the data lands — so exactly-once survives a reconnect **and a server restart**. A replay of the same unit of work is detected (marker already present, or an OCC conflict on the marker key) and short-circuits to success without re-applying.
- **Opt-in**: plain `Commit` is unchanged and writes no marker, so idempotent-by-key workloads pay nothing. Idempotency requires a stable client-supplied key (only the retry driver has one), which is why it lives at commit, not as an implicit default.
- **Reserved "system key" keyspace** (leading `0x00`) added to `collections`+`db`: output scans / queries / `DeleteWhere` skip system keys via a cheap first-byte check, while **compaction, key lookup, and snapshot/restore preserve them** (so "durable" holds across restart, and a normal query never sees a marker). `StartIdemReaper(interval, maxAge)` TTL-expires markers.
- Tests: exactly-once replay (replaying different data is a no-op), marker invisibility, durability across a server+db restart, and reaping.

## Testing
`go build ./... && go test ./...` green in `collections`, `db`, and `dbrpc`; `go vet` and `gofmt -s` clean. htcondordb (a downstream `dbrpc` consumer) builds against the new API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
