### PR TITLE
collections: Bloom-gated sealed-segment probe (pageable primary index, phase 2)

### DIFF
--- a/collections/docs/pageable-key-index.md
+++ b/collections/docs/pageable-key-index.md
@@ -145,9 +145,13 @@ recovery is per-segment, not whole-store.
    honored). Also fixed a latent loader bug: `.idx`/`.kidx` sidecar names matched the
    segment-file `Sscanf` (trailing input ignored), so sidecars were loaded as phantom
    segments — now the loader requires an exact `.dat` suffix.
-2. **Bloom filters + sealed-segment probe** in `Get`/`Put`/`Delete`, behind the
-   existing RAM dir (dir still authoritative). Validates probe correctness against
-   the dir as an oracle.
+2. **Bloom filters + sealed-segment probe** — DONE. A resident per-segment key Bloom
+   (built from the key index at seal/load) gates a `shard.lookupSealed` probe that
+   locates a key's current record in the sealed segments (Bloom → key index →
+   `supersededBySeq == seqMax`). The directory is still authoritative; the probe is
+   validated against it by an oracle test (for every key: a sealed-resident record is
+   reproduced by the probe at the same location, an active-resident one is correctly
+   missed, a deleted one is not found).
 3. **Evict sealed keys from `shard.dir`** — the RAM win. Flip the lookup order to
    dir-then-probe. Extensive fuzz/property tests: for every op sequence, dir+probe
    must equal a full-scan oracle.

--- a/collections/keyindex_phase2_test.go
+++ b/collections/keyindex_phase2_test.go
@@ -1,0 +1,94 @@
+package collections
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/classad"
+)
+
+// TestSealedProbeOracle validates phase 2: the Bloom-gated sealed-segment probe
+// (lookupSealed) agrees exactly with the authoritative in-RAM directory. For every
+// key, the current record found by the directory is reproduced by the probe when it
+// lives in a sealed segment, the probe correctly misses when it lives in the active
+// segment (which it does not scan), and both miss for a deleted key. This is the
+// oracle check that lets phase 3 evict sealed keys from the directory and rely on the
+// probe instead.
+func TestSealedProbeOracle(t *testing.T) {
+	dir := t.TempDir()
+	open := func() *Collection {
+		c, err := Open(Options{Dir: dir, Shards: 4, SegmentSize: 4096})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return c
+	}
+	k := func(i int) []byte { return []byte(fmt.Sprintf("k%05d", i)) }
+	put := func(c *Collection, i, seq int) {
+		ad, err := classad.Parse(fmt.Sprintf(`[ Seq=%d ]`, seq))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := c.Put(k(i), ad); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	c := open()
+	for i := 0; i < 600; i++ {
+		put(c, i, i)
+	}
+	for i := 0; i < 50; i++ {
+		c.Delete(k(i))
+	}
+	for i := 200; i < 280; i++ { // updates: supersede older versions
+		put(c, i, i+10000)
+	}
+	if err := c.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	c2 := open()
+	defer c2.Close()
+
+	sealedN, activeN, deletedN := 0, 0, 0
+	for i := 0; i < 600; i++ {
+		key := k(i)
+		h := c2.h.Hash(key)
+		sh := c2.shards[c2.shardOf(key, h)]
+
+		sh.mu.RLock()
+		dirLoc, dirFound := sh.findCurrent(sh.dirGet(h), key)
+		probeLoc, probeFound := sh.lookupSealed(key, h)
+		act := sh.act
+		var dirSeg *segment
+		if dirFound {
+			dirSeg = sh.segs[dirLoc.seg]
+		}
+		sh.mu.RUnlock()
+
+		switch {
+		case !dirFound:
+			if probeFound {
+				t.Fatalf("key %q absent in directory but the probe found it at %v", key, probeLoc)
+			}
+			deletedN++
+		case dirSeg == act:
+			// Current record is in the active segment; the sealed-only probe must miss.
+			if probeFound {
+				t.Fatalf("key %q current in the active segment but the probe found it at %v", key, probeLoc)
+			}
+			activeN++
+		default:
+			// Current record is in a sealed segment; the probe must find it there.
+			if !probeFound || probeLoc != dirLoc {
+				t.Fatalf("key %q current at sealed %v: probe found=%v loc=%v", key, dirLoc, probeFound, probeLoc)
+			}
+			sealedN++
+		}
+	}
+	if sealedN == 0 {
+		t.Fatal("no sealed-resident keys were checked -- test is ineffective")
+	}
+	t.Logf("oracle validated: %d sealed, %d active, %d deleted keys", sealedN, activeN, deletedN)
+}

--- a/collections/sealed_index.go
+++ b/collections/sealed_index.go
@@ -55,12 +55,26 @@ func (c *Collection) publishSidecar(seg *segment, path string, spec *indexSpec) 
 		_ = closer()
 		return false
 	}
+	// Phase 2: a resident key Bloom over the segment's key-hashes, built from the key
+	// index, gates the sealed-segment probe. Published after keyIdx so a probe that
+	// observes the Bloom always finds the index behind it.
+	seg.keyBloom.Store(bloomFromKeyIndex(ki))
 	if mm != nil {
 		seg.msidx.Store(mm)
 		seg.idx.Store(nil) // free the heap attr index; readIdx now returns msidx
 	}
 	seg.setOnReapKey(func() { _ = closer() })
 	return true
+}
+
+// bloomFromKeyIndex builds a membership filter over a key index's hashes. It over-
+// counts multi-version keys (harmless; only slightly over-sizes the filter).
+func bloomFromKeyIndex(ki *mmapKeyIndex) *bloomFilter {
+	bf := newBloom(int(ki.count))
+	for i := uint32(0); i < ki.count; i++ {
+		bf.addHash(ki.hashAt(i))
+	}
+	return bf
 }
 
 // sealSegmentIndex writes a sealed persistent segment's combined sidecar container --

--- a/collections/segment.go
+++ b/collections/segment.go
@@ -120,6 +120,12 @@ type segment struct {
 	keyIdx    atomic.Pointer[mmapKeyIndex]
 	onReapKey func() // key-sidecar unmap; run with onReap at reap/close
 
+	// keyBloom is a resident membership filter over this sealed segment's key-hashes
+	// (phase 2), built from keyIdx at seal/load. It gates the sealed-segment probe so
+	// a Get miss in the active directory only touches segments that might hold the
+	// key. Nil until the segment is sealed with a key index.
+	keyBloom atomic.Pointer[bloomFilter]
+
 	// pinReap makes a RAM segment (file==nil) participate in pin/reap anyway, because it
 	// carries an anonymous mmap sidecar index (in-memory sealing): the anon mapping is not
 	// GC-managed, so scans must pin it and compaction/Close must unmap it via onReap, exactly

--- a/collections/shard.go
+++ b/collections/shard.go
@@ -233,6 +233,32 @@ func (sh *shard) get(h uint64, key []byte) ([]byte, Codec, bool) {
 	return out, seg.codec, true
 }
 
+// lookupSealed probes this shard's SEALED segments for key's current record, gated by
+// each segment's key Bloom (phase 2 of the pageable primary index). It returns the
+// record's location or (noLoc, false). Phase 2 keeps the in-RAM directory
+// authoritative; this probe is validated against it (see the oracle test) and becomes
+// the lookup path for cold keys once they are evicted from the directory. A record is
+// current iff supersededBySeq == seqMax -- a local property -- so no cross-segment
+// version ordering is needed. Caller holds at least the shard read lock.
+func (sh *shard) lookupSealed(key []byte, h uint64) (loc, bool) {
+	for _, seg := range sh.segs {
+		if seg == nil || seg == sh.act {
+			continue
+		}
+		bf := seg.keyBloom.Load()
+		ki := seg.keyIdx.Load()
+		if bf == nil || ki == nil || !bf.mayContain(h) {
+			continue
+		}
+		for _, off := range ki.lookup(h) {
+			if recSuperseded(seg.data, off) == seqMax && bytes.Equal(recKey(seg.data, off), key) {
+				return loc{seg: seg.id, off: off}, true
+			}
+		}
+	}
+	return noLoc, false
+}
+
 // segWindow is a frozen view of one segment at scan start: its immutable backing,
 // the write watermark captured under the read lock, and the codec its records
 // were compressed with.


### PR DESCRIPTION
Phase 2 of moving the primary key directory out of RAM (see `collections/docs/pageable-key-index.md`). It adds the **lookup path** that phase 3 will use once sealed keys are evicted from the directory, and validates it against the directory as an oracle. **No behavior change** — the in-RAM directory stays authoritative.

## What's here
- **Per-segment key Bloom** — a resident membership filter over a sealed segment's key-hashes, built from the key index at seal/load (reuses the existing `bloomFilter`). It gates the probe so a directory miss only touches segments that might actually hold the key.
- **`shard.lookupSealed(key, hash)`** — probes sealed segments (Bloom → key index → `supersededBySeq == seqMax`) for a key's current record. Currency is a *local* property, so there's no cross-segment version ordering.
- **Oracle test** — for every key, the probe reproduces the directory's answer for a sealed-resident record (same location), correctly **misses** an active-resident one (the probe doesn't scan the active segment), and doesn't find a deleted one. *382 sealed / 168 active / 50 deleted keys validated.* Full `collections` race suite green.

## Next (phase 3 — the RAM win)
Evict sealed keys from `shard.dir` and flip Get/Put/Delete to dir-then-probe, so resident RAM becomes O(active-segment keys) + O(Bloom bits) instead of O(all keys). This oracle test is the safety net that makes that flip trustworthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
