### PR TITLE
collections: make dict persistence resilient to a missing dicts dir

### DIFF
--- a/collections/dict_dir_test.go
+++ b/collections/dict_dir_test.go
@@ -1,0 +1,70 @@
+package collections
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestWriteDictFileRecreatesMissingDir is the regression guard for the retrain
+// failure "open .../dicts/N.zst: no such file or directory": if the dicts
+// directory has gone missing at runtime, writing a dictionary must recreate it
+// rather than fail with ENOENT.
+func TestWriteDictFileRecreatesMissingDir(t *testing.T) {
+	dir := t.TempDir()
+	// dicts/ does not exist (simulating it having disappeared after Open).
+	path := filepath.Join(dir, "dicts", "6.zst")
+	if err := writeDictFile(path, []byte("dict-bytes")); err != nil {
+		t.Fatalf("writeDictFile must recreate the missing dir, got: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil || string(got) != "dict-bytes" {
+		t.Fatalf("dict not written after dir recreate: %q err=%v", got, err)
+	}
+}
+
+// TestRegisterRecreatesMissingDir checks the register path (the caller in
+// RetrainDict) self-heals the missing dir and registers the codec, and that a
+// failed write does NOT register a codec whose file is missing.
+func TestRegisterRecreatesMissingDir(t *testing.T) {
+	dir := t.TempDir()
+	dictsDir := filepath.Join(dir, "dicts")
+	r := newDictReg(identityCodec{})
+	r.dir = dictsDir
+	// dicts/ absent -> register must recreate it and persist the file.
+	c := &countingCodec{}
+	id, err := r.register(c, []byte("d"))
+	if err != nil {
+		t.Fatalf("register should self-heal the missing dir: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dictsDir, "1.zst")); err != nil {
+		t.Errorf("dict file not written (id=%d): %v", id, err)
+	}
+	if got, ok := r.idFor(c); !ok || got != id {
+		t.Errorf("codec not registered after successful write (id=%d ok=%v)", got, ok)
+	}
+
+	// Now make the write fail: put a regular file where the dicts dir must be, on a
+	// fresh registry, so MkdirAll fails -> the codec must NOT be registered.
+	dir2 := t.TempDir()
+	blocker := filepath.Join(dir2, "dicts")
+	if err := os.WriteFile(blocker, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	r2 := newDictReg(identityCodec{})
+	r2.dir = blocker // MkdirAll(blocker) fails: it is a file
+	c2 := &countingCodec{}
+	if _, err := r2.register(c2, []byte("d")); err == nil {
+		t.Fatal("register must fail when the dict file cannot be written")
+	}
+	if _, ok := r2.idFor(c2); ok {
+		t.Error("a codec whose dict write failed must not be registered (recovery hazard)")
+	}
+}
+
+// countingCodec is a distinct Codec value for registry tests (identity behavior).
+type countingCodec struct{}
+
+func (countingCodec) Name() string                       { return "test-counting" }
+func (countingCodec) Compress(dst, src []byte) []byte    { return append(dst, src...) }
+func (countingCodec) Decompress(dst, src []byte) ([]byte, error) { return append(dst, src...), nil }

--- a/collections/dict_dir_test.go
+++ b/collections/dict_dir_test.go
@@ -65,6 +65,6 @@ func TestRegisterRecreatesMissingDir(t *testing.T) {
 // countingCodec is a distinct Codec value for registry tests (identity behavior).
 type countingCodec struct{}
 
-func (countingCodec) Name() string                       { return "test-counting" }
-func (countingCodec) Compress(dst, src []byte) []byte    { return append(dst, src...) }
+func (countingCodec) Name() string                               { return "test-counting" }
+func (countingCodec) Compress(dst, src []byte) []byte            { return append(dst, src...) }
 func (countingCodec) Decompress(dst, src []byte) ([]byte, error) { return append(dst, src...), nil }

--- a/collections/persist.go
+++ b/collections/persist.go
@@ -63,25 +63,38 @@ func (r *dictReg) codecFor(id uint32) (Codec, bool) {
 // (for a persistent collection) writes the dictionary bytes durably to
 // <dir>/dicts/<id>.zst so recovery can reconstruct the codec. Returns the id.
 func (r *dictReg) register(codec Codec, dict []byte) (uint32, error) {
+	// Reserve the id under the lock (so concurrent registers never collide), but do
+	// NOT register the codec in byID/idOf yet: for a persistent collection we must
+	// persist the dictionary bytes FIRST, so a failed write never leaves a codec
+	// whose backing dict file is missing (a recovery hazard) -- segments would be
+	// tagged with a dictionary id whose .zst does not exist. A failed write leaves a
+	// hole in the id sequence, which is harmless (loadDicts resumes at max+1).
 	r.mu.Lock()
 	id := r.next
 	r.next++
-	r.byID[id] = codec
-	r.idOf[codec] = id
 	dir := r.dir
 	r.mu.Unlock()
-	if dir == "" {
-		return id, nil // in-memory: nothing to persist
+	if dir != "" {
+		if err := writeDictFile(filepath.Join(dir, fmt.Sprintf("%d.zst", id)), dict); err != nil {
+			return 0, err
+		}
 	}
-	if err := writeDictFile(filepath.Join(dir, fmt.Sprintf("%d.zst", id)), dict); err != nil {
-		return id, err
-	}
+	r.mu.Lock()
+	r.byID[id] = codec
+	r.idOf[codec] = id
+	r.mu.Unlock()
 	return id, nil
 }
 
 // writeDictFile writes a dictionary's bytes to path and fsyncs it (so a codec that
 // segments already reference cannot be lost across a crash).
 func writeDictFile(path string, dict []byte) error {
+	// Recreate the dicts directory if it went missing at runtime. It is created at
+	// Open, but a retrain must not fail with ENOENT (open ".../dicts/N.zst: no such
+	// file or directory") just because the directory disappeared underneath us.
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
 	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o644)
 	if err != nil {
 		return err


### PR DESCRIPTION
`.retrain` on a busy DB failed with `open .../dicts/N.zst: no such file or directory` -- the dicts dir (created at Open) had gone missing at runtime, and each retrain burned the next id (observed `6.zst` then `7.zst`).

- `writeDictFile` now `MkdirAll`s the parent dir before creating the file (self-heal).
- `register` persists the `.zst` **before** committing the codec to `byID/idOf`, so a failed write never registers a codec whose backing file is missing (recovery hazard).

Tests: `writeDictFile`/`register` recreate a missing dir; a failed write does not register the codec. (Still open: *what* removes the dir at runtime -- no in-tree `os.Remove` of it; this makes retrain resilient regardless.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)