### PR TITLE
db,dbrpc: materialized views — incremental aggregate views for Prometheus

### DIFF
--- a/db/catalog.go
+++ b/db/catalog.go
@@ -28,6 +28,7 @@ type Catalog struct {
 	mu       sync.Mutex
 	tables   map[string]*DB
 	archives map[string]*ArchiveTable
+	views    map[string]*View
 }
 
 // tablesSubdir / archivesSubdir are where a persistent catalog keeps its per-table
@@ -35,6 +36,7 @@ type Catalog struct {
 const (
 	tablesSubdir   = "tables"
 	archivesSubdir = "archives"
+	viewsSubdir    = "views"
 )
 
 // CatalogConfig configures a catalog, including encryption at rest applied to every
@@ -60,6 +62,7 @@ func OpenCatalog(dir string) (*Catalog, error) {
 func OpenCatalogConfig(cfg CatalogConfig) (*Catalog, error) {
 	cat := &Catalog{
 		dir: cfg.Dir, tables: map[string]*DB{}, archives: map[string]*ArchiveTable{},
+		views:    map[string]*View{},
 		poolKeys: cfg.PoolKeys, encAttrs: cfg.EncryptedAttrs,
 	}
 	if cfg.Dir == "" {
@@ -105,6 +108,15 @@ func OpenCatalogConfig(cfg CatalogConfig) (*Catalog, error) {
 			return nil, fmt.Errorf("catalog: opening archive %q: %w", e.Name(), err)
 		}
 		cat.archives[e.Name()] = at
+	}
+	// Recover materialized views from <dir>/views/. A view's DATA is not persisted; only
+	// its definition is, so each view is rebuilt from its base table here. This runs after
+	// tables are loaded so a view's base table exists. A view whose rebuild fails (e.g.
+	// cardinality) or whose base table is absent does NOT fail catalog open -- it loads in
+	// the failed/stale state and can be fixed by the operator.
+	if err := cat.recoverViews(); err != nil {
+		cat.closeAll()
+		return nil, err
 	}
 	return cat, nil
 }
@@ -359,6 +371,10 @@ func (cat *Catalog) closeAll() error {
 			first = err
 		}
 		delete(cat.archives, name)
+	}
+	for name, v := range cat.views {
+		v.stop() // cancels the live updater and closes the in-memory backing
+		delete(cat.views, name)
 	}
 	return first
 }

--- a/db/catalog.go
+++ b/db/catalog.go
@@ -187,6 +187,9 @@ func (cat *Catalog) CreateTableOpts(name string, opts TableOptions) (*DB, error)
 	if _, ok := cat.archives[name]; ok {
 		return nil, fmt.Errorf("catalog: %q already exists as an archive table", name)
 	}
+	if _, ok := cat.views[name]; ok {
+		return nil, fmt.Errorf("catalog: %q already exists as a materialized view", name)
+	}
 	cfgDir := ""
 	if cat.dir != "" && !opts.InMemory {
 		cfgDir = filepath.Join(cat.dir, tablesSubdir, name)

--- a/db/view.go
+++ b/db/view.go
@@ -1,0 +1,625 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/PelicanPlatform/classad/classad"
+)
+
+// Materialized views are cardinality-limited, in-memory aggregates over a base table,
+// maintained incrementally from the base table's change stream (db.Watch). The view
+// DEFINITION (ViewSpec) is persisted in the catalog; the DATA is in-memory and is rebuilt
+// from the base table on reload. Views are intended for Prometheus metrics: columns are
+// typed by alias prefix -- label_* is a Prometheus label, metric_* a metric value.
+//
+// Because the change stream has no before-image (an upsert carries only the new ad; a
+// delete carries only the key), the view keeps a per-key contribution store so it can
+// subtract a key's OLD contribution on update/delete. Memory is therefore O(base rows).
+// Only COUNT/SUM/AVG are supported -- they are the aggregates maintainable by delta
+// (MIN/MAX would need a rescan when the current extreme is removed).
+
+// ViewAggFunc is a delta-maintainable aggregate.
+type ViewAggFunc string
+
+const (
+	ViewCount ViewAggFunc = "count"
+	ViewSum   ViewAggFunc = "sum"
+	ViewAvg   ViewAggFunc = "avg"
+)
+
+// ViewGroupCol is one GROUP BY column: the base-table attribute and the alias it is stored
+// under in the materialized rows (e.g. attr "Owner", alias "label_owner").
+type ViewGroupCol struct {
+	Attr  string `json:"attr"`
+	Alias string `json:"alias"`
+}
+
+// ViewMetric is one aggregate output: the function, its argument attribute ("*" for
+// COUNT(*)), and the alias it is stored under (e.g. "metric_jobs").
+type ViewMetric struct {
+	Func  ViewAggFunc `json:"func"`
+	Arg   string      `json:"arg"`
+	Alias string      `json:"alias"`
+}
+
+// ViewSpec is a materialized view's persisted definition.
+type ViewSpec struct {
+	BaseTable string         `json:"baseTable"`
+	Groups    []ViewGroupCol `json:"groups"`
+	Metrics   []ViewMetric   `json:"metrics"`
+	// Cardinality is the hard maximum number of groups (output series). Exceeding it fails
+	// the build (CreateView error) or, at runtime, moves the view to the failed state.
+	Cardinality int `json:"cardinality"`
+	// SelectText is the original SELECT for display (.views); not used for execution.
+	SelectText string `json:"selectText"`
+}
+
+// Validate checks a spec is well-formed and delta-maintainable.
+func (s ViewSpec) Validate() error {
+	if s.BaseTable == "" {
+		return fmt.Errorf("view: base table is required")
+	}
+	if len(s.Groups) == 0 {
+		return fmt.Errorf("view: at least one GROUP BY column is required")
+	}
+	if len(s.Metrics) == 0 {
+		return fmt.Errorf("view: at least one aggregate metric is required")
+	}
+	if s.Cardinality <= 0 {
+		return fmt.Errorf("view: a positive cardinality limit is required")
+	}
+	for _, m := range s.Metrics {
+		switch m.Func {
+		case ViewCount, ViewSum, ViewAvg:
+		default:
+			return fmt.Errorf("view: unsupported aggregate %q (only COUNT/SUM/AVG are maintainable)", m.Func)
+		}
+		if m.Func != ViewCount && m.Arg == "*" {
+			return fmt.Errorf("view: %s requires an attribute argument, not *", m.Func)
+		}
+	}
+	return nil
+}
+
+// ViewState is a view's lifecycle state.
+type ViewState uint8
+
+const (
+	// ViewBuilding: the initial catch-up is in progress.
+	ViewBuilding ViewState = iota
+	// ViewActive: built and maintaining live.
+	ViewActive
+	// ViewStale: definition loaded but the base table is absent; will bind on the next
+	// activation once the base table exists.
+	ViewStale
+	// ViewFailed: a runtime error (e.g. cardinality exceeded); the updater has stopped.
+	ViewFailed
+)
+
+func (s ViewState) String() string {
+	switch s {
+	case ViewBuilding:
+		return "building"
+	case ViewActive:
+		return "active"
+	case ViewStale:
+		return "stale"
+	case ViewFailed:
+		return "failed"
+	default:
+		return "unknown"
+	}
+}
+
+// metricInput is a key's evaluated contribution to one metric.
+type metricInput struct {
+	defined bool    // whether the metric's argument was defined for this key
+	val     float64 // the numeric argument value (SUM/AVG); unused for COUNT
+}
+
+// contribution is what one base-table key contributes to the view, remembered so the OLD
+// contribution can be subtracted on update/delete (the stream carries no before-image).
+type contribution struct {
+	groupKey string
+	labels   []string
+	inputs   []metricInput
+}
+
+func (c contribution) equal(o contribution) bool {
+	if c.groupKey != o.groupKey || len(c.inputs) != len(o.inputs) {
+		return false
+	}
+	for i := range c.inputs {
+		if c.inputs[i] != o.inputs[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// metricAcc is one group's running accumulator for one metric.
+type metricAcc struct {
+	rows int64   // COUNT(*): every contributing key
+	defN int64   // rows where the argument is defined (COUNT(col) and AVG denominator)
+	sum  float64 // running sum (SUM/AVG)
+}
+
+// groupAcc is one group's state: its label values, how many base keys contribute (so it
+// can be evicted when empty), and a per-metric accumulator.
+type groupAcc struct {
+	labels  []string
+	members int64
+	accs    []metricAcc
+}
+
+// View is a live materialized view: its spec, the per-key contribution store, per-group
+// accumulators, and an in-memory backing DB holding one rendered ad per group (so the view
+// is queried like a table). All mutable state is guarded by mu.
+type View struct {
+	spec    ViewSpec
+	backing *DB // in-memory; one ad per group, keyed by groupKey
+
+	mu      sync.Mutex
+	state   ViewState
+	failErr error
+	contrib map[string]contribution // base key -> contribution
+	groups  map[string]*groupAcc    // groupKey -> accumulator
+	cursor  []byte                  // last durable watch cursor (for resume/persist)
+
+	cancel   context.CancelFunc // stops the live updater
+	stopOnce sync.Once
+}
+
+// newView constructs a view around a spec and an (empty, in-memory) backing DB.
+func newView(spec ViewSpec, backing *DB) *View {
+	return &View{
+		spec:    spec,
+		backing: backing,
+		state:   ViewBuilding,
+		contrib: make(map[string]contribution),
+		groups:  make(map[string]*groupAcc),
+	}
+}
+
+// Spec returns the view's definition.
+func (v *View) Spec() ViewSpec { return v.spec }
+
+// Backing returns the in-memory table holding the materialized rows (read-only in intent).
+func (v *View) Backing() *DB { return v.backing }
+
+// State reports the view's lifecycle state and any failure error.
+func (v *View) State() (ViewState, error) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	return v.state, v.failErr
+}
+
+// SeriesCount returns the current number of groups (Prometheus series).
+func (v *View) SeriesCount() int {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	return len(v.groups)
+}
+
+// contributionOf evaluates a base ad into this view's group key, label values, and metric
+// inputs.
+func (v *View) contributionOf(ad *classad.ClassAd) contribution {
+	labels := make([]string, len(v.spec.Groups))
+	for i, g := range v.spec.Groups {
+		labels[i] = renderLabel(ad.EvaluateAttr(g.Attr))
+	}
+	inputs := make([]metricInput, len(v.spec.Metrics))
+	for i, m := range v.spec.Metrics {
+		if m.Func == ViewCount && m.Arg == "*" {
+			inputs[i] = metricInput{defined: true}
+			continue
+		}
+		val := ad.EvaluateAttr(m.Arg)
+		if val.IsUndefined() || val.IsError() {
+			inputs[i] = metricInput{defined: false}
+			continue
+		}
+		if m.Func == ViewCount {
+			inputs[i] = metricInput{defined: true} // COUNT(col): defined-only
+			continue
+		}
+		num, ok := ad.EvaluateAttrNumber(m.Arg)
+		inputs[i] = metricInput{defined: ok, val: num}
+	}
+	return contribution{groupKey: strings.Join(labels, "\x00"), labels: labels, inputs: inputs}
+}
+
+// add folds a key's contribution into its group (+1 member, +metrics). Creates the group if
+// absent; returns an error if creating it would exceed the cardinality limit.
+func (v *View) add(c contribution) error {
+	g := v.groups[c.groupKey]
+	if g == nil {
+		if len(v.groups) >= v.spec.Cardinality {
+			return fmt.Errorf("view: cardinality limit %d exceeded", v.spec.Cardinality)
+		}
+		g = &groupAcc{labels: c.labels, accs: make([]metricAcc, len(v.spec.Metrics))}
+		v.groups[c.groupKey] = g
+	}
+	g.members++
+	for i, in := range c.inputs {
+		g.accs[i].rows++
+		if in.defined {
+			g.accs[i].defN++
+			g.accs[i].sum += in.val
+		}
+	}
+	return nil
+}
+
+// sub removes a key's contribution from its group, evicting the group when empty.
+func (v *View) sub(c contribution) {
+	g := v.groups[c.groupKey]
+	if g == nil {
+		return
+	}
+	g.members--
+	for i, in := range c.inputs {
+		g.accs[i].rows--
+		if in.defined {
+			g.accs[i].defN--
+			g.accs[i].sum -= in.val
+		}
+	}
+	if g.members <= 0 {
+		delete(v.groups, c.groupKey)
+	}
+}
+
+// applyUpsert applies an upsert of key with ad, maintaining the accumulators and the
+// backing rows. Idempotent: a re-delivered identical ad is a no-op.
+func (v *View) applyUpsert(key string, ad *classad.ClassAd) error {
+	newC := v.contributionOf(ad)
+	old, existed := v.contrib[key]
+	if existed && old.equal(newC) {
+		return nil // duplicate delivery
+	}
+	if existed {
+		v.sub(old)
+	}
+	if err := v.add(newC); err != nil {
+		// Roll back the subtraction so the accumulators stay consistent, then fail.
+		if existed {
+			_ = v.add(old)
+		}
+		return err
+	}
+	v.contrib[key] = newC
+	// Re-render the affected groups.
+	if existed && old.groupKey != newC.groupKey {
+		v.renderGroup(old.groupKey)
+	}
+	v.renderGroup(newC.groupKey)
+	return nil
+}
+
+// applyDelete applies a delete of key.
+func (v *View) applyDelete(key string) {
+	old, existed := v.contrib[key]
+	if !existed {
+		return
+	}
+	v.sub(old)
+	delete(v.contrib, key)
+	v.renderGroup(old.groupKey)
+}
+
+// renderGroup syncs the backing row for groupKey: writes the rendered ad, or deletes it if
+// the group was evicted.
+func (v *View) renderGroup(groupKey string) {
+	g := v.groups[groupKey]
+	if g == nil {
+		_, _ = v.backing.Delete(groupKey)
+		return
+	}
+	ad := classad.New()
+	for i, gc := range v.spec.Groups {
+		ad.InsertAttrString(gc.Alias, g.labels[i])
+	}
+	for i, m := range v.spec.Metrics {
+		acc := g.accs[i]
+		switch m.Func {
+		case ViewCount:
+			if m.Arg == "*" {
+				ad.InsertAttr(m.Alias, acc.rows)
+			} else {
+				ad.InsertAttr(m.Alias, acc.defN)
+			}
+		case ViewSum:
+			ad.InsertAttrFloat(m.Alias, acc.sum)
+		case ViewAvg:
+			avg := 0.0
+			if acc.defN > 0 {
+				avg = acc.sum / float64(acc.defN)
+			}
+			ad.InsertAttrFloat(m.Alias, avg)
+		}
+	}
+	_ = v.backing.Put(groupKey, ad)
+}
+
+// reset clears all view state and the backing (WatchReset: a full rebuild follows).
+func (v *View) reset() {
+	v.contrib = make(map[string]contribution)
+	v.groups = make(map[string]*groupAcc)
+	v.backing.Truncate()
+}
+
+// run does the initial catch-up and then live maintenance over a SINGLE watch (replay then
+// tail), so there is never a second concurrent watch racing the base's segment windows. It
+// signals ready exactly once: nil on the first WatchSynced (the view is built), or an error
+// if the build failed (e.g. a cardinality overflow). After signaling built it keeps
+// maintaining until ctx is cancelled. On WatchReset it rebuilds; on WatchResync it
+// reconnects from the last durable cursor.
+func (v *View) run(ctx context.Context, base *DB, ready chan<- error) {
+	var once sync.Once
+	signal := func(err error) { once.Do(func() { ready <- err }) }
+
+	cursor := []byte(nil) // start from the beginning
+	for {
+		seq, err := base.Watch(ctx, cursor)
+		if err != nil {
+			signal(err)
+			return
+		}
+		resync := false
+		for ev := range seq {
+			v.mu.Lock()
+			var applyErr error
+			switch ev.Kind {
+			case WatchReset:
+				v.reset()
+			case WatchUpsert:
+				if ev.Ad != nil { // a bare upsert with a nil ad is a synced marker at this layer
+					applyErr = v.applyUpsert(ev.Key, ev.Ad)
+				}
+			case WatchDelete:
+				v.applyDelete(ev.Key)
+			case WatchSynced:
+				v.cursor = ev.Cursor
+				if v.state == ViewBuilding {
+					v.state = ViewActive
+				}
+			case WatchResync:
+				resync = true
+			}
+			if applyErr != nil {
+				v.state, v.failErr = ViewFailed, applyErr
+				v.mu.Unlock()
+				signal(applyErr) // the initial build failed (no-op if already live)
+				return
+			}
+			synced := ev.Kind == WatchSynced
+			cur := v.cursor
+			v.mu.Unlock()
+			if synced {
+				signal(nil) // built (first synced); no-op afterwards
+			}
+			if resync {
+				cursor = cur // reconnect from the last durable cursor
+				break
+			}
+		}
+		if ctx.Err() != nil || !resync {
+			signal(ctx.Err()) // stream ended before we ever synced
+			return
+		}
+	}
+}
+
+// Cursor returns the last durable resume cursor (for persistence).
+func (v *View) Cursor() []byte {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	return v.cursor
+}
+
+// stop cancels the live updater and closes the backing. Idempotent (called from CreateView
+// rollback, DropView, and catalog Close).
+func (v *View) stop() {
+	v.stopOnce.Do(func() {
+		if v.cancel != nil {
+			v.cancel()
+		}
+		if v.backing != nil {
+			_ = v.backing.Close()
+		}
+	})
+}
+
+// renderLabel converts an evaluated ClassAd value to a label string. Undefined/error render
+// empty so an absent attribute groups as "".
+func renderLabel(v classad.Value) string {
+	switch {
+	case v.IsUndefined(), v.IsError():
+		return ""
+	case v.IsString():
+		s, _ := v.StringValue()
+		return s
+	case v.IsBool():
+		b, _ := v.BoolValue()
+		return strconv.FormatBool(b)
+	case v.IsInteger():
+		i, _ := v.IntValue()
+		return strconv.FormatInt(i, 10)
+	case v.IsReal():
+		r, _ := v.RealValue()
+		return strconv.FormatFloat(r, 'g', -1, 64)
+	default:
+		return v.String()
+	}
+}
+
+// sortedViewNames returns view names sorted (for deterministic listings).
+func sortedViewNames(m map[string]*View) []string {
+	names := make([]string, 0, len(m))
+	for n := range m {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// --- Catalog view management ---
+
+// CreateView creates a materialized view named name over spec.BaseTable, materializing it
+// synchronously (so a cardinality-limit overflow or an aggregation error fails the create
+// and leaves nothing behind) and then maintaining it live from the base table's change
+// stream. The definition is persisted for a persistent catalog.
+func (cat *Catalog) CreateView(name string, spec ViewSpec) error {
+	if !ValidTableName(name) {
+		return fmt.Errorf("catalog: invalid view name %q", name)
+	}
+	if err := spec.Validate(); err != nil {
+		return err
+	}
+	cat.mu.Lock()
+	defer cat.mu.Unlock()
+	if _, ok := cat.views[name]; ok {
+		return fmt.Errorf("catalog: view %q already exists", name)
+	}
+	if _, ok := cat.tables[name]; ok {
+		return fmt.Errorf("catalog: %q already exists as a table", name)
+	}
+	if _, ok := cat.archives[name]; ok {
+		return fmt.Errorf("catalog: %q already exists as an archive table", name)
+	}
+	base, ok := cat.tables[spec.BaseTable]
+	if !ok {
+		return fmt.Errorf("catalog: view base table %q does not exist", spec.BaseTable)
+	}
+	backing, err := OpenConfig(cat.tableConfig("")) // in-memory
+	if err != nil {
+		return fmt.Errorf("catalog: creating view backing for %q: %w", name, err)
+	}
+	v := newView(spec, backing)
+
+	// Start the single build+maintain goroutine and wait for the initial build to finish.
+	// A cardinality/aggregation error during the build fails the create and leaves nothing
+	// behind; on success the goroutine keeps maintaining the view live.
+	ctx, cancel := context.WithCancel(context.Background())
+	v.cancel = cancel
+	ready := make(chan error, 1)
+	go v.run(ctx, base, ready)
+	if err := <-ready; err != nil {
+		v.stop()
+		return fmt.Errorf("catalog: building view %q: %w", name, err)
+	}
+
+	if cat.dir != "" {
+		if err := saveViewDef(cat.dir, name, spec); err != nil {
+			v.stop()
+			return fmt.Errorf("catalog: persisting view %q: %w", name, err)
+		}
+	}
+	cat.views[name] = v
+	return nil
+}
+
+// DropView removes a view: it stops the updater, drops the in-memory data, and deletes the
+// persisted definition.
+func (cat *Catalog) DropView(name string) error {
+	cat.mu.Lock()
+	defer cat.mu.Unlock()
+	v, ok := cat.views[name]
+	if !ok {
+		return fmt.Errorf("catalog: no such view %q", name)
+	}
+	delete(cat.views, name)
+	v.stop()
+	if cat.dir != "" {
+		if err := os.RemoveAll(filepath.Join(cat.dir, viewsSubdir, name)); err != nil {
+			return fmt.Errorf("catalog: removing view %q: %w", name, err)
+		}
+	}
+	return nil
+}
+
+// Views returns the view names, sorted.
+func (cat *Catalog) Views() []string {
+	cat.mu.Lock()
+	defer cat.mu.Unlock()
+	return sortedViewNames(cat.views)
+}
+
+// View returns the named view.
+func (cat *Catalog) View(name string) (*View, bool) {
+	cat.mu.Lock()
+	defer cat.mu.Unlock()
+	v, ok := cat.views[name]
+	return v, ok
+}
+
+// ViewBacking returns the in-memory backing table of a view, so reads (SELECT/query)
+// resolve a view name to its materialized rows.
+func (cat *Catalog) ViewBacking(name string) (*DB, bool) {
+	cat.mu.Lock()
+	defer cat.mu.Unlock()
+	v, ok := cat.views[name]
+	if !ok {
+		return nil, false
+	}
+	return v.backing, true
+}
+
+// recoverViews reconstructs views from <dir>/views on catalog open. Data is not persisted,
+// so each view is rebuilt from its base table. A view whose base table is absent loads
+// stale (rebound on a later restart once the table exists); a view whose rebuild fails
+// (e.g. cardinality) loads failed. Neither fails catalog open. Runs single-threaded during
+// open (no cat.mu needed). Returns an error only for an infrastructure failure.
+func (cat *Catalog) recoverViews() error {
+	root := filepath.Join(cat.dir, viewsSubdir)
+	entries, err := os.ReadDir(root)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("catalog: reading views dir: %w", err)
+	}
+	for _, e := range entries {
+		if !e.IsDir() || !ValidTableName(e.Name()) {
+			continue
+		}
+		name := e.Name()
+		spec, err := loadViewDef(cat.dir, name)
+		if err != nil {
+			continue // skip an unreadable/corrupt definition rather than fail open
+		}
+		backing, err := OpenConfig(cat.tableConfig(""))
+		if err != nil {
+			return fmt.Errorf("catalog: creating view backing for %q: %w", name, err)
+		}
+		v := newView(spec, backing)
+		base, ok := cat.tables[spec.BaseTable]
+		if !ok {
+			v.state = ViewStale
+			v.failErr = fmt.Errorf("base table %q does not exist", spec.BaseTable)
+			cat.views[name] = v
+			continue
+		}
+		ctx, cancel := context.WithCancel(context.Background())
+		v.cancel = cancel
+		ready := make(chan error, 1)
+		go v.run(ctx, base, ready)
+		if berr := <-ready; berr != nil {
+			// Rebuild failed (e.g. cardinality). Do not fail catalog open; the run
+			// goroutine has already marked the view failed and returned; stop it (cancel +
+			// close backing) and register the failed view so the operator can see it.
+			v.stop()
+			v.state, v.failErr = ViewFailed, berr
+		}
+		cat.views[name] = v
+	}
+	return nil
+}

--- a/db/view_test.go
+++ b/db/view_test.go
@@ -1,0 +1,246 @@
+package db
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/PelicanPlatform/classad/classad"
+)
+
+func viewJob(t *testing.T, owner string, mem int) *classad.ClassAd {
+	t.Helper()
+	ad, err := classad.ParseOld(fmt.Sprintf("Owner = %q\nRequestMemory = %d", owner, mem))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ad
+}
+
+// clusterUsageSpec is the running example: COUNT(*), SUM(RequestMemory), AVG(RequestMemory)
+// grouped by Owner.
+func clusterUsageSpec() ViewSpec {
+	return ViewSpec{
+		BaseTable: "jobs",
+		Groups:    []ViewGroupCol{{Attr: "Owner", Alias: "label_owner"}},
+		Metrics: []ViewMetric{
+			{Func: ViewCount, Arg: "*", Alias: "metric_jobs"},
+			{Func: ViewSum, Arg: "RequestMemory", Alias: "metric_mem"},
+			{Func: ViewAvg, Arg: "RequestMemory", Alias: "metric_avg"},
+		},
+		Cardinality: 100,
+	}
+}
+
+// viewGroup reads the materialized row for a group key from the view backing.
+func viewGroup(t *testing.T, cat *Catalog, view, groupKey string) (*classad.ClassAd, bool) {
+	t.Helper()
+	b, ok := cat.ViewBacking(view)
+	if !ok {
+		t.Fatalf("view %q has no backing", view)
+	}
+	return b.LookupClassAd(groupKey)
+}
+
+// waitSeries polls until the view reports want series (or fails after a timeout) -- live
+// maintenance is asynchronous.
+func waitSeries(t *testing.T, cat *Catalog, view string, want int) {
+	t.Helper()
+	v, ok := cat.View(view)
+	if !ok {
+		t.Fatalf("no view %q", view)
+	}
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if v.SeriesCount() == want {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("view %q series = %d, want %d (timed out)", view, v.SeriesCount(), want)
+}
+
+func TestViewBuildAndQuery(t *testing.T) {
+	cat, err := OpenCatalog(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cat.Close()
+	base, err := cat.CreateTable("jobs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// alice: 2 jobs (100, 300); bob: 1 job (200).
+	if err := base.Put("1", viewJob(t, "alice", 100)); err != nil {
+		t.Fatal(err)
+	}
+	if err := base.Put("2", viewJob(t, "alice", 300)); err != nil {
+		t.Fatal(err)
+	}
+	if err := base.Put("3", viewJob(t, "bob", 200)); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := cat.CreateView("cluster_usage", clusterUsageSpec()); err != nil {
+		t.Fatalf("CreateView: %v", err)
+	}
+
+	// Build is synchronous, so the two groups are materialized immediately.
+	v, _ := cat.View("cluster_usage")
+	if got := v.SeriesCount(); got != 2 {
+		t.Fatalf("series = %d, want 2", got)
+	}
+	alice, ok := viewGroup(t, cat, "cluster_usage", "alice")
+	if !ok {
+		t.Fatal("missing alice group")
+	}
+	if n, _ := alice.EvaluateAttrInt("metric_jobs"); n != 2 {
+		t.Errorf("alice jobs = %d, want 2", n)
+	}
+	if s, _ := alice.EvaluateAttrReal("metric_mem"); s != 400 {
+		t.Errorf("alice mem = %v, want 400", s)
+	}
+	if a, _ := alice.EvaluateAttrReal("metric_avg"); a != 200 {
+		t.Errorf("alice avg = %v, want 200", a)
+	}
+	if o, _ := alice.EvaluateAttrString("label_owner"); o != "alice" {
+		t.Errorf("alice label = %q", o)
+	}
+	if st, _ := v.State(); st != ViewActive {
+		t.Errorf("state = %v, want active", st)
+	}
+}
+
+func TestViewLiveUpsertUpdateDelete(t *testing.T) {
+	cat, err := OpenCatalog(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cat.Close()
+	base, _ := cat.CreateTable("jobs")
+	base.Put("1", viewJob(t, "alice", 100))
+	base.Put("2", viewJob(t, "bob", 200))
+	if err := cat.CreateView("cluster_usage", clusterUsageSpec()); err != nil {
+		t.Fatal(err)
+	}
+	waitSeries(t, cat, "cluster_usage", 2)
+
+	// Insert a new alice job -> alice count 1->2, mem 100->400.
+	base.Put("3", viewJob(t, "alice", 300))
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if a, ok := viewGroup(t, cat, "cluster_usage", "alice"); ok {
+			if n, _ := a.EvaluateAttrInt("metric_jobs"); n == 2 {
+				break
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if a, _ := viewGroup(t, cat, "cluster_usage", "alice"); func() int64 { n, _ := a.EvaluateAttrInt("metric_jobs"); return n }() != 2 {
+		t.Fatal("live insert did not update alice count to 2")
+	}
+
+	// Update job 2's owner bob->carol: bob group evicted, carol appears (series stays 2, so
+	// poll for the actual transition rather than the count).
+	base.Put("2", viewJob(t, "carol", 200))
+	deadline = time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		_, bobOK := viewGroup(t, cat, "cluster_usage", "bob")
+		_, carolOK := viewGroup(t, cat, "cluster_usage", "carol")
+		if !bobOK && carolOK {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if _, ok := viewGroup(t, cat, "cluster_usage", "bob"); ok {
+		t.Error("bob group should be gone after its only member moved to carol")
+	}
+	if _, ok := viewGroup(t, cat, "cluster_usage", "carol"); !ok {
+		t.Error("carol group should exist after the update")
+	}
+
+	// Delete carol's only job: carol evicted -> 1 series.
+	if _, err := base.Delete("2"); err != nil {
+		t.Fatal(err)
+	}
+	waitSeries(t, cat, "cluster_usage", 1)
+	if _, ok := viewGroup(t, cat, "cluster_usage", "carol"); ok {
+		t.Error("carol group should be evicted after deleting its last member")
+	}
+}
+
+func TestViewCardinalityHardError(t *testing.T) {
+	cat, err := OpenCatalog(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cat.Close()
+	base, _ := cat.CreateTable("jobs")
+	for i := 0; i < 5; i++ {
+		base.Put(fmt.Sprintf("%d", i), viewJob(t, fmt.Sprintf("owner%d", i), 10))
+	}
+	spec := clusterUsageSpec()
+	spec.Cardinality = 3 // 5 distinct owners > 3
+	if err := cat.CreateView("cluster_usage", spec); err == nil {
+		t.Fatal("CreateView should fail when the base exceeds the cardinality limit")
+	}
+	if _, ok := cat.View("cluster_usage"); ok {
+		t.Fatal("a view that failed its cardinality build must not be registered")
+	}
+}
+
+func TestViewReloadRebuilds(t *testing.T) {
+	dir := t.TempDir()
+	cat, err := OpenCatalog(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	base, _ := cat.CreateTable("jobs")
+	base.Put("1", viewJob(t, "alice", 100))
+	base.Put("2", viewJob(t, "bob", 200))
+	if err := cat.CreateView("cluster_usage", clusterUsageSpec()); err != nil {
+		t.Fatal(err)
+	}
+	if err := cat.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Reopen: the view definition is persisted; its data is rebuilt from the base table.
+	cat2, err := OpenCatalog(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cat2.Close()
+	if names := cat2.Views(); len(names) != 1 || names[0] != "cluster_usage" {
+		t.Fatalf("views after reload = %v, want [cluster_usage]", names)
+	}
+	v, _ := cat2.View("cluster_usage")
+	if st, _ := v.State(); st != ViewActive {
+		t.Fatalf("reloaded view state = %v, want active", st)
+	}
+	if v.SeriesCount() != 2 {
+		t.Fatalf("reloaded series = %d, want 2", v.SeriesCount())
+	}
+	if a, ok := viewGroup(t, cat2, "cluster_usage", "alice"); !ok || func() int64 { n, _ := a.EvaluateAttrInt("metric_jobs"); return n }() != 1 {
+		t.Fatal("reloaded alice group missing/wrong")
+	}
+}
+
+func TestViewSpecValidate(t *testing.T) {
+	good := clusterUsageSpec()
+	if err := good.Validate(); err != nil {
+		t.Fatalf("valid spec rejected: %v", err)
+	}
+	bad := []ViewSpec{
+		{BaseTable: "", Groups: good.Groups, Metrics: good.Metrics, Cardinality: 1},
+		{BaseTable: "jobs", Metrics: good.Metrics, Cardinality: 1},                                                                  // no groups
+		{BaseTable: "jobs", Groups: good.Groups, Cardinality: 1},                                                                    // no metrics
+		{BaseTable: "jobs", Groups: good.Groups, Metrics: good.Metrics},                                                             // cardinality 0
+		{BaseTable: "jobs", Groups: good.Groups, Metrics: []ViewMetric{{Func: "min", Arg: "x", Alias: "metric_x"}}, Cardinality: 1}, // MIN unsupported
+	}
+	for i, s := range bad {
+		if err := s.Validate(); err == nil {
+			t.Errorf("bad spec %d passed validation", i)
+		}
+	}
+}

--- a/db/viewpersist.go
+++ b/db/viewpersist.go
@@ -1,0 +1,47 @@
+package db
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// A materialized view persists only its DEFINITION (ViewSpec) at
+// <dir>/views/<name>/view.json; its data is in-memory and is rebuilt from the base table
+// on reload (see Catalog.recoverViews). The definition is written atomically (tmp+rename),
+// mirroring db/indexpersist.go.
+
+const viewDefFile = "view.json"
+
+// saveViewDef writes a view's definition under <dir>/views/<name>/view.json.
+func saveViewDef(dir, name string, spec ViewSpec) error {
+	vdir := filepath.Join(dir, viewsSubdir, name)
+	if err := os.MkdirAll(vdir, 0o750); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(spec, "", "  ")
+	if err != nil {
+		return err
+	}
+	path := filepath.Join(vdir, viewDefFile)
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+// loadViewDef reads the persisted definition for a view.
+func loadViewDef(dir, name string) (ViewSpec, error) {
+	path := filepath.Join(dir, viewsSubdir, name, viewDefFile)
+	data, err := os.ReadFile(path) //nolint:gosec // G304 - path is catalog-internal
+	if err != nil {
+		return ViewSpec{}, err
+	}
+	var spec ViewSpec
+	if err := json.Unmarshal(data, &spec); err != nil {
+		return ViewSpec{}, fmt.Errorf("view %q: %w", name, err)
+	}
+	return spec, nil
+}

--- a/db/watch.go
+++ b/db/watch.go
@@ -22,6 +22,13 @@ const (
 	// initial full replay, or a re-sync after the cursor fell out of retention). Key
 	// and Ad are empty.
 	WatchReset
+	// WatchSynced: end of the initial catch-up/replay; the watcher is now live. Cursor is
+	// a durable resume point (and, after a Reset, the point at which a shadow rebuild goes
+	// live). Key and Ad are empty.
+	WatchSynced
+	// WatchResync: the live stream fell behind; reconnect with the last persisted cursor
+	// (which re-enters catch-up). Key and Ad are empty; no state is implied.
+	WatchResync
 )
 
 // WatchEvent is one change to the log. Cursor resumes a watch just after this event
@@ -54,6 +61,10 @@ func (db *DB) Watch(ctx context.Context, cursor []byte) (iter.Seq[WatchEvent], e
 				we.Kind = WatchDelete
 			case collections.WatchReset:
 				we.Kind = WatchReset
+			case collections.WatchSynced:
+				we.Kind = WatchSynced
+			case collections.WatchResync:
+				we.Kind = WatchResync
 			}
 			if !yield(we) {
 				return

--- a/dbrpc/proto.go
+++ b/dbrpc/proto.go
@@ -88,6 +88,12 @@ const (
 	opQueryRawProj   op = 37 // [table][limit i32][constraint][nattrs i32]{[attr]} -> stream of [oldClassAdText] projected to attrs (+ MyType/TargetType); server-side projection so only requested attributes cross the wire
 	opCreateTableMem op = 38 // [table] -> status; create a RAM-only (non-persistent) table; mutating
 	opTableToMemory  op = 39 // [table] -> status; drop an existing table's on-disk backing (DAEMON-only); mutating
+
+	// Materialized views: cardinality-limited in-memory aggregates maintained from the base
+	// table's change stream. The definition rides as a JSON db.ViewSpec (like opArchiveCreate).
+	opCreateView op = 40 // [name][json db.ViewSpec] -> status; mutating
+	opDropView   op = 41 // [name] -> status; mutating
+	opListViews  op = 42 // -> [n i32]{[name]}
 )
 
 // String names an opcode for diagnostics (e.g. the read-only rejection message).
@@ -139,6 +145,12 @@ func (o op) String() string {
 		return "CreateTableInMemory"
 	case opTableToMemory:
 		return "ConvertTableToMemory"
+	case opCreateView:
+		return "CreateView"
+	case opDropView:
+		return "DropView"
+	case opListViews:
+		return "ListViews"
 	case opDropTable:
 		return "DropTable"
 	case opListTables:

--- a/dbrpc/server.go
+++ b/dbrpc/server.go
@@ -52,6 +52,12 @@ type Catalog interface {
 	ArchiveTable(name string) (*db.ArchiveTable, bool)
 	CreateArchiveTable(name string, cfg db.ArchiveConfig) (*db.ArchiveTable, error)
 	ArchiveTables() []string
+	// CreateView / DropView / Views manage materialized views; ViewBacking returns a view's
+	// in-memory backing so reads resolve a view name to its materialized rows.
+	CreateView(name string, spec db.ViewSpec) error
+	DropView(name string) error
+	Views() []string
+	ViewBacking(name string) (*db.DB, bool)
 }
 
 // DefaultTable is the table name a single-DB server serves and the client
@@ -109,7 +115,15 @@ func (s singleCatalog) ConvertTableToMemory(name string) error {
 func (s singleCatalog) DropTable(name string) error {
 	return fmt.Errorf("single-table server: cannot drop tables")
 }
-func (s singleCatalog) Tables() []string { return []string{s.name} }
+func (s singleCatalog) CreateView(name string, spec db.ViewSpec) error {
+	return fmt.Errorf("single-table server: materialized views unsupported")
+}
+func (s singleCatalog) DropView(name string) error {
+	return fmt.Errorf("single-table server: materialized views unsupported")
+}
+func (s singleCatalog) Views() []string                   { return nil }
+func (s singleCatalog) ViewBacking(string) (*db.DB, bool) { return nil, false }
+func (s singleCatalog) Tables() []string                  { return []string{s.name} }
 
 func (s singleCatalog) ArchiveTable(string) (*db.ArchiveTable, bool) { return nil, false }
 func (s singleCatalog) CreateArchiveTable(string, db.ArchiveConfig) (*db.ArchiveTable, error) {
@@ -166,7 +180,7 @@ type QueryLog struct {
 func (o op) isMutating() bool {
 	switch o {
 	case opNewAd, opDestroyAd, opSetAttr, opDeleteAttr, opAdmin, opCreateTable, opDropTable,
-		opCreateTableMem, opTableToMemory,
+		opCreateTableMem, opTableToMemory, opCreateView, opDropView,
 		opArchiveCreate, opArchiveAppend, opArchiveRotate, opDeleteWhere, opCommitIdem:
 		return true
 	}
@@ -269,6 +283,12 @@ func (s *Server) StartMaintenance(interval time.Duration, opts db.MaintainOption
 func (s *Server) tableOr(reqID uint64, name string, write func([]byte)) (*db.DB, bool) {
 	d, ok := s.cat.Table(name)
 	if !ok {
+		// A materialized view is queried like a table via its in-memory backing. Only reads
+		// reach tableOr; writes (opBegin) resolve through cat.Table only, so a view stays
+		// read-only.
+		if d, ok = s.cat.ViewBacking(name); ok {
+			return d, true
+		}
 		write(respErr(reqID, "no such table: "+name))
 	}
 	return d, ok
@@ -617,6 +637,39 @@ func (s *Server) handle(sc *serverConn, reqID uint64, o op, r *reader, includePr
 
 	case opListTables:
 		names := s.cat.Tables()
+		b := putI32(resp(reqID, stOK), int32(len(names)))
+		for _, n := range names {
+			b = putStr(b, n)
+		}
+		return b
+
+	case opCreateView:
+		name := r.str()
+		specJSON := r.bytesRef()
+		if r.err != nil {
+			return respBad(reqID)
+		}
+		var spec db.ViewSpec
+		if err := json.Unmarshal(specJSON, &spec); err != nil {
+			return respErr(reqID, "view spec: "+err.Error())
+		}
+		if err := s.cat.CreateView(name, spec); err != nil {
+			return respErr(reqID, err.Error())
+		}
+		return resp(reqID, stOK)
+
+	case opDropView:
+		name := r.str()
+		if r.err != nil {
+			return respBad(reqID)
+		}
+		if err := s.cat.DropView(name); err != nil {
+			return respErr(reqID, err.Error())
+		}
+		return resp(reqID, stOK)
+
+	case opListViews:
+		names := s.cat.Views()
 		b := putI32(resp(reqID, stOK), int32(len(names)))
 		for _, n := range names {
 			b = putStr(b, n)

--- a/dbrpc/view.go
+++ b/dbrpc/view.go
@@ -1,0 +1,58 @@
+package dbrpc
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/PelicanPlatform/classad/db"
+)
+
+// CreateView creates a materialized view named name from spec. The server materializes it
+// synchronously and then maintains it live from the base table's change stream, so an error
+// (e.g. the base table exceeds the view's cardinality limit) is reported here. A view is
+// queried like a table (SELECT ... FROM <name>) but is read-only.
+func (c *Client) CreateView(ctx context.Context, name string, spec db.ViewSpec) error {
+	data, err := json.Marshal(spec)
+	if err != nil {
+		return err
+	}
+	status, body, err := c.callCtx(ctx, func(id uint64) []byte {
+		return putBytes(putStr(req(id, opCreateView), name), data)
+	})
+	if err != nil {
+		return err
+	}
+	if status != stOK {
+		return statusErr(status, body)
+	}
+	return nil
+}
+
+// DropView removes a materialized view (its definition and its in-memory data).
+func (c *Client) DropView(ctx context.Context, name string) error {
+	status, body, err := c.callCtx(ctx, func(id uint64) []byte { return putStr(req(id, opDropView), name) })
+	if err != nil {
+		return err
+	}
+	if status != stOK {
+		return statusErr(status, body)
+	}
+	return nil
+}
+
+// ListViews returns the materialized view names.
+func (c *Client) ListViews(ctx context.Context) ([]string, error) {
+	status, body, err := c.callCtx(ctx, func(id uint64) []byte { return req(id, opListViews) })
+	if err != nil {
+		return nil, err
+	}
+	if status != stOK {
+		return nil, statusErr(status, body)
+	}
+	n := int(body.i32())
+	names := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		names = append(names, body.str())
+	}
+	return names, nil
+}

--- a/dbrpc/view_wire_test.go
+++ b/dbrpc/view_wire_test.go
@@ -1,0 +1,78 @@
+package dbrpc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/classad"
+	"github.com/PelicanPlatform/classad/db"
+)
+
+// TestViewWire exercises the view opcodes end to end: create a view over a seeded base
+// table, list it, query it like a table (reads resolve to the backing), confirm writes to a
+// view are refused, and drop it.
+func TestViewWire(t *testing.T) {
+	cat, err := db.OpenCatalog(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	base, err := cat.CreateTable("jobs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, j := range []struct {
+		key, owner string
+	}{{"1", "alice"}, {"2", "alice"}, {"3", "bob"}} {
+		ad, _ := classad.ParseOld("Owner = \"" + j.owner + "\"")
+		if err := base.Put(j.key, ad); err != nil {
+			t.Fatal(err)
+		}
+	}
+	s := NewServerCatalog(cat)
+	cconn, sconn := netPipe()
+	go func() { _ = s.ServeConn(sconn) }()
+	c := NewClient(cconn)
+	defer func() { c.Close(); s.Close(); cat.Close() }()
+	ctx := context.Background()
+
+	spec := db.ViewSpec{
+		BaseTable:   "jobs",
+		Groups:      []db.ViewGroupCol{{Attr: "Owner", Alias: "label_owner"}},
+		Metrics:     []db.ViewMetric{{Func: db.ViewCount, Arg: "*", Alias: "metric_jobs"}},
+		Cardinality: 100,
+	}
+	if err := c.CreateView(ctx, "usage", spec); err != nil {
+		t.Fatalf("CreateView: %v", err)
+	}
+
+	// Listed as a view, not a table.
+	views, err := c.ListViews(ctx)
+	if err != nil || len(views) != 1 || views[0] != "usage" {
+		t.Fatalf("ListViews = %v, %v; want [usage]", views, err)
+	}
+	if tables, _ := c.Tables(ctx); contains(tables, "usage") {
+		t.Fatal("a view must not appear in the table listing")
+	}
+
+	// Queried like a table: two groups (alice, bob).
+	rows, err := c.QueryTable(ctx, "usage", "true", 0)
+	if err != nil {
+		t.Fatalf("query view: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("view query returned %d rows, want 2", len(rows))
+	}
+
+	// Writes to a view are refused (a view is not a writable table).
+	if _, err := c.BeginTable(ctx, "usage"); err == nil {
+		t.Fatal("beginning a transaction on a view should be refused")
+	}
+
+	// Drop it.
+	if err := c.DropView(ctx, "usage"); err != nil {
+		t.Fatalf("DropView: %v", err)
+	}
+	if views, _ := c.ListViews(ctx); len(views) != 0 {
+		t.Fatalf("views after drop = %v, want none", views)
+	}
+}


### PR DESCRIPTION
Cardinality-limited, in-memory aggregate views over a base table, maintained incrementally from the base table's change stream. The definition persists in the catalog; the data is in-memory and rebuilt from the base table on reload. Aimed at Prometheus: columns are typed by alias prefix (`label_*` = a label, `metric_*` = a metric value).

This is the **golang-classads half** (db engine + dbrpc wire). The htcondordb CLI (`CREATE MATERIALIZED VIEW … AS SELECT …`, `.export`) + a `/metrics` endpoint are a follow-up once this is tagged.

## db (Stage 1)
- `ViewSpec`: base table, GROUP BY columns, metrics (**COUNT/SUM/AVG only** — the delta-maintainable ones; MIN/MAX rejected), a hard cardinality limit.
- The change stream has **no before-image** (upsert = new ad; delete = key only), so each view keeps a **per-key contribution store** to subtract a key's old contribution on update/delete (memory O(base rows)).
- A **single watch goroutine** does the initial catch-up (replay) then live maintenance — no second concurrent watch racing the base's segment windows. `CreateView` blocks on a ready signal, so a **cardinality overflow fails the create** (hard error); at runtime an overflow moves the view to `failed`. Upserts are diff-idempotent; deletes on unknown keys no-op; `WatchReset` rebuilds; group-key changes evict emptied groups.
- Materialized rows render into an in-memory backing table (one ad per group) so a view is **queried like a table**.
- Catalog: `views` map + `CreateView`/`DropView`/`Views`/`View`/`ViewBacking`; reconstruction from `<dir>/views` on open (missing base → stale, failed rebuild → failed; neither fails catalog open). Definition at `<dir>/views/<name>/view.json`.
- `db.Watch` now surfaces `WatchSynced`/`WatchResync`.

## dbrpc (Stage 2)
- `opCreateView`/`opDropView`/`opListViews` (create ships the `ViewSpec` as JSON, like `opArchiveCreate`); create/drop mutating. `tableOr` falls through to `ViewBacking` so reads resolve a view; writes (`opBegin`) use `cat.Table` only → views are **read-only**. Client methods added.

## Tests
db: build+query, live upsert/update(group-key change)/delete + eviction, cardinality hard-error, reload rebuild, spec validation. dbrpc: create/list/query/read-only/drop over the wire. **Full db + dbrpc suites green under `-race`.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)