### PR TITLE
dbrpc: require DAEMON authorization for all admin/maintenance actions

### DIFF
--- a/dbrpc/diag.go
+++ b/dbrpc/diag.go
@@ -66,33 +66,33 @@ func (s *Server) diagJSON(t *db.DB) ([]byte, error) {
 //	truncate                          remove every ad (DAEMON-only, DB-wide locked)
 //	backup.key                        export the backup key, hex (DAEMON-only escrow key)
 func (s *Server) admin(t *db.DB, action string, args []string, privileged bool) (string, error) {
+	// Every admin action mutates storage policy or physical layout -- indexes, the hot
+	// set, the codec dictionary, compaction, encryption policy, truncation. These are
+	// administrative operations in HTCondor's model, so the whole table is DAEMON-gated:
+	// an ordinary WRITE-level session may read and write ads but must not retune or
+	// restructure the store. (dispatch already blocks opAdmin on READ-level connections;
+	// this additionally blocks WRITE-level ones. Read-only diagnostics use opDiag and are
+	// unaffected.) Authorize before touching args so action existence is not probed.
+	if !privileged {
+		return "", fmt.Errorf("admin action %q requires DAEMON authorization", action)
+	}
 	switch action {
 	case "encrypt.set":
-		// Changing which attributes are encrypted at rest is a security-policy change,
-		// so it is DAEMON-level -- refused even to an ordinary writer. args is the new
-		// explicit set (private attributes are always encrypted regardless). An empty
-		// args clears the explicit set.
-		if !privileged {
-			return "", fmt.Errorf("encrypt.set requires DAEMON authorization")
-		}
+		// Changing which attributes are encrypted at rest is a security-policy change.
+		// args is the new explicit set (private attributes are always encrypted
+		// regardless). An empty args clears the explicit set.
 		if err := t.SetEncryptedAttrs(args); err != nil {
 			return "", err
 		}
 		return "encrypted attributes: " + join(t.EncryptedAttrNames()), nil
 	case "truncate":
-		// Removing every ad is a destructive, DB-wide-locked operation -- DAEMON-level.
-		if !privileged {
-			return "", fmt.Errorf("truncate requires DAEMON authorization")
-		}
+		// Removing every ad is a destructive, DB-wide-locked operation.
 		t.Truncate()
 		return "database truncated", nil
 	case "backup.key":
 		// Export the backup key (hex) so an operator can escrow it and decrypt/restore
-		// encrypted snapshots without the pool keys. DAEMON-only: it is a secret that
-		// opens every backup. It is NOT the live-data key and cannot read the store.
-		if !privileged {
-			return "", fmt.Errorf("backup.key requires DAEMON authorization")
-		}
+		// encrypted snapshots without the pool keys: a secret that opens every backup. It
+		// is NOT the live-data key and cannot read the store.
 		k := t.BackupKey()
 		if k == nil {
 			return "", fmt.Errorf("encryption at rest is not enabled")
@@ -263,13 +263,16 @@ func (c *Client) MatchExplain(ctx context.Context, reqTable, jobSelector, resTab
 	return &ex, nil
 }
 
-// Admin runs a management action (index/hot-set) on the default table.
+// Admin runs a management action (index/hot-set) on the default table. Requires a
+// DAEMON-authorized connection (see AdminTable).
 func (c *Client) Admin(ctx context.Context, action string, args ...string) (string, error) {
 	return c.AdminTable(ctx, DefaultTable, action, args...)
 }
 
 // AdminTable runs a management action on the named table; it returns the server's
-// human-readable result. Refused on a read-only connection.
+// human-readable result. Every admin action retunes or restructures the store, so it
+// requires DAEMON authorization -- refused on read-only and ordinary read-write
+// connections alike.
 func (c *Client) AdminTable(ctx context.Context, table, action string, args ...string) (string, error) {
 	status, body, err := c.callCtx(ctx, func(id uint64) []byte {
 		b := putStr(putStr(req(id, opAdmin), table), action)

--- a/dbrpc/diag_test.go
+++ b/dbrpc/diag_test.go
@@ -7,8 +7,22 @@ import (
 	"github.com/PelicanPlatform/classad/db"
 )
 
+// adminPair returns a client on a DAEMON-privileged connection (admin actions require it).
+func adminPair(t *testing.T) (*Client, func()) {
+	t.Helper()
+	d, err := db.Open("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := NewServer(d)
+	cconn, sconn := netPipe()
+	go func() { _ = s.ServeConnOpts(sconn, ServeOptions{Privileged: true}) }()
+	c := NewClient(cconn)
+	return c, func() { c.Close(); s.Close(); d.Close() }
+}
+
 func TestDiagnosticsAndAdmin(t *testing.T) {
-	c, cleanup := testPair(t)
+	c, cleanup := adminPair(t)
 	defer cleanup()
 
 	tx, _ := c.Begin(context.Background())
@@ -94,6 +108,56 @@ func TestDiagnosticsAndAdmin(t *testing.T) {
 	}
 	if rows, err := c.Query(context.Background(), "Owner == \"alice\""); err != nil || len(rows) != 1 {
 		t.Fatalf("after rewrite/compact Query = %v,%v want 1 row", rows, err)
+	}
+}
+
+// TestAdminRefusedUnprivileged is the regression for the admin-authz gap: a WRITE-level
+// session (not read-only, but not DAEMON-privileged) can read and write ads but must NOT
+// be able to retune or restructure the store. Every maintenance/optimization action is
+// refused, while ordinary data writes and read-only diagnostics still work.
+func TestAdminRefusedUnprivileged(t *testing.T) {
+	c, cleanup := testPair(t) // ServeConn default: WRITE-level, not Privileged
+	defer cleanup()
+
+	// A normal data write succeeds on this connection.
+	tx, _ := c.Begin(context.Background())
+	if err := tx.NewClassAd(context.Background(), "1", "Owner = \"alice\""); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Commit(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	// Every admin action is refused for a non-DAEMON writer.
+	for _, tc := range []struct {
+		action string
+		args   []string
+	}{
+		{"index.add.categorical", []string{"Owner"}},
+		{"index.add.value", []string{"Cpus"}},
+		{"index.drop", []string{"Owner"}},
+		{"index.reindex", nil},
+		{"compact", nil},
+		{"rewrite", nil},
+		{"codec.retrain", nil},
+		{"hot.add", []string{"Owner"}},
+		{"hot.refresh", []string{"100", "8"}},
+		{"encrypt.set", []string{"Owner"}},
+		{"truncate", nil},
+		{"backup.key", nil},
+	} {
+		if _, err := c.Admin(context.Background(), tc.action, tc.args...); err == nil {
+			t.Errorf("admin %q on a WRITE-level connection should be refused", tc.action)
+		}
+	}
+
+	// Read-only diagnostics remain available to a non-privileged session.
+	if _, err := c.Diagnostics(context.Background()); err != nil {
+		t.Fatalf("Diagnostics should work for a WRITE-level session: %v", err)
+	}
+	// And the data write actually landed (proving the connection is functional, not blanket-denied).
+	if rows, err := c.Query(context.Background(), `Owner == "alice"`); err != nil || len(rows) != 1 {
+		t.Fatalf("data write/read should work: rows=%v err=%v", rows, err)
 	}
 }
 

--- a/dbrpc/server.go
+++ b/dbrpc/server.go
@@ -123,10 +123,12 @@ type ServeOptions struct {
 	// under-privileged peer never learns claim ids and other secrets.
 	IncludePrivate bool
 
-	// Privileged admits the DAEMON-level administrative actions -- those that change
-	// security or durability policy (e.g. the encryption toggle), as opposed to the
-	// ordinary WRITE-level admin actions (index/hot/compact) that any writer may run.
-	// When false, a privileged action is refused even on a read-write connection.
+	// Privileged admits the DAEMON-level administrative actions -- ALL of the admin
+	// table (index/hot/compact/rewrite/codec.retrain, plus the security/durability ones
+	// like the encryption toggle and truncate). These retune or restructure the store,
+	// so an ordinary WRITE-level session (which may read and write ads) is refused them;
+	// only a DAEMON peer sets this true. Read-only diagnostics are a separate opcode and
+	// are not gated here.
 	Privileged bool
 }
 


### PR DESCRIPTION
The admin action table gated only the security/durability actions (`encrypt.set`, `truncate`, `backup.key`) on the connection's DAEMON privilege. The maintenance/optimization actions — `index.add`/`drop`, `index.reindex`, `compact`, `rewrite`, `codec.retrain`, `hot.add`, `hot.refresh` — had **no** guard, so any **WRITE-level** session (an ordinary authenticated client, e.g. an unprivileged htcondordb CLI user) could retune and restructure the store. `dispatch()` already refuses `opAdmin` on a READ-only connection, so READ was blocked but WRITE was not.

**Fix (altitude-correct):** every action reachable through `admin()` mutates storage policy or physical layout; read-only diagnostics use a separate opcode (`opDiag`). So gate the **whole table** with a single top-level `if !privileged` check rather than scattering per-action guards — a newly added admin action can no longer forget it. `ServeOptions.Privileged` is true only for a DAEMON-authenticated peer (htcondordb maps `LevelDaemon → Privileged`), so normal WRITE clients keep data read/write only.

Also updates the stale `ServeOptions.Privileged` and `AdminTable` docs.

**Tests:** `TestAdminRefusedUnprivileged` (a WRITE session is refused every admin action while data writes and read-only diagnostics still work); `TestDiagnosticsAndAdmin` now uses a privileged pair. dbrpc suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)