### PR TITLE
db,dbrpc: memory-only table create + convert-existing

### DIFF
--- a/db/catalog.go
+++ b/db/catalog.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -184,6 +185,61 @@ func (cat *Catalog) CreateTableOpts(name string, opts TableOptions) (*DB, error)
 	}
 	cat.tables[name] = d
 	return d, nil
+}
+
+// CreateTableInMemory creates (or returns the existing) table named name as RAM-only,
+// even in a persistent catalog -- shorthand for CreateTableOpts with InMemory set. If the
+// table already exists its backing is unchanged (options are not re-applied); use
+// ConvertTableToMemory to drop an existing persistent table's on-disk backing.
+func (cat *Catalog) CreateTableInMemory(name string) (*DB, error) {
+	return cat.CreateTableOpts(name, TableOptions{InMemory: true})
+}
+
+// ConvertTableToMemory drops the on-disk backing of an existing persistent table, keeping
+// its current contents live in RAM only. It copies the table through a consistent snapshot
+// into a fresh in-memory table (preserving ads, index configuration, hot set, codec, and
+// encryption policy), swaps that in, then closes and deletes the on-disk original.
+//
+// It is a no-op when the catalog itself is in-memory or the table is already RAM-only. Like
+// Rewrite, it takes a consistent snapshot but does not globally quiesce writers, so a write
+// that races the swap can be lost -- run it during low write activity. DAEMON-level: it
+// changes a table's durability, so callers gate it above ordinary WRITE.
+func (cat *Catalog) ConvertTableToMemory(name string) error {
+	cat.mu.Lock()
+	defer cat.mu.Unlock()
+	old, ok := cat.tables[name]
+	if !ok {
+		if _, isArch := cat.archives[name]; isArch {
+			return fmt.Errorf("catalog: %q is an archive table, not a mutable table", name)
+		}
+		return fmt.Errorf("catalog: no such table %q", name)
+	}
+	if cat.dir == "" || old.InMemory() {
+		return nil // whole catalog is in-memory, or this table is already RAM-only
+	}
+
+	// Build the RAM replacement with the same table configuration (crucially the same
+	// pool keys, so the encrypted snapshot round-trips), then copy the full contents in
+	// via a snapshot -- the same consistent mechanism backups/HA use.
+	mem, err := OpenConfig(cat.tableConfig(""))
+	if err != nil {
+		return fmt.Errorf("catalog: creating in-memory replacement for %q: %w", name, err)
+	}
+	pr, pw := io.Pipe()
+	go func() { pw.CloseWithError(old.Snapshot(pw)) }()
+	if err := mem.Restore(pr); err != nil {
+		_ = pr.CloseWithError(err)
+		_ = mem.Close()
+		return fmt.Errorf("catalog: copying %q into memory: %w", name, err)
+	}
+
+	// Swap in the RAM table and retire the on-disk original.
+	cat.tables[name] = mem
+	_ = old.Close()
+	if err := os.RemoveAll(filepath.Join(cat.dir, tablesSubdir, name)); err != nil {
+		return fmt.Errorf("catalog: removing on-disk data for %q: %w", name, err)
+	}
+	return nil
 }
 
 // DropTable closes and removes the table named name, deleting its on-disk data.

--- a/db/catalog_convert_test.go
+++ b/db/catalog_convert_test.go
@@ -1,0 +1,118 @@
+package db
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/classad"
+)
+
+func mustParseOld(t *testing.T, s string) *classad.ClassAd {
+	t.Helper()
+	ad, err := classad.ParseOld(s)
+	if err != nil {
+		t.Fatalf("parse %q: %v", s, err)
+	}
+	return ad
+}
+
+// TestConvertTableToMemory: a persistent table's data survives conversion, the on-disk
+// backing is removed, the table reports InMemory, and after a catalog reopen the (now
+// RAM-only) table is gone -- proving persistence was actually dropped.
+func TestConvertTableToMemory(t *testing.T) {
+	dir := t.TempDir()
+	cat, err := OpenCatalog(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	d, err := cat.CreateTable("jobs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, k := range []string{"1.0", "2.0", "3.0"} {
+		if err := d.Put(k, mustParseOld(t, `Owner = "alice"`)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	tableDir := filepath.Join(dir, tablesSubdir, "jobs")
+	if _, err := os.Stat(tableDir); err != nil {
+		t.Fatalf("persistent table dir missing before convert: %v", err)
+	}
+
+	if err := cat.ConvertTableToMemory("jobs"); err != nil {
+		t.Fatalf("ConvertTableToMemory: %v", err)
+	}
+
+	// Data preserved, table now RAM-only, on-disk backing gone.
+	got, ok := cat.Table("jobs")
+	if !ok {
+		t.Fatal("table missing after convert")
+	}
+	if !got.InMemory() {
+		t.Fatal("table should report InMemory after convert")
+	}
+	if got.Len() != 3 {
+		t.Fatalf("Len after convert = %d, want 3", got.Len())
+	}
+	if _, ok := got.LookupClassAd("2.0"); !ok {
+		t.Fatal("key 2.0 missing after convert")
+	}
+	if _, err := os.Stat(tableDir); !os.IsNotExist(err) {
+		t.Fatalf("on-disk table dir still present after convert (err=%v)", err)
+	}
+
+	// Idempotent: converting again is a no-op.
+	if err := cat.ConvertTableToMemory("jobs"); err != nil {
+		t.Fatalf("second ConvertTableToMemory should be a no-op: %v", err)
+	}
+	if err := cat.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// After a restart the converted table is not recovered (it was RAM-only).
+	cat2, err := OpenCatalog(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cat2.Close()
+	if _, ok := cat2.Table("jobs"); ok {
+		t.Fatal("RAM-only table should not survive a catalog reopen")
+	}
+}
+
+// TestConvertTableErrors covers the guarded paths.
+func TestConvertTableErrors(t *testing.T) {
+	dir := t.TempDir()
+	cat, err := OpenCatalog(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cat.Close()
+
+	if err := cat.ConvertTableToMemory("nope"); err == nil {
+		t.Fatal("converting a nonexistent table should error")
+	}
+	// A table created in-memory converts to a no-op (already RAM-only).
+	if _, err := cat.CreateTableInMemory("mem"); err != nil {
+		t.Fatal(err)
+	}
+	if !mustTable(t, cat, "mem").InMemory() {
+		t.Fatal("CreateTableInMemory should yield an in-memory table")
+	}
+	if _, err := os.Stat(filepath.Join(dir, tablesSubdir, "mem")); !os.IsNotExist(err) {
+		t.Fatal("CreateTableInMemory must not create an on-disk dir")
+	}
+	if err := cat.ConvertTableToMemory("mem"); err != nil {
+		t.Fatalf("converting an already-in-memory table should be a no-op: %v", err)
+	}
+}
+
+func mustTable(t *testing.T, cat *Catalog, name string) *DB {
+	t.Helper()
+	d, ok := cat.Table(name)
+	if !ok {
+		t.Fatalf("table %q not found", name)
+	}
+	return d
+}

--- a/db/db.go
+++ b/db/db.go
@@ -128,6 +128,10 @@ func (db *DB) ID() string { return db.id }
 // HA replicas exist, when replicas of one DB share ID but differ by InstanceID.
 func (db *DB) InstanceID() string { return db.instance }
 
+// InMemory reports whether the table's data lives only in RAM (no on-disk backing),
+// i.e. it was opened with an empty Dir. Such a table is not recovered across restarts.
+func (db *DB) InMemory() bool { return db.dir == "" }
+
 func randID() string {
 	var b [16]byte
 	_, _ = rand.Read(b[:])

--- a/dbrpc/diag.go
+++ b/dbrpc/diag.go
@@ -331,6 +331,35 @@ func (c *Client) CreateTable(ctx context.Context, name string) error {
 	return nil
 }
 
+// CreateTableInMemory creates (or no-ops if present) the named table as RAM-only: its data
+// lives only in memory and is not recovered across a server restart. On a persistent server
+// this avoids the disk I/O of persistence for high-churn, reconstructible data.
+func (c *Client) CreateTableInMemory(ctx context.Context, name string) error {
+	status, body, err := c.callCtx(ctx, func(id uint64) []byte { return putStr(req(id, opCreateTableMem), name) })
+	if err != nil {
+		return err
+	}
+	if status != stOK {
+		return statusErr(status, body)
+	}
+	return nil
+}
+
+// ConvertTableToMemory drops an existing table's on-disk backing, keeping its current
+// contents in RAM only (they are gone after a server restart). Requires DAEMON
+// authorization. Best run during low write activity: a write that races the conversion can
+// be lost (the server takes a consistent snapshot but does not globally quiesce writers).
+func (c *Client) ConvertTableToMemory(ctx context.Context, name string) error {
+	status, body, err := c.callCtx(ctx, func(id uint64) []byte { return putStr(req(id, opTableToMemory), name) })
+	if err != nil {
+		return err
+	}
+	if status != stOK {
+		return statusErr(status, body)
+	}
+	return nil
+}
+
 // DropTable removes the named table and its data.
 func (c *Client) DropTable(ctx context.Context, name string) error {
 	status, body, err := c.callCtx(ctx, func(id uint64) []byte { return putStr(req(id, opDropTable), name) })

--- a/dbrpc/proto.go
+++ b/dbrpc/proto.go
@@ -77,15 +77,17 @@ const (
 	opRestoreEnd   op = 28 // ends the upload; server restores from the spooled file, then replies
 
 	// Archive (history) tables: append-only, rotated, newest-first queries.
-	opArchiveCreate op = 29 // [name][json ArchiveConfig] -> status; mutating
-	opArchiveAppend op = 30 // [name][adText] -> status; mutating
-	opArchiveQuery  op = 31 // [name][limit i32][constraint] -> stream of [adText], newest first
-	opArchiveList   op = 32 // -> [n i32]{[name]}
-	opArchiveRotate op = 33 // [name] -> [dropped i32]; enforce retention (server clock); mutating
-	opDeleteWhere   op = 34 // [table][constraint] -> [removed i32]; bulk delete-by-constraint, mutating
-	opQueryRaw      op = 35 // [table][limit i32][constraint] -> stream of [oldClassAdText]; wire-form, AST-free relay
-	opCommitIdem    op = 36 // [txnID][idemKey] -> status (like opCommit) + durable idempotency marker; opt-in exactly-once, mutating
-	opQueryRawProj  op = 37 // [table][limit i32][constraint][nattrs i32]{[attr]} -> stream of [oldClassAdText] projected to attrs (+ MyType/TargetType); server-side projection so only requested attributes cross the wire
+	opArchiveCreate  op = 29 // [name][json ArchiveConfig] -> status; mutating
+	opArchiveAppend  op = 30 // [name][adText] -> status; mutating
+	opArchiveQuery   op = 31 // [name][limit i32][constraint] -> stream of [adText], newest first
+	opArchiveList    op = 32 // -> [n i32]{[name]}
+	opArchiveRotate  op = 33 // [name] -> [dropped i32]; enforce retention (server clock); mutating
+	opDeleteWhere    op = 34 // [table][constraint] -> [removed i32]; bulk delete-by-constraint, mutating
+	opQueryRaw       op = 35 // [table][limit i32][constraint] -> stream of [oldClassAdText]; wire-form, AST-free relay
+	opCommitIdem     op = 36 // [txnID][idemKey] -> status (like opCommit) + durable idempotency marker; opt-in exactly-once, mutating
+	opQueryRawProj   op = 37 // [table][limit i32][constraint][nattrs i32]{[attr]} -> stream of [oldClassAdText] projected to attrs (+ MyType/TargetType); server-side projection so only requested attributes cross the wire
+	opCreateTableMem op = 38 // [table] -> status; create a RAM-only (non-persistent) table; mutating
+	opTableToMemory  op = 39 // [table] -> status; drop an existing table's on-disk backing (DAEMON-only); mutating
 )
 
 // String names an opcode for diagnostics (e.g. the read-only rejection message).
@@ -133,6 +135,10 @@ func (o op) String() string {
 		return "Admin"
 	case opCreateTable:
 		return "CreateTable"
+	case opCreateTableMem:
+		return "CreateTableInMemory"
+	case opTableToMemory:
+		return "ConvertTableToMemory"
 	case opDropTable:
 		return "DropTable"
 	case opListTables:

--- a/dbrpc/server.go
+++ b/dbrpc/server.go
@@ -38,6 +38,11 @@ type Catalog interface {
 	Table(name string) (*db.DB, bool)
 	// CreateTable creates (or returns the existing) named table.
 	CreateTable(name string) (*db.DB, error)
+	// CreateTableInMemory creates (or returns the existing) named table as RAM-only.
+	CreateTableInMemory(name string) (*db.DB, error)
+	// ConvertTableToMemory drops an existing table's on-disk backing, keeping its data in
+	// RAM only. DAEMON-gated by the server (it changes a table's durability).
+	ConvertTableToMemory(name string) error
 	// DropTable removes the named table and its data.
 	DropTable(name string) error
 	// Tables lists the table names.
@@ -94,6 +99,12 @@ func (s singleCatalog) CreateTable(name string) (*db.DB, error) {
 		return s.d, nil
 	}
 	return nil, fmt.Errorf("single-table server: cannot create table %q", name)
+}
+func (s singleCatalog) CreateTableInMemory(name string) (*db.DB, error) {
+	return nil, fmt.Errorf("single-table server: cannot create in-memory tables")
+}
+func (s singleCatalog) ConvertTableToMemory(name string) error {
+	return fmt.Errorf("single-table server: cannot convert tables")
 }
 func (s singleCatalog) DropTable(name string) error {
 	return fmt.Errorf("single-table server: cannot drop tables")
@@ -155,6 +166,7 @@ type QueryLog struct {
 func (o op) isMutating() bool {
 	switch o {
 	case opNewAd, opDestroyAd, opSetAttr, opDeleteAttr, opAdmin, opCreateTable, opDropTable,
+		opCreateTableMem, opTableToMemory,
 		opArchiveCreate, opArchiveAppend, opArchiveRotate, opDeleteWhere, opCommitIdem:
 		return true
 	}
@@ -525,6 +537,31 @@ func (s *Server) handle(sc *serverConn, reqID uint64, o op, r *reader, includePr
 			return respBad(reqID)
 		}
 		if _, err := s.cat.CreateTable(name); err != nil {
+			return respErr(reqID, err.Error())
+		}
+		return resp(reqID, stOK)
+
+	case opCreateTableMem:
+		name := r.str()
+		if r.err != nil {
+			return respBad(reqID)
+		}
+		if _, err := s.cat.CreateTableInMemory(name); err != nil {
+			return respErr(reqID, err.Error())
+		}
+		return resp(reqID, stOK)
+
+	case opTableToMemory:
+		name := r.str()
+		if r.err != nil {
+			return respBad(reqID)
+		}
+		// Converting a table's durability is a DAEMON-level administrative action, like the
+		// admin() maintenance ops -- refused to an ordinary writer.
+		if !privileged {
+			return respErr(reqID, "ConvertTableToMemory requires DAEMON authorization")
+		}
+		if err := s.cat.ConvertTableToMemory(name); err != nil {
 			return respErr(reqID, err.Error())
 		}
 		return resp(reqID, stOK)

--- a/dbrpc/tablemem_test.go
+++ b/dbrpc/tablemem_test.go
@@ -1,0 +1,69 @@
+package dbrpc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/db"
+)
+
+// TestTableMemoryOps covers the wire ops for RAM-only tables: creating one, converting an
+// existing persistent table (DAEMON-gated), and the WRITE-level refusal of convert.
+func TestTableMemoryOps(t *testing.T) {
+	cat, err := db.OpenCatalog(t.TempDir()) // persistent catalog
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := NewServerCatalog(cat)
+	ctx := context.Background()
+
+	// Privileged (DAEMON) connection.
+	dcc, dsc := netPipe()
+	go func() { _ = s.ServeConnOpts(dsc, ServeOptions{Privileged: true}) }()
+	dc := NewClient(dcc)
+	// Ordinary WRITE connection (not privileged, not read-only).
+	wcc, wsc := netPipe()
+	go func() { _ = s.ServeConn(wsc) }()
+	wc := NewClient(wcc)
+	defer func() { dc.Close(); wc.Close(); s.Close(); cat.Close() }()
+
+	// CreateTableInMemory yields a RAM-only table even on a persistent catalog.
+	if err := dc.CreateTableInMemory(ctx, "ephemeral"); err != nil {
+		t.Fatalf("CreateTableInMemory: %v", err)
+	}
+	if d, ok := cat.Table("ephemeral"); !ok || !d.InMemory() {
+		t.Fatalf("ephemeral not created in-memory (ok=%v)", ok)
+	}
+
+	// A persistent table with data, then converted to RAM-only.
+	if err := dc.CreateTable(ctx, "jobs"); err != nil {
+		t.Fatal(err)
+	}
+	if d, _ := cat.Table("jobs"); d.InMemory() {
+		t.Fatal("jobs should start persistent")
+	}
+	tx, err := wc.BeginTable(ctx, "jobs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = tx.NewClassAd(ctx, "1", `Owner = "alice"`)
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	// A WRITE-level session may NOT convert (DAEMON-gated).
+	if err := wc.ConvertTableToMemory(ctx, "jobs"); err == nil {
+		t.Fatal("ConvertTableToMemory on a WRITE connection should be refused")
+	}
+	// The DAEMON session may, and the data is preserved.
+	if err := dc.ConvertTableToMemory(ctx, "jobs"); err != nil {
+		t.Fatalf("ConvertTableToMemory (privileged): %v", err)
+	}
+	if d, _ := cat.Table("jobs"); !d.InMemory() {
+		t.Fatal("jobs should be in-memory after convert")
+	}
+	rows, err := dc.QueryTable(ctx, "jobs", "true", 0)
+	if err != nil || len(rows) != 1 {
+		t.Fatalf("after convert QueryTable = %v (n=%d), want 1 row", err, len(rows))
+	}
+}


### PR DESCRIPTION
Exposes RAM-only tables (`db.TableOptions.InMemory`, landed in #49) through the catalog and the wire, so a client can both **create** a table as memory-only and **convert** an existing persistent one.

## db
- `DB.InMemory()` — whether a table has no on-disk backing.
- `Catalog.CreateTableInMemory(name)` — shorthand for `CreateTableOpts{InMemory:true}`.
- `Catalog.ConvertTableToMemory(name)` — drops an existing persistent table's on-disk backing, keeping its data in RAM. It copies the table through a **consistent snapshot** into a fresh in-memory table (preserving ads, index config, hot set, codec, and encryption policy — the RAM replacement shares the catalog's pool keys, so an encrypted snapshot round-trips), swaps it in, then closes and removes the original. No-op when the catalog is in-memory or the table is already RAM-only. Like `Rewrite`, it snapshots consistently but does not globally quiesce writers, so it is best run during low write activity.

## dbrpc
- New ops `opCreateTableMem` (WRITE) and `opTableToMemory` (**DAEMON-gated** — it changes a table's durability, like the `admin()` maintenance ops), plus Catalog-interface + client methods `CreateTableInMemory` / `ConvertTableToMemory`.

## Tests
- db: round-trips a persistent table to memory (data preserved, on-disk dir removed, table gone after a catalog reopen) + guarded paths.
- dbrpc: the two wire ops incl. the WRITE-level refusal of convert.

The htcondordb CLI surface (`CREATE TABLE … MEMORY` and the `.memory` meta-command) is a companion PR that consumes these once this is tagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)