### PR TITLE
collections: serialize forwarded strings with old-ClassAd rules

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -119,6 +119,64 @@ func AppendQuoteStringBytes(dst, s []byte) []byte {
 	return append(dst, '"')
 }
 
+// AppendQuoteStringOld quotes s as an OLD-ClassAd string literal: it wraps s in
+// double quotes and escapes ONLY an embedded double-quote (as \"). A backslash is
+// emitted literally, because old-ClassAd string lexing (C++
+// Lexer::tokenizeStringOld) does no escape processing and treats every backslash
+// as a literal character -- so this is the exact inverse of that lexer (and of
+// the collections old-ClassAd ingest fast path).
+//
+// This is the correct serialization for values sent over the wire in old-ClassAd
+// form, e.g. a collector forwarding a startd ad whose OSIssue is the two bytes
+// `\` `S`. Using the new-ClassAd quoter (AppendQuoteString) there would double
+// the backslash to `\\` on every hop, and for a value ending in a backslash would
+// emit an unterminated string the receiver rejects (a forwarding connection
+// reset). A value ending in a lone backslash, or containing a backslash
+// immediately before a quote, cannot be represented unambiguously in old-ClassAd
+// at all -- the same inherent limitation C++ has; such values do not occur in the
+// machine/job ads this serves.
+func AppendQuoteStringOld(dst []byte, s string) []byte {
+	dst = append(dst, '"')
+	if strings.IndexByte(s, '"') < 0 {
+		dst = append(dst, s...)
+		return append(dst, '"')
+	}
+	for i := 0; i < len(s); i++ {
+		if s[i] == '"' {
+			dst = append(dst, '\\', '"')
+		} else {
+			dst = append(dst, s[i])
+		}
+	}
+	return append(dst, '"')
+}
+
+// AppendQuoteStringOldBytes is AppendQuoteStringOld for a value already in a byte
+// slice (e.g. a string literal's bytes inside a wire buffer), quoting it without
+// first copying it into a Go string.
+func AppendQuoteStringOldBytes(dst, s []byte) []byte {
+	dst = append(dst, '"')
+	q := -1
+	for i := 0; i < len(s); i++ {
+		if s[i] == '"' {
+			q = i
+			break
+		}
+	}
+	if q < 0 {
+		dst = append(dst, s...)
+		return append(dst, '"')
+	}
+	for i := 0; i < len(s); i++ {
+		if s[i] == '"' {
+			dst = append(dst, '\\', '"')
+		} else {
+			dst = append(dst, s[i])
+		}
+	}
+	return append(dst, '"')
+}
+
 // appendEscapedRune appends one rune of a string value using only the escapes the
 // lexer decodes (\b \f \n \r \t \\ \"), octal (\NNN) for other control characters,
 // and the rune verbatim otherwise. Shared by the string and []byte quoters.

--- a/ast/quote_old_test.go
+++ b/ast/quote_old_test.go
@@ -1,0 +1,29 @@
+package ast
+
+import "testing"
+
+func TestAppendQuoteStringOld(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{``, `""`},
+		{`plain`, `"plain"`},
+		{`X86_64`, `"X86_64"`},
+		// The agetty escape from /etc/issue: two bytes, backslash and S. Old-ClassAd
+		// keeps the backslash literal -- it must NOT double to \\S.
+		{"\\S", `"\S"`},
+		{"C:\\Users\\me", `"C:\Users\me"`},   // literal backslashes preserved
+		{"a\\r\\l\\m", `"a\r\l\m"`},          // more agetty escapes, all literal
+		{`he said "hi"`, `"he said \"hi\""`}, // embedded quote escaped as \"
+		{"back\\slash and \"q\"", `"back\slash and \"q\""`},
+	}
+	for _, c := range cases {
+		if got := string(AppendQuoteStringOld(nil, c.in)); got != c.want {
+			t.Errorf("AppendQuoteStringOld(%q) = %s, want %s", c.in, got, c.want)
+		}
+		if got := string(AppendQuoteStringOldBytes(nil, []byte(c.in))); got != c.want {
+			t.Errorf("AppendQuoteStringOldBytes(%q) = %s, want %s", c.in, got, c.want)
+		}
+	}
+}

--- a/collections/forward_oldclassad_test.go
+++ b/collections/forward_oldclassad_test.go
@@ -1,0 +1,42 @@
+package collections
+
+import (
+	"strings"
+	"testing"
+
+	classad "github.com/PelicanPlatform/classad/classad"
+)
+
+// TestForwardOldClassAdBackslashLiteral guards the collector's forwarding path.
+// A startd ad's OSIssue = "\S" (backslash-S, the agetty /etc/issue escape) is,
+// in old-ClassAd, the two bytes `\` and `S`. When the collector forwards the ad
+// it must re-serialize that value with old-ClassAd rules (backslash literal), not
+// new-ClassAd rules (which double it to "\\S"). The doubling corrupts the value
+// on every hop and, for a value ending in a backslash, produces an unterminated
+// string the receiving daemon rejects -- surfacing as forwarding connection
+// resets. See ast.AppendQuoteStringOld.
+func TestForwardOldClassAdBackslashLiteral(t *testing.T) {
+	in := "MyType = \"Machine\"\nName = \"x\"\nOSIssue = \"\\S\"\n"
+
+	c := New(Options{Shards: 1})
+	if err := c.UpdateOld([]OldAdUpdate{{Key: []byte("k"), Text: in}}); err != nil {
+		t.Fatalf("UpdateOld: %v", err)
+	}
+
+	var line string
+	for ra := range c.ScanRaw() {
+		for _, e := range ra.Exprs {
+			if strings.HasPrefix(string(e), "OSIssue ") {
+				line = string(e)
+			}
+		}
+		break
+	}
+	if want := `OSIssue = "\S"`; line != want {
+		t.Errorf("forwarded OSIssue = %q, want %q (backslash must stay literal)", line, want)
+	}
+	// The forwarded ad must re-parse, or a downstream would reset the connection.
+	if _, err := classad.ParseOld(line + "\n"); err != nil {
+		t.Errorf("forwarded line does not re-parse: %v", err)
+	}
+}

--- a/collections/rawdecode.go
+++ b/collections/rawdecode.go
@@ -177,7 +177,7 @@ func appendWireValue(dst, node []byte, table *wire.InternTable) ([]byte, error) 
 	// String literals are the most common non-numeric attribute value; quote their
 	// bytes straight from the wire (no string copy) before the general literal path.
 	if s, ok := wire.StringLiteralValue(node); ok {
-		return ast.AppendQuoteStringBytes(dst, s), nil
+		return ast.AppendQuoteStringOldBytes(dst, s), nil
 	}
 	if lit, ok := wire.LiteralValue(node); ok {
 		switch lit.Kind {
@@ -186,7 +186,7 @@ func appendWireValue(dst, node []byte, table *wire.InternTable) ([]byte, error) 
 		case wire.LitReal:
 			return strconv.AppendFloat(dst, lit.Real, 'g', -1, 64), nil
 		case wire.LitString:
-			return ast.AppendQuoteString(dst, lit.Str), nil
+			return ast.AppendQuoteStringOld(dst, lit.Str), nil
 		case wire.LitBool:
 			if lit.Bool {
 				return append(dst, "true"...), nil


### PR DESCRIPTION
collections: serialize forwarded strings with old-ClassAd rules

The collector's forwarding path (RawAd, via Collection.QueryRaw/ScanRaw
-> appendWireValue) rendered string attribute values with the new-ClassAd
quoter (ast.AppendQuoteString), which escapes a backslash as `\\`. But
the wire form it produces is OLD-ClassAd, whose string lexing treats a
backslash as a literal character (Lexer::tokenizeStringOld). So a startd
ad's `OSIssue = "\S"` -- the two bytes `\` and `S` from the agetty
/etc/issue escapes -- was forwarded as `OSIssue = "\\S"`.

This is the send-side twin of the ingest fix: it corrupts the value by
doubling the backslash on every hop, and for a value that ends in a
backslash the doubled `\\` before the closing quote makes the string
unterminated, so the receiving daemon rejects the ad and the forwarding
connection resets.

Add ast.AppendQuoteStringOld / AppendQuoteStringOldBytes -- old-ClassAd
string quoting that escapes only an embedded double-quote (`\"`) and
keeps backslashes literal, the exact inverse of the old-ClassAd lexer and
the collections ingest fast path -- and use them in appendWireValue for
both the wire string-literal and the LitString cases. Both collector
store backends forward through this path (the db backend's QueryRaw
delegates to collections).

Note: classad.MarshalOld still uses new-ClassAd string quoting via
Value.String(); it is not on the forwarding path (it backs snapshots and
client-facing output) and is left for a separate change.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
