### PR TITLE
db: per-table in-memory (RAM-only) option

### DIFF
--- a/db/catalog.go
+++ b/db/catalog.go
@@ -143,9 +143,26 @@ func (cat *Catalog) Table(name string) (*DB, bool) {
 	return d, ok
 }
 
+// TableOptions tunes how a table is created. The zero value creates a normal
+// table (persistent when the catalog has a directory).
+type TableOptions struct {
+	// InMemory makes the table's data live only in RAM even in a persistent
+	// catalog: no <dir>/tables/<name> directory is created, so the table is not
+	// recovered across restarts (it reappears empty). Useful for high-churn,
+	// reconstructible data (e.g. frequently-replaced ads) that is not worth the
+	// disk I/O of persistence. In an already-in-memory catalog it is a no-op.
+	InMemory bool
+}
+
 // CreateTable creates (or returns the existing) table named name. Its data
 // persists under <dir>/tables/<name> for a persistent catalog.
 func (cat *Catalog) CreateTable(name string) (*DB, error) {
+	return cat.CreateTableOpts(name, TableOptions{})
+}
+
+// CreateTableOpts is CreateTable with options; see TableOptions. If the table
+// already exists it is returned as-is (options are not re-applied).
+func (cat *Catalog) CreateTableOpts(name string, opts TableOptions) (*DB, error) {
 	if !ValidTableName(name) {
 		return nil, fmt.Errorf("catalog: invalid table name %q", name)
 	}
@@ -158,7 +175,7 @@ func (cat *Catalog) CreateTable(name string) (*DB, error) {
 		return nil, fmt.Errorf("catalog: %q already exists as an archive table", name)
 	}
 	cfgDir := ""
-	if cat.dir != "" {
+	if cat.dir != "" && !opts.InMemory {
 		cfgDir = filepath.Join(cat.dir, tablesSubdir, name)
 	}
 	d, err := OpenConfig(cat.tableConfig(cfgDir))

--- a/db/catalog_test.go
+++ b/db/catalog_test.go
@@ -1,6 +1,8 @@
 package db
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/PelicanPlatform/classad/classad"
@@ -68,6 +70,68 @@ func TestCatalogCreateDropPersist(t *testing.T) {
 	defer cat3.Close()
 	if _, ok := cat3.Table("machines"); ok {
 		t.Fatal("dropped table machines reappeared after reopen")
+	}
+}
+
+// TestCatalogInMemoryTable checks that a table created with TableOptions.InMemory
+// in a persistent catalog keeps its data only in RAM: no on-disk directory is
+// created and the data is gone after reopen, while a normal table alongside it
+// persists.
+func TestCatalogInMemoryTable(t *testing.T) {
+	dir := t.TempDir()
+
+	cat, err := OpenCatalog(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	disk, err := cat.CreateTable("persisted")
+	if err != nil {
+		t.Fatal(err)
+	}
+	mem, err := cat.CreateTableOpts("ephemeral", TableOptions{InMemory: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		d    *DB
+		name string
+	}{{disk, "persisted"}, {mem, "ephemeral"}} {
+		tx := tc.d.Begin()
+		ad, _ := classad.ParseOld("Name = \"" + tc.name + "\"")
+		tx.NewClassAd("k", ad)
+		if err := tx.Commit(); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// The in-memory table must not create a <dir>/tables/<name> directory.
+	memDir := filepath.Join(dir, tablesSubdir, "ephemeral")
+	if _, err := os.Stat(memDir); !os.IsNotExist(err) {
+		t.Fatalf("in-memory table created on-disk dir %s (err=%v)", memDir, err)
+	}
+	diskDir := filepath.Join(dir, tablesSubdir, "persisted")
+	if _, err := os.Stat(diskDir); err != nil {
+		t.Fatalf("persistent table missing on-disk dir %s: %v", diskDir, err)
+	}
+	if err := cat.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Reopen: the persistent table's data survives; the in-memory table is gone.
+	cat2, err := OpenCatalog(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cat2.Close()
+	d, ok := cat2.Table("persisted")
+	if !ok {
+		t.Fatal("persisted table missing after reopen")
+	}
+	if _, ok := d.LookupClassAd("k"); !ok {
+		t.Fatal("persisted data lost after reopen")
+	}
+	if _, ok := cat2.Table("ephemeral"); ok {
+		t.Fatal("in-memory table recovered after reopen (should be gone)")
 	}
 }
 


### PR DESCRIPTION
Adds `db.TableOptions{InMemory bool}` and `Catalog.CreateTableOpts(name, opts)`. An in-memory table keeps its data only in RAM even in a **persistent** catalog: no `<dir>/tables/<name>` directory is created, so it is not recovered across restarts (it reappears empty).

## Why
High-churn, reconstructible data — e.g. frequently-replaced private/startd ads that are re-advertised on every update cycle — is not worth the disk I/O and write amplification of persistence. This lets a catalog hold such a table in RAM while its neighbors persist.

## Mechanism
The RAM path already exists one layer down: `OpenConfig(Config{Dir:""})` selects `collections.New` (pure in-memory) instead of `collections.Open` (mmap). `CreateTableOpts` just forces the empty table dir when `InMemory` is set — one branch:
```go
cfgDir := ""
if cat.dir != "" && !opts.InMemory {
    cfgDir = filepath.Join(cat.dir, tablesSubdir, name)
}
```
`CreateTable(name)` is unchanged — it delegates with a zero `TableOptions`, so existing callers and the wire protocol are untouched.

## Test
`TestCatalogInMemoryTable`: in a persistent catalog, an in-memory table creates no on-disk dir and its data is gone after reopen, while a normal table alongside it persists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)