### PR TITLE
collections: release segment fds after mmap + scan-free reopen on clean shutdown

### DIFF
--- a/collections/dirsnapshot.go
+++ b/collections/dirsnapshot.go
@@ -1,0 +1,255 @@
+package collections
+
+import (
+	"encoding/binary"
+	"errors"
+	"hash/crc32"
+	"os"
+	"path/filepath"
+)
+
+// errStaleDirEntry aborts a snapshot write when a directory entry points at a
+// retired segment (an unexpected state); the reopen then falls back to a scan.
+var errStaleDirEntry = errors.New("collections: directory entry references a retired segment")
+
+// A directory snapshot is a per-shard fast-reopen optimization. On a clean Close the
+// shard writes its directory (key-hash -> record location), commit sequence, and live
+// count to <shardDir>/dir.snap; a subsequent Open restores the directory from that
+// file instead of scanning every record to rebuild it (rebuildDir, which is O(DB)).
+//
+// The snapshot is a pure optimization and never the source of truth: it is validated
+// exhaustively (CRC, plus the exact segment set it was taken over -- basename and
+// durable length, in load order) and on ANY discrepancy the reopen falls back to the
+// full scan, so a stale or corrupt snapshot can never yield incorrect state. It is
+// also consume-once (removed as it is read), so it is trusted only for the one reopen
+// immediately following the clean Close that wrote it; a crash mid-life leaves no
+// snapshot and forces the scan.
+//
+// Correctness rests on one invariant: the snapshot exists only after a clean Close,
+// and a clean Close flushes every segment (so all supersession flags are durable and
+// no compaction is mid-flight). That is exactly the state rebuildDir's crash-dedup
+// pass exists to repair, so a clean reopen can safely skip both the rebuild and the
+// dedup.
+const (
+	dirSnapName    = "dir.snap"
+	dirSnapMagic   = 0x53524944 // "DIRS"
+	dirSnapVersion = 1
+)
+
+// writeDirSnapshot persists shard sh's directory to <shardDir>/dir.snap. The caller
+// holds sh.mu and must have flushed every segment durable first, so the snapshot
+// never references not-yet-durable bytes. Best effort: an error just means the next
+// open falls back to a full scan.
+func writeDirSnapshot(sh *shard, shardDir string) error {
+	// Segments are referenced by their file basename, which is stable across reopen;
+	// array indices are not (compaction leaves nil holes and reopen reloads without
+	// them). Assign each live (non-nil) segment a snapshot slot and record its
+	// basename + durable length; directory entries then reference the slot.
+	slotOf := make(map[uint32]uint32, len(sh.segs)) // array index -> snapshot slot
+	buf := make([]byte, 0, 32+len(sh.segs)*24+len(sh.dir)*16)
+	buf = binary.LittleEndian.AppendUint32(buf, dirSnapMagic)
+	buf = binary.LittleEndian.AppendUint32(buf, dirSnapVersion)
+	buf = binary.LittleEndian.AppendUint64(buf, sh.commitSeq)
+	buf = binary.LittleEndian.AppendUint64(buf, uint64(sh.count))
+	nSegOff := len(buf)
+	buf = binary.LittleEndian.AppendUint32(buf, 0) // segment count, back-patched below
+	var nSegs uint32
+	for ai, seg := range sh.segs {
+		if seg == nil {
+			continue // a retired (compacted-away) slot
+		}
+		slotOf[uint32(ai)] = nSegs
+		nSegs++
+		name := filepath.Base(seg.path)
+		buf = binary.LittleEndian.AppendUint64(buf, uint64(seg.used))
+		buf = binary.LittleEndian.AppendUint16(buf, uint16(len(name)))
+		buf = append(buf, name...)
+	}
+	binary.LittleEndian.PutUint32(buf[nSegOff:], nSegs)
+	nEntOff := len(buf)
+	buf = binary.LittleEndian.AppendUint64(buf, 0) // entry count, back-patched below
+	var nEntries uint64
+	for h, l := range sh.dir {
+		slot, ok := slotOf[l.seg]
+		if !ok {
+			// A live directory entry pointing at a retired segment should never
+			// happen on a clean shutdown; if it does, skip the snapshot entirely so
+			// the reopen falls back to the authoritative scan.
+			return errStaleDirEntry
+		}
+		buf = binary.LittleEndian.AppendUint64(buf, h)
+		buf = binary.LittleEndian.AppendUint32(buf, slot)
+		buf = binary.LittleEndian.AppendUint32(buf, l.off)
+		nEntries++
+	}
+	binary.LittleEndian.PutUint64(buf[nEntOff:], nEntries)
+	buf = binary.LittleEndian.AppendUint32(buf, crc32.ChecksumIEEE(buf))
+
+	tmp := filepath.Join(shardDir, dirSnapName+".tmp")
+	f, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
+	if err != nil {
+		return err
+	}
+	if _, err := f.Write(buf); err != nil {
+		f.Close()
+		os.Remove(tmp)
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		f.Close()
+		os.Remove(tmp)
+		return err
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(tmp)
+		return err
+	}
+	return os.Rename(tmp, filepath.Join(shardDir, dirSnapName))
+}
+
+// onDirSnapLoad, if set, is notified whether a shard's directory was restored from a
+// snapshot (true) or fell back to a full rebuild (false). Test-only; nil in production.
+var onDirSnapLoad func(loaded bool)
+
+// tryLoadDirSnapshot restores shard sh's directory from a clean Close's dir.snap,
+// returning whether it succeeded. On any error/mismatch it returns false (the caller
+// runs rebuildDir). It always removes the file (consume-once). Caller holds sh.mu.
+func (c *Collection) tryLoadDirSnapshot(sh *shard, shardDir string) bool {
+	ok := c.loadDirSnapshot(sh, shardDir)
+	if onDirSnapLoad != nil {
+		onDirSnapLoad(ok)
+	}
+	return ok
+}
+
+func (c *Collection) loadDirSnapshot(sh *shard, shardDir string) bool {
+	path := filepath.Join(shardDir, dirSnapName)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false // no snapshot: first open, or a prior crash
+	}
+	_ = os.Remove(path) // consume-once: trusted only for this immediate reopen
+
+	// Verify the trailing CRC before trusting any length field (so a corrupt file
+	// cannot drive a huge allocation or an out-of-bounds read).
+	if len(data) < 4 {
+		return false
+	}
+	body := data[:len(data)-4]
+	if crc32.ChecksumIEEE(body) != binary.LittleEndian.Uint32(data[len(data)-4:]) {
+		return false
+	}
+
+	// Map each loaded segment's basename to its array index (the reopen loads only
+	// live files, in counter order, with no nil holes).
+	byName := make(map[string]uint32, len(sh.segs))
+	for ai, seg := range sh.segs {
+		if seg != nil {
+			byName[filepath.Base(seg.path)] = uint32(ai)
+		}
+	}
+
+	r := snapReader{b: body}
+	if r.u32() != dirSnapMagic || r.u32() != dirSnapVersion {
+		return false
+	}
+	commitSeq := r.u64()
+	count := int(r.u64())
+	nSegs := int(r.u32())
+	if r.err || nSegs != len(byName) {
+		return false // the live segment set changed since the snapshot
+	}
+	// Resolve each snapshot slot to a loaded segment by basename, verifying its
+	// durable length is unchanged.
+	slotToArray := make([]uint32, nSegs)
+	for j := 0; j < nSegs; j++ {
+		used := int(r.u64())
+		name := r.str16()
+		if r.err {
+			return false
+		}
+		ai, ok := byName[name]
+		if !ok || used != sh.segs[ai].used {
+			return false
+		}
+		slotToArray[j] = ai
+	}
+	nEntries := int(r.u64())
+	if r.err {
+		return false
+	}
+	dir := make(map[uint64]loc, nEntries)
+	for i := 0; i < nEntries; i++ {
+		h := r.u64()
+		slot := int(r.u32())
+		off := r.u32()
+		if r.err || slot >= nSegs {
+			return false
+		}
+		l := loc{seg: slotToArray[slot], off: off}
+		s := sh.segs[l.seg]
+		if int(l.off)+recHeaderSize > s.used || recTotalLen(s.data, l.off) == 0 {
+			return false // location out of the durable region / unwritten
+		}
+		dir[h] = l
+	}
+	if r.err || r.pos != len(body) {
+		return false // trailing garbage
+	}
+
+	sh.dir = dir
+	sh.commitSeq = commitSeq
+	sh.count = count
+	if len(sh.segs) > 0 {
+		sh.act = sh.segs[len(sh.segs)-1]
+	}
+	return true
+}
+
+// snapReader is a bounds-checked little-endian reader over a snapshot body; any
+// short read latches err so the caller can bail without a panic.
+type snapReader struct {
+	b   []byte
+	pos int
+	err bool
+}
+
+func (r *snapReader) need(n int) bool {
+	if r.err || r.pos+n > len(r.b) {
+		r.err = true
+		return false
+	}
+	return true
+}
+
+func (r *snapReader) u32() uint32 {
+	if !r.need(4) {
+		return 0
+	}
+	v := binary.LittleEndian.Uint32(r.b[r.pos:])
+	r.pos += 4
+	return v
+}
+
+func (r *snapReader) u64() uint64 {
+	if !r.need(8) {
+		return 0
+	}
+	v := binary.LittleEndian.Uint64(r.b[r.pos:])
+	r.pos += 8
+	return v
+}
+
+func (r *snapReader) str16() string {
+	if !r.need(2) {
+		return ""
+	}
+	n := int(binary.LittleEndian.Uint16(r.b[r.pos:]))
+	r.pos += 2
+	if !r.need(n) {
+		return ""
+	}
+	s := string(r.b[r.pos : r.pos+n])
+	r.pos += n
+	return s
+}

--- a/collections/dirsnapshot_test.go
+++ b/collections/dirsnapshot_test.go
@@ -1,0 +1,105 @@
+package collections
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/classad"
+)
+
+// TestDirSnapshotFastReopen proves the clean-shutdown fast reopen: after a clean
+// Close, a reopen restores every shard's directory from its snapshot without the
+// full record scan (rebuildDir), and the recovered state -- including deletes -- is
+// exactly correct.
+func TestDirSnapshotFastReopen(t *testing.T) {
+	var loaded, scanned int
+	onDirSnapLoad = func(ok bool) {
+		if ok {
+			loaded++
+		} else {
+			scanned++
+		}
+	}
+	defer func() { onDirSnapLoad = nil }()
+
+	dir := t.TempDir()
+	openIt := func() *Collection {
+		c, err := Open(Options{Dir: dir, Shards: 4, SegmentSize: 4096})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return c
+	}
+
+	c := openIt()
+	for i := 0; i < 400; i++ {
+		ad, err := classad.Parse(fmt.Sprintf(`[ Owner="u%d"; Seq=%d ]`, i%7, i))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := c.Put([]byte(fmt.Sprintf("k%d", i)), ad); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for i := 0; i < 60; i++ { // delete a chunk so the fast path must honor tombstones
+		c.Delete([]byte(fmt.Sprintf("k%d", i)))
+	}
+	if err := c.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// --- Clean reopen: every shard takes the snapshot fast path (no scan). ---
+	loaded, scanned = 0, 0
+	c2 := openIt()
+	nShards := len(c2.shards)
+	if scanned != 0 || loaded != nShards {
+		t.Fatalf("clean reopen: loaded=%d scanned=%d, want loaded=%d scanned=0", loaded, scanned, nShards)
+	}
+	if got := c2.Len(); got != 340 {
+		t.Fatalf("reopened Len=%d, want 340 (400 put, 60 deleted)", got)
+	}
+	for i := 60; i < 400; i++ {
+		ad, ok := c2.Get([]byte(fmt.Sprintf("k%d", i)))
+		if !ok {
+			t.Fatalf("k%d missing after fast reopen", i)
+		}
+		if v, _ := ad.EvaluateAttrInt("Seq"); v != int64(i) {
+			t.Fatalf("k%d Seq=%d, want %d", i, v, i)
+		}
+	}
+	for i := 0; i < 60; i++ {
+		if _, ok := c2.Get([]byte(fmt.Sprintf("k%d", i))); ok {
+			t.Fatalf("deleted k%d resurfaced after fast reopen", i)
+		}
+	}
+	if err := c2.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// --- Corrupt one shard's snapshot: that shard must fall back to the scan and
+	// still recover correctly; the others still fast-load. ---
+	snap := filepath.Join(dir, "0", dirSnapName)
+	if err := os.WriteFile(snap, []byte("garbage-not-a-valid-snapshot"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	loaded, scanned = 0, 0
+	c3 := openIt()
+	defer c3.Close()
+	if scanned < 1 {
+		t.Fatalf("corrupted shard should have fallen back to a scan; scanned=%d", scanned)
+	}
+	if loaded+scanned != nShards {
+		t.Fatalf("each shard should load-or-scan exactly once: loaded=%d scanned=%d", loaded, scanned)
+	}
+	if got := c3.Len(); got != 340 {
+		t.Fatalf("after corrupt-snapshot fallback, Len=%d, want 340", got)
+	}
+	// Spot-check a key that hashes into the corrupted shard 0 recovered correctly.
+	for i := 60; i < 400; i++ {
+		if _, ok := c3.Get([]byte(fmt.Sprintf("k%d", i))); !ok {
+			t.Fatalf("k%d lost after corrupt-snapshot fallback", i)
+		}
+	}
+}

--- a/collections/fdrelease_test.go
+++ b/collections/fdrelease_test.go
@@ -1,0 +1,83 @@
+package collections
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/classad"
+)
+
+// TestPersistentSegmentsReleaseFDs verifies the file-descriptor scaling fix: a
+// persistent segment releases its backing fd once mapped, so a store with many
+// segments holds no per-segment fds -- yet the data stays durable and reloads
+// correctly. Segments are tiny here so a few hundred ads span many of them.
+func TestPersistentSegmentsReleaseFDs(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	c, err := Open(Options{Dir: dir, Shards: 1, SegmentSize: 4096})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const n = 400
+	for i := 0; i < n; i++ {
+		ad, err := classad.Parse(fmt.Sprintf(`[ Owner="u%d"; Seq=%d ]`, i%7, i))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := c.Put([]byte(fmt.Sprintf("k%d", i)), ad); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Every persistent segment must be marked persistent AND hold no open fd (it was
+	// released right after mmap). Tiny segments guarantee we made many of them.
+	segs, withFD := 0, 0
+	for _, sh := range c.shards {
+		sh.mu.RLock()
+		for _, seg := range sh.segs {
+			if seg == nil {
+				continue
+			}
+			segs++
+			if !seg.persistent {
+				t.Errorf("segment %d not marked persistent", seg.id)
+			}
+			if seg.file != nil {
+				withFD++
+			}
+		}
+		sh.mu.RUnlock()
+	}
+	if segs < 5 {
+		t.Fatalf("expected many tiny segments, got %d", segs)
+	}
+	if withFD != 0 {
+		t.Fatalf("%d of %d segments still hold an fd; want 0 (released after mmap)", withFD, segs)
+	}
+	t.Logf("%d segments, 0 open fds", segs)
+
+	// Durability across all those fd-released segments: reopen and confirm every ad
+	// survived with its value intact.
+	if err := c.Close(); err != nil {
+		t.Fatal(err)
+	}
+	c2, err := Open(Options{Dir: dir, Shards: 1, SegmentSize: 4096})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c2.Close()
+	if got := c2.Len(); got != n {
+		t.Fatalf("recovered %d ads, want %d", got, n)
+	}
+	for i := 0; i < n; i++ {
+		ad, ok := c2.Get([]byte(fmt.Sprintf("k%d", i)))
+		if !ok {
+			t.Fatalf("k%d missing after reopen", i)
+			continue
+		}
+		if v, _ := ad.EvaluateAttrInt("Seq"); v != int64(i) {
+			t.Fatalf("k%d Seq=%d after reopen, want %d", i, v, i)
+		}
+	}
+}

--- a/collections/mmapseg.go
+++ b/collections/mmapseg.go
@@ -37,23 +37,32 @@ func newMmapSegment(id uint32, size int, codec Codec, path string) (*segment, er
 		os.Remove(path)
 		return nil, fmt.Errorf("mmap %s: %w", path, err)
 	}
-	return &segment{id: id, data: data, codec: codec, file: f, path: path}, nil
+	// The mapping keeps the file alive on its own (mmap adds a reference the fd's
+	// close does not drop), and nothing after this needs the fd: writes go to the
+	// mapping, durability is msync (address-based), and retirement munmaps + unlinks
+	// by path. So release the fd now -- a large store otherwise holds one fd per
+	// live segment (thousands past RAM). See segment.persistent.
+	f.Close()
+	return &segment{id: id, data: data, codec: codec, persistent: true, path: path}, nil
 }
 
 // openMmapSegment maps an existing segment file (recovery). used is set by the
-// caller after scanning the durable region.
+// caller after scanning the durable region. The fd is released once mapped (the
+// caller reads through seg.data, not the file); see newMmapSegment.
 func openMmapSegment(id uint32, codec Codec, f *os.File, size int) (*segment, error) {
+	path := f.Name()
 	data, err := unix.Mmap(int(f.Fd()), 0, size, unix.PROT_READ|unix.PROT_WRITE, unix.MAP_SHARED)
 	if err != nil {
 		return nil, fmt.Errorf("mmap fd: %w", err)
 	}
-	return &segment{id: id, data: data, codec: codec, file: f, path: f.Name()}, nil
+	f.Close()
+	return &segment{id: id, data: data, codec: codec, persistent: true, path: path}, nil
 }
 
 // flush msyncs the not-yet-durable bytes [synced, used) to disk and advances the
 // durable length. Page-aligned start is required by msync. No-op for RAM segments.
 func (s *segment) flush() error {
-	if s.file == nil || s.used <= s.synced {
+	if !s.persistent || s.used <= s.synced {
 		return nil
 	}
 	const page = 4096
@@ -69,7 +78,7 @@ func (s *segment) flush() error {
 // Used by group-commit durability, which advances synced under the shard lock and
 // then calls this lock-free. No-op for RAM segments.
 func (s *segment) msyncRange(from, to int) error {
-	if s.file == nil || to <= from {
+	if !s.persistent || to <= from {
 		return nil
 	}
 	const page = 4096
@@ -81,12 +90,15 @@ func (s *segment) msyncRange(from, to int) error {
 // retired mmap segment. Called at most once, after the pin count drains to zero.
 // No-op for a RAM segment.
 func (s *segment) reap() error {
-	if s.file == nil {
+	if !s.persistent {
 		return nil
 	}
 	err := unix.Munmap(s.data)
-	if e := s.file.Close(); err == nil {
-		err = e
+	if s.file != nil { // normally already released after mmap; guard for safety
+		if e := s.file.Close(); err == nil {
+			err = e
+		}
+		s.file = nil
 	}
 	if s.path != "" {
 		if e := os.Remove(s.path); err == nil {
@@ -94,22 +106,23 @@ func (s *segment) reap() error {
 		}
 		os.Remove(s.path + ".idx") // best-effort: drop the index snapshot with the segment
 	}
-	s.file = nil
 	return err
 }
 
 // unmap flushes, unmaps, and closes an mmap segment's file. No-op for RAM.
 func (s *segment) unmap() error {
-	if s.file == nil {
+	if !s.persistent {
 		return nil
 	}
 	err := s.flush()
 	if e := unix.Munmap(s.data); err == nil {
 		err = e
 	}
-	if e := s.file.Close(); err == nil {
-		err = e
+	if s.file != nil { // normally already released after mmap; guard for safety
+		if e := s.file.Close(); err == nil {
+			err = e
+		}
+		s.file = nil
 	}
-	s.file = nil
 	return err
 }

--- a/collections/mmapseg_stub.go
+++ b/collections/mmapseg_stub.go
@@ -17,28 +17,28 @@ func openMmapSegment(id uint32, codec Codec, f *os.File, size int) (*segment, er
 }
 
 func (s *segment) flush() error {
-	if s.file == nil {
+	if !s.persistent {
 		return nil
 	}
 	return errNoMmap
 }
 
 func (s *segment) msyncRange(from, to int) error {
-	if s.file == nil {
+	if !s.persistent {
 		return nil
 	}
 	return errNoMmap
 }
 
 func (s *segment) reap() error {
-	if s.file == nil {
+	if !s.persistent {
 		return nil
 	}
 	return errNoMmap
 }
 
 func (s *segment) unmap() error {
-	if s.file == nil {
+	if !s.persistent {
 		return nil
 	}
 	return errNoMmap

--- a/collections/persist.go
+++ b/collections/persist.go
@@ -289,7 +289,17 @@ func (c *Collection) loadShard(sh *shard, shardDir string) (uint64, error) {
 		seg.synced = used
 		sh.segs = append(sh.segs, seg)
 	}
-	c.rebuildDir(sh) // sets sh.act to the last (active) segment
+	// Fast reopen: a clean Close leaves a directory snapshot; restore from it instead
+	// of scanning every record (rebuildDir). It is validated against the loaded
+	// segment set and falls back to the full scan on any mismatch. Chained
+	// collections are excluded (their per-parent child counts would also need
+	// rebuilding); a stale snapshot in that case is discarded, not trusted.
+	if sh.childParentHash != nil {
+		os.Remove(filepath.Join(shardDir, dirSnapName))
+		c.rebuildDir(sh)
+	} else if !c.tryLoadDirSnapshot(sh, shardDir) {
+		c.rebuildDir(sh) // sets sh.act to the last (active) segment
+	}
 	// Map each sealed segment's existing sidecar directly (skip the active append target,
 	// which stays in-RAM): the reopen restores the index by mmapping it instead of
 	// re-indexing every record. A missing/invalid/stale sidecar leaves msidx nil so the
@@ -403,8 +413,23 @@ func (c *Collection) rebuildDir(sh *shard) {
 // after Close.
 func (c *Collection) Close() error {
 	var firstErr error
-	for _, sh := range c.shards {
+	for i, sh := range c.shards {
 		sh.mu.Lock()
+		// Flush every segment durable BEFORE writing the directory snapshot, so the
+		// snapshot never references bytes not yet on disk.
+		for _, seg := range sh.segs {
+			if seg != nil {
+				if err := seg.flush(); err != nil && firstErr == nil {
+					firstErr = err
+				}
+			}
+		}
+		// Persist the directory for a scan-free reopen (best effort; skipped for a
+		// chained collection -- see tryLoadDirSnapshot). Only for a persistent store.
+		if c.dir != "" && sh.childParentHash == nil {
+			shardDir := filepath.Join(c.dir, fmt.Sprintf("%d", i))
+			_ = writeDirSnapshot(sh, shardDir)
+		}
 		for _, seg := range sh.segs {
 			if seg == nil {
 				continue

--- a/collections/segment.go
+++ b/collections/segment.go
@@ -89,9 +89,14 @@ type segment struct {
 	// Persistent (mmap) segments only; nil/zero for RAM segments. See mmapseg.go.
 	// The file name is independent of the logical id (id == array index, reassigned
 	// at compaction install and on recovery), so no rename is needed when id changes.
-	file   *os.File // backing file (non-nil ⇒ mmap-backed)
-	path   string   // backing file path (for unlink on retirement)
-	synced int      // bytes msync'd to disk (the durable length); guarded by shard lock
+	// persistent marks a file-backed (mmap) segment, independent of whether its fd is
+	// currently open. It is the durable-segment predicate (flush/msync, CRC, mapped,
+	// reap-unlink) so those keep working after the fd is released. Set once at
+	// creation; immutable.
+	persistent bool
+	file       *os.File // backing fd; released (nil) right after mmap -- see mmapseg.go
+	path       string   // backing file path (for unlink on retirement)
+	synced     int      // bytes msync'd to disk (the durable length); guarded by shard lock
 
 	// Reclamation of mmap segments (RAM segments are freed by the GC once scans drop
 	// their windows). A scan pins the segments it reads; a segment retired by
@@ -118,7 +123,7 @@ type segment struct {
 // mapped reports whether the segment holds a non-GC mapping that scans must pin and reap
 // must tear down: a file-backed data mmap, or (RAM store) an anon-mmap sealed sidecar. A
 // plain RAM segment (neither) relies on the GC and skips pin/reap entirely.
-func (s *segment) mapped() bool { return s.file != nil || s.pinReap }
+func (s *segment) mapped() bool { return s.persistent || s.pinReap }
 
 // readIdx returns the segment's queryable index behind the readIndex interface: the mmap'd
 // sidecar (msidx) once the segment is sealed and converted, else the in-RAM segIndex, else
@@ -308,7 +313,7 @@ func (s *segment) append(seq uint64, next loc, key, ad []byte) (uint32, bool) {
 	copy(b[adLenOff+4:], ad)
 	// Trailing CRC over the immutable bytes (persistent segments only; recovery
 	// uses it to detect a torn tail). RAM segments never recover, so skip the cost.
-	if s.file != nil {
+	if s.persistent {
 		crcOff := adLenOff + 4 + len(ad)
 		binary.LittleEndian.PutUint32(b[crcOff:], recCRC(b, crcOff))
 	}


### PR DESCRIPTION
Two independent, self-contained steps toward running the persistent `collections` store larger than RAM (motivated by scaling analysis of the mmap-segment engine). Both are validated by the full race suite.

## 1. Release segment fds after mmap
A persistent segment kept its backing `*os.File` open for its whole life — **one open fd per live segment**. With 1 MiB default segments, a store past RAM reaches thousands of segments and exhausts the fd limit.

Nothing needs the fd after mapping: the mapping keeps the file alive on its own, writes go to the mapping, durability is `msync` (address-based), and retirement munmaps + unlinks by path. So the fd is now **closed right after `mmap`**. A new immutable `segment.persistent` flag becomes the durable-segment predicate (replacing the now-nil `file != nil` checks in flush/msync/reap/CRC/mapped).

**fd count: O(#segments) → ~0.** (The remaining segment-count pressure is VMA count — `vm.max_map_count` — for which the lever is a larger `Options.SegmentSize`.)

## 2. Skip the reopen scan on a clean shutdown
Reopen rebuilt each shard's key directory by **scanning every record** (`rebuildDir`, O(DB) I/O per startup). On a clean `Close`, each shard now writes a **directory snapshot** (`<shard>/dir.snap`: key-hash → record location, commit sequence, live count, and the segment set it covers), and `Open` restores the directory from it instead of scanning.

**It is a pure optimization, never trusted blindly:**
- **consume-once** — removed as it is read, so it is trusted only for the one reopen immediately after the clean `Close` that wrote it;
- **CRC-checked**, and validated against the **exact live segment set** (by stable file basename — array indices shift across compaction/reopen);
- **any mismatch → full `rebuildDir`**, so a stale or corrupt snapshot can only cost a scan, never correctness.

Correctness rests on one invariant: the snapshot exists *only* after a clean `Close`, which flushes every segment's supersession flags with no compaction in flight — precisely the torn/duplicate state `rebuildDir`'s crash-dedup pass exists to repair. So a clean reopen safely skips *both* the directory rebuild and the dedup pass. Chained collections (which also maintain per-parent child counts) fall back to the scan.

## Testing
- `fdrelease_test.go` — 0 open fds across many tiny segments, and full durability across reopen.
- `dirsnapshot_test.go` — a clean reopen fast-loads **every** shard with **no scan** and honors deletes; a **corrupted** snapshot makes that shard fall back to the scan and still recover every key.
- The **full `collections` race suite passes** with both changes; `db` builds + tests green; `go vet` and `gofmt -s` clean.

## Not included (next step)
The key **directory itself is still O(#keys) in RAM** (`shard.dir`), even with the snapshot — so *value* size can exceed RAM today, but *key count* cannot. Making the primary index pageable (a per-sealed-segment key sidecar, only the active segment's keys in RAM) is the larger architectural change and will come with a design proposal first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
