### PR TITLE
dbrpc: opt-in query log + server-side raw-query projection

### DIFF
--- a/dbrpc/proto.go
+++ b/dbrpc/proto.go
@@ -85,6 +85,7 @@ const (
 	opDeleteWhere   op = 34 // [table][constraint] -> [removed i32]; bulk delete-by-constraint, mutating
 	opQueryRaw      op = 35 // [table][limit i32][constraint] -> stream of [oldClassAdText]; wire-form, AST-free relay
 	opCommitIdem    op = 36 // [txnID][idemKey] -> status (like opCommit) + durable idempotency marker; opt-in exactly-once, mutating
+	opQueryRawProj  op = 37 // [table][limit i32][constraint][nattrs i32]{[attr]} -> stream of [oldClassAdText] projected to attrs (+ MyType/TargetType); server-side projection so only requested attributes cross the wire
 )
 
 // String names an opcode for diagnostics (e.g. the read-only rejection message).

--- a/dbrpc/querylog_test.go
+++ b/dbrpc/querylog_test.go
@@ -1,0 +1,76 @@
+package dbrpc
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestQueryLog verifies the opt-in per-query log: ServeOptions.QueryLog is called
+// once per streamed query with the op, table, constraint, and the row count.
+func TestQueryLog(t *testing.T) {
+	var mu sync.Mutex
+	var logs []QueryLog
+	c, cleanup := serveOptsPair(t, ServeOptions{
+		QueryLog: func(q QueryLog) {
+			mu.Lock()
+			logs = append(logs, q)
+			mu.Unlock()
+		},
+	})
+	defer cleanup()
+
+	ctx := context.Background()
+	tx, err := c.Begin(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = tx.NewClassAd(ctx, "a", `Name = "a"`+"\n"+`State = "Idle"`)
+	_ = tx.NewClassAd(ctx, "b", `Name = "b"`+"\n"+`State = "Claimed"`)
+	_ = tx.NewClassAd(ctx, "c", `Name = "c"`+"\n"+`State = "Idle"`)
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	if rows, err := c.Query(ctx, `State == "Idle"`); err != nil || len(rows) != 2 {
+		t.Fatalf("Query: rows=%d err=%v, want 2 rows", len(rows), err)
+	}
+
+	// The log fires on the server after the response is streamed, so wait for it.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		mu.Lock()
+		got := len(logs)
+		mu.Unlock()
+		if got >= 1 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("QueryLog was not called within 2s")
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(logs) != 1 {
+		t.Fatalf("QueryLog called %d times, want 1", len(logs))
+	}
+	e := logs[0]
+	if e.Op != "Query" {
+		t.Errorf("Op = %q, want Query", e.Op)
+	}
+	if e.Table != DefaultTable {
+		t.Errorf("Table = %q, want %q", e.Table, DefaultTable)
+	}
+	if e.Constraint != `State == "Idle"` {
+		t.Errorf("Constraint = %q", e.Constraint)
+	}
+	if e.Rows != 2 {
+		t.Errorf("Rows = %d, want 2", e.Rows)
+	}
+	if e.Duration <= 0 {
+		t.Errorf("Duration = %v, want > 0", e.Duration)
+	}
+}

--- a/dbrpc/queryraw.go
+++ b/dbrpc/queryraw.go
@@ -3,6 +3,7 @@ package dbrpc
 import (
 	"context"
 	"strings"
+	"time"
 
 	"github.com/PelicanPlatform/classad/classad"
 	"github.com/PelicanPlatform/classad/collections"
@@ -26,10 +27,17 @@ func (c *Client) QueryRawTable(ctx context.Context, table, constraint string, li
 
 // streamQueryRaw streams matching ads as old-ClassAd wire text, rendered from the
 // db QueryRaw pushdown (no AST decode), one frame per ad like streamQuery.
-func (s *Server) streamQueryRaw(ctx context.Context, reqID uint64, r *reader, includePrivate bool, write func([]byte)) {
+func (s *Server) streamQueryRaw(ctx context.Context, reqID uint64, r *reader, includePrivate bool, write func([]byte), qlog func(QueryLog)) {
+	start := time.Now()
 	table := r.str()
 	limit := int(r.i32())
 	constraint := r.str()
+	n := 0
+	if qlog != nil {
+		defer func() {
+			qlog(QueryLog{Op: "QueryRaw", Table: table, Constraint: constraint, Limit: limit, Rows: n, Duration: time.Since(start)})
+		}()
+	}
 	if r.err != nil {
 		write(respBad(reqID))
 		return
@@ -43,7 +51,6 @@ func (s *Server) streamQueryRaw(ctx context.Context, reqID uint64, r *reader, in
 		write(respErr(reqID, err.Error()))
 		return
 	}
-	n := 0
 	for ra := range seq {
 		if cancelled(ctx) {
 			return

--- a/dbrpc/queryraw.go
+++ b/dbrpc/queryraw.go
@@ -25,6 +25,22 @@ func (c *Client) QueryRawTable(ctx context.Context, table, constraint string, li
 	})
 }
 
+// QueryRawProject is QueryRawTable with a server-side projection: each returned ad
+// carries only the attributes in attrs (matched case-insensitively) plus
+// MyType/TargetType, so a query for a few attributes does not pull every attribute
+// of every ad across the wire. An empty attrs behaves like QueryRawTable (all
+// attributes). Private attributes are stripped unless the connection is privileged.
+func (c *Client) QueryRawProject(ctx context.Context, table, constraint string, attrs []string, limit int) ([]string, error) {
+	return c.streamCtx(ctx, func(id uint64) []byte {
+		b := putStr(putI32(putStr(req(id, opQueryRawProj), table), int32(limit)), constraint)
+		b = putI32(b, int32(len(attrs)))
+		for _, a := range attrs {
+			b = putStr(b, a)
+		}
+		return b
+	})
+}
+
 // streamQueryRaw streams matching ads as old-ClassAd wire text, rendered from the
 // db QueryRaw pushdown (no AST decode), one frame per ad like streamQuery.
 func (s *Server) streamQueryRaw(ctx context.Context, reqID uint64, r *reader, includePrivate bool, write func([]byte), qlog func(QueryLog)) {
@@ -102,4 +118,84 @@ func rawExprName(expr []byte) string {
 		i++
 	}
 	return string(expr[start:i])
+}
+
+// streamQueryRawProject is streamQueryRaw with a projection: it streams each
+// matching ad rendered to only the requested attributes (plus MyType/TargetType),
+// so a client that needs a handful of attributes does not pull every attribute of
+// every ad across the wire. The projection is applied server-side; matching is
+// case-insensitive (ClassAd attribute names are).
+func (s *Server) streamQueryRawProject(ctx context.Context, reqID uint64, r *reader, includePrivate bool, write func([]byte), qlog func(QueryLog)) {
+	start := time.Now()
+	table := r.str()
+	limit := int(r.i32())
+	constraint := r.str()
+	nattrs := int(r.i32())
+	attrs := make([]string, 0, nattrs)
+	for i := 0; i < nattrs; i++ {
+		attrs = append(attrs, r.str())
+	}
+	n := 0
+	if qlog != nil {
+		defer func() {
+			qlog(QueryLog{Op: "QueryRawProject", Table: table, Constraint: constraint, Limit: limit, Rows: n, Duration: time.Since(start)})
+		}()
+	}
+	if r.err != nil {
+		write(respBad(reqID))
+		return
+	}
+	d, ok := s.tableOr(reqID, table, write)
+	if !ok {
+		return
+	}
+	proj := make(map[string]struct{}, len(attrs))
+	for _, a := range attrs {
+		proj[strings.ToLower(a)] = struct{}{}
+	}
+	seq, err := d.QueryRaw(constraint)
+	if err != nil {
+		write(respErr(reqID, err.Error()))
+		return
+	}
+	for ra := range seq {
+		if cancelled(ctx) {
+			return
+		}
+		write(putStr(respHead(reqID, stStream), rawAdToOldTextProjected(ra, proj, includePrivate)))
+		n++
+		if limit > 0 && n >= limit {
+			break
+		}
+	}
+	write(respHead(reqID, stStreamEnd))
+}
+
+// rawAdToOldTextProjected is rawAdToOldText restricted to the attributes in proj
+// (lowercased names) -- plus MyType/TargetType, always kept so the ad stays
+// identifiable. Private attributes are still dropped unless includePrivate.
+func rawAdToOldTextProjected(ra collections.RawAd, proj map[string]struct{}, includePrivate bool) string {
+	var b strings.Builder
+	if ra.MyType != "" {
+		b.WriteString(`MyType = "`)
+		b.WriteString(ra.MyType)
+		b.WriteString("\"\n")
+	}
+	if ra.TargetType != "" {
+		b.WriteString(`TargetType = "`)
+		b.WriteString(ra.TargetType)
+		b.WriteString("\"\n")
+	}
+	for _, e := range ra.Exprs {
+		name := rawExprName(e)
+		if _, ok := proj[strings.ToLower(name)]; !ok {
+			continue
+		}
+		if !includePrivate && classad.IsPrivateAttribute(name) {
+			continue
+		}
+		b.Write(e)
+		b.WriteByte('\n')
+	}
+	return b.String()
 }

--- a/dbrpc/server.go
+++ b/dbrpc/server.go
@@ -312,6 +312,8 @@ func (sc *serverConn) dispatch(frame []byte) {
 		sc.s.streamQuery(sc.ctx, reqID, body, priv, sc.write, sc.opts.QueryLog)
 	case opQueryRaw:
 		sc.s.streamQueryRaw(sc.ctx, reqID, body, priv, sc.write, sc.opts.QueryLog)
+	case opQueryRawProj:
+		sc.s.streamQueryRawProject(sc.ctx, reqID, body, priv, sc.write, sc.opts.QueryLog)
 	case opMatchSorted:
 		sc.s.streamMatchSorted(sc.ctx, reqID, body, priv, sc.write)
 	case opOrdered:

--- a/dbrpc/server.go
+++ b/dbrpc/server.go
@@ -128,6 +128,24 @@ type ServeOptions struct {
 	// ordinary WRITE-level admin actions (index/hot/compact) that any writer may run.
 	// When false, a privileged action is refused even on a read-write connection.
 	Privileged bool
+
+	// QueryLog, if set, is called once per streamed query with a summary of what
+	// the client asked for and what it cost. It is an opt-in query log for
+	// operators: it makes visible, for example, a client that fetches every
+	// attribute of every ad instead of projecting server-side (a slow, chatty
+	// query pattern). Called from the connection's read-loop goroutine, so it must
+	// not block.
+	QueryLog func(QueryLog)
+}
+
+// QueryLog is one observed query, passed to ServeOptions.QueryLog.
+type QueryLog struct {
+	Op         string        // the query opcode: "Query", "QueryRaw", ...
+	Table      string        // the queried table
+	Constraint string        // the constraint expression ("" / "true" = match-all)
+	Limit      int           // the client's LIMIT (0 = unlimited)
+	Rows       int           // rows streamed back
+	Duration   time.Duration // wall-clock time to run + stream the query
 }
 
 // isMutating reports whether o writes to a transaction (and so is refused on a
@@ -291,9 +309,9 @@ func (sc *serverConn) dispatch(frame []byte) {
 	priv := sc.opts.IncludePrivate
 	switch o {
 	case opQuery:
-		sc.s.streamQuery(sc.ctx, reqID, body, priv, sc.write)
+		sc.s.streamQuery(sc.ctx, reqID, body, priv, sc.write, sc.opts.QueryLog)
 	case opQueryRaw:
-		sc.s.streamQueryRaw(sc.ctx, reqID, body, priv, sc.write)
+		sc.s.streamQueryRaw(sc.ctx, reqID, body, priv, sc.write, sc.opts.QueryLog)
 	case opMatchSorted:
 		sc.s.streamMatchSorted(sc.ctx, reqID, body, priv, sc.write)
 	case opOrdered:
@@ -389,10 +407,17 @@ func (sc *serverConn) stopWatch(watchReqID uint64) {
 // streamQuery streams the committed ads matching a constraint. Each result is its own
 // frame under reqID, so its frames interleave with other calls' -- no head-of-line
 // blocking -- and end with a terminator.
-func (s *Server) streamQuery(ctx context.Context, reqID uint64, r *reader, includePrivate bool, write func([]byte)) {
+func (s *Server) streamQuery(ctx context.Context, reqID uint64, r *reader, includePrivate bool, write func([]byte), qlog func(QueryLog)) {
+	start := time.Now()
 	table := r.str()
 	limit := int(r.i32())
 	constraint := r.str()
+	n := 0
+	if qlog != nil {
+		defer func() {
+			qlog(QueryLog{Op: "Query", Table: table, Constraint: constraint, Limit: limit, Rows: n, Duration: time.Since(start)})
+		}()
+	}
 	if r.err != nil {
 		write(respBad(reqID))
 		return
@@ -408,7 +433,6 @@ func (s *Server) streamQuery(ctx context.Context, reqID uint64, r *reader, inclu
 	}
 	// Push LIMIT down: stopping the range stops the underlying scan, so a small
 	// LIMIT does proportionally less work instead of scanning everything.
-	n := 0
 	for ad := range seq {
 		if cancelled(ctx) {
 			return // client gone: stop the scan


### PR DESCRIPTION
Two related query-side additions to dbrpc (kept together so they release in one tag):

### 1. `ServeOptions.QueryLog` — an opt-in per-query log
Called once per streamed query with `QueryLog{Op, Table, Constraint, Limit, Rows, Duration}`, wired into the streaming query ops via a deferred call (reports the final row count/duration, fires even on early return). Off by default, zero cost when unset. Lets an operator see, e.g., a client that fetches every attribute of every ad instead of projecting server-side.

### 2. `QueryRawProject` — server-side projection for raw queries
`opQueryRawProject` streams each matching ad rendered to **only the requested attributes** (matched case-insensitively) plus `MyType`/`TargetType`, so a query for a few attributes doesn't pull every attribute of every ad across the wire. Applied server-side on the AST-free RawAd relay path; private attributes still stripped unless privileged; logged like the others.

This is the wire half of **collector projection pushdown**: a view collector answering a projected `condor_status` query (e.g. `-totals`) can push the projection to the database instead of fetching whole ads and projecting locally.

Tests cover both (query-log fields; projection keeps only the requested attrs + MyType, drops the rest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
