### PR TITLE
collections/db/dbrpc: operational timing counters (OpStats)

### DIFF
--- a/collections/commit.go
+++ b/collections/commit.go
@@ -1,5 +1,7 @@
 package collections
 
+import "time"
+
 // Group commit. Concurrent writers to a shard are coalesced so that a batch of
 // writes is applied under a single commitSeq bump and a single durability sync.
 // Today the store is in-memory and the sync is a no-op, so coalescing is roughly
@@ -115,13 +117,13 @@ func (sh *shard) finishFlush() {
 // applyWrites commits a single writer's writes under the shard lock at a fresh
 // commit sequence, then runs the durability sync once.
 func (sh *shard) applyWrites(writes []pendingPut) {
-	sh.mu.Lock()
+	acq, held := sh.lockWrite()
 	seq := sh.commitSeq + 1
 	for i := range writes {
 		sh.put(writes[i].hash, writes[i].key, writes[i].ad, seq, writes[i].codec)
 	}
 	sh.commitSeq = seq
-	sh.mu.Unlock()
+	sh.unlockWrite(acq, held)
 	sh.sync()
 	if sh.hub != nil {
 		for i := range writes {
@@ -133,11 +135,11 @@ func (sh *shard) applyWrites(writes []pendingPut) {
 // applyOne commits a single write under the shard lock at a fresh commit
 // sequence, then runs the durability sync once.
 func (sh *shard) applyOne(p pendingPut) {
-	sh.mu.Lock()
+	acq, held := sh.lockWrite()
 	seq := sh.commitSeq + 1
 	sh.put(p.hash, p.key, p.ad, seq, p.codec)
 	sh.commitSeq = seq
-	sh.mu.Unlock()
+	sh.unlockWrite(acq, held)
 	sh.sync()
 	if sh.hub != nil {
 		sh.hub.publish(sh.idx, seq, p.key, p.ad, p.codec, false)
@@ -147,7 +149,7 @@ func (sh *shard) applyOne(p pendingPut) {
 // applyBatch commits a coalesced batch of requests under the shard lock at a
 // single fresh commit sequence, then runs the durability sync once for the batch.
 func (sh *shard) applyBatch(batch []*commitReq) {
-	sh.mu.Lock()
+	acq, held := sh.lockWrite()
 	seq := sh.commitSeq + 1
 	for _, r := range batch {
 		for i := range r.writes {
@@ -155,7 +157,7 @@ func (sh *shard) applyBatch(batch []*commitReq) {
 		}
 	}
 	sh.commitSeq = seq
-	sh.mu.Unlock()
+	sh.unlockWrite(acq, held)
 	sh.sync()
 	if sh.hub != nil {
 		for _, r := range batch {
@@ -209,6 +211,10 @@ func (sh *shard) sync() {
 		s.seg.pin()
 	}
 	sh.mu.Unlock()
+	// Time the actual durability flush -- the msync syscalls -- so an operator can see
+	// whether stalls are "just an fsync thing". The unpin bookkeeping below is cheap and
+	// excluded.
+	syncStart := time.Now()
 	for _, r := range ranges {
 		_ = r.seg.msyncRange(r.from, r.to)
 	}
@@ -221,6 +227,7 @@ func (sh *shard) sync() {
 		off := int(s.off) + recSupOff
 		_ = s.seg.msyncRange(off, off+8)
 	}
+	sh.metrics.sync.observe(time.Since(syncStart))
 	for i := range ranges {
 		ranges[i].seg.unpin()
 	}

--- a/collections/compact.go
+++ b/collections/compact.go
@@ -40,6 +40,8 @@ const (
 // safe to call concurrently with reads and writes. Returns the number of shards where
 // space was reclaimed (by either mechanism).
 func (c *Collection) Compact() int {
+	start := time.Now()
+	defer func() { c.opm.compact.observe(time.Since(start)) }()
 	target := c.currentCodec()
 	n := 0
 	for _, sh := range c.shards {
@@ -182,6 +184,8 @@ func (c *Collection) Rewrite() int {
 // scans are unaffected: they decode retired segments with the codec those
 // segments were written under (recorded per segment). Returns the dictionary size.
 func (c *Collection) RetrainDict(sampleMax int) (int, error) {
+	start := time.Now()
+	defer func() { c.opm.retrain.observe(time.Since(start)) }()
 	dict, err := TrainDict(c.CollectSamples(sampleMax))
 	if err != nil {
 		return 0, err

--- a/collections/index_query.go
+++ b/collections/index_query.go
@@ -4,6 +4,7 @@ import (
 	"math"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/RoaringBitmap/roaring/v2"
 
@@ -24,6 +25,8 @@ import (
 // span of segments therefore evolves toward the current spec at whatever cadence
 // the caller reindexes — no write-path or compaction coupling.
 func (c *Collection) Reindex() {
+	start := time.Now()
+	defer func() { c.opm.reindex.observe(time.Since(start)) }()
 	spec := c.spec.Load()
 	persistent := c.dir != ""
 	for _, sh := range c.shards {

--- a/collections/opstats.go
+++ b/collections/opstats.go
@@ -1,0 +1,99 @@
+package collections
+
+import (
+	"sync/atomic"
+	"time"
+)
+
+// Operational timing counters -- "where does the collection block the world?"
+//
+// A collection stalls its callers in a handful of places: waiting for and holding a
+// shard's write lock, allocating a new arena segment (a syscall under the shard
+// lock), flushing mmap'd data to disk (msync), holding the collection-wide snapshot
+// lock exclusively (Truncate/Restore reload the world), and the heavy maintenance
+// passes (compact, dict retrain, reindex). opMetrics accumulates, for each of those,
+// how many times it ran and the total wall time spent in it, as monotonic counters.
+//
+// The design is Prometheus-friendly: OpStats() returns cumulative {Count, Nanos}
+// pairs, so a scraper (e.g. htcondordb, which runs the store in a separate process)
+// derives rate() from the counters and mean latency from Nanos/Count -- exactly the
+// _sum/_count pair a Prometheus summary exposes. Nothing here depends on a metrics
+// library, keeping the collections package dependency-free.
+//
+// Per-shard counters live on the shard itself so writers under the shard lock and
+// concurrent readers do not all contend on one cache line; collection-wide counters
+// (maintenance, snapshot lock) are infrequent and live on the Collection. All are
+// plain atomics, read locklessly by OpStats().
+
+// opCounter is one instrumented operation: a call count and cumulative nanoseconds.
+type opCounter struct {
+	count atomic.Int64
+	nanos atomic.Int64
+}
+
+// observe records one occurrence lasting d.
+func (o *opCounter) observe(d time.Duration) {
+	o.count.Add(1)
+	o.nanos.Add(int64(d))
+}
+
+// snapshot reads the counter locklessly.
+func (o *opCounter) snapshot() OpStat {
+	return OpStat{Count: o.count.Load(), Nanos: o.nanos.Load()}
+}
+
+// shardMetrics are the per-shard operational counters, kept on each shard to avoid
+// cross-shard contention on a single collection-wide atomic under multi-shard writes.
+// Read-lock timing is intentionally omitted: a reader that holds a shard too long
+// shows up as writeWait on the writers it blocks, which is the signal that matters.
+type shardMetrics struct {
+	writeWait opCounter // time blocked acquiring the shard write lock
+	writeHold opCounter // time holding the shard write lock (the world is blocked)
+	segAlloc  opCounter // time allocating/mapping a new arena segment
+	sync      opCounter // time flushing segment bytes to disk (msync/fsync)
+}
+
+// opMetrics are the collection-wide maintenance-pass counters; per-shard counters
+// live on each shard's shardMetrics. (The collection-wide snapshot lock lives in the
+// db package, which keeps its own counter -- see db.OpStats.)
+type opMetrics struct {
+	compact opCounter // Compact() reclaiming dead space
+	retrain opCounter // dictionary retrain + rewrite
+	reindex opCounter // index rebuild
+}
+
+// OpStat is one operation's cumulative call count and total wall-nanoseconds. Both
+// are monotonic; a scraper derives rate and mean latency (Nanos/Count) from deltas.
+type OpStat struct {
+	Count int64 `json:"count"`
+	Nanos int64 `json:"nanos"`
+}
+
+// OpStats is a snapshot of a collection's operational timing counters -- the wall
+// time its callers spent blocked in, or holding, each of the store's stall points.
+// Shard counters are summed across all shards. See opMetrics for what each measures.
+// OpStats reports, per stall point, the cumulative call count and total wall time.
+// The collection-wide snapshot lock (Truncate/Restore) lives one layer up in the db
+// package, which composes its own snapshot-lock counter onto this snapshot.
+type OpStats struct {
+	ShardWriteWait OpStat `json:"shardWriteWait"`
+	ShardWriteHold OpStat `json:"shardWriteHold"`
+	SegmentAlloc   OpStat `json:"segmentAlloc"`
+	Sync           OpStat `json:"sync"`
+	Compact        OpStat `json:"compact"`
+	Retrain        OpStat `json:"retrain"`
+	Reindex        OpStat `json:"reindex"`
+}
+
+// add accumulates one shard's counters into the snapshot.
+func (s *OpStats) add(m *shardMetrics) {
+	addStat(&s.ShardWriteWait, m.writeWait.snapshot())
+	addStat(&s.ShardWriteHold, m.writeHold.snapshot())
+	addStat(&s.SegmentAlloc, m.segAlloc.snapshot())
+	addStat(&s.Sync, m.sync.snapshot())
+}
+
+func addStat(dst *OpStat, v OpStat) {
+	dst.Count += v.Count
+	dst.Nanos += v.Nanos
+}

--- a/collections/opstats_test.go
+++ b/collections/opstats_test.go
@@ -1,0 +1,68 @@
+package collections
+
+import (
+	"fmt"
+	"testing"
+)
+
+// TestOpStatsWriteAndSegmentCounters: writes count shard write-lock wait/hold and
+// segment allocations.
+func TestOpStatsWriteAndSegmentCounters(t *testing.T) {
+	t.Parallel()
+	c := New(Options{Shards: 4, SegmentSize: 1 << 14})
+	const n = 300
+	for i := 0; i < n; i++ {
+		if err := c.Put([]byte(fmt.Sprintf("k%d", i)), mustAd(t, fmt.Sprintf(`[Id=%d]`, i))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	op := c.OpStats()
+	if op.ShardWriteHold.Count == 0 {
+		t.Error("ShardWriteHold.Count = 0; every write holds a shard lock")
+	}
+	if op.ShardWriteWait.Count == 0 {
+		t.Error("ShardWriteWait.Count = 0; every write acquires a shard lock")
+	}
+	if op.ShardWriteHold.Count != op.ShardWriteWait.Count {
+		t.Errorf("wait/hold counts differ (%d vs %d); they are recorded as a pair",
+			op.ShardWriteWait.Count, op.ShardWriteHold.Count)
+	}
+	if op.SegmentAlloc.Count == 0 {
+		t.Error("SegmentAlloc.Count = 0; the first write to each shard allocates a segment")
+	}
+	// Counters are cumulative and non-negative.
+	if op.ShardWriteHold.Nanos < 0 || op.SegmentAlloc.Nanos < 0 {
+		t.Errorf("negative cumulative nanos: hold=%d seg=%d", op.ShardWriteHold.Nanos, op.SegmentAlloc.Nanos)
+	}
+}
+
+// TestOpStatsMaintenanceCounters: each maintenance pass bumps exactly its own counter.
+func TestOpStatsMaintenanceCounters(t *testing.T) {
+	t.Parallel()
+	c := New(Options{Shards: 2, SegmentSize: 1 << 14})
+	for i := 0; i < 50; i++ {
+		if err := c.Put([]byte(fmt.Sprintf("k%d", i)), mustAd(t, fmt.Sprintf(`[Id=%d]`, i))); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	before := c.OpStats()
+	c.Compact()
+	if got, want := c.OpStats().Compact.Count, before.Compact.Count+1; got != want {
+		t.Errorf("Compact.Count = %d, want %d", got, want)
+	}
+
+	before = c.OpStats()
+	c.Reindex()
+	if got, want := c.OpStats().Reindex.Count, before.Reindex.Count+1; got != want {
+		t.Errorf("Reindex.Count = %d, want %d", got, want)
+	}
+
+	before = c.OpStats()
+	if _, err := c.RetrainDict(64); err != nil {
+		t.Logf("RetrainDict returned %v (still expected to record a timing)", err)
+	}
+	if got, want := c.OpStats().Retrain.Count, before.Retrain.Count+1; got != want {
+		t.Errorf("Retrain.Count = %d, want %d", got, want)
+	}
+}

--- a/collections/shard.go
+++ b/collections/shard.go
@@ -3,6 +3,7 @@ package collections
 import (
 	"bytes"
 	"sync"
+	"time"
 )
 
 // shard owns an independent slice of the keyspace: a directory mapping a key hash
@@ -71,6 +72,29 @@ type shard struct {
 	// hashing to h has zero children, so this parent does too. Guarded by mu.
 	childParentHash func(key []byte) (uint64, bool)
 	childCount      map[uint64]int
+
+	// metrics accumulates this shard's operational timings (write-lock wait/hold,
+	// segment allocation, durability sync). See opstats.go.
+	metrics shardMetrics
+}
+
+// lockWrite acquires the shard write lock, returning the timestamps unlockWrite needs
+// to attribute time to the writeWait (blocked acquiring) and writeHold (blocking the
+// world) counters. Every lockWrite must be paired with an unlockWrite.
+func (sh *shard) lockWrite() (acq, held time.Time) {
+	acq = time.Now()
+	sh.mu.Lock()
+	held = time.Now()
+	return
+}
+
+// unlockWrite releases the shard write lock and records the wait/hold timings. The
+// counter updates run after Unlock so they never extend the critical section.
+func (sh *shard) unlockWrite(acq, held time.Time) {
+	hold := time.Since(held)
+	sh.mu.Unlock()
+	sh.metrics.writeWait.observe(held.Sub(acq))
+	sh.metrics.writeHold.observe(hold)
 }
 
 // supRef identifies a supersededBySeq field (a record's tombstone) that must be
@@ -93,6 +117,8 @@ func newShard(segSize int, onSync func()) *shard {
 // returns nil; the caller must treat the write as failed. Caller holds the write
 // lock.
 func (sh *shard) allocSeg(id uint32, size int, codec Codec) *segment {
+	start := time.Now()
+	defer func() { sh.metrics.segAlloc.observe(time.Since(start)) }()
 	if sh.alloc == nil {
 		s := newSegment(id, size, codec)
 		s.pinReap = sh.sealRAM // pin/reap-eligible so its anon sidecar tears down safely

--- a/collections/stats.go
+++ b/collections/stats.go
@@ -44,3 +44,20 @@ func (c *Collection) Stats() Stats {
 	}
 	return s
 }
+
+// OpStats returns a snapshot of the collection's operational timing counters -- where
+// its callers spent time blocked in, or holding, each of the store's stall points
+// (shard write lock, segment allocation, durability sync, and the maintenance passes).
+// Per-shard counters are summed across all shards; every value is a monotonic
+// cumulative total, so a scraper derives rate and mean latency from deltas. It reads
+// atomics locklessly, so it never contends with readers or writers.
+func (c *Collection) OpStats() OpStats {
+	var s OpStats
+	for _, sh := range c.shards {
+		s.add(&sh.metrics)
+	}
+	s.Compact = c.opm.compact.snapshot()
+	s.Retrain = c.opm.retrain.snapshot()
+	s.Reindex = c.opm.reindex.snapshot()
+	return s
+}

--- a/collections/store.go
+++ b/collections/store.go
@@ -214,6 +214,10 @@ type Collection struct {
 	sealer    wire.Sealer
 	encAttrs  atomic.Pointer[encSetHolder]
 	privCache sync.Map // attribute name -> bool (classad.IsPrivateAttribute), memoized
+
+	// opm accumulates the collection-wide maintenance timings (compact/retrain/reindex)
+	// for OpStats; per-shard write/segment/sync timings live on each shard. See opstats.go.
+	opm opMetrics
 }
 
 // rootKey returns the key of the family root for key: it follows parentKeyFor to
@@ -500,13 +504,13 @@ func (c *Collection) Put(key []byte, ad *classad.ClassAd) error {
 func (c *Collection) Delete(key []byte) bool {
 	h := c.h.Hash(key)
 	sh := c.shards[c.shardOf(key, h)]
-	sh.mu.Lock()
+	acq, held := sh.lockWrite()
 	seq := sh.commitSeq + 1
 	ok, parentEmptied := sh.del(h, key, seq)
 	if ok {
 		sh.commitSeq = seq
 	}
-	sh.mu.Unlock()
+	sh.unlockWrite(acq, held)
 	if ok {
 		c.removeOrdered(key)
 		sh.sync() // durability point for the tombstone (not coalesced)

--- a/collections/txn.go
+++ b/collections/txn.go
@@ -124,7 +124,7 @@ type txnWrite struct {
 // respect to other committers (first-committer-wins). Conflicting writes are skipped
 // and flagged; the rest commit at one fresh sequence.
 func (sh *shard) commitTxn(ws []*txnWrite, durable bool) {
-	sh.mu.Lock()
+	acq, held := sh.lockWrite()
 	seq := sh.commitSeq + 1
 	// Single-writer fast path: all of a shard's buffered writes share one snapshot
 	// (ws[0].base). If no one has committed to this shard since -- commitSeq is still
@@ -154,7 +154,7 @@ func (sh *shard) commitTxn(ws []*txnWrite, durable bool) {
 	if changed {
 		sh.commitSeq = seq
 	}
-	sh.mu.Unlock()
+	sh.unlockWrite(acq, held)
 	if changed {
 		if durable {
 			sh.sync()

--- a/db/db.go
+++ b/db/db.go
@@ -20,6 +20,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/PelicanPlatform/classad/classad"
@@ -42,6 +43,25 @@ type DB struct {
 	// commits proceed); Truncate/Restore take it exclusively so a reload is atomic against
 	// all writers. See db/snapshot.go.
 	snapMu sync.RWMutex
+
+	// snapLock{Count,Nanos} accumulate how long snapMu was held exclusively (a
+	// Truncate/Restore blocks every writer for the whole reload); surfaced via OpStats.
+	snapLockCount atomic.Int64
+	snapLockNanos atomic.Int64
+}
+
+// lockSnapExclusive takes the DB-wide snapshot lock exclusively and returns a release
+// func that records the exclusive-hold duration -- the wall time the whole store was
+// blocked. Use as: defer db.lockSnapExclusive()().
+func (db *DB) lockSnapExclusive() func() {
+	db.snapMu.Lock()
+	held := time.Now()
+	return func() {
+		hold := time.Since(held)
+		db.snapMu.Unlock()
+		db.snapLockCount.Add(1)
+		db.snapLockNanos.Add(int64(hold))
+	}
 }
 
 // OrderSpec, SortKey, OrderedAd, OrderCursor configure and drive maintained ordered
@@ -294,6 +314,26 @@ func (db *DB) ExplainMatch(job *classad.ClassAd, targetConstraint string) MatchE
 // Stats returns a snapshot of the store's storage (ad count, segment/arena/dead
 // bytes) for observability.
 func (db *DB) Stats() Stats { return db.c.Stats() }
+
+// OpStat is one operation's cumulative call count and total wall-nanoseconds.
+type OpStat = collections.OpStat
+
+// OpStats is a snapshot of the store's operational timing counters -- where callers
+// spent time blocked in, or holding, each stall point (see collections.OpStats) --
+// plus the DB-wide snapshot lock's exclusive-hold time (Truncate/Restore). Every value
+// is a monotonic cumulative total; a scraper derives rate and mean latency from deltas.
+type OpStats struct {
+	collections.OpStats
+	SnapshotLock OpStat `json:"snapshotLock"`
+}
+
+// OpStats returns the store's operational timing counters (see the OpStats type).
+func (db *DB) OpStats() OpStats {
+	return OpStats{
+		OpStats:      db.c.OpStats(),
+		SnapshotLock: OpStat{Count: db.snapLockCount.Load(), Nanos: db.snapLockNanos.Load()},
+	}
+}
 
 // HotAttrs returns the current hot attributes (front-loaded in each ad's hot
 // header for cheap access).

--- a/db/opstats_test.go
+++ b/db/opstats_test.go
@@ -1,0 +1,33 @@
+package db
+
+import "testing"
+
+// TestOpStatsSnapshotLockAndWrites: transactional writes accumulate the shard
+// write-lock counters (via collections), and a Truncate records the DB-wide snapshot
+// lock's exclusive hold.
+func TestOpStatsSnapshotLockAndWrites(t *testing.T) {
+	db, err := Open(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	fill(t, db, "a", 100)
+
+	op := db.OpStats()
+	if op.ShardWriteHold.Count == 0 {
+		t.Error("ShardWriteHold.Count = 0; the committed transaction holds shard write locks")
+	}
+	if op.SnapshotLock.Count != 0 {
+		t.Errorf("SnapshotLock.Count = %d before any Truncate/Restore, want 0", op.SnapshotLock.Count)
+	}
+
+	db.Truncate()
+	op = db.OpStats()
+	if op.SnapshotLock.Count != 1 {
+		t.Errorf("SnapshotLock.Count = %d after one Truncate, want 1", op.SnapshotLock.Count)
+	}
+	if op.SnapshotLock.Nanos < 0 {
+		t.Errorf("SnapshotLock.Nanos = %d, want >= 0", op.SnapshotLock.Nanos)
+	}
+}

--- a/db/snapshot.go
+++ b/db/snapshot.go
@@ -162,8 +162,7 @@ func (db *DB) snapshotTo(bw *bufio.Writer) ([]byte, error) {
 // DB-wide lock exclusively). A DAEMON-level operation -- the first half of a restore, or
 // a deliberate wipe.
 func (db *DB) Truncate() {
-	db.snapMu.Lock()
-	defer db.snapMu.Unlock()
+	defer db.lockSnapExclusive()()
 	db.c.Truncate()
 	db.c.Reindex()
 }
@@ -218,8 +217,7 @@ func (db *DB) restore(r io.Reader, keys SnapshotKeys) error {
 // end-of-body marker, since every read is byte-exact), so a catalog restore can read
 // several table sections from one shared reader. It takes the DB-wide lock exclusively.
 func (db *DB) restoreFrom(br *bufio.Reader, keys SnapshotKeys) error {
-	db.snapMu.Lock()
-	defer db.snapMu.Unlock()
+	defer db.lockSnapExclusive()()
 
 	magic := make([]byte, len(snapMagic))
 	if _, err := io.ReadFull(br, magic); err != nil {

--- a/dbrpc/diag.go
+++ b/dbrpc/diag.go
@@ -15,6 +15,7 @@ import (
 // commands.
 type Diagnostics struct {
 	Stats              db.Stats             `json:"stats"`
+	OpStats            db.OpStats           `json:"opStats"`
 	Hot                []string             `json:"hot"`
 	CategoricalIndexes []string             `json:"categoricalIndexes"`
 	ValueIndexes       []string             `json:"valueIndexes"`
@@ -37,6 +38,7 @@ func (s *Server) diagJSON(t *db.DB) ([]byte, error) {
 	cat, val := t.IndexedAttrs()
 	d := Diagnostics{
 		Stats:              t.Stats(),
+		OpStats:            t.OpStats(),
 		Hot:                t.HotAttrs(),
 		CategoricalIndexes: cat,
 		ValueIndexes:       val,


### PR DESCRIPTION
## Why
The Go collector went unresponsive under load, and it wasn't clear which part of the store was **blocking the world**. This adds cumulative timing counters at each stall point so an operator can attribute stalls without attaching a profiler — and surfaces them through the existing `.stats` diagnostic, so a separate process (**htcondordb**) can scrape them.

## What's measured (`collections`)
A lockless `opCounter` (call count + cumulative nanos) at each stall point — **per-shard** where it's hot (so writes don't all contend on one cache line), **collection-wide** for the rare maintenance passes:

| Counter | What it captures |
|---|---|
| `shardWriteWait` | time blocked *acquiring* a shard write lock (contention) |
| `shardWriteHold` | time *holding* a shard write lock (the world is blocked) |
| `segmentAlloc` | new arena segment allocation (the `mmap` syscall, under the write lock) |
| `sync` | the durability flush — the `msync` syscalls — isolated in `shard.sync()` |
| `compact` / `retrain` / `reindex` | the heavy maintenance passes |
| `snapshotLock` (db layer) | DB-wide snapshot lock held exclusively (Truncate/Restore reload the world) |

Write-lock timing is applied at **every** write site via `lockWrite`/`unlockWrite` helpers — including `commitTxn`, which is the path the dbrpc/collector transactions actually take. Timings are recorded **after `Unlock`**, so instrumentation never extends the critical section.

Read-lock timing is intentionally omitted: a slow reader shows up as `shardWriteWait` on the writers it blocks, which is the signal that matters.

## Prometheus-friendly by design
`Collection.OpStats()` returns plain `{Count, Nanos}` pairs (summed across shards) — the same `_sum`/`_count` shape a Prometheus summary exposes, so a scraper derives `rate()` and mean latency (`Nanos/Count`) from deltas. **No metrics-library dependency** is added to the store.

## Exposure
- `collections.OpStats()` — the store-level snapshot.
- `db.OpStats` embeds `collections.OpStats` and adds `SnapshotLock` (the DB-wide lock lives in `db`); `db.OpStats()` composes them.
- `dbrpc.Diagnostics` now carries `OpStats`, so the `.stats` payload already plumbed to the collector/CLI includes the operational counters.

## Tests
- Write and segment counters accumulate; wait/hold are recorded as a pair.
- Each maintenance pass bumps exactly its own counter — recorded even when `RetrainDict` errors (defer-based).
- A `Truncate` records exactly one exclusive snapshot-lock hold.

`collections`, `db`, and `dbrpc` suites all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
