### PR TITLE
collections: benchmark the pageable primary index probe cost

### DIFF
--- a/collections/docs/pageable-key-index.md
+++ b/collections/docs/pageable-key-index.md
@@ -184,10 +184,37 @@ recovery is per-segment, not whole-store.
 Each phase is independently shippable and testable; the RAM behavior only changes at
 phase 3.
 
+## Measured probe cost (`keyindex_probe_bench_test.go`)
+
+Benchmarked on an M2 Pro, 200k keys, resident vs evicted reading the *same* mmap sealed
+segments (so the delta is directory-hit vs probe, not RAM vs disk):
+
+| Path | Resident | Evicted (probe) | Ratio |
+| --- | --- | --- | --- |
+| `Get` | ~460 ns/op | ~690 ns/op | ~1.5× |
+| `Put` (update) | ~7.6 µs/op | ~10.9 µs/op | ~1.44× |
+
+Both are modest, and the design's premise holds: the cost falls only on *cold* keys —
+hot keys are rewritten into the active segment on update and stay directory-resident, so
+they never pay it. The evicted `Put` delta is the probe plus one extra msync of the
+superseded record's sealed region.
+
+The read fan-out sweep is the scaling watch-item: evicted `Get` is **~O(#sealed
+segments)** in cheap per-segment Bloom checks (660 ns at 16 segments → 820 ns at 200), not
+flat — a key lives in exactly one segment, so the probe consults Blooms until it finds
+that segment (~n/2 on average). Bounded and cheap at these sizes, but at extreme segment
+counts (100 GB / 8 MiB ≈ 12k segments) this per-Get Bloom scan would dominate, which is
+what motivates the partitioned/hierarchical-filter follow-up below. Bigger segments
+(fewer Blooms) are the immediate lever.
+
 ## Risks / open questions
 
-- **Probe cost under adversarial update patterns** (many cold-key updates). Needs a
-  benchmark; may motivate a small "recently-touched sealed keys" RAM cache.
+- **Probe read fan-out is O(#segments)** in Bloom checks (measured above). Fine to
+  thousands of segments; a partitioned/hierarchical filter (or a shard-level summary
+  Bloom that prunes whole segment groups) would flatten it for very large stores.
+- **Cold-key write amplification** (~1.44×, measured) — acceptable for the target
+  append-mostly workloads; a small "recently-touched sealed keys" RAM cache could absorb
+  a bursty cold-update pattern if one ever shows up.
 - **Bloom sizing / false-positive budget** vs probe cost — tune with real key
   cardinalities.
 - **Interaction with chaining** (`childParentHash`) and **ordered indexes**

--- a/collections/keyindex_probe_bench_test.go
+++ b/collections/keyindex_probe_bench_test.go
@@ -1,0 +1,130 @@
+package collections
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+)
+
+// These benchmarks quantify the pageable primary index's central cost trade (phase 3): a
+// key evicted from the resident directory is served by the Bloom-gated sealed-segment probe
+// instead of an O(1) map hit. The design doc flags probe read/write amplification as its one
+// open question; these measure it.
+//
+// openPersistProbe writes n counters into a persistent collection. With reopen=true it is
+// closed and reopened, so every sealed segment's keys are evicted from the directory and
+// lookups go through the probe; with reopen=false the keys stay directory-resident. Both
+// variants read the identical mmap sealed segments, so a resident-vs-evicted delta is purely
+// directory-hit vs probe -- not RAM vs disk.
+func openPersistProbe(b *testing.B, n, segSize int, reopen bool) (*Collection, [][]byte) {
+	b.Helper()
+	dir := b.TempDir()
+	open := func() *Collection {
+		c, err := Open(Options{Dir: dir, Shards: 8, SegmentSize: segSize})
+		if err != nil {
+			b.Fatal(err)
+		}
+		return c
+	}
+	keys := make([][]byte, n)
+	for i := range keys {
+		keys[i] = []byte(fmt.Sprintf("k%08d", i))
+	}
+	ad := mustAd(b, `[ N = 0 ]`)
+	c := open()
+	for i := 0; i < n; i++ {
+		if err := c.Put(keys[i], ad); err != nil {
+			b.Fatal(err)
+		}
+	}
+	if reopen {
+		if err := c.Close(); err != nil {
+			b.Fatal(err)
+		}
+		c = open()
+	}
+	return c, keys
+}
+
+// BenchmarkProbeGet compares Get latency for directory-resident keys against keys evicted to
+// the sealed probe, at a fixed store size. The delta is the read amplification a Get pays for
+// a key that no longer has a resident directory entry.
+func BenchmarkProbeGet(b *testing.B) {
+	const n = 200_000
+	const segSize = 256 << 10
+	for _, tc := range []struct {
+		name   string
+		reopen bool
+	}{
+		{"resident", false},
+		{"evicted", true},
+	} {
+		c, keys := openPersistProbe(b, n, segSize, tc.reopen)
+		b.Run(tc.name, func(b *testing.B) {
+			rng := rand.New(rand.NewSource(1))
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if _, ok := c.Get(keys[rng.Intn(n)]); !ok {
+					b.Fatal("unexpected miss")
+				}
+			}
+		})
+		c.Close()
+	}
+}
+
+// BenchmarkProbeGetFanout measures evicted-key Get as the sealed-segment count grows (smaller
+// segments -> more segments -> more per-segment Bloom filters to consult). The per-segment
+// Bloom gates the probe to the ~one segment that actually holds the key, so cost should stay
+// roughly flat rather than scale with segment count -- the claim that read fan-out is bounded.
+func BenchmarkProbeGetFanout(b *testing.B) {
+	const n = 200_000
+	for _, segSize := range []int{64 << 10, 256 << 10, 1 << 20} {
+		c, keys := openPersistProbe(b, n, segSize, true)
+		b.Run(fmt.Sprintf("nseg=%d", liveSegments(c)), func(b *testing.B) {
+			rng := rand.New(rand.NewSource(1))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if _, ok := c.Get(keys[rng.Intn(n)]); !ok {
+					b.Fatal("unexpected miss")
+				}
+			}
+		})
+		c.Close()
+	}
+}
+
+// BenchmarkProbeUpdateResident updates directory-resident keys: findCurrent hits the dir
+// chain, the old record is superseded in place, and the new version is appended. Write-path
+// baseline for the evicted comparison below.
+func BenchmarkProbeUpdateResident(b *testing.B) {
+	const n = 50_000
+	c, keys := openPersistProbe(b, n, 256<<10, false)
+	defer c.Close()
+	ad := mustAd(b, `[ N = 1 ]`)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := c.Put(keys[i%n], ad); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkProbeUpdateEvicted updates keys whose current version lives in a sealed segment:
+// the directory misses, so put locates the old version through the probe and supersedes it
+// there (an extra msync of the sealed region) before appending the new version. This is the
+// cold-key write amplification the pageable design trades for the RAM win. Sized so nKeys ==
+// b.N and each iteration touches a distinct still-evicted key -- a second update to a key
+// would find it directory-resident (its new version is in the active segment).
+func BenchmarkProbeUpdateEvicted(b *testing.B) {
+	c, keys := openPersistProbe(b, b.N, 256<<10, true)
+	defer c.Close()
+	ad := mustAd(b, `[ N = 1 ]`)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := c.Put(keys[i], ad); err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
Validates the pageable primary index's one open design question: what does a directory-**evicted** key cost when served by the Bloom-gated sealed-segment probe instead of an O(1) directory hit?

resident vs evicted read the **same** mmap sealed segments (reopen evicts the keys; no-reopen leaves them directory-resident), so the delta is purely directory-hit vs probe — not RAM vs disk.

| Path | Resident | Evicted (probe) | Ratio |
| --- | --- | --- | --- |
| `Get` | ~460 ns/op | ~690 ns/op | ~1.5× |
| `Put` (update) | ~7.6 µs/op | ~10.9 µs/op | ~1.44× |

(M2 Pro, 200k/50k keys.) Both modest, and the cost falls **only on cold keys** — hot keys are rewritten into the active segment on update and stay resident, never paying it. The evicted `Put` delta is the probe plus one extra msync of the superseded record's sealed region.

**The scaling watch-item** (fan-out sweep): evicted `Get` is **~O(#sealed segments)** in cheap per-segment Bloom checks (660 ns at 16 segments → 820 ns at 200), because a key lives in exactly one segment and the probe consults Blooms until it finds it. Bounded and cheap to thousands of segments; at ~12k segments (100 GB / 8 MiB) the per-Get Bloom scan would dominate — which is what motivates the partitioned/hierarchical-filter follow-up now written up in the design doc. Bigger segments (fewer Blooms) are the immediate lever.

Bench-and-docs only; no production code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)