### PR TITLE
collections: per-segment key index in the sidecar container (pageable primary index, phase 1)

### DIFF
--- a/collections/docs/pageable-key-index.md
+++ b/collections/docs/pageable-key-index.md
@@ -1,0 +1,176 @@
+# Design: pageable primary key index (key-count past RAM)
+
+Status: proposal / RFC
+Scope: `collections` mmap-segment store (and, transitively, `db`, the collector, htcondordb)
+
+## Problem
+
+The store already keeps ad **values** and **attribute indexes** out of RAM: values
+live in demand-paged mmap segments, and a sealed segment's query index converts to a
+pageable mmap sidecar (`msidx`). So *value* footprint can exceed RAM today.
+
+What cannot exceed RAM is **key count**. Every live key has an entry in an in-RAM
+hash directory, `shard.dir map[uint64]loc` (`shard.go`), consulted by every
+`Get`/`Put`/`Delete`. At ~40–50 B/key with Go-map overhead, 100M keys ≈ 4–5 GB of
+directory that must be resident. For a store whose *working set* is small but whose
+*key count* is large (htcondordb history; a very large pool), the directory is the
+binding limit.
+
+Goal: make the primary key index **pageable**, so steady-state RAM ≈ working set
+(the active segment's keys + hot pages + per-segment filters), not O(total keys).
+
+Non-goals: changing the query/scan engine, the MVCC/seq model, or the value
+encoding. This is about *where the key→location directory lives*.
+
+## What makes this tractable: currency is already a local property
+
+A naive "page out the directory" reads like an LSM-tree conversion (sorted runs,
+newest-wins merge, tombstones). It is simpler here because of an existing invariant:
+
+> A record is **current** iff its `supersededBySeq` field == `seqMax`. When a key is
+> updated or deleted, the store marks the *old* record superseded **in place**,
+> wherever it lives — including in a sealed segment (segments stay RW-mapped for
+> exactly this).
+
+So we never need cross-segment version ordering to decide currency: at most one
+record per key is non-superseded, anywhere in the store. Finding a key's current
+value is "find the record for this key whose `supersededBySeq == seqMax`." That
+turns the problem from "merge sorted runs" into "locate the key's live record,"
+which a per-segment key index answers directly.
+
+## Design
+
+### 1. Per-sealed-segment key sidecar
+When a segment seals (a new active segment is allocated, or at compaction/close), an
+immutable **key index** is written for it: `key-hash → in-segment offset` for every
+record, a sorted `(hash, off)` array (binary search, ~12 B/key, pageable). Same
+lifecycle as the attribute-index sidecar (`msidx`): built once at seal, mmapped on
+reopen, torn down with the segment at reap. A sealed segment is immutable, so its key
+index never changes (supersession flips a bit in the segment *data*, not the index).
+
+**One sidecar file per segment.** To keep the per-segment file/inode/fd footprint at
+two (`.dat` + `.idx`) — the same budget the fd work targets — the key index does not
+get its own file; it is embedded in the existing `.idx` **container**: the attribute
+blob first (offset 0, so its roaring bitmaps stay aligned and the existing ARCX
+writer/parser — shared with the archive table type — are reused unchanged), the key
+blob second, and a 12-byte trailer with the two lengths. The container is now written
+for **every** persistent sealed segment (previously the `.idx` existed only when
+attribute indexes were configured); the attribute section is simply empty for a
+key-only collection.
+
+### 2. Per-segment Bloom filter
+A small Bloom filter per sealed segment, keyed on key-hash, bounds probe fan-out: a
+lookup only touches sidecars whose Bloom says "maybe." At ~1% FPR that is ~1.2 B/key
+(~120 MB for 100M keys) — the one structure we may keep resident, and it can itself be
+mmapped if needed. This is the RAM floor of the design, ~40× smaller than today's
+directory.
+
+### 3. RAM directory holds only the active segment
+`shard.dir` keeps entries **only for the active (unsealed) segment's keys**. When a
+segment seals, its key sidecar + Bloom are written and its keys are **evicted** from
+`shard.dir`. RAM for the directory is thus bounded by the active segment size, not
+total keys.
+
+### Read / write / delete paths
+
+- **Get(key)**: check `shard.dir` (active) → if a current record, return it. Else
+  probe sealed segments newest→oldest, Bloom-gated; for each sidecar hit, read the
+  record and check `supersededBySeq == seqMax`. The single live record wins; a key
+  whose records are all superseded (deleted, or only stale versions) is absent.
+- **Put(key)**: append the new version to the active segment; set `shard.dir[hash]`.
+  Mark the previous current record superseded — it is either in `shard.dir` (O(1)) or,
+  if the key's live version was in a sealed segment, located via the same Bloom-gated
+  sidecar probe and its `supersededBySeq` written (segments are RW-mapped; the
+  supersession write is msync'd, as tombstones already are).
+- **Delete(key)**: locate the current record (active or sealed-probe) and mark it
+  superseded; if it was in the active segment, drop it from `shard.dir`.
+- **Scan/Query**: unchanged. Scans already walk segment records via `forEachVisible`
+  (superseded-aware) and never consult `shard.dir`.
+
+### Compaction
+Unchanged in spirit (rewrite live records into fresh segments, drop superseded/dead,
+reap sources), plus: emit the key sidecar + Bloom for each destination segment, and
+keep evicted keys out of `shard.dir`. Compaction is also what bounds probe fan-out:
+it collapses a key's stale copies across segments down to one.
+
+### Reopen (subsumes the clean-shutdown snapshot)
+The per-segment key sidecars **are** a persisted per-segment directory. On reopen the
+full directory is assembled by mapping the sidecars (pageable) + scanning only the
+active segment — O(active), no full record scan. This generalizes the increment-2
+`dir.snap` (a whole-shard directory snapshot): the snapshot was the stepping stone;
+per-segment sidecars are the same idea made pageable and compaction-friendly. A
+missing/invalid sidecar for a segment falls back to scanning *that segment* (not the
+whole store) to rebuild it, mirroring how `msidx` already degrades.
+
+## RAM budget
+
+| Structure | Today | Proposed |
+| --- | --- | --- |
+| Primary directory | O(all keys), resident (~4–5 GB @ 100M) | O(active-segment keys), resident |
+| Per-segment key index | — | pageable mmap sidecar (~12 B/key) |
+| Per-segment Bloom | — | ~1.2 B/key (~120 MB @ 100M), resident or mmap |
+| Values, attr indexes | already pageable | unchanged |
+
+Net: resident RAM goes from O(all keys) to O(active keys) + O(#keys × Bloom bits),
+the latter ~40× smaller and itself pageable.
+
+## Costs and mitigations
+
+- **Write read-amplification on cold keys.** Updating/deleting a key whose live
+  version is in a sealed segment now costs a Bloom-gated sidecar probe to find the
+  old record to supersede (was O(1) via the RAM dir). Mitigation: hot keys are
+  rewritten into the active segment on update, so they stay in the RAM dir; the probe
+  cost falls only on *cold-key* mutations, which are rare in the target workloads
+  (history is append-mostly; the collector's working set fits in RAM and is
+  unaffected).
+- **Read fan-out.** A `Get` miss in the active dir probes sealed segments; Blooms cap
+  this to ~(#segments the key was ever in), which compaction keeps small.
+- **Bloom is still O(#keys) bits.** Acceptable (~40× under the directory) and
+  pageable; a stronger scheme (partitioned/hierarchical filters) is possible later.
+
+## Crash consistency
+
+Sidecars are derived data: a torn/absent sidecar is rebuilt by scanning its (single)
+segment, exactly as `msidx` degrades today. Supersession writes into sealed segments
+are already msync'd (the tombstone path). So no new durability primitive is needed;
+recovery is per-segment, not whole-store.
+
+## Phasing
+
+1. **Key sidecar format + build-at-seal + mmap-on-reopen** — DONE. The key index is
+   embedded in the always-present `.idx` container; built at seal (the Reindex pass)
+   and at Close, mapped on reopen, torn down with the segment. No eviction yet (the
+   directory is still full and authoritative); the sidecar is populated and validated
+   beside it (every record findable by hash, every live key locatable, deletes
+   honored). Also fixed a latent loader bug: `.idx`/`.kidx` sidecar names matched the
+   segment-file `Sscanf` (trailing input ignored), so sidecars were loaded as phantom
+   segments — now the loader requires an exact `.dat` suffix.
+2. **Bloom filters + sealed-segment probe** in `Get`/`Put`/`Delete`, behind the
+   existing RAM dir (dir still authoritative). Validates probe correctness against
+   the dir as an oracle.
+3. **Evict sealed keys from `shard.dir`** — the RAM win. Flip the lookup order to
+   dir-then-probe. Extensive fuzz/property tests: for every op sequence, dir+probe
+   must equal a full-scan oracle.
+4. **Retire `dir.snap`** (increment 2) in favor of per-segment sidecars.
+
+Each phase is independently shippable and testable; the RAM behavior only changes at
+phase 3.
+
+## Risks / open questions
+
+- **Probe cost under adversarial update patterns** (many cold-key updates). Needs a
+  benchmark; may motivate a small "recently-touched sealed keys" RAM cache.
+- **Bloom sizing / false-positive budget** vs probe cost — tune with real key
+  cardinalities.
+- **Interaction with chaining** (`childParentHash`) and **ordered indexes**
+  (`ordered.byKey`, itself O(#keys) RAM) — ordered indexes would need the same
+  pageable treatment to fully realize the RAM win for negotiator-style workloads;
+  out of scope here, noted as a sibling follow-up.
+- **Sidecar format stability** / versioning for on-disk compatibility.
+
+## Relationship to shipped work
+
+- Increment 1 (release fds after mmap) — orthogonal; already merged-pending (#38).
+- Increment 2 (`dir.snap` clean-shutdown snapshot) — a stepping stone this design
+  generalizes and eventually retires (phase 4).
+- This proposal (increment 3) is the one that lifts the **key-count** ceiling.

--- a/collections/keyindex.go
+++ b/collections/keyindex.go
@@ -1,0 +1,205 @@
+package collections
+
+import (
+	"encoding/binary"
+	"fmt"
+	"hash/crc32"
+	"os"
+	"sort"
+)
+
+// A key-index sidecar is a sealed segment's pageable primary-key index: for every
+// record in the segment, an entry mapping the record's key-hash to its in-segment
+// offset, sorted by hash for binary search. It lives beside the segment file as
+// <seg>.kidx, is mmapped read-only on reopen, and is torn down with the segment.
+//
+// This is phase 1 of moving the primary key directory out of RAM (see
+// docs/pageable-key-index.md): it establishes the on-disk index and the lookup path.
+// It does NOT yet replace shard.dir -- the directory is still authoritative and fully
+// resident; the sidecar is built and validated beside it. Because a record's currency
+// is a local property (supersededBySeq == seqMax), a lookup that finds a key's
+// records via the sidecar decides which is live by reading that field, with no
+// cross-segment version ordering.
+//
+// Format (little-endian):
+//
+//	magic u32 | version u16 | pad u16 | upto u32 | count u32
+//	count * { hash u64, off u32 }   (sorted by hash, then off)
+//	crc32 u32   (IEEE, over all preceding bytes)
+const (
+	keyIdxMagic     = 0x4b494458 // "KIDX"
+	keyIdxVersion   = 1
+	keyIdxHeaderLen = 16 // magic+version+pad+upto+count
+	keyIdxEntryLen  = 12 // hash u64 + off u32
+)
+
+// buildKeyIndex scans a segment's records in [0, upto) and returns the serialized key
+// sidecar: one (key-hash, offset) entry per record, sorted by hash. h must be the
+// same Hasher the directory uses, so sidecar hashes match directory hashes.
+func buildKeyIndex(data []byte, upto int, h Hasher) []byte {
+	type ent struct {
+		hash uint64
+		off  uint32
+	}
+	var ents []ent
+	for off := 0; off < upto; {
+		o := uint32(off)
+		total := recTotalLen(data, o)
+		if total == 0 {
+			break
+		}
+		ents = append(ents, ent{h.Hash(recKey(data, o)), o})
+		off += int(total)
+	}
+	sort.Slice(ents, func(i, j int) bool {
+		if ents[i].hash != ents[j].hash {
+			return ents[i].hash < ents[j].hash
+		}
+		return ents[i].off < ents[j].off
+	})
+
+	buf := make([]byte, 0, keyIdxHeaderLen+len(ents)*keyIdxEntryLen+4)
+	buf = binary.LittleEndian.AppendUint32(buf, keyIdxMagic)
+	buf = binary.LittleEndian.AppendUint16(buf, keyIdxVersion)
+	buf = binary.LittleEndian.AppendUint16(buf, 0)
+	buf = binary.LittleEndian.AppendUint32(buf, uint32(upto))
+	buf = binary.LittleEndian.AppendUint32(buf, uint32(len(ents)))
+	for _, e := range ents {
+		buf = binary.LittleEndian.AppendUint64(buf, e.hash)
+		buf = binary.LittleEndian.AppendUint32(buf, e.off)
+	}
+	buf = binary.LittleEndian.AppendUint32(buf, crc32.ChecksumIEEE(buf))
+	return buf
+}
+
+// mmapKeyIndex is a read-only view over a key sidecar's bytes (an mmap on reopen, or
+// a plain slice in tests). It holds no heap copy of the entries -- lookups binary-
+// search directly over the mapping, so a large sidecar stays pageable.
+type mmapKeyIndex struct {
+	upto  uint32
+	count uint32
+	ents  []byte // count*keyIdxEntryLen bytes, sorted by hash
+}
+
+// parseKeyIndex validates a key sidecar's bytes (magic, version, CRC, length) and
+// returns a view over them. The bytes must outlive the view (they alias the mmap).
+func parseKeyIndex(data []byte) (*mmapKeyIndex, error) {
+	if len(data) < keyIdxHeaderLen+4 {
+		return nil, fmt.Errorf("collections: key sidecar too short")
+	}
+	if binary.LittleEndian.Uint32(data) != keyIdxMagic {
+		return nil, fmt.Errorf("collections: key sidecar bad magic")
+	}
+	if v := binary.LittleEndian.Uint16(data[4:]); v != keyIdxVersion {
+		return nil, fmt.Errorf("collections: key sidecar version %d", v)
+	}
+	body := data[:len(data)-4]
+	if crc32.ChecksumIEEE(body) != binary.LittleEndian.Uint32(data[len(data)-4:]) {
+		return nil, fmt.Errorf("collections: key sidecar bad CRC")
+	}
+	upto := binary.LittleEndian.Uint32(data[8:])
+	count := binary.LittleEndian.Uint32(data[12:])
+	entStart := keyIdxHeaderLen
+	entEnd := entStart + int(count)*keyIdxEntryLen
+	if entEnd != len(body) {
+		return nil, fmt.Errorf("collections: key sidecar count %d does not match length", count)
+	}
+	return &mmapKeyIndex{upto: upto, count: count, ents: data[entStart:entEnd]}, nil
+}
+
+func (m *mmapKeyIndex) hashAt(i uint32) uint64 {
+	return binary.LittleEndian.Uint64(m.ents[i*keyIdxEntryLen:])
+}
+func (m *mmapKeyIndex) offAt(i uint32) uint32 {
+	return binary.LittleEndian.Uint32(m.ents[i*keyIdxEntryLen+8:])
+}
+
+// lookup returns the offsets of every record in the segment whose key-hash == hash
+// (a key's several versions, plus any hash collisions). The caller reads each record
+// to match the full key and pick the live one (supersededBySeq == seqMax).
+func (m *mmapKeyIndex) lookup(hash uint64) []uint32 {
+	lo, hi := uint32(0), m.count
+	for lo < hi {
+		mid := (lo + hi) / 2
+		if m.hashAt(mid) < hash {
+			lo = mid + 1
+		} else {
+			hi = mid
+		}
+	}
+	var offs []uint32
+	for i := lo; i < m.count && m.hashAt(i) == hash; i++ {
+		offs = append(offs, m.offAt(i))
+	}
+	return offs
+}
+
+// A segment sidecar container packs the (optional) attribute-index blob and the
+// key-index blob into ONE file (<seg>.idx), so a persistent segment carries a single
+// sidecar rather than two. The attribute blob is written first so it keeps offset 0 --
+// its roaring bitmaps stay aligned and the existing ARCX writer/parser (shared with
+// the archive table type) handle it unchanged; the offset-insensitive key blob
+// follows; a fixed trailer records the two lengths:
+//
+//	[attr blob (attrLen bytes; ARCX; empty when no attr index)]
+//	[key  blob (keyLen bytes; KIDX)]
+//	[attrLen u32 | keyLen u32 | containerMagic u32]   (12-byte trailer)
+const (
+	sidecarContainerMagic = 0x53434e54 // "SCNT"
+	sidecarTrailerLen     = 12
+)
+
+// buildSegmentSidecar packs an attribute-index blob (may be empty) and a key-index
+// blob into the container byte layout.
+func buildSegmentSidecar(attrBlob, keyBlob []byte) []byte {
+	b := make([]byte, 0, len(attrBlob)+len(keyBlob)+sidecarTrailerLen)
+	b = append(b, attrBlob...)
+	b = append(b, keyBlob...)
+	b = binary.LittleEndian.AppendUint32(b, uint32(len(attrBlob)))
+	b = binary.LittleEndian.AppendUint32(b, uint32(len(keyBlob)))
+	b = binary.LittleEndian.AppendUint32(b, sidecarContainerMagic)
+	return b
+}
+
+// splitSegmentSidecar returns the attribute and key sub-slices of a container, or
+// ok=false if data is not a well-formed container (bare/old sidecar, or corruption).
+func splitSegmentSidecar(data []byte) (attr, key []byte, ok bool) {
+	if len(data) < sidecarTrailerLen {
+		return nil, nil, false
+	}
+	t := data[len(data)-sidecarTrailerLen:]
+	if binary.LittleEndian.Uint32(t[8:]) != sidecarContainerMagic {
+		return nil, nil, false
+	}
+	attrLen := int(binary.LittleEndian.Uint32(t[0:]))
+	keyLen := int(binary.LittleEndian.Uint32(t[4:]))
+	if attrLen < 0 || keyLen < 0 || attrLen+keyLen+sidecarTrailerLen != len(data) {
+		return nil, nil, false
+	}
+	return data[:attrLen], data[attrLen : attrLen+keyLen], true
+}
+
+// writeFileAtomic writes b to path via a temp file + fsync + rename, so a crash never
+// leaves a torn sidecar.
+func writeFileAtomic(path string, b []byte) error {
+	tmp := path + ".tmp"
+	f, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
+	if err != nil {
+		return err
+	}
+	if _, err := f.Write(b); err != nil {
+		f.Close()
+		os.Remove(tmp)
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		f.Close()
+		os.Remove(tmp)
+		return err
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(tmp)
+		return err
+	}
+	return os.Rename(tmp, path)
+}

--- a/collections/keyindex_test.go
+++ b/collections/keyindex_test.go
@@ -1,0 +1,151 @@
+package collections
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/classad"
+)
+
+// TestKeyIndexSidecar validates phase 1 of the pageable primary index: after a clean
+// Close builds each sealed segment's key sidecar, a reopen maps it, and (a) every
+// record in a sealed segment is findable by its key-hash via the sidecar, and (b)
+// every live key's current record is locatable via the sidecars (+ the active
+// segment), matching the authoritative directory. The sidecar does not yet replace
+// the directory; this proves it is correct and ready to.
+func TestKeyIndexSidecar(t *testing.T) {
+	dir := t.TempDir()
+	open := func() *Collection {
+		c, err := Open(Options{Dir: dir, Shards: 2, SegmentSize: 4096})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return c
+	}
+	k := func(i int) []byte { return []byte(fmt.Sprintf("k%05d", i)) }
+	put := func(c *Collection, i, seq int) {
+		ad, err := classad.Parse(fmt.Sprintf(`[ Seq=%d ]`, seq))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := c.Put(k(i), ad); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	c := open()
+	for i := 0; i < 500; i++ {
+		put(c, i, i)
+	}
+	for i := 0; i < 40; i++ { // tombstones
+		c.Delete(k(i))
+	}
+	for i := 100; i < 160; i++ { // updates: supersede older versions (multi-version keys)
+		put(c, i, i+1000)
+	}
+	if err := c.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	c2 := open()
+	defer c2.Close()
+
+	// (a) Every record in every sealed segment that carries a sidecar is findable by
+	// its own key-hash, and the sidecar's coverage/count are exact.
+	sealedWithIdx := 0
+	for _, sh := range c2.shards {
+		sh.mu.RLock()
+		for _, seg := range sh.segs {
+			if seg == nil || seg == sh.act {
+				continue
+			}
+			ki := seg.keyIdx.Load()
+			if ki == nil {
+				continue
+			}
+			sealedWithIdx++
+			if int(ki.upto) != seg.used {
+				t.Fatalf("sidecar upto=%d, seg.used=%d", ki.upto, seg.used)
+			}
+			recs := 0
+			for off := 0; off < seg.used; {
+				o := uint32(off)
+				total := recTotalLen(seg.data, o)
+				if total == 0 {
+					break
+				}
+				recs++
+				offs := ki.lookup(c2.h.Hash(recKey(seg.data, o)))
+				if !containsOff(offs, o) {
+					t.Fatalf("record at off %d (key %q) missing from key sidecar", o, recKey(seg.data, o))
+				}
+				off += int(total)
+			}
+			if int(ki.count) != recs {
+				t.Fatalf("sidecar count=%d, actual records=%d", ki.count, recs)
+			}
+		}
+		sh.mu.RUnlock()
+	}
+	if sealedWithIdx == 0 {
+		t.Fatal("no sealed segment carried a key sidecar -- test is ineffective")
+	}
+	t.Logf("validated key sidecars on %d sealed segments", sealedWithIdx)
+
+	// (b) Every live key's current record is locatable via the sidecars + active
+	// segment, and deleted keys are not.
+	for i := 0; i < 500; i++ {
+		key := k(i)
+		_, live := c2.Get(key)
+		found := locateCurrentRecord(c2, key)
+		if live != found {
+			t.Fatalf("key %q: Get live=%v but sidecar-locate found=%v", key, live, found)
+		}
+	}
+}
+
+func containsOff(offs []uint32, o uint32) bool {
+	for _, x := range offs {
+		if x == o {
+			return true
+		}
+	}
+	return false
+}
+
+// locateCurrentRecord finds key's current (non-superseded) record within its shard,
+// using each sealed segment's key sidecar where present and a linear scan of a
+// sidecar-less (active) segment otherwise -- the phase-2 lookup path, exercised here
+// as a validation.
+func locateCurrentRecord(c *Collection, key []byte) bool {
+	h := c.h.Hash(key)
+	sh := c.shards[c.shardOf(key, h)]
+	sh.mu.RLock()
+	defer sh.mu.RUnlock()
+	for _, seg := range sh.segs {
+		if seg == nil {
+			continue
+		}
+		var offs []uint32
+		if ki := seg.keyIdx.Load(); ki != nil {
+			offs = ki.lookup(h)
+		} else {
+			for off := 0; off < seg.used; {
+				o := uint32(off)
+				total := recTotalLen(seg.data, o)
+				if total == 0 {
+					break
+				}
+				offs = append(offs, o)
+				off += int(total)
+			}
+		}
+		for _, o := range offs {
+			if recSuperseded(seg.data, o) == seqMax && bytes.Equal(recKey(seg.data, o), key) {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/collections/mmapseg.go
+++ b/collections/mmapseg.go
@@ -104,7 +104,7 @@ func (s *segment) reap() error {
 		if e := os.Remove(s.path); err == nil {
 			err = e
 		}
-		os.Remove(s.path + ".idx") // best-effort: drop the index snapshot with the segment
+		os.Remove(s.path + ".idx") // best-effort: drop the sidecar container with the segment
 	}
 	return err
 }

--- a/collections/persist.go
+++ b/collections/persist.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"sync"
 	"sync/atomic"
 )
@@ -240,6 +241,12 @@ func (c *Collection) loadShard(sh *shard, shardDir string) (uint64, error) {
 		if e.IsDir() {
 			continue
 		}
+		// Match segment data files only. Sscanf ignores trailing input, so a sidecar
+		// (seg-N.dX.dat.idx / .kidx) would otherwise parse as a phantom segment; require
+		// the name to end exactly in ".dat".
+		if !strings.HasSuffix(e.Name(), ".dat") {
+			continue
+		}
 		var n uint64
 		var dictID uint32
 		if _, err := fmt.Sscanf(e.Name(), "seg-%d.d%d.dat", &n, &dictID); err == nil {
@@ -304,11 +311,15 @@ func (c *Collection) loadShard(sh *shard, shardDir string) (uint64, error) {
 	// which stays in-RAM): the reopen restores the index by mmapping it instead of
 	// re-indexing every record. A missing/invalid/stale sidecar leaves msidx nil so the
 	// Reindex that follows Open rebuilds and re-seals that segment.
-	if spec := c.spec.Load(); spec != nil && spec.any() {
-		for _, seg := range sh.segs {
-			if seg != nil && seg != sh.act {
-				c.loadSealedIndex(seg, spec)
-			}
+	// Map each sealed segment's sidecar container: its key index (phase 1 of the
+	// pageable primary index, always present on a persistent segment) and, when present
+	// and matching the current spec, its attribute index. Runs regardless of whether
+	// attribute indexes are configured. A missing/invalid sidecar is left unmapped and
+	// rebuilt later; the directory stays authoritative.
+	spec := c.spec.Load()
+	for _, seg := range sh.segs {
+		if seg != nil && seg != sh.act {
+			c.loadSealedIndex(seg, spec)
 		}
 	}
 	return maxNum, nil
@@ -421,6 +432,17 @@ func (c *Collection) Close() error {
 			if seg != nil {
 				if err := seg.flush(); err != nil && firstErr == nil {
 					firstErr = err
+				}
+			}
+		}
+		// Ensure each sealed (non-active) segment has its sidecar container on disk so a
+		// reopen can map it -- the key index (phase 1 of the pageable primary index) plus
+		// any in-RAM attribute index. sealSegmentIndex is a no-op for a segment already
+		// sealed (by the Reindex pass during operation). Best effort; data is still mapped.
+		if c.dir != "" {
+			for _, seg := range sh.segs {
+				if seg != nil && seg != sh.act {
+					c.sealSegmentIndex(seg, seg.idx.Load())
 				}
 			}
 		}

--- a/collections/readindex_test.go
+++ b/collections/readindex_test.go
@@ -195,7 +195,22 @@ func TestSealedIndexBackings(t *testing.T) {
 	}
 
 	check("file", func(si *segIndex) (*mmapSegIndex, func() error, error) {
-		return sealedIndexFromFile(filepath.Join(t.TempDir(), "s.idx"), si)
+		// Bare ARCX round-trip (the attribute-index format, unchanged by the sidecar
+		// container): write, map, parse.
+		path := filepath.Join(t.TempDir(), "s.idx")
+		if err := writeSidecarIndex(path, si); err != nil {
+			return nil, nil, err
+		}
+		data, closer, err := mapFile(path)
+		if err != nil {
+			return nil, nil, err
+		}
+		mm, err := parseMmapSidecar(data)
+		if err != nil {
+			_ = closer()
+			return nil, nil, err
+		}
+		return mm, closer, nil
 	})
 	check("anon", sealedIndexAnon)
 }

--- a/collections/sealed_index.go
+++ b/collections/sealed_index.go
@@ -11,25 +11,7 @@ package collections
 // drops a segment tears down its index mapping at the same pin-drained moment (no scan reads
 // a torn mapping). The active segment keeps its mutable in-RAM segIndex.
 
-// sealedIndexFromFile writes si's sidecar to path, maps the file, and returns the read-only
-// mmap view plus an unmap closer (persistent sealed segment).
-func sealedIndexFromFile(path string, si *segIndex) (*mmapSegIndex, func() error, error) {
-	if err := writeSidecarIndex(path, si); err != nil {
-		return nil, nil, err
-	}
-	data, closer, err := mapFile(path)
-	if err != nil {
-		return nil, nil, err
-	}
-	mm, err := parseMmapSidecar(data)
-	if err != nil {
-		_ = closer()
-		return nil, nil, err
-	}
-	return mm, closer, nil
-}
-
-// snapshotPath is where a persistent segment's sidecar index lives: beside the segment file,
+// snapshotPath is where a persistent segment's sidecar lives: beside the segment file,
 // sharing its name so compaction/rotation drops it with the segment (reap unlinks it). "" for
 // a RAM segment (in-memory collection), which has no on-disk sidecar.
 func snapshotPath(seg *segment) string {
@@ -39,58 +21,81 @@ func snapshotPath(seg *segment) string {
 	return seg.path + ".idx"
 }
 
-// sealSegmentIndex converts a sealed persistent segment's in-RAM index (si) to the pageable
-// mmap sidecar: write+map the sidecar file, publish it as msidx, register its unmap with reap
-// (onReap), and drop the heap copy. Best-effort -- on any error the in-RAM index stays and
-// the segment is simply not converted this pass. No-op for a RAM segment or one already
-// sealed. Once converted the segment's index config is frozen (a later index add/drop does
-// not rebuild it; the new attribute is full-scanned via covers()=false), which is correct --
-// only less selective for that attribute on already-sealed data.
-func (c *Collection) sealSegmentIndex(seg *segment, si *segIndex) {
-	path := snapshotPath(seg)
-	if path == "" || si == nil || seg.msidx.Load() != nil {
-		return
-	}
-	mm, closer, err := sealedIndexFromFile(path, si)
+// publishSidecar maps a just-written or existing container file at path and publishes
+// its sections into the segment: keyIdx always (the primary-key sidecar, phase 1 of
+// the pageable index), and msidx when a valid attribute-index section covering the
+// segment is present. One mapping backs both, released by a single reap hook. spec, if
+// non-nil, gates the attribute section on its generation (a reopen); a nil spec accepts
+// any (a fresh seal). Returns false (unmapping) on any mismatch; the sidecar is derived,
+// so any doubt is left unpublished and rebuilt later.
+func (c *Collection) publishSidecar(seg *segment, path string, spec *indexSpec) bool {
+	data, closer, err := mapFile(path)
 	if err != nil {
-		return
+		return false
 	}
-	// CAS so a concurrent conversion of the same segment can't leak a mapping: the loser
-	// unmaps its own and bails.
-	if !seg.msidx.CompareAndSwap(nil, mm) {
+	attr, key, ok := splitSegmentSidecar(data)
+	if !ok {
 		_ = closer()
-		return
+		return false
 	}
-	seg.setOnReap(func() { _ = closer() }) // unmap the sidecar when the segment's scan pins drain (reap)
-	seg.idx.Store(nil)                     // free the heap index; readIdx now returns msidx
+	ki, err := parseKeyIndex(key)
+	if err != nil || int(ki.upto) != seg.used {
+		_ = closer()
+		return false
+	}
+	var mm *mmapSegIndex
+	if len(attr) > 0 && sidecarCRCValid(attr) {
+		if m, e := parseMmapSidecar(attr); e == nil && m != nil && int(m.upto) == seg.used && (spec == nil || m.specGen == spec.gen) {
+			mm = m
+		}
+	}
+	// keyIdx is set exactly once per seal and is the "sealed" marker; CAS so a
+	// concurrent seal cannot leak a mapping.
+	if !seg.keyIdx.CompareAndSwap(nil, ki) {
+		_ = closer()
+		return false
+	}
+	if mm != nil {
+		seg.msidx.Store(mm)
+		seg.idx.Store(nil) // free the heap attr index; readIdx now returns msidx
+	}
+	seg.setOnReapKey(func() { _ = closer() })
+	return true
 }
 
-// loadSealedIndex maps an existing on-disk sidecar for a sealed persistent segment (on Open),
-// returning true if a valid, current sidecar was mapped into msidx. A miss -- no file,
-// unreadable, bad CRC, wrong version, a different spec generation, or coverage != the
-// segment's recovered extent -- leaves msidx nil so Reindex rebuilds and re-seals it. The
-// sidecar is derived, so any doubt is a rebuild, never a wrong index.
+// sealSegmentIndex writes a sealed persistent segment's combined sidecar container --
+// the key index (always) plus the attribute index (si, if any) -- maps it, and
+// publishes both. Best-effort and idempotent: a no-op for a RAM segment or one already
+// sealed (keyIdx set), and on any error the segment is left unsealed for a later pass.
+func (c *Collection) sealSegmentIndex(seg *segment, si *segIndex) {
+	path := snapshotPath(seg)
+	if path == "" || seg.keyIdx.Load() != nil {
+		return
+	}
+	var attrBlob []byte
+	if si != nil {
+		b, err := buildSidecarIndex(si)
+		if err != nil {
+			return
+		}
+		attrBlob = b
+	}
+	container := buildSegmentSidecar(attrBlob, buildKeyIndex(seg.data, seg.used, c.h))
+	if err := writeFileAtomic(path, container); err != nil {
+		return
+	}
+	c.publishSidecar(seg, path, nil)
+}
+
+// loadSealedIndex maps a sealed persistent segment's sidecar container on Open,
+// publishing its key index (always) and, if valid and matching spec, its attribute
+// index. A miss leaves the segment unsealed so the reopen rebuilds it.
 func (c *Collection) loadSealedIndex(seg *segment, spec *indexSpec) bool {
 	path := snapshotPath(seg)
 	if path == "" {
 		return false
 	}
-	data, closer, err := mapFile(path)
-	if err != nil {
-		return false
-	}
-	if !sidecarCRCValid(data) {
-		_ = closer()
-		return false
-	}
-	mm, err := parseMmapSidecar(data)
-	if err != nil || mm == nil || mm.specGen != spec.gen || int(mm.upto) != seg.used {
-		_ = closer()
-		return false
-	}
-	seg.setOnReap(func() { _ = closer() })
-	seg.msidx.Store(mm)
-	return true
+	return c.publishSidecar(seg, path, spec)
 }
 
 // sealSegmentIndexAnon is the in-memory analogue of sealSegmentIndex: it converts a sealed

--- a/collections/segment.go
+++ b/collections/segment.go
@@ -113,6 +113,13 @@ type segment struct {
 	// reaped, so a query scanning a rotating segment never reads a torn index mapping.
 	onReap func()
 
+	// keyIdx is a sealed segment's pageable key-index sidecar (key-hash -> record
+	// offset), or nil. Phase 1 of the pageable primary index: built at seal, mmapped
+	// on reopen, torn down with the segment (onReapKey, run alongside onReap). It does
+	// not yet replace the in-RAM directory -- it is populated and validated beside it.
+	keyIdx    atomic.Pointer[mmapKeyIndex]
+	onReapKey func() // key-sidecar unmap; run with onReap at reap/close
+
 	// pinReap makes a RAM segment (file==nil) participate in pin/reap anyway, because it
 	// carries an anonymous mmap sidecar index (in-memory sealing): the anon mapping is not
 	// GC-managed, so scans must pin it and compaction/Close must unmap it via onReap, exactly
@@ -222,12 +229,24 @@ func (s *segment) setOnReap(f func()) {
 // Close uses it to unmap a segment's sidecar index without unlinking its files.
 func (s *segment) runReapHook() {
 	s.reapMu.Lock()
-	h := s.onReap
-	s.onReap = nil
+	h, hk := s.onReap, s.onReapKey
+	s.onReap, s.onReapKey = nil, nil
 	s.reapMu.Unlock()
 	if h != nil {
 		h()
 	}
+	if hk != nil {
+		hk()
+	}
+}
+
+// setOnReapKey registers the key-sidecar unmap, run with onReap when the segment is
+// reaped or unmapped. Independent of onReap so a segment can carry both an attribute
+// sidecar and a key sidecar.
+func (s *segment) setOnReapKey(f func()) {
+	s.reapMu.Lock()
+	s.onReapKey = f
+	s.reapMu.Unlock()
 }
 
 // reapAndHook reaps the segment (munmap + unlink of its data) and then runs onReap


### PR DESCRIPTION
**Stacked on #38** (fd release + clean-shutdown snapshot) — review/merge that first; this branch is based on it.

Phase 1 of moving the primary key directory out of RAM (see `collections/docs/pageable-key-index.md`, added here). It establishes an on-disk, **pageable per-segment key index** and its lookup path. The directory (`shard.dir`) is still authoritative and fully resident — this adds the sidecar *beside* it and validates it; **eviction (the actual RAM win) is a later phase**.

## What's here
- **Key index**: for every record in a sealed segment, a sorted `(key-hash, offset)` array (binary search, ~12 B/key, pageable). A record's currency is a *local* property (`supersededBySeq == seqMax`), so a lookup finds a key's records via the index and picks the live one by reading that field — no cross-segment version ordering (this is what keeps it far simpler than an LSM merge).
- **One sidecar file per segment.** Rather than a second file, the key index is embedded in the existing `.idx` as a **container**: `[attr blob (ARCX, at offset 0 so its roaring bitmaps stay aligned, reused unchanged)][key blob][12-byte trailer]`. The container is now written for *every* persistent sealed segment (previously `.idx` existed only when attribute indexes were configured); the attribute section is empty for a key-only collection. This holds the per-segment footprint at two files (`.dat` + `.idx`) — the same budget the fd work targets.
- **Lifecycle**: built at seal (the Reindex pass) and at Close; mapped on reopen (`loadSealedIndex`, now ungated by attribute-index config); one mapping backs both sections, released by a single reap hook. `sealed_index.go` reworked around a shared `publishSidecar`. The archive table type's own sidecar path is untouched (the container wraps the shared ARCX writer/parser on sub-slices).
- **Latent-bug fix**: sidecar names (`seg-N.dX.dat.idx`) matched the segment-file `Sscanf` because it ignores trailing input, so sidecars were being loaded as **phantom segments** (harmless before, but exposed by #38's segment-set validation + this change's always-present sidecar). The loader now requires an exact `.dat` suffix.

## Testing
`keyindex_test.go`: every record in a sealed segment is findable by its key-hash; every live key is locatable via the sidecars + active segment; deletes are honored. The attribute-index round-trip, suggest-indexes, dir-snapshot, fd-release, and persistence/compaction suites still pass. **Full `collections` race suite green.**

## Next (later phases, per the design doc)
Per-segment Bloom filters + sealed-segment probe in Get/Put/Delete (behind the dir as an oracle), then **evict sealed keys from `shard.dir`** — the RAM win — then retire `dir.snap`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
