### PR TITLE
dbrpc: reclaim dead space on a standalone compaction cadence

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -164,6 +164,15 @@ type MaintainOptions struct {
 	// Retrain retrains the ZSTD dictionary (recompacting + reindexing). Expensive on a
 	// large store, so a server may run it on a longer cadence than the rest.
 	Retrain bool
+	// CompactInterval is the cadence of a lightweight, standalone compaction pass
+	// (dbrpc.Server.StartMaintenance) that reclaims dead space independently of the
+	// expensive retrain-dominated Maintain pass. Compaction is cheap and self-limiting
+	// (it unlinks fully-dead segments for free and only recompacts shards past the
+	// dead-byte threshold), so it runs far more often than Maintain -- essential for a
+	// high-churn table (e.g. a collector re-advertising every few minutes) where dead
+	// space would otherwise grow unbounded between the throttled retrain passes. 0 uses
+	// a default cadence; a negative value disables the standalone compaction pass.
+	CompactInterval time.Duration
 	// MinIndexDemand is the minimum observed query count for the auto-tuner to add an
 	// index; 0 leaves index auto-tune off (no demand-driven adds).
 	MinIndexDemand int64

--- a/dbrpc/compact_maintenance_test.go
+++ b/dbrpc/compact_maintenance_test.go
@@ -1,0 +1,113 @@
+package dbrpc
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/PelicanPlatform/classad/classad"
+	"github.com/PelicanPlatform/classad/db"
+)
+
+// TestStartMaintenanceCompactsDeadSpace verifies the standalone compaction pass:
+// a high-churn table (records repeatedly superseded) accumulates dead space, and
+// the maintenance server reclaims it on the short compaction cadence WITHOUT
+// waiting on the expensive retrain-dominated Maintain pass (retrain is off and the
+// Maintain interval is set far in the future here, so only compaction can run).
+func TestStartMaintenanceCompactsDeadSpace(t *testing.T) {
+	cat, err := db.OpenCatalog("") // in-memory catalog
+	if err != nil {
+		t.Fatal(err)
+	}
+	d, err := cat.CreateTable("t")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	big := strings.Repeat("x", 500)
+	mkAd := func(i int) *classad.ClassAd {
+		ad, perr := classad.ParseOld(fmt.Sprintf("Name = \"k%d\"\nData = \"%s\"", i, big))
+		if perr != nil {
+			t.Fatal(perr)
+		}
+		return ad
+	}
+	// Write 4000 keys, then overwrite them all twice more: ~2/3 of used bytes become
+	// dead (superseded), comfortably past the 50% compaction threshold and -- with
+	// enough volume to clear the per-shard 64 KiB minimum across the default 16
+	// shards -- the minimum-shard floor.
+	writePass := func() {
+		tx := d.Begin()
+		for i := 0; i < 4000; i++ {
+			tx.NewClassAd(fmt.Sprintf("k%d", i), mkAd(i))
+		}
+		if cerr := tx.Commit(); cerr != nil {
+			t.Fatal(cerr)
+		}
+	}
+	writePass()
+	writePass()
+	writePass()
+
+	before := d.Stats()
+	if before.UsedBytes == 0 || float64(before.DeadBytes) < 0.5*float64(before.UsedBytes) {
+		t.Fatalf("test setup: want dead > 50%% of used; got used=%d dead=%d", before.UsedBytes, before.DeadBytes)
+	}
+
+	s := NewServerCatalog(cat)
+	defer s.Close()
+	// Maintain (retrain) interval far in the future so it cannot run during the
+	// test; only the standalone compaction pass (10ms) should reclaim the dead space.
+	s.StartMaintenance(time.Hour, db.MaintainOptions{CompactInterval: 10 * time.Millisecond})
+
+	deadline := time.Now().Add(3 * time.Second)
+	var after db.Stats
+	for time.Now().Before(deadline) {
+		after = d.Stats()
+		if float64(after.DeadBytes) < 0.5*float64(before.DeadBytes) {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if float64(after.DeadBytes) >= 0.5*float64(before.DeadBytes) {
+		t.Fatalf("compaction did not reclaim dead space: dead %d -> %d (used %d -> %d)",
+			before.DeadBytes, after.DeadBytes, before.UsedBytes, after.UsedBytes)
+	}
+	// Live data must be intact: a live record must still resolve.
+	if _, ok := d.LookupClassAd("k0"); !ok {
+		t.Error("k0 missing after compaction")
+	}
+}
+
+// TestStartMaintenanceCompactionDisabled verifies a negative CompactInterval turns
+// the standalone compaction pass off (leaving only the retrain-paced Maintain pass).
+func TestStartMaintenanceCompactionDisabled(t *testing.T) {
+	cat, err := db.OpenCatalog("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	d, err := cat.CreateTable("t")
+	if err != nil {
+		t.Fatal(err)
+	}
+	big := strings.Repeat("y", 500)
+	for pass := 0; pass < 3; pass++ {
+		tx := d.Begin()
+		for i := 0; i < 4000; i++ {
+			ad, _ := classad.ParseOld(fmt.Sprintf("Name = \"k%d\"\nData = \"%s\"", i, big))
+			tx.NewClassAd(fmt.Sprintf("k%d", i), ad)
+		}
+		_ = tx.Commit()
+	}
+	before := d.Stats()
+
+	s := NewServerCatalog(cat)
+	defer s.Close()
+	s.StartMaintenance(time.Hour, db.MaintainOptions{CompactInterval: -1})
+
+	time.Sleep(200 * time.Millisecond)
+	if d.Stats().DeadBytes < before.DeadBytes {
+		t.Errorf("compaction ran despite CompactInterval=-1 (dead %d -> %d)", before.DeadBytes, d.Stats().DeadBytes)
+	}
+}

--- a/dbrpc/server.go
+++ b/dbrpc/server.go
@@ -171,6 +171,13 @@ const defaultMaintenanceInterval = 15 * time.Minute
 // D never runs more often than every D/dutyCycle. At 1% a 30s pass paces to >=50 minutes.
 const maintenanceMaxDutyCycle = 0.01
 
+// defaultCompactInterval is the cadence of the standalone compaction pass when
+// MaintainOptions.CompactInterval is 0. It is far shorter than the maintenance
+// (retrain) cadence on purpose: compaction is cheap and self-limiting, and a
+// high-churn table accumulates dead space continuously, so reclaiming it must not
+// wait on the throttled retrain-dominated Maintain pass.
+const defaultCompactInterval = 2 * time.Minute
+
 // StartMaintenance starts server-managed background maintenance: a single goroutine that,
 // each tick, re-enumerates the catalog's tables and runs one Maintain pass (index
 // auto-tune, hot-set refresh, and -- if opts.Retrain -- dictionary retrain) on each.
@@ -211,6 +218,38 @@ func (s *Server) StartMaintenance(interval time.Duration, opts db.MaintainOption
 		}
 	}()
 	s.stopBG = append(s.stopBG, func() { close(done) })
+
+	// Standalone compaction pass, decoupled from the retrain-dominated Maintain
+	// pass above. Compaction is cheap and self-limiting (Compact unlinks fully-dead
+	// segments for free and only recompacts shards past the dead-byte threshold), so
+	// it runs on a short fixed cadence -- a high-churn table reclaims dead space
+	// continuously instead of only when the throttled retrain happens to run. A
+	// negative CompactInterval disables it; 0 uses defaultCompactInterval.
+	if opts.CompactInterval >= 0 {
+		compactEvery := opts.CompactInterval
+		if compactEvery == 0 {
+			compactEvery = defaultCompactInterval
+		}
+		cdone := make(chan struct{})
+		go func() {
+			ct := time.NewTimer(compactEvery)
+			defer ct.Stop()
+			for {
+				select {
+				case <-cdone:
+					return
+				case <-ct.C:
+				}
+				for _, name := range s.cat.Tables() {
+					if d, ok := s.cat.Table(name); ok {
+						d.Compact()
+					}
+				}
+				ct.Reset(compactEvery) // reset after the pass so a slow pass never overlaps
+			}
+		}()
+		s.stopBG = append(s.stopBG, func() { close(cdone) })
+	}
 }
 
 // tableOr writes a "no such table" error under reqID and returns ok=false if the


### PR DESCRIPTION
Dead-space reclamation was only a side-effect of the retrain-dominated Maintain pass, which StartMaintenance throttles to <=1% duty cycle -- so on a high-churn table dead space grew unbounded (observed ~81% dead on a live collector; `retrained: never`). Adds a separate, frequent compaction loop (`MaintainOptions.CompactInterval`, default 2m; negative disables) that runs the cheap, threshold-driven `Compact()` on every table, decoupled from retrain. Tests: reclaims within the interval; -1 disables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)