### PR TITLE
ci: run PR workflows on every base branch (fix no-CI on stacked PRs)

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -8,8 +8,8 @@ name: Fuzz
 # fuzz/README.md); the rest of CI (.github/workflows/test.yml) builds without it.
 
 on:
+  # Run on every PR regardless of its base branch, so a stacked PR still gets CI.
   pull_request:
-    branches: [ main, develop ]
   push:
     branches: [ main, develop ]
   workflow_dispatch:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,8 +3,10 @@ name: Tests
 on:
   push:
     branches: [ main, develop ]
+  # Run on every PR regardless of its base branch, so a stacked PR (one based on
+  # another feature branch, not main/develop) still gets CI. Push CI stays scoped to
+  # the long-lived branches above.
   pull_request:
-    branches: [ main, develop ]
 
 jobs:
   test:


### PR DESCRIPTION
The `test` and `fuzz` workflows triggered `pull_request` only on base `main`/`develop`, so a **stacked PR** (one based on another feature branch — e.g. #39, based on #38's branch) got **no CI at all**. This drops the base-branch filter on `pull_request` so every PR is checked; `push` CI stays scoped to `main`/`develop`.

Merging this makes #39 (and any future stacked PR) start getting CI on its next push/synchronize.

🤖 Generated with [Claude Code](https://claude.com/claude-code)