### PR TITLE
collections: pageable primary index phase 3 + eviction follow-ups + dead-segment reclaim

### DIFF
--- a/collections/compact.go
+++ b/collections/compact.go
@@ -34,25 +34,117 @@ const (
 	compactMinBytes = 1 << 16
 )
 
-// Compact compacts every shard whose dead-byte ratio warrants it, recompressing
-// records into the collection's current codec. It is safe to call concurrently
-// with reads and writes. Returns the number of shards compacted.
+// Compact reclaims space from superseded/deleted records. For each shard it first
+// unlinks any fully-dead segment cheaply (no rewrite), then, if the shard's dead-byte
+// ratio still warrants it, recompresses the live records into fresh segments. It is
+// safe to call concurrently with reads and writes. Returns the number of shards where
+// space was reclaimed (by either mechanism).
 func (c *Collection) Compact() int {
 	target := c.currentCodec()
 	n := 0
 	for _, sh := range c.shards {
+		// First drop any fully-dead segment cheaply (unlink, no rewrite). This reclaims a
+		// segment whose records are all superseded without copying the shard's live data,
+		// and by removing those dead bytes it can pull the shard back under the compaction
+		// threshold -- so concentrated garbage (e.g. a batch of keys all deleted) costs an
+		// unlink, and only genuinely fragmented garbage triggers the full rewrite below.
+		reclaimed := c.reclaimDeadShard(sh) > 0
 		sh.mu.RLock()
 		do := sh.shouldCompact()
 		sh.mu.RUnlock()
 		if do {
 			c.compactShard(sh, target)
 			n++
+		} else if reclaimed {
+			n++ // space was freed by unlinking dead segments, though no rewrite was needed
 		}
 	}
 	if n > 0 {
 		c.reindexAfterCompaction()
 	}
 	return n
+}
+
+// reclaimDeadShard unlinks every sealed (non-active) segment whose records are all
+// superseded (seg.dead >= seg.used), reclaiming its file/mmap/VMA/sidecar without the
+// full-shard rewrite compactShard performs. Returns the number of segments reclaimed.
+//
+// A fully-dead segment holds no current record, so nothing in the directory or the sealed
+// probe points at it as live. But its superseded records may still sit MID-CHAIN in a
+// shared hash bucket -- recNext chains are per-bucket, not per-key (shard.put links a new
+// record to the previous bucket head), so a colliding key's live record can live deeper in
+// the chain. Each dead record is therefore spliced out of its bucket chain before the
+// segment is dropped, so no surviving recNext dangles into the reaped mapping. The pageable
+// probe (forEachSealedRecord) locates records by key index, never following recNext, so
+// evicted buckets (absent from the directory) have no chain to repair.
+//
+// As with compaction, dropping superseded records raises the GC floor so an older snapshot
+// that can no longer find a key conservatively conflicts (see conflictSince), and the reap
+// is pin-aware so an in-flight scan keeps the mapping mapped until it unpins.
+func (c *Collection) reclaimDeadShard(sh *shard) int {
+	sh.mu.Lock()
+	var dead []*segment
+	for _, seg := range sh.segs {
+		if seg == nil || seg == sh.act || seg.used == 0 {
+			continue
+		}
+		if seg.dead >= int64(seg.used) {
+			dead = append(dead, seg)
+		}
+	}
+	if len(dead) == 0 {
+		sh.mu.Unlock()
+		return 0
+	}
+	deadSet := make(map[uint32]struct{}, len(dead))
+	for _, seg := range dead {
+		deadSet[seg.id] = struct{}{}
+	}
+	// Splice every dead-segment record out of its (shared) hash-bucket chain. Only buckets
+	// present in the directory are ever walked by recNext, so repair just those, once each.
+	repaired := make(map[uint64]struct{})
+	for _, seg := range dead {
+		for off := 0; off < seg.used; {
+			o := uint32(off)
+			total := recTotalLen(seg.data, o)
+			if total == 0 {
+				break
+			}
+			h := c.h.Hash(recKey(seg.data, o))
+			if _, done := repaired[h]; !done {
+				repaired[h] = struct{}{}
+				if _, ok := sh.dir[h]; ok {
+					sh.spliceDeadFromChain(h, deadSet)
+				}
+			}
+			off += int(total)
+		}
+	}
+	// Remove the dead segments from the live set and the pending-sync lists.
+	var toReap []*segment
+	for i, seg := range sh.segs {
+		if seg == nil {
+			continue
+		}
+		if _, isDead := deadSet[seg.id]; isDead {
+			if seg.retire() {
+				toReap = append(toReap, seg)
+			}
+			sh.segs[i] = nil
+		}
+	}
+	sh.dropDirtySegs(deadSet)
+	// Superseded records were dropped: raise the GC floor so a snapshot older than now that
+	// cannot find a key conservatively conflicts rather than trusting a truncated chain.
+	if sh.commitSeq > sh.gcFloor {
+		sh.gcFloor = sh.commitSeq
+	}
+	sh.mu.Unlock()
+
+	for _, seg := range toReap {
+		_ = seg.reapAndHook()
+	}
+	return len(dead)
 }
 
 // Rewrite re-encodes every live ad with the current hot set (and match closure)

--- a/collections/compact.go
+++ b/collections/compact.go
@@ -118,7 +118,11 @@ func (c *Collection) RetrainDict(sampleMax int) (int, error) {
 // segments (their fresh copies carry no index), so queries stay pruned and estimates
 // stay populated instead of silently falling back to a full scan until the next Reindex.
 func (c *Collection) reindexAfterCompaction() {
-	if c.spec.Load().any() {
+	// Reindex rebuilds the attribute indexes and, for a persistent collection, seals each
+	// compacted segment's key sidecar and evicts its keys from the directory (phase 3), so
+	// compaction re-bounds the resident directory to O(active-segment) instead of leaving
+	// the full directory it just rebuilt. Run it whenever either applies.
+	if c.spec.Load().any() || c.dir != "" {
 		c.Reindex()
 	}
 }

--- a/collections/docs/pageable-key-index.md
+++ b/collections/docs/pageable-key-index.md
@@ -184,10 +184,37 @@ recovery is per-segment, not whole-store.
 Each phase is independently shippable and testable; the RAM behavior only changes at
 phase 3.
 
+## Measured probe cost (`keyindex_probe_bench_test.go`)
+
+Benchmarked on an M2 Pro, 200k keys, resident vs evicted reading the *same* mmap sealed
+segments (so the delta is directory-hit vs probe, not RAM vs disk):
+
+| Path | Resident | Evicted (probe) | Ratio |
+| --- | --- | --- | --- |
+| `Get` | ~460 ns/op | ~690 ns/op | ~1.5× |
+| `Put` (update) | ~7.6 µs/op | ~10.9 µs/op | ~1.44× |
+
+Both are modest, and the design's premise holds: the cost falls only on *cold* keys —
+hot keys are rewritten into the active segment on update and stay directory-resident, so
+they never pay it. The evicted `Put` delta is the probe plus one extra msync of the
+superseded record's sealed region.
+
+The read fan-out sweep is the scaling watch-item: evicted `Get` is **~O(#sealed
+segments)** in cheap per-segment Bloom checks (660 ns at 16 segments → 820 ns at 200), not
+flat — a key lives in exactly one segment, so the probe consults Blooms until it finds
+that segment (~n/2 on average). Bounded and cheap at these sizes, but at extreme segment
+counts (100 GB / 8 MiB ≈ 12k segments) this per-Get Bloom scan would dominate, which is
+what motivates the partitioned/hierarchical-filter follow-up below. Bigger segments
+(fewer Blooms) are the immediate lever.
+
 ## Risks / open questions
 
-- **Probe cost under adversarial update patterns** (many cold-key updates). Needs a
-  benchmark; may motivate a small "recently-touched sealed keys" RAM cache.
+- **Probe read fan-out is O(#segments)** in Bloom checks (measured above). Fine to
+  thousands of segments; a partitioned/hierarchical filter (or a shard-level summary
+  Bloom that prunes whole segment groups) would flatten it for very large stores.
+- **Cold-key write amplification** (~1.44×, measured) — acceptable for the target
+  append-mostly workloads; a small "recently-touched sealed keys" RAM cache could absorb
+  a bursty cold-update pattern if one ever shows up.
 - **Bloom sizing / false-positive budget** vs probe cost — tune with real key
   cardinalities.
 - **Interaction with chaining** (`childParentHash`) and **ordered indexes**

--- a/collections/docs/pageable-key-index.md
+++ b/collections/docs/pageable-key-index.md
@@ -162,10 +162,23 @@ recovery is per-segment, not whole-store.
    is O(active segment), not O(all keys) -- 3% of the keys in the test. Tests: the
    probe/dir oracle, an **OCC torture test** (concurrent increments on *evicted*
    counters converge with no lost updates), evicted write-write conflict, evicted
-   snapshot isolation; full race suite green. STILL TO DO within this phase:
-   operation-time eviction (a background seal+evict pass, so a long-running process
-   realizes the win before reopen) and **compaction** eviction (compaction currently
-   rebuilds the full directory -- correct, but re-populates it until the next reopen).
+   snapshot isolation; full race suite green.
+
+   **Operation-time and compaction eviction** — DONE. A shared `sealAndEvictShard`
+   pass seals every sealed (non-active) persistent segment's key sidecar (off-lock)
+   and evicts its keys from the resident directory (under the write lock). It runs at
+   the end of `Reindex` (so a long-running process that reindexes periodically
+   realizes the win without a reopen) and, via `reindexAfterCompaction`, after every
+   compaction (so compaction's freshly-rebuilt full directory is re-bounded to
+   O(active-segment) instead of leaking back). It is safe alongside concurrent writes:
+   a write that supersedes an evicted key's sealed record re-appends it to the active
+   segment, moving its directory entry off the segment being evicted, so the eviction
+   declines to drop it. The clean-shutdown `dir.snap` already stores the live count
+   independently of the resident entries, so a Close after eviction snapshots the
+   partial directory faithfully and the reopen restores the full store through the
+   probe. Tests: operation-time eviction (Reindex drops the directory to ~3% mid-run,
+   Len/Get intact, plus a Close→reopen roundtrip over the partial snapshot) and
+   compaction eviction (Compact re-bounds the directory to ~12%).
 4. **Retire `dir.snap`** (increment 2) in favor of per-segment sidecars.
 
 Each phase is independently shippable and testable; the RAM behavior only changes at

--- a/collections/docs/pageable-key-index.md
+++ b/collections/docs/pageable-key-index.md
@@ -152,9 +152,20 @@ recovery is per-segment, not whole-store.
    validated against it by an oracle test (for every key: a sealed-resident record is
    reproduced by the probe at the same location, an active-resident one is correctly
    missed, a deleted one is not found).
-3. **Evict sealed keys from `shard.dir`** — the RAM win. Flip the lookup order to
-   dir-then-probe. Extensive fuzz/property tests: for every op sequence, dir+probe
-   must equal a full-scan oracle.
+3. **Evict sealed keys from `shard.dir`** — the RAM win. DONE (first cut). Every
+   by-key path is now dir-then-probe -- `get`, `put`/`del` (probe + supersede a
+   sealed old version), and the MVCC paths `getAt` (snapshot probe) and
+   `conflictSince` (the OCC guard also scans the sealed records, so a conflict on an
+   evicted key is still detected). Eviction happens at **reopen**, where every sealed
+   segment is indexed so no version escapes the probe (a version lives one per
+   segment; dir-chain + sealed-probe cover them all). Result: the resident directory
+   is O(active segment), not O(all keys) -- 3% of the keys in the test. Tests: the
+   probe/dir oracle, an **OCC torture test** (concurrent increments on *evicted*
+   counters converge with no lost updates), evicted write-write conflict, evicted
+   snapshot isolation; full race suite green. STILL TO DO within this phase:
+   operation-time eviction (a background seal+evict pass, so a long-running process
+   realizes the win before reopen) and **compaction** eviction (compaction currently
+   rebuilds the full directory -- correct, but re-populates it until the next reopen).
 4. **Retire `dir.snap`** (increment 2) in favor of per-segment sidecars.
 
 Each phase is independently shippable and testable; the RAM behavior only changes at

--- a/collections/index_query.go
+++ b/collections/index_query.go
@@ -89,6 +89,15 @@ func (c *Collection) Reindex() {
 			}
 		}
 	}
+	// Realize the pageable-directory RAM win now (phase 3): seal any sealed segment that
+	// still lacks a key sidecar (a key-only collection never entered the loop above) and
+	// evict every sealed segment's keys from the resident directory. Idempotent, so a
+	// segment sealed just above is only evicted here, not re-written.
+	if persistent {
+		for _, sh := range c.shards {
+			c.sealAndEvictShard(sh)
+		}
+	}
 }
 
 // usableProbe is a query Probe matched to a configured index (interned attr id,

--- a/collections/keyindex_evict_test.go
+++ b/collections/keyindex_evict_test.go
@@ -1,0 +1,127 @@
+package collections
+
+import (
+	"fmt"
+	"testing"
+)
+
+// residentDir sums the resident directory entries across all shards (the RAM the
+// pageable primary index bounds).
+func residentDir(c *Collection) int {
+	n := 0
+	for _, sh := range c.shards {
+		sh.mu.RLock()
+		n += len(sh.dir)
+		sh.mu.RUnlock()
+	}
+	return n
+}
+
+// TestOperationTimeEviction proves phase-3 eviction happens DURING operation, not only at
+// reopen: after writing enough keys to fill many sealed segments (so the directory holds
+// them all), a plain Reindex seals each sealed segment's key sidecar and evicts its keys,
+// dropping the resident directory to ~the active segment while Len and every Get stay
+// intact. Without operation-time eviction the directory would stay O(all keys) until Close.
+func TestOperationTimeEviction(t *testing.T) {
+	const n = 3000
+	dir := t.TempDir()
+	c, err := Open(Options{Dir: dir, Shards: 4, SegmentSize: 4096})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+	for i := 0; i < n; i++ {
+		if err := c.Put([]byte(fmt.Sprintf("c%05d", i)), mustAd(t, `[ N = 0 ]`)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Before eviction the directory holds (nearly) every key -- sealing/eviction has not
+	// run yet during this uninterrupted write burst.
+	if before := residentDir(c); before < n/2 {
+		t.Fatalf("directory holds %d entries before Reindex; expected close to %d (no eviction yet)", before, n)
+	}
+
+	c.Reindex() // the operation-time seal + evict pass
+
+	after := residentDir(c)
+	if after > n/4 {
+		t.Fatalf("directory holds %d entries after Reindex; expected a small active-segment fraction", after)
+	}
+	if c.Len() != n {
+		t.Fatalf("Len = %d, want %d", c.Len(), n)
+	}
+	for i := 0; i < n; i++ {
+		key := []byte(fmt.Sprintf("c%05d", i))
+		if _, ok := c.Get(key); !ok {
+			t.Fatalf("key %q missing after operation-time eviction", key)
+		}
+	}
+	t.Logf("operation-time eviction: directory %d -> %d entries for %d live keys (%.0f%%)",
+		n, after, n, 100*float64(after)/float64(n))
+
+	// Roundtrip: a clean Close now snapshots an already-partial directory (dir.snap stores
+	// the live count separately from the resident entries), and the reopen must restore the
+	// full store -- every key present, count intact -- served by the sealed probe.
+	if err := c.Close(); err != nil {
+		t.Fatal(err)
+	}
+	c2, err := Open(Options{Dir: dir, Shards: 4, SegmentSize: 4096})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c2.Close()
+	if c2.Len() != n {
+		t.Fatalf("after reopen Len = %d, want %d", c2.Len(), n)
+	}
+	for i := 0; i < n; i++ {
+		if _, ok := c2.Get([]byte(fmt.Sprintf("c%05d", i))); !ok {
+			t.Fatalf("key c%05d missing after reopen of an evicted store", i)
+		}
+	}
+}
+
+// TestCompactionEviction proves compaction re-bounds the resident directory. Compaction
+// rebuilds the full directory as it installs fresh segments; the reindex-after-compaction
+// pass must then seal those segments and evict their keys, so a long-running process that
+// compacts does not leak the directory back to O(all keys). Writes create heavy garbage
+// (each key overwritten many times) so compaction actually fires.
+func TestCompactionEviction(t *testing.T) {
+	const n = 2000
+	dir := t.TempDir()
+	c, err := Open(Options{Dir: dir, Shards: 4, SegmentSize: 4096})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+	// Write each key several times: the superseded old versions are the garbage that makes
+	// shouldCompact fire, and give the destination segments something to seal.
+	for pass := 0; pass < 6; pass++ {
+		for i := 0; i < n; i++ {
+			if err := c.Put([]byte(fmt.Sprintf("c%05d", i)), mustAd(t, fmt.Sprintf(`[ N = %d ]`, pass))); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	if got := c.Compact(); got == 0 {
+		t.Fatal("no shard compacted; test did not exercise the compaction-eviction path")
+	}
+
+	after := residentDir(c)
+	if after > n/4 {
+		t.Fatalf("directory holds %d entries after compaction; expected a small active-segment fraction (compaction re-leaked the directory)", after)
+	}
+	if c.Len() != n {
+		t.Fatalf("Len = %d, want %d", c.Len(), n)
+	}
+	for i := 0; i < n; i++ {
+		ad, ok := c.Get([]byte(fmt.Sprintf("c%05d", i)))
+		if !ok {
+			t.Fatalf("key c%05d missing after compaction eviction", i)
+		}
+		if v, _ := ad.EvaluateAttrInt("N"); v != 5 { // last pass wrote N=5
+			t.Fatalf("key c%05d = %d, want 5", i, v)
+		}
+	}
+	t.Logf("compaction eviction: directory holds %d entries for %d live keys (%.0f%%)",
+		after, n, 100*float64(after)/float64(n))
+}

--- a/collections/keyindex_phase2_test.go
+++ b/collections/keyindex_phase2_test.go
@@ -51,44 +51,39 @@ func TestSealedProbeOracle(t *testing.T) {
 	c2 := open()
 	defer c2.Close()
 
-	sealedN, activeN, deletedN := 0, 0, 0
+	// After reopen the directory holds only active-segment keys; the rest were evicted
+	// and are served by the probe. For every key the union (directory OR probe) must
+	// equal ground truth (Get), and no key may be found in both (that would be two
+	// live records). Most keys are probe-resolved (they were sealed at reopen).
+	probeN, dirN, deletedN := 0, 0, 0
 	for i := 0; i < 600; i++ {
 		key := k(i)
 		h := c2.h.Hash(key)
 		sh := c2.shards[c2.shardOf(key, h)]
 
 		sh.mu.RLock()
-		dirLoc, dirFound := sh.findCurrent(sh.dirGet(h), key)
-		probeLoc, probeFound := sh.lookupSealed(key, h)
-		act := sh.act
-		var dirSeg *segment
-		if dirFound {
-			dirSeg = sh.segs[dirLoc.seg]
-		}
+		_, dirFound := sh.findCurrent(sh.dirGet(h), key)
+		_, probeFound := sh.lookupSealed(key, h)
 		sh.mu.RUnlock()
+		_, live := c2.Get(key)
 
+		if (dirFound || probeFound) != live {
+			t.Fatalf("key %q: Get live=%v but dir=%v probe=%v", key, live, dirFound, probeFound)
+		}
+		if dirFound && probeFound {
+			t.Fatalf("key %q found in BOTH the directory and a sealed segment (two live records)", key)
+		}
 		switch {
-		case !dirFound:
-			if probeFound {
-				t.Fatalf("key %q absent in directory but the probe found it at %v", key, probeLoc)
-			}
+		case !live:
 			deletedN++
-		case dirSeg == act:
-			// Current record is in the active segment; the sealed-only probe must miss.
-			if probeFound {
-				t.Fatalf("key %q current in the active segment but the probe found it at %v", key, probeLoc)
-			}
-			activeN++
+		case probeFound:
+			probeN++
 		default:
-			// Current record is in a sealed segment; the probe must find it there.
-			if !probeFound || probeLoc != dirLoc {
-				t.Fatalf("key %q current at sealed %v: probe found=%v loc=%v", key, dirLoc, probeFound, probeLoc)
-			}
-			sealedN++
+			dirN++
 		}
 	}
-	if sealedN == 0 {
-		t.Fatal("no sealed-resident keys were checked -- test is ineffective")
+	if probeN == 0 {
+		t.Fatal("no probe-resolved keys -- eviction/probe path not exercised")
 	}
-	t.Logf("oracle validated: %d sealed, %d active, %d deleted keys", sealedN, activeN, deletedN)
+	t.Logf("phase-3 oracle: %d probe-resolved, %d directory-resident, %d deleted", probeN, dirN, deletedN)
 }

--- a/collections/keyindex_phase3_test.go
+++ b/collections/keyindex_phase3_test.go
@@ -1,0 +1,161 @@
+package collections
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+)
+
+// openEvicted opens a persistent collection, writes n counters, closes it, and
+// reopens it -- so on reopen every counter is in a sealed segment and evicted from
+// the directory (served by the sealed probe). It returns the reopened collection.
+func openEvicted(t *testing.T, n int) *Collection {
+	t.Helper()
+	dir := t.TempDir()
+	c, err := Open(Options{Dir: dir, Shards: 4, SegmentSize: 4096})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < n; i++ {
+		if err := c.Put([]byte(fmt.Sprintf("c%05d", i)), mustAd(t, `[ N = 0 ]`)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := c.Close(); err != nil {
+		t.Fatal(err)
+	}
+	c2, err := Open(Options{Dir: dir, Shards: 4, SegmentSize: 4096})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return c2
+}
+
+// TestPhase3DirectoryEvicted proves the RAM win: after reopening a store whose keys
+// are all in sealed segments, the resident directory holds only the active segment's
+// keys (~0 on a fresh reopen), not all of them, while Len (the live count) is intact.
+func TestPhase3DirectoryEvicted(t *testing.T) {
+	const n = 3000 // enough keys for many segments per shard, so the active fraction is small
+	c := openEvicted(t, n)
+	defer c.Close()
+
+	resident := 0
+	for _, sh := range c.shards {
+		sh.mu.RLock()
+		resident += len(sh.dir)
+		sh.mu.RUnlock()
+	}
+	if c.Len() != n {
+		t.Fatalf("Len = %d, want %d", c.Len(), n)
+	}
+	// The directory is bounded by the active segment (a fixed size regardless of the
+	// total key count) -- O(working set), not O(all keys). It must be a small fraction
+	// of n; the rest are served by the sealed probe.
+	if resident > n/4 {
+		t.Fatalf("directory holds %d entries for %d live keys; expected a small active-segment fraction (eviction did not happen)", resident, n)
+	}
+	t.Logf("RAM win: directory holds %d entries for %d live keys (%.0f%%)", resident, n, 100*float64(resident)/float64(n))
+}
+
+// TestTxnPhase3EvictedWriteWriteConflict: a write-write conflict on a key that was
+// evicted from the directory is still detected -- conflictSince finds the conflicting
+// version through the sealed probe.
+func TestTxnPhase3EvictedWriteWriteConflict(t *testing.T) {
+	c := openEvicted(t, 200)
+	defer c.Close()
+	key := []byte("c00100")
+
+	a := c.Begin()
+	b := c.Begin()
+	_ = txnGetInt(t, a, "c00100", "N") // reads the evicted key via the snapshot probe
+	_ = txnGetInt(t, b, "c00100", "N")
+	a.Put(key, mustAd(t, `[ N = 10 ]`))
+	b.Put(key, mustAd(t, `[ N = 20 ]`))
+	if r := a.Commit(); r.Conflicted() {
+		t.Fatalf("first commit conflicted: %+v", r)
+	}
+	if r := b.Commit(); !r.Conflicted() || len(r.Conflicts) != 1 {
+		t.Fatalf("second commit on an evicted key = %+v, want 1 conflict", r)
+	}
+	if ad, _ := c.Get(key); func() int64 { v, _ := ad.EvaluateAttrInt("N"); return v }() != 10 {
+		t.Fatal("loser's write should not have applied")
+	}
+}
+
+// TestTxnPhase3EvictedConcurrentIncrement is the OCC torture test for phase 3:
+// concurrent read-modify-write increments to counters that start EVICTED must
+// converge with no lost updates. A lost update would mean conflictSince missed a
+// write-write conflict on an evicted key (the probe's correctness), and the counter
+// would end below its increment count. Reads go through the snapshot probe (getAt).
+func TestTxnPhase3EvictedConcurrentIncrement(t *testing.T) {
+	const nCounters = 100
+	c := openEvicted(t, nCounters)
+	defer c.Close()
+
+	const workers, perWorker = 8, 300
+	want := make([]int64, nCounters)
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func(seed uint32) {
+			defer wg.Done()
+			r := seed | 1
+			for i := 0; i < perWorker; i++ {
+				r = r*1664525 + 1013904223 // deterministic LCG (reproducible, no shared rand)
+				ci := int(r>>8) % nCounters
+				ks := fmt.Sprintf("c%05d", ci)
+				kb := []byte(ks)
+				for { // retry until this increment commits
+					tx := c.Begin()
+					v := txnGetInt(t, tx, ks, "N")
+					tx.Put(kb, mustAd(t, fmt.Sprintf(`[ N = %d ]`, v+1)))
+					if !tx.Commit().Conflicted() {
+						break
+					}
+				}
+				mu.Lock()
+				want[ci]++
+				mu.Unlock()
+			}
+		}(uint32(w) + 1)
+	}
+	wg.Wait()
+
+	for i := 0; i < nCounters; i++ {
+		ad, ok := c.Get([]byte(fmt.Sprintf("c%05d", i)))
+		if !ok {
+			t.Fatalf("counter %d missing after concurrent increments", i)
+		}
+		got, _ := ad.EvaluateAttrInt("N")
+		if got != want[i] {
+			t.Fatalf("counter %d = %d, want %d -- lost update (conflictSince missed a conflict on an evicted key)", i, got, want[i])
+		}
+	}
+}
+
+// TestTxnPhase3EvictedSnapshotIsolation: a transaction that reads an evicted key sees
+// its snapshot version even after another writer updates it -- the snapshot probe
+// (getAt via lookupSealedAt) respects MVCC visibility.
+func TestTxnPhase3EvictedSnapshotIsolation(t *testing.T) {
+	c := openEvicted(t, 50)
+	defer c.Close()
+	key := []byte("c00010")
+
+	tx := c.Begin()
+	if v := txnGetInt(t, tx, "c00010", "N"); v != 0 { // pins the snapshot at the evicted version
+		t.Fatalf("initial read = %d, want 0", v)
+	}
+	// A concurrent unconditional write bumps the key.
+	if err := c.Put(key, mustAd(t, `[ N = 99 ]`)); err != nil {
+		t.Fatal(err)
+	}
+	// The transaction still sees its snapshot (0), not the new value.
+	if v := txnGetInt(t, tx, "c00010", "N"); v != 0 {
+		t.Fatalf("snapshot read after concurrent write = %d, want 0", v)
+	}
+	// A fresh read sees the update.
+	if ad, _ := c.Get(key); func() int64 { v, _ := ad.EvaluateAttrInt("N"); return v }() != 99 {
+		t.Fatal("fresh Get should see the concurrent write")
+	}
+}

--- a/collections/keyindex_probe_bench_test.go
+++ b/collections/keyindex_probe_bench_test.go
@@ -1,0 +1,130 @@
+package collections
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+)
+
+// These benchmarks quantify the pageable primary index's central cost trade (phase 3): a
+// key evicted from the resident directory is served by the Bloom-gated sealed-segment probe
+// instead of an O(1) map hit. The design doc flags probe read/write amplification as its one
+// open question; these measure it.
+//
+// openPersistProbe writes n counters into a persistent collection. With reopen=true it is
+// closed and reopened, so every sealed segment's keys are evicted from the directory and
+// lookups go through the probe; with reopen=false the keys stay directory-resident. Both
+// variants read the identical mmap sealed segments, so a resident-vs-evicted delta is purely
+// directory-hit vs probe -- not RAM vs disk.
+func openPersistProbe(b *testing.B, n, segSize int, reopen bool) (*Collection, [][]byte) {
+	b.Helper()
+	dir := b.TempDir()
+	open := func() *Collection {
+		c, err := Open(Options{Dir: dir, Shards: 8, SegmentSize: segSize})
+		if err != nil {
+			b.Fatal(err)
+		}
+		return c
+	}
+	keys := make([][]byte, n)
+	for i := range keys {
+		keys[i] = []byte(fmt.Sprintf("k%08d", i))
+	}
+	ad := mustAd(b, `[ N = 0 ]`)
+	c := open()
+	for i := 0; i < n; i++ {
+		if err := c.Put(keys[i], ad); err != nil {
+			b.Fatal(err)
+		}
+	}
+	if reopen {
+		if err := c.Close(); err != nil {
+			b.Fatal(err)
+		}
+		c = open()
+	}
+	return c, keys
+}
+
+// BenchmarkProbeGet compares Get latency for directory-resident keys against keys evicted to
+// the sealed probe, at a fixed store size. The delta is the read amplification a Get pays for
+// a key that no longer has a resident directory entry.
+func BenchmarkProbeGet(b *testing.B) {
+	const n = 200_000
+	const segSize = 256 << 10
+	for _, tc := range []struct {
+		name   string
+		reopen bool
+	}{
+		{"resident", false},
+		{"evicted", true},
+	} {
+		c, keys := openPersistProbe(b, n, segSize, tc.reopen)
+		b.Run(tc.name, func(b *testing.B) {
+			rng := rand.New(rand.NewSource(1))
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if _, ok := c.Get(keys[rng.Intn(n)]); !ok {
+					b.Fatal("unexpected miss")
+				}
+			}
+		})
+		c.Close()
+	}
+}
+
+// BenchmarkProbeGetFanout measures evicted-key Get as the sealed-segment count grows (smaller
+// segments -> more segments -> more per-segment Bloom filters to consult). The per-segment
+// Bloom gates the probe to the ~one segment that actually holds the key, so cost should stay
+// roughly flat rather than scale with segment count -- the claim that read fan-out is bounded.
+func BenchmarkProbeGetFanout(b *testing.B) {
+	const n = 200_000
+	for _, segSize := range []int{64 << 10, 256 << 10, 1 << 20} {
+		c, keys := openPersistProbe(b, n, segSize, true)
+		b.Run(fmt.Sprintf("nseg=%d", liveSegments(c)), func(b *testing.B) {
+			rng := rand.New(rand.NewSource(1))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if _, ok := c.Get(keys[rng.Intn(n)]); !ok {
+					b.Fatal("unexpected miss")
+				}
+			}
+		})
+		c.Close()
+	}
+}
+
+// BenchmarkProbeUpdateResident updates directory-resident keys: findCurrent hits the dir
+// chain, the old record is superseded in place, and the new version is appended. Write-path
+// baseline for the evicted comparison below.
+func BenchmarkProbeUpdateResident(b *testing.B) {
+	const n = 50_000
+	c, keys := openPersistProbe(b, n, 256<<10, false)
+	defer c.Close()
+	ad := mustAd(b, `[ N = 1 ]`)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := c.Put(keys[i%n], ad); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkProbeUpdateEvicted updates keys whose current version lives in a sealed segment:
+// the directory misses, so put locates the old version through the probe and supersedes it
+// there (an extra msync of the sealed region) before appending the new version. This is the
+// cold-key write amplification the pageable design trades for the RAM win. Sized so nKeys ==
+// b.N and each iteration touches a distinct still-evicted key -- a second update to a key
+// would find it directory-resident (its new version is in the active segment).
+func BenchmarkProbeUpdateEvicted(b *testing.B) {
+	c, keys := openPersistProbe(b, b.N, 256<<10, true)
+	defer c.Close()
+	ad := mustAd(b, `[ N = 1 ]`)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := c.Put(keys[i], ad); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/collections/keyindex_reclaim_test.go
+++ b/collections/keyindex_reclaim_test.go
@@ -1,0 +1,189 @@
+package collections
+
+import (
+	"fmt"
+	"testing"
+)
+
+// liveSegments counts the non-nil segments across all shards (files/mmaps/VMAs held).
+func liveSegments(c *Collection) int {
+	n := 0
+	for _, sh := range c.shards {
+		sh.mu.RLock()
+		for _, seg := range sh.segs {
+			if seg != nil {
+				n++
+			}
+		}
+		sh.mu.RUnlock()
+	}
+	return n
+}
+
+// oneBucketHasher forces every key into a single directory bucket (and, with Shards:1, a
+// single shard), so all records share one recNext chain. It makes a reclaimed segment sit
+// mid-chain for live keys, exercising spliceDeadFromChain -- the case a per-key chain would
+// never hit.
+type oneBucketHasher struct{}
+
+func (oneBucketHasher) Hash([]byte) uint64 { return 0x1234 }
+
+// TestReclaimDeadSegments: overwriting every key leaves the early segments fully superseded;
+// Compact must unlink them (fewer live segments) without a full rewrite, and every key must
+// still resolve to its latest value.
+func TestReclaimDeadSegments(t *testing.T) {
+	const n = 800
+	dir := t.TempDir()
+	c, err := Open(Options{Dir: dir, Shards: 4, SegmentSize: 4096})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+	for i := 0; i < n; i++ {
+		if err := c.Put([]byte(fmt.Sprintf("k%05d", i)), mustAd(t, `[ N = 1 ]`)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Rewrite every key: the original versions (in the early segments) all become superseded,
+	// so those segments go fully dead. The peak segment count is after the rewrite.
+	for i := 0; i < n; i++ {
+		if err := c.Put([]byte(fmt.Sprintf("k%05d", i)), mustAd(t, `[ N = 2 ]`)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	before := liveSegments(c)
+	c.Compact()
+	after := liveSegments(c)
+	if after >= before {
+		t.Fatalf("live segments %d -> %d; expected fully-dead early segments to be reclaimed", before, after)
+	}
+	if c.Len() != n {
+		t.Fatalf("Len = %d, want %d", c.Len(), n)
+	}
+	for i := 0; i < n; i++ {
+		ad, ok := c.Get([]byte(fmt.Sprintf("k%05d", i)))
+		if !ok {
+			t.Fatalf("key k%05d missing after reclaim", i)
+		}
+		if v, _ := ad.EvaluateAttrInt("N"); v != 2 {
+			t.Fatalf("key k%05d = %d, want 2", i, v)
+		}
+	}
+	t.Logf("reclaim: live segments %d -> %d for %d keys", before, after, after)
+}
+
+// TestReclaimChainSpliceForcedCollision is the correctness core: with every key in one
+// shared chain, some keys are overwritten (their old versions form fully-dead segments that
+// get reclaimed) while others stay put -- so the survivors' records sit on the far side of a
+// reclaimed, spliced segment. Every survivor and every rewritten key must still resolve, and
+// deleted keys must stay gone. A botched splice would dangle the chain or drop a live key.
+func TestReclaimChainSpliceForcedCollision(t *testing.T) {
+	dir := t.TempDir()
+	c, err := Open(Options{Dir: dir, Shards: 1, SegmentSize: 512, Hasher: oneBucketHasher{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+
+	const n = 300
+	// Interleave: even keys get many rewrites (churn -> dead segments mid-chain), odd keys
+	// are written once and left (survivors reachable only through the churned region).
+	for i := 0; i < n; i++ {
+		if err := c.Put([]byte(fmt.Sprintf("k%04d", i)), mustAd(t, `[ N = 0 ]`)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for round := 1; round <= 8; round++ {
+		for i := 0; i < n; i += 2 { // rewrite only the even keys
+			if err := c.Put([]byte(fmt.Sprintf("k%04d", i)), mustAd(t, fmt.Sprintf(`[ N = %d ]`, round))); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	// Delete a scattered handful so the absent-key path is exercised too.
+	deleted := map[int]bool{6: true, 20: true, 150: true, 298: true}
+	for i := range deleted {
+		c.Delete([]byte(fmt.Sprintf("k%04d", i)))
+	}
+
+	before := liveSegments(c)
+	c.Compact()
+	after := liveSegments(c)
+	if after >= before {
+		t.Fatalf("no segments reclaimed (%d -> %d); the splice path was not exercised", before, after)
+	}
+
+	for i := 0; i < n; i++ {
+		key := []byte(fmt.Sprintf("k%04d", i))
+		ad, ok := c.Get(key)
+		if deleted[i] {
+			if ok {
+				t.Fatalf("deleted key k%04d resurfaced after reclaim", i)
+			}
+			continue
+		}
+		if !ok {
+			t.Fatalf("live key k%04d lost after chain splice", i)
+		}
+		want := int64(0)
+		if i%2 == 0 {
+			want = 8 // last rewrite round
+		}
+		if v, _ := ad.EvaluateAttrInt("N"); v != want {
+			t.Fatalf("key k%04d = %d, want %d", i, v, want)
+		}
+	}
+	wantLen := n - len(deleted)
+	if c.Len() != wantLen {
+		t.Fatalf("Len = %d, want %d", c.Len(), wantLen)
+	}
+	t.Logf("forced-collision splice: live segments %d -> %d, %d live keys intact", before, after, wantLen)
+}
+
+// TestReclaimMVCCConflictAfterGCFloor: a transaction reads a key at an old snapshot; the key
+// is then deleted and its evidence-bearing segment reclaimed. The transaction's later commit
+// must CONFLICT (the reclaim raised the GC floor), not silently succeed on the stale read --
+// otherwise reclaim would resurrect a deleted key.
+func TestReclaimMVCCConflictAfterGCFloor(t *testing.T) {
+	dir := t.TempDir()
+	c, err := Open(Options{Dir: dir, Shards: 1, SegmentSize: 512, Hasher: oneBucketHasher{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+
+	const target = "k0000"
+	if err := c.Put([]byte(target), mustAd(t, `[ N = 7 ]`)); err != nil {
+		t.Fatal(err)
+	}
+	// Old transaction pins its snapshot by reading the key while it is still live.
+	tx := c.Begin()
+	if v := txnGetInt(t, tx, target, "N"); v != 7 {
+		t.Fatalf("snapshot read = %d, want 7", v)
+	}
+
+	// Delete the key (supersedes its only record), then churn other keys so the segment
+	// holding the target's now-superseded record goes fully dead and is reclaimed.
+	c.Delete([]byte(target))
+	for round := 0; round < 12; round++ {
+		for i := 1; i < 60; i++ {
+			if err := c.Put([]byte(fmt.Sprintf("k%04d", i)), mustAd(t, fmt.Sprintf(`[ N = %d ]`, round))); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	c.Compact()
+	if _, ok := c.Get([]byte(target)); ok {
+		t.Fatal("target should be deleted")
+	}
+
+	// The stale transaction now tries to write the key. Its snapshot predates the delete and
+	// the reclaim, so the commit must be refused.
+	tx.Put([]byte(target), mustAd(t, `[ N = 99 ]`))
+	if r := tx.Commit(); !r.Conflicted() {
+		t.Fatal("stale commit after reclaim should conflict (GC floor), but it succeeded")
+	}
+	if _, ok := c.Get([]byte(target)); ok {
+		t.Fatal("conflicted commit must not have resurrected the deleted key")
+	}
+}

--- a/collections/persist.go
+++ b/collections/persist.go
@@ -319,7 +319,13 @@ func (c *Collection) loadShard(sh *shard, shardDir string) (uint64, error) {
 	spec := c.spec.Load()
 	for _, seg := range sh.segs {
 		if seg != nil && seg != sh.act {
-			c.loadSealedIndex(seg, spec)
+			if c.loadSealedIndex(seg, spec) {
+				// Phase 3: the segment's keys are now reachable through the sealed
+				// probe, so evict them from the resident directory -- the RAM win. Safe
+				// here because loadShard runs single-threaded during Open and every
+				// sealed segment is indexed, so no version escapes the probe.
+				sh.evictSegKeys(seg)
+			}
 		}
 	}
 	return maxNum, nil

--- a/collections/sealed_index.go
+++ b/collections/sealed_index.go
@@ -101,6 +101,55 @@ func (c *Collection) sealSegmentIndex(seg *segment, si *segIndex) {
 	c.publishSidecar(seg, path, nil)
 }
 
+// sealAndEvictShard realizes the pageable-directory RAM win (phase 3) during operation,
+// not only at reopen: for every sealed (non-active) persistent segment it ensures a key
+// sidecar exists, then evicts that segment's keys from the resident directory so they are
+// served by the sealed probe instead. Without it, a long-running process keeps the full
+// directory resident until its next Close/reopen; with it, compaction and periodic Reindex
+// bring the directory back down to O(active-segment). A no-op for RAM collections, and
+// idempotent (an already-sealed/-evicted segment is skipped).
+//
+// Safe alongside concurrent writes: the active segment is never touched, and a write that
+// supersedes an evicted key's sealed record and re-appends it to the active segment moves
+// its directory entry off the segment being evicted, so the phase-C check declines to drop
+// it (dir[h].seg != seg.id). Reads/writes of an evicted key already go dir-then-probe.
+func (c *Collection) sealAndEvictShard(sh *shard) {
+	if c.dir == "" {
+		return // RAM collection: no file sidecars, the directory stays resident
+	}
+	// Phase A: snapshot the sealed persistent segments under the read lock. The active
+	// segment is skipped (still appended to); its keys stay resident.
+	sh.mu.RLock()
+	act := sh.act
+	var segs []*segment
+	for _, seg := range sh.segs {
+		if seg == nil || seg == act || seg.used == 0 {
+			continue
+		}
+		segs = append(segs, seg)
+	}
+	sh.mu.RUnlock()
+
+	// Phase B: build any missing key sidecars off-lock (file I/O). sealSegmentIndex is
+	// idempotent and folds in the attribute index if one is already built for the segment,
+	// so a segment Reindex already sealed is left untouched here.
+	for _, seg := range segs {
+		if seg.keyIdx.Load() == nil {
+			c.sealSegmentIndex(seg, seg.idx.Load())
+		}
+	}
+
+	// Phase C: evict, under the write lock, every segment now carrying a key index. A
+	// segment whose sidecar failed to build keeps its keys resident (still correct).
+	sh.mu.Lock()
+	for _, seg := range segs {
+		if seg.keyIdx.Load() != nil {
+			sh.evictSegKeys(seg)
+		}
+	}
+	sh.mu.Unlock()
+}
+
 // loadSealedIndex maps a sealed persistent segment's sidecar container on Open,
 // publishing its key index (always) and, if valid and matching spec, its attribute
 // index. A miss leaves the segment unsealed so the reopen rebuilds it.

--- a/collections/segment.go
+++ b/collections/segment.go
@@ -47,7 +47,7 @@ const (
 	noSeg  = ^uint32(0)
 	seqMax = ^uint64(0)
 
-	defaultSegmentSize = 1 << 20 // 1 MiB
+	defaultSegmentSize = 8 * (1 << 20) // 8 MiB
 )
 
 // loc identifies a record: its segment id and byte offset. It is all scalars so

--- a/collections/shard.go
+++ b/collections/shard.go
@@ -307,6 +307,62 @@ func (sh *shard) lookupSealedAt(key []byte, h uint64, s0 uint64) (loc, bool) {
 	return found, ok
 }
 
+// spliceDeadFromChain removes every record that lives in a reclaimed (dead) segment from
+// hash bucket h's recNext chain, so no surviving link dangles into the reaped mapping. The
+// bucket head is a current record and a fully-dead segment holds none, so the head is
+// normally not dead; the leading loop still advances (or clears) it defensively, since after
+// the reap the directory must not reference a removed segment. Caller holds the write lock.
+func (sh *shard) spliceDeadFromChain(h uint64, deadSet map[uint32]struct{}) {
+	isDead := func(l loc) bool { _, d := deadSet[l.seg]; return l.valid() && d }
+	head := sh.dir[h]
+	for isDead(head) {
+		head = recNext(sh.segs[head.seg].data, head.off)
+	}
+	if head != sh.dir[h] {
+		if head.valid() {
+			sh.dir[h] = head
+		} else {
+			delete(sh.dir, h)
+		}
+	}
+	for l := head; l.valid(); {
+		seg := sh.segs[l.seg]
+		nxt := recNext(seg.data, l.off)
+		orig := nxt
+		for isDead(nxt) {
+			nxt = recNext(sh.segs[nxt.seg].data, nxt.off)
+		}
+		if nxt != orig {
+			setRecNext(seg.data, l.off, nxt)
+		}
+		l = nxt
+	}
+}
+
+// dropDirtySegs removes the given segments from the pending-sync lists: their bytes are
+// being unlinked, so a later sync must not msync one. Mirrors compaction's list pruning.
+// Caller holds the write lock.
+func (sh *shard) dropDirtySegs(deadSet map[uint32]struct{}) {
+	if len(sh.dirty) > 0 {
+		kept := sh.dirty[:0]
+		for _, s := range sh.dirty {
+			if _, d := deadSet[s.id]; !d {
+				kept = append(kept, s)
+			}
+		}
+		sh.dirty = kept
+	}
+	if len(sh.dirtySup) > 0 {
+		kept := sh.dirtySup[:0]
+		for _, s := range sh.dirtySup {
+			if _, d := deadSet[s.seg.id]; !d {
+				kept = append(kept, s)
+			}
+		}
+		sh.dirtySup = kept
+	}
+}
+
 // evictSegKeys removes from the directory the entries whose current record lives in
 // seg (a just-indexed sealed segment): those keys are now reachable through the
 // sealed probe, so dropping them from the directory is the RAM win. Caller holds the

--- a/collections/shard.go
+++ b/collections/shard.go
@@ -146,6 +146,16 @@ func (sh *shard) put(h uint64, key, ad []byte, seq uint64, codec Codec) {
 		seg := sh.segs[old.seg]
 		setRecSuperseded(seg.data, old.off, seq)
 		seg.dead += int64(recTotalLen(seg.data, old.off))
+	} else if old, ok := sh.lookupSealed(key, h); ok {
+		// The key's current version lives in a sealed segment (evicted from the
+		// directory). Supersede it there so it does not remain a second live record,
+		// and flush the supersession (it lands in an already-synced region).
+		seg := sh.segs[old.seg]
+		setRecSuperseded(seg.data, old.off, seq)
+		seg.dead += int64(recTotalLen(seg.data, old.off))
+		if sh.alloc != nil {
+			sh.dirtySup = append(sh.dirtySup, supRef{seg, old.off})
+		}
 	} else {
 		sh.count++
 		// A newly-inserted chained child bumps its parent's live-child count. Re-puts
@@ -170,7 +180,11 @@ func (sh *shard) put(h uint64, key, ad []byte, seq uint64, codec Codec) {
 func (sh *shard) del(h uint64, key []byte, seq uint64) (removed, parentEmptied bool) {
 	old, ok := sh.findCurrent(sh.dirGet(h), key)
 	if !ok {
-		return false, false
+		// Not in the active directory; probe the sealed segments (evicted keys).
+		old, ok = sh.lookupSealed(key, h)
+		if !ok {
+			return false, false
+		}
 	}
 	seg := sh.segs[old.seg]
 	setRecSuperseded(seg.data, old.off, seq)
@@ -224,7 +238,9 @@ func (sh *shard) get(h uint64, key []byte) ([]byte, Codec, bool) {
 	defer sh.mu.RUnlock()
 	l, ok := sh.findCurrent(sh.dirGet(h), key)
 	if !ok {
-		return nil, nil, false
+		if l, ok = sh.lookupSealed(key, h); !ok {
+			return nil, nil, false
+		}
 	}
 	seg := sh.segs[l.seg]
 	ad := recAd(seg.data, l.off)
@@ -233,14 +249,14 @@ func (sh *shard) get(h uint64, key []byte) ([]byte, Codec, bool) {
 	return out, seg.codec, true
 }
 
-// lookupSealed probes this shard's SEALED segments for key's current record, gated by
-// each segment's key Bloom (phase 2 of the pageable primary index). It returns the
-// record's location or (noLoc, false). Phase 2 keeps the in-RAM directory
-// authoritative; this probe is validated against it (see the oracle test) and becomes
-// the lookup path for cold keys once they are evicted from the directory. A record is
-// current iff supersededBySeq == seqMax -- a local property -- so no cross-segment
-// version ordering is needed. Caller holds at least the shard read lock.
-func (sh *shard) lookupSealed(key []byte, h uint64) (loc, bool) {
+// forEachSealedRecord calls fn for every record in this shard's SEALED, indexed
+// segments whose key-hash is h and whose inline key equals key (Bloom-gated). It
+// stops early if fn returns false. This is the shared access path the by-key MVCC
+// operations use for keys that have been evicted from the directory: a key's versions
+// live one per segment, so dir-chain walking plus this cover every version (some
+// possibly twice, which is harmless -- every consumer here is find-first or an
+// idempotent predicate). Caller holds at least the shard read lock.
+func (sh *shard) forEachSealedRecord(key []byte, h uint64, fn func(seg *segment, off uint32) bool) {
 	for _, seg := range sh.segs {
 		if seg == nil || seg == sh.act {
 			continue
@@ -251,12 +267,61 @@ func (sh *shard) lookupSealed(key []byte, h uint64) (loc, bool) {
 			continue
 		}
 		for _, off := range ki.lookup(h) {
-			if recSuperseded(seg.data, off) == seqMax && bytes.Equal(recKey(seg.data, off), key) {
-				return loc{seg: seg.id, off: off}, true
+			if bytes.Equal(recKey(seg.data, off), key) {
+				if !fn(seg, off) {
+					return
+				}
 			}
 		}
 	}
-	return noLoc, false
+}
+
+// lookupSealed returns the location of key's current (non-superseded) record among
+// this shard's sealed segments, or (noLoc, false). Currency is a local property
+// (supersededBySeq == seqMax), so no cross-segment version ordering is needed.
+func (sh *shard) lookupSealed(key []byte, h uint64) (loc, bool) {
+	var found loc
+	ok := false
+	sh.forEachSealedRecord(key, h, func(seg *segment, off uint32) bool {
+		if recSuperseded(seg.data, off) == seqMax {
+			found, ok = loc{seg: seg.id, off: off}, true
+			return false
+		}
+		return true
+	})
+	return found, ok
+}
+
+// lookupSealedAt returns the location of key's record live at snapshot s0
+// (seq <= s0 < supersededBySeq) among this shard's sealed segments, or (noLoc, false).
+func (sh *shard) lookupSealedAt(key []byte, h uint64, s0 uint64) (loc, bool) {
+	var found loc
+	ok := false
+	sh.forEachSealedRecord(key, h, func(seg *segment, off uint32) bool {
+		if recSeq(seg.data, off) <= s0 && recSuperseded(seg.data, off) > s0 {
+			found, ok = loc{seg: seg.id, off: off}, true
+			return false
+		}
+		return true
+	})
+	return found, ok
+}
+
+// evictSegKeys removes from the directory the entries whose current record lives in
+// seg (a just-indexed sealed segment): those keys are now reachable through the
+// sealed probe, so dropping them from the directory is the RAM win. Caller holds the
+// write lock. Safe only once seg carries a key index (the probe can find the keys).
+func (sh *shard) evictSegKeys(seg *segment) {
+	ki := seg.keyIdx.Load()
+	if ki == nil {
+		return
+	}
+	for i := uint32(0); i < ki.count; i++ {
+		h := ki.hashAt(i)
+		if l, ok := sh.dir[h]; ok && l.seg == seg.id {
+			delete(sh.dir, h)
+		}
+	}
 }
 
 // segWindow is a frozen view of one segment at scan start: its immutable backing,

--- a/collections/store.go
+++ b/collections/store.go
@@ -25,7 +25,7 @@ type Options struct {
 	// Shards is the number of independently-locked shards; rounded up to a power
 	// of two. Default 16.
 	Shards int
-	// SegmentSize is the arena segment size in bytes. Default 1 MiB.
+	// SegmentSize is the arena segment size in bytes. Default 8 MiB.
 	SegmentSize int
 	// Hasher routes keys to shards / directory buckets. Default 64-bit FNV-1a.
 	Hasher Hasher

--- a/collections/txn.go
+++ b/collections/txn.go
@@ -48,7 +48,9 @@ func (sh *shard) getAt(h uint64, key []byte, s0 uint64) ([]byte, Codec, bool) {
 	defer sh.mu.RUnlock()
 	l, ok := sh.findVisible(sh.dirGet(h), key, s0)
 	if !ok {
-		return nil, nil, false
+		if l, ok = sh.lookupSealedAt(key, h, s0); !ok {
+			return nil, nil, false
+		}
 	}
 	seg := sh.segs[l.seg]
 	ad := recAd(seg.data, l.off)
@@ -64,21 +66,35 @@ func (sh *shard) getAt(h uint64, key []byte, s0 uint64) ([]byte, Codec, bool) {
 // after s0 (a later update or delete; delete leaves no new record, so the
 // supersede clause is what catches it). Caller holds at least the read lock.
 func (sh *shard) conflictSince(h uint64, key []byte, s0 uint64) bool {
-	hasLive := false
+	hasLive, conflict := false, false
+	// check applies the conflict test to one record; returns false to stop the scan.
+	check := func(seg *segment, off uint32) bool {
+		if recSeq(seg.data, off) > s0 {
+			conflict = true
+			return false
+		}
+		if sup := recSuperseded(seg.data, off); sup != seqMax && sup > s0 {
+			conflict = true
+			return false
+		}
+		if recSuperseded(seg.data, off) == seqMax {
+			hasLive = true
+		}
+		return true
+	}
 	for l := sh.dirGet(h); l.valid(); {
 		seg := sh.segs[l.seg]
-		if bytes.Equal(recKey(seg.data, l.off), key) {
-			if recSeq(seg.data, l.off) > s0 {
-				return true
-			}
-			if sup := recSuperseded(seg.data, l.off); sup != seqMax && sup > s0 {
-				return true
-			}
-			if recSuperseded(seg.data, l.off) == seqMax {
-				hasLive = true
-			}
+		if bytes.Equal(recKey(seg.data, l.off), key) && !check(seg, l.off) {
+			return true
 		}
 		l = recNext(seg.data, l.off)
+	}
+	// Also scan versions evicted from the directory into the sealed segments. A key's
+	// versions live one per segment, so the chain walk above plus this cover them all
+	// (an overlap is harmless -- check is an idempotent predicate).
+	sh.forEachSealedRecord(key, h, check)
+	if conflict {
+		return true
 	}
 	// A currently-absent key whose snapshot predates the last compaction: its delete
 	// evidence may have been reclaimed, so we cannot prove it was not deleted after s0.


### PR DESCRIPTION
**Retargeted to `main`.** This branch now carries three commits that were reviewed as the stacked PRs #42/#43/#44 (the latter two were merged into this branch rather than main during the stacked-merge, so they land here):

1. **Phase 3 — evict sealed keys from the directory** (the RAM win): directory becomes O(active segment). All by-key paths go dir-then-probe, including the OCC `conflictSince` guard; torture-tested (concurrent increments on evicted keys, no lost updates).
2. **Operation-time + compaction eviction** (was #43): `sealAndEvictShard` realizes the win during `Reindex` and after compaction, not only at reopen.
3. **Fully-dead segment reclaim + default 8 MiB segments** (was #44): `reclaimDeadShard` unlinks fully-superseded segments without a rewrite, splicing each dead record out of its shared hash-bucket chain first; GC-floor + pin-aware reap for MVCC safety.

Full `collections` race suite green at each step. The probe-cost benchmark stacks on top as #45.

🤖 Generated with [Claude Code](https://claude.com/claude-code)