### PR TITLE
Time travel: point-in-time (AS OF) queries over the MVCC store

### DIFF
--- a/collections/commit.go
+++ b/collections/commit.go
@@ -123,6 +123,7 @@ func (sh *shard) applyWrites(writes []pendingPut) {
 		sh.put(writes[i].hash, writes[i].key, writes[i].ad, seq, writes[i].codec)
 	}
 	sh.commitSeq = seq
+	sh.maybeCheckpoint(seq)
 	sh.unlockWrite(acq, held)
 	sh.sync()
 	if sh.hub != nil {
@@ -139,6 +140,7 @@ func (sh *shard) applyOne(p pendingPut) {
 	seq := sh.commitSeq + 1
 	sh.put(p.hash, p.key, p.ad, seq, p.codec)
 	sh.commitSeq = seq
+	sh.maybeCheckpoint(seq)
 	sh.unlockWrite(acq, held)
 	sh.sync()
 	if sh.hub != nil {
@@ -157,6 +159,7 @@ func (sh *shard) applyBatch(batch []*commitReq) {
 		}
 	}
 	sh.commitSeq = seq
+	sh.maybeCheckpoint(seq)
 	sh.unlockWrite(acq, held)
 	sh.sync()
 	if sh.hub != nil {

--- a/collections/compact.go
+++ b/collections/compact.go
@@ -85,12 +85,19 @@ func (c *Collection) Compact() int {
 // is pin-aware so an in-flight scan keeps the mapping mapped until it unpins.
 func (c *Collection) reclaimDeadShard(sh *shard) int {
 	sh.mu.Lock()
+	retain := sh.retainFloorLocked()
 	var dead []*segment
 	for _, seg := range sh.segs {
 		if seg == nil || seg == sh.act || seg.used == 0 {
 			continue
 		}
-		if seg.dead >= int64(seg.used) {
+		// A segment is fully reclaimable when it holds no current record and every
+		// version in it was superseded at or below the retain floor (so no AS OF query
+		// within the window needs it). This is marker-aware, unlike a dead>=used byte
+		// check: a history segment carrying checkpoint markers still reclaims once its
+		// data has aged out. With time travel off, retain == commitSeq, so any
+		// all-superseded segment qualifies -- exactly the previous behavior.
+		if seg.metaReady && seg.liveCount == 0 && seg.maxSup <= retain {
 			dead = append(dead, seg)
 		}
 	}
@@ -136,11 +143,13 @@ func (c *Collection) reclaimDeadShard(sh *shard) int {
 		}
 	}
 	sh.dropDirtySegs(deadSet)
-	// Superseded records were dropped: raise the GC floor so a snapshot older than now that
-	// cannot find a key conservatively conflicts rather than trusting a truncated chain.
-	if sh.commitSeq > sh.gcFloor {
-		sh.gcFloor = sh.commitSeq
+	// Superseded records at or below the retain floor were dropped: raise the GC floor
+	// to it so a snapshot older than the floor conservatively conflicts rather than
+	// trusting a truncated chain. With time travel off, retain == commitSeq (as before).
+	if retain > sh.gcFloor {
+		sh.gcFloor = retain
 	}
+	sh.tseq.trim(retain)
 	sh.mu.Unlock()
 
 	for _, seg := range toReap {
@@ -231,6 +240,14 @@ func (sh *shard) shouldCompact() bool {
 		if seg == nil {
 			continue
 		}
+		// Exclude pure-history segments (no current record) from the trigger: their
+		// dead bytes are retained time-travel history, not reclaimable garbage, so they
+		// must not drive compaction of the live working set (which would recopy history
+		// every pass). With time travel off there are none (reclaimDeadShard drops them
+		// first), so this is a no-op and the ratio is over the whole shard, as before.
+		if seg.metaReady && seg.liveCount == 0 {
+			continue
+		}
 		used += int64(seg.used)
 		dead += seg.dead
 	}
@@ -251,72 +268,103 @@ type movedRec struct {
 
 // compactShard performs concurrent compaction of one shard (see the package
 // comment). target is the codec destination records are (re)compressed into.
+//
+// With time travel enabled, compaction is retention- and segregation-aware. It only
+// rewrites the working-set segments (those with a current record); pure-history
+// segments (all versions superseded, none current) are left untouched so they are not
+// recopied on every pass (they are dropped by reclaimDeadShard once they age past the
+// retain floor). From each working-set segment it splits records into two destination
+// streams: CURRENT versions go to fresh live segments (rebuilt into the directory), and
+// superseded versions still newer than the retain floor go to separate HISTORY segments
+// (no current record, so scans skip them at the current time but read them for an AS OF
+// query). Versions superseded at or below the retain floor -- and checkpoint markers
+// that old -- are dropped. With time travel off the retain floor is the current commit
+// sequence, so no version is retained and this behaves exactly as before.
 func (c *Collection) compactShard(sh *shard, target Codec) {
-	// Phase 1 (lock): snapshot the source segments and seal the active segment so
-	// concurrent writes land in fresh post-barrier segments.
+	// Phase 1 (lock): choose the working-set sources (segments with a current record),
+	// capture the retain floor, and seal the active segment so concurrent writes land
+	// in fresh post-barrier segments. Pure-history segments are not sources.
 	sh.mu.Lock()
-	srcSegs := make([]*segment, len(sh.segs))
-	copy(srcSegs, sh.segs)
-	srcCount := len(srcSegs)
+	retain := sh.retainFloorLocked()
+	origLen := len(sh.segs)
+	sources := make([]*segment, 0, origLen)
+	sourceSet := make(map[*segment]struct{}, origLen)
+	for _, seg := range sh.segs {
+		if seg == nil || seg.used == 0 {
+			continue
+		}
+		if seg.metaReady && seg.liveCount == 0 {
+			continue // pure-history (or fully-dead) segment: leave it in place
+		}
+		sources = append(sources, seg)
+		sourceSet[seg] = struct{}{}
+	}
 	sh.act = nil
 	sh.mu.Unlock()
 
-	// Phase 2 (lock-free): recompress current records into private destination
-	// segments. Reads of source records are safe: bytes are immutable and the
-	// superseded flag is read atomically.
-	var dstSegs []*segment
-	var cur *segment
-	alloc := func(minSize int, codec Codec) {
+	// Phase 2 (lock-free): copy into private destination segments -- current versions to
+	// the live stream, retained superseded versions to the history stream. Reads of
+	// source records are safe: bytes are immutable and the superseded flag is atomic.
+	var dstSegs, histSegs []*segment
+	var cur, hcur *segment
+	newDst := func(streamSegs *[]*segment, minSize int, codec Codec) *segment {
 		size := sh.segSize
 		if minSize > size {
 			size = minSize
 		}
-		// Persistent shards allocate mmap segments so compacted data is durable;
-		// real id is assigned at install (file name is id-independent).
 		if sh.alloc != nil {
 			if seg, err := sh.alloc(0, size, codec); err == nil {
-				cur = seg
-				dstSegs = append(dstSegs, cur)
-				return
+				*streamSegs = append(*streamSegs, seg)
+				return seg
 			}
-			// On allocation error, fall back to a RAM segment (best-effort; P4 makes
-			// compaction allocation failure durable/abortable).
+			// On allocation error, fall back to a RAM segment (best-effort).
 		}
-		cur = newSegment(0, size, codec)
-		cur.pinReap = sh.sealRAM // keep the compacted RAM segment pin/reap-eligible for anon sealing
-		dstSegs = append(dstSegs, cur)
+		s := newSegment(0, size, codec)
+		s.pinReap = sh.sealRAM
+		*streamSegs = append(*streamSegs, s)
+		return s
 	}
 	var moved []movedRec
-	// Scratch buffers reused across every record's decompress/recompress: append
-	// copies the record into the destination segment, so these are transient. This
-	// avoids two fresh allocations per record (heavy GC churn at recompaction).
+	// Scratch buffers reused across every record's decompress/recompress.
 	var decBuf, encBuf []byte
-	for _, seg := range srcSegs {
-		if seg == nil {
-			continue
+	recompress := func(seg *segment, ad []byte) ([]byte, Codec) {
+		if seg.codec == target {
+			return ad, seg.codec
 		}
+		if w, err := seg.codec.Decompress(decBuf[:0], ad); err == nil {
+			decBuf = w
+			out := target.Compress(encBuf[:0], w)
+			encBuf = out
+			return out, target
+		}
+		return ad, seg.codec
+	}
+	for _, seg := range sources {
 		for off := 0; off < seg.used; {
 			o := uint32(off)
 			total := recTotalLen(seg.data, o)
 			if total == 0 {
 				break
 			}
-			if recSuperseded(seg.data, o) == seqMax {
-				key := recKey(seg.data, o)
-				ad := recAd(seg.data, o)
-				seq := recSeq(seg.data, o)
-				outAd, outCodec := ad, seg.codec
-				if seg.codec != target {
-					if w, err := seg.codec.Decompress(decBuf[:0], ad); err == nil {
-						decBuf = w
-						outAd = target.Compress(encBuf[:0], w)
-						encBuf = outAd
-						outCodec = target
+			seq := recSeq(seg.data, o)
+			if recIsMarker(seg.data, o) {
+				if seq > retain { // carry an in-window checkpoint forward (to history)
+					if hcur == nil || hcur.used+recordLen(0, 8) > len(hcur.data) {
+						hcur = newDst(&histSegs, recordLen(0, 8), target)
 					}
+					hcur.appendMarker(seq, recMarkerMillis(seg.data, o))
 				}
+				off += int(total)
+				continue
+			}
+			sup := recSuperseded(seg.data, o)
+			if sup == seqMax {
+				// Current version -> live stream (rebuilt into the directory).
+				key := recKey(seg.data, o)
+				outAd, outCodec := recompress(seg, recAd(seg.data, o))
 				rl := recordLen(len(key), len(outAd))
 				if cur == nil || cur.codec != outCodec || cur.used+rl > len(cur.data) {
-					alloc(rl, outCodec)
+					cur = newDst(&dstSegs, rl, outCodec)
 				}
 				dstOff, _ := cur.append(seq, noLoc, key, outAd)
 				moved = append(moved, movedRec{
@@ -325,34 +373,48 @@ func (c *Collection) compactShard(sh *shard, target Codec) {
 					key:  append([]byte(nil), key...),
 					hash: c.h.Hash(key),
 				})
+			} else if sup > retain {
+				// Superseded but still within the travel window -> history stream,
+				// preserving its original supersededBySeq (supersedeRec keeps the
+				// segment's live/dead counters right: appended live, then retired).
+				key := recKey(seg.data, o)
+				outAd, outCodec := recompress(seg, recAd(seg.data, o))
+				rl := recordLen(len(key), len(outAd))
+				if hcur == nil || hcur.codec != outCodec || hcur.used+rl > len(hcur.data) {
+					hcur = newDst(&histSegs, rl, outCodec)
+				}
+				dstOff, _ := hcur.append(seq, noLoc, key, outAd)
+				hcur.supersedeRec(dstOff, sup)
 			}
+			// else: superseded at or below the retain floor -> reclaimed (dropped).
 			off += int(total)
 		}
 	}
 
-	// Make the compacted (destination) records durable BEFORE any source segment is
-	// retired/unlinked, so a crash cannot lose them (the source still holds a copy
-	// until it is reaped, and recovery dedups if both survive). No-op for RAM.
+	// Make destination records durable BEFORE any source is retired (crash safety).
 	for _, seg := range dstSegs {
+		_ = seg.flush()
+	}
+	for _, seg := range histSegs {
 		_ = seg.flush()
 	}
 
 	// Phase 3 (lock): finalize, rebuild the directory, and install.
 	sh.mu.Lock()
+	allDst := append(append([]*segment{}, dstSegs...), histSegs...)
 	baseID := uint32(len(sh.segs))
-	for i, s := range dstSegs {
+	for i, s := range allDst {
 		s.id = baseID + uint32(i)
 	}
-	// Transfer any supersession that happened during Phase 2 onto the destination
-	// copies, so a stale copy is not seen as current by a later scan.
+	// Transfer any supersession that happened during Phase 2 onto the destination live
+	// copies, so a stale copy is not seen as current (supersedeRec keeps counters right).
 	for i := range moved {
 		if sup := recSuperseded(moved[i].srcSeg.data, moved[i].srcOff); sup != seqMax {
-			setRecSuperseded(moved[i].dstSeg.data, moved[i].dstOff, sup)
+			moved[i].dstSeg.supersedeRec(moved[i].dstOff, sup)
 		}
 	}
-	// Rebuild the directory from every current record: destination copies still
-	// current, plus current records in post-barrier segments (written during the
-	// copy). Chains are rebuilt fresh, so no entry references a retired segment.
+	// Rebuild the directory from every current record: destination live copies still
+	// current, plus current records in post-barrier segments (written during the copy).
 	newDir := make(map[uint64]loc, sh.count)
 	count := 0
 	for i := range moved {
@@ -364,7 +426,7 @@ func (c *Collection) compactShard(sh *shard, target Codec) {
 		newDir[m.hash] = loc{seg: m.dstSeg.id, off: m.dstOff}
 		count++
 	}
-	for id := srcCount; id < int(baseID); id++ { // post-barrier segments
+	for id := origLen; id < int(baseID); id++ { // post-barrier segments
 		seg := sh.segs[id]
 		if seg == nil {
 			continue
@@ -375,7 +437,7 @@ func (c *Collection) compactShard(sh *shard, target Codec) {
 			if total == 0 {
 				break
 			}
-			if recSuperseded(seg.data, o) == seqMax {
+			if !recIsMarker(seg.data, o) && recSuperseded(seg.data, o) == seqMax {
 				h := c.h.Hash(recKey(seg.data, o))
 				setRecNext(seg.data, o, dirGetOr(newDir, h))
 				newDir[h] = loc{seg: seg.id, off: o}
@@ -385,20 +447,23 @@ func (c *Collection) compactShard(sh *shard, target Codec) {
 		}
 	}
 
-	sh.segs = append(sh.segs, dstSegs...)
-	// Retire the source segments. RAM segments are just dropped (the GC frees them
-	// once in-flight scans release their windows). mmap segments are munmap'd +
-	// unlinked, but only once no scan references them: retire() reaps immediately if
-	// unpinned, else the last unpin reaps. Defer the actual reap (syscalls) until
-	// after the lock is dropped.
+	sh.segs = append(sh.segs, allDst...)
+	// Retire only the source (working-set) segments; pure-history segments left in
+	// place above are kept. RAM segments are dropped (GC frees them once scans release
+	// their windows); mmap segments munmap+unlink once unpinned.
 	var toReap []*segment
 	retired := make(map[*segment]struct{})
-	for i := 0; i < srcCount; i++ {
-		if seg := sh.segs[i]; seg != nil {
-			retired[seg] = struct{}{}
-			if seg.retire() {
-				toReap = append(toReap, seg)
-			}
+	for i := 0; i < origLen; i++ {
+		seg := sh.segs[i]
+		if seg == nil {
+			continue
+		}
+		if _, isSrc := sourceSet[seg]; !isSrc {
+			continue // pure-history segment kept in place
+		}
+		retired[seg] = struct{}{}
+		if seg.retire() {
+			toReap = append(toReap, seg)
 		}
 		sh.segs[i] = nil
 	}
@@ -429,12 +494,15 @@ func (c *Collection) compactShard(sh *shard, target Codec) {
 	if len(dstSegs) > 0 {
 		sh.act = dstSegs[len(dstSegs)-1]
 	}
-	// Superseded records (delete evidence) at or below the current sequence were just
-	// dropped; raise the transaction GC floor so a snapshot older than this can no
-	// longer trust a bucket-chain walk for a currently-absent key (see conflictSince).
-	if sh.commitSeq > sh.gcFloor {
-		sh.gcFloor = sh.commitSeq
+	// Superseded/delete evidence at or below the retain floor was just dropped; raise
+	// the transaction GC floor to it so a snapshot older than the floor can no longer
+	// trust a bucket-chain walk for a currently-absent key (see conflictSince). With
+	// time travel off the floor is the current commit sequence, exactly as before.
+	if retain > sh.gcFloor {
+		sh.gcFloor = retain
 	}
+	// Checkpoints for versions that just aged out of the window are no longer needed.
+	sh.tseq.trim(retain)
 	sh.mu.Unlock()
 
 	for _, seg := range toReap {

--- a/collections/compact.go
+++ b/collections/compact.go
@@ -97,7 +97,7 @@ func (c *Collection) reclaimDeadShard(sh *shard) int {
 		// check: a history segment carrying checkpoint markers still reclaims once its
 		// data has aged out. With time travel off, retain == commitSeq, so any
 		// all-superseded segment qualifies -- exactly the previous behavior.
-		if seg.metaReady && seg.liveCount == 0 && seg.maxSup <= retain {
+		if seg.dead >= int64(seg.used) && seg.maxSup <= retain {
 			dead = append(dead, seg)
 		}
 	}
@@ -245,7 +245,7 @@ func (sh *shard) shouldCompact() bool {
 		// must not drive compaction of the live working set (which would recopy history
 		// every pass). With time travel off there are none (reclaimDeadShard drops them
 		// first), so this is a no-op and the ratio is over the whole shard, as before.
-		if seg.metaReady && seg.liveCount == 0 {
+		if seg.dead >= int64(seg.used) {
 			continue
 		}
 		used += int64(seg.used)
@@ -293,8 +293,8 @@ func (c *Collection) compactShard(sh *shard, target Codec) {
 		if seg == nil || seg.used == 0 {
 			continue
 		}
-		if seg.metaReady && seg.liveCount == 0 {
-			continue // pure-history (or fully-dead) segment: leave it in place
+		if seg.dead >= int64(seg.used) && seg.maxSup > retain {
+			continue // in-window history segment: leave it in place, don't recopy
 		}
 		sources = append(sources, seg)
 		sourceSet[seg] = struct{}{}

--- a/collections/parallel_scan.go
+++ b/collections/parallel_scan.go
@@ -68,6 +68,10 @@ func forEachVisibleWindow(s0 uint64, w segWindow, fn func(ad []byte, codec Codec
 		if total == 0 {
 			break
 		}
+		if recIsMarker(w.data, o) {
+			off += int(total) // time-checkpoint marker, not a data record
+			continue
+		}
 		if recSeq(w.data, o) <= s0 && recSuperseded(w.data, o) > s0 {
 			if !fn(recAd(w.data, o), w.codec) {
 				return
@@ -86,6 +90,10 @@ func forEachVisibleWindowKeyed(s0 uint64, w segWindow, fn func(key, ad []byte, c
 		total := recTotalLen(w.data, o)
 		if total == 0 {
 			break
+		}
+		if recIsMarker(w.data, o) {
+			off += int(total) // time-checkpoint marker, not a data record
+			continue
 		}
 		if recSeq(w.data, o) <= s0 && recSuperseded(w.data, o) > s0 {
 			if !fn(recKey(w.data, o), recAd(w.data, o), w.codec) {

--- a/collections/persist.go
+++ b/collections/persist.go
@@ -314,7 +314,10 @@ func (c *Collection) loadShard(sh *shard, shardDir string) (uint64, error) {
 	// segment set and falls back to the full scan on any mismatch. Chained
 	// collections are excluded (their per-parent child counts would also need
 	// rebuilding); a stale snapshot in that case is discarded, not trusted.
-	if sh.childParentHash != nil {
+	// Time travel also forces the full scan: rebuildDir is what rebuilds the per-shard
+	// time->seq checkpoint index (and the segment scan-pruning counters) from the
+	// segment markers, which the directory snapshot does not carry.
+	if sh.childParentHash != nil || c.timeTravel() != nil {
 		os.Remove(filepath.Join(shardDir, dirSnapName))
 		c.rebuildDir(sh)
 	} else if !c.tryLoadDirSnapshot(sh, shardDir) {

--- a/collections/persist.go
+++ b/collections/persist.go
@@ -378,6 +378,25 @@ func (c *Collection) rebuildDir(sh *shard) {
 			if sup != seqMax && sup > maxSeq {
 				maxSeq = sup
 			}
+			// Rebuild the segment's scan-pruning metadata from disk (zeroed on reopen).
+			if seg.minSeq == 0 || seq < seg.minSeq {
+				seg.minSeq = seq
+			}
+			// A time-checkpoint marker feeds the shard time index; it is not a data
+			// record, so it does not enter the directory or the live/dead accounting.
+			if recIsMarker(seg.data, o) {
+				sh.tseq.record(seq, recMarkerMillis(seg.data, o))
+				off += int(total)
+				continue
+			}
+			if sup == seqMax {
+				seg.liveCount++
+			} else {
+				seg.dead += int64(total)
+				if sup > seg.maxSup {
+					seg.maxSup = sup
+				}
+			}
 			key := string(recKey(seg.data, o))
 			if b, ok := byKey[key]; !ok || seq >= b.seq {
 				byKey[key] = best{loc{seg.id, o}, seq, sup}
@@ -408,13 +427,16 @@ func (c *Collection) rebuildDir(sh *shard) {
 			if total == 0 {
 				break
 			}
+			if recIsMarker(seg.data, o) {
+				off += int(total) // marker, not a data record
+				continue
+			}
 			if recSuperseded(seg.data, o) == seqMax {
 				b := byKey[string(recKey(seg.data, o))]
 				if b.loc.seg != seg.id || b.loc.off != o {
 					// A stale still-current duplicate/older version: retire it at its
 					// own seq so seq <= S0 < sup is false for every scan.
-					setRecSuperseded(seg.data, o, recSeq(seg.data, o))
-					seg.dead += int64(total)
+					seg.supersedeRec(o, recSeq(seg.data, o))
 				}
 			}
 			off += int(total)
@@ -435,6 +457,13 @@ func (c *Collection) rebuildDir(sh *shard) {
 	sh.count = count
 	if len(sh.segs) > 0 {
 		sh.act = sh.segs[len(sh.segs)-1]
+	}
+	// Every record was walked above, so the per-segment scan-pruning counters
+	// (minSeq/liveCount/maxSup) are now known-good and the segments may be skipped.
+	for _, seg := range sh.segs {
+		if seg != nil {
+			seg.metaReady = true
+		}
 	}
 }
 

--- a/collections/persist.go
+++ b/collections/persist.go
@@ -385,16 +385,16 @@ func (c *Collection) rebuildDir(sh *shard) {
 			if seg.minSeq == 0 || seq < seg.minSeq {
 				seg.minSeq = seq
 			}
-			// A time-checkpoint marker feeds the shard time index; it is not a data
-			// record, so it does not enter the directory or the live/dead accounting.
+			// A time-checkpoint marker feeds the shard time index; it never enters the
+			// directory, and its bytes count as dead (as appendMarker does at runtime)
+			// so a history-only segment reaches dead >= used.
 			if recIsMarker(seg.data, o) {
 				sh.tseq.record(seq, recMarkerMillis(seg.data, o))
+				seg.dead += int64(total)
 				off += int(total)
 				continue
 			}
-			if sup == seqMax {
-				seg.liveCount++
-			} else {
+			if sup != seqMax {
 				seg.dead += int64(total)
 				if sup > seg.maxSup {
 					seg.maxSup = sup
@@ -460,13 +460,6 @@ func (c *Collection) rebuildDir(sh *shard) {
 	sh.count = count
 	if len(sh.segs) > 0 {
 		sh.act = sh.segs[len(sh.segs)-1]
-	}
-	// Every record was walked above, so the per-segment scan-pruning counters
-	// (minSeq/liveCount/maxSup) are now known-good and the segments may be skipped.
-	for _, seg := range sh.segs {
-		if seg != nil {
-			seg.metaReady = true
-		}
 	}
 }
 

--- a/collections/segment.go
+++ b/collections/segment.go
@@ -44,6 +44,15 @@ const (
 	recKeyOff      = 32
 	recHeaderSize  = 32
 
+	// markerFlag is the high bit of the keyLen field, set on a "time checkpoint"
+	// marker entry (see timeseq.go): a non-keyed arena record whose 8-byte payload is
+	// a wall-clock unixMillis and whose seq is the shard commitSeq at that instant.
+	// Real keys are tiny, so the low 31 bits (keyLenMask) always hold the true key
+	// length and existing on-disk records (flag clear) read as ordinary records --
+	// the discriminator is backward compatible and needs no header growth.
+	markerFlag = uint32(1) << 31
+	keyLenMask = markerFlag - 1
+
 	noSeg  = ^uint32(0)
 	seqMax = ^uint64(0)
 
@@ -73,6 +82,25 @@ type segment struct {
 	data []byte   // immutable full backing; aliases raw (RAM) or the mmap region (persistent)
 	used int      // write cursor (guarded by shard lock)
 	dead int64    // bytes belonging to superseded/dead records (updated under shard lock)
+
+	// Time-travel scan pruning (guarded by the shard lock; recomputed on recovery).
+	// A scan at snapshot S0 can skip this segment entirely when no record in it is
+	// visible at S0 -- either every record was born after S0 (minSeq > S0) or every
+	// record was already superseded by S0 (effectiveMaxSup() <= S0). This keeps
+	// current-time scans O(live) even when time travel retains a large history in
+	// separate (history-only) segments. minSeq is the smallest seq written here (0 =
+	// none yet); liveCount is the number of current (non-superseded, non-marker)
+	// records; maxSup is the largest finite supersededBySeq stamped here.
+	minSeq    uint64
+	liveCount int
+	maxSup    uint64
+	// metaReady is true once minSeq/liveCount/maxSup are known-good: for a segment
+	// built by appends from empty (its counters are maintained from birth) or one
+	// whose records were walked by recovery (rebuildDir). A segment reopened via the
+	// fast directory-snapshot path has NOT been walked, so it stays false and is never
+	// skipped by a scan -- correctness over the optimization. Compaction produces fresh
+	// segments (metaReady true), so time travel's history-segment skipping still applies.
+	metaReady bool
 
 	codec Codec // the codec that compressed this segment's records (immutable)
 
@@ -290,7 +318,7 @@ func newSegment(id uint32, size int, codec Codec) *segment {
 	}
 	raw := make([]uint64, size/8)
 	data := unsafe.Slice((*byte)(unsafe.Pointer(&raw[0])), size)
-	return &segment{id: id, raw: raw, data: data, codec: codec}
+	return &segment{id: id, raw: raw, data: data, codec: codec, metaReady: true}
 }
 
 func recAlign(n int) int { return (n + 7) &^ 7 }
@@ -342,14 +370,88 @@ func (s *segment) append(seq uint64, next loc, key, ad []byte) (uint32, bool) {
 		crcOff := adLenOff + 4 + len(ad)
 		binary.LittleEndian.PutUint32(b[crcOff:], recCRC(b, crcOff))
 	}
+	if s.minSeq == 0 || seq < s.minSeq {
+		s.minSeq = seq
+	}
+	s.liveCount++ // born current; drops in supersedeRec
 	return uint32(off), true
+}
+
+// appendMarker writes a time-checkpoint marker (see timeseq.go) at the current end of
+// the segment: a non-keyed record whose keyLen field carries markerFlag and whose
+// 8-byte payload is unixMillis. Its seq is the shard commitSeq at the checkpoint. It
+// reuses the ordinary record framing (empty key, 8-byte "ad") so the linear arena
+// walk, CRC, and recovery treat it uniformly; only the flag bit distinguishes it. The
+// caller holds the shard lock.
+func (s *segment) appendMarker(seq uint64, millis uint64) (uint32, bool) {
+	var ad [8]byte
+	binary.LittleEndian.PutUint64(ad[:], millis)
+	rl := recordLen(0, len(ad))
+	off := s.used
+	if off+rl > len(s.data) {
+		return 0, false
+	}
+	b := s.data[off : off+rl]
+	s.used = off + rl
+	binary.LittleEndian.PutUint64(b[recSeqOff:], seq)
+	binary.LittleEndian.PutUint64(b[recSupOff:], seqMax)
+	binary.LittleEndian.PutUint32(b[recNextSegOff:], noSeg)
+	binary.LittleEndian.PutUint32(b[recNextOffOff:], 0)
+	binary.LittleEndian.PutUint32(b[recTotalLenOff:], uint32(rl))
+	binary.LittleEndian.PutUint32(b[recKeyLenOff:], markerFlag) // flag set, key length 0
+	adLenOff := recKeyOff
+	binary.LittleEndian.PutUint32(b[adLenOff:], uint32(len(ad)))
+	copy(b[adLenOff+4:], ad[:])
+	if s.persistent {
+		crcOff := adLenOff + 4 + len(ad)
+		binary.LittleEndian.PutUint32(b[crcOff:], recCRC(b, crcOff))
+	}
+	if s.minSeq == 0 || seq < s.minSeq {
+		s.minSeq = seq
+	}
+	// A marker is not a data record: it does NOT count toward liveCount, so a
+	// history-only segment that still carries checkpoints stays skippable.
+	return uint32(off), true
+}
+
+// supersedeRec marks the record at off superseded at seq: it stamps the field, adds
+// its bytes to the dead total, drops the live count, and advances maxSup. Caller holds
+// the shard write lock. This is the one place a record leaves the "current" set, so the
+// scan-pruning metadata stays consistent.
+func (s *segment) supersedeRec(off uint32, seq uint64) {
+	setRecSuperseded(s.data, off, seq)
+	s.dead += int64(recTotalLen(s.data, off))
+	s.liveCount--
+	if seq > s.maxSup {
+		s.maxSup = seq
+	}
+}
+
+// effectiveMaxSup is the highest snapshot S0 at which some record here is still
+// visible: seqMax while any current record remains, else the largest finite
+// supersededBySeq. A scan at S0 >= this can skip the segment (nothing visible).
+func (s *segment) effectiveMaxSup() uint64 {
+	if s.liveCount > 0 {
+		return seqMax
+	}
+	return s.maxSup
+}
+
+// visibleAt reports whether any record in the segment is visible at snapshot s0
+// (seq <= s0 < sup for some record). It is a conservative skip test for scans: false
+// means definitely nothing visible; true means scan the segment.
+func (s *segment) visibleAt(s0 uint64) bool {
+	if !s.metaReady {
+		return true // counters not computed (fast reopen); never skip
+	}
+	return s.minSeq <= s0 && s.effectiveMaxSup() > s0
 }
 
 // recVerifyCRC reports whether the record at off has a valid trailing CRC (i.e. it
 // was fully written). Used by recovery to stop at a torn tail. b is the segment's
 // data; the caller has already bounds-checked the record's totalLen.
 func recVerifyCRC(b []byte, off uint32) bool {
-	kl := binary.LittleEndian.Uint32(b[off+recKeyLenOff:])
+	kl := recKeyLen(b, off)
 	adLenOff := off + recKeyOff + kl
 	if int(adLenOff)+4 > len(b) {
 		return false
@@ -399,14 +501,32 @@ func recTotalLen(b []byte, off uint32) uint32 {
 	return binary.LittleEndian.Uint32(b[off+recTotalLenOff:])
 }
 
+// recKeyLen is the true key length: the low 31 bits of the keyLen field, masking off
+// the marker flag (markerFlag) so a marker (flag set, key length 0) reads as keyless.
+func recKeyLen(b []byte, off uint32) uint32 {
+	return binary.LittleEndian.Uint32(b[off+recKeyLenOff:]) & keyLenMask
+}
+
+// recIsMarker reports whether the record at off is a time-checkpoint marker (see
+// timeseq.go) rather than a keyed data record.
+func recIsMarker(b []byte, off uint32) bool {
+	return binary.LittleEndian.Uint32(b[off+recKeyLenOff:])&markerFlag != 0
+}
+
+// recMarkerMillis reads a marker's wall-clock payload (unixMillis). Only valid when
+// recIsMarker(b, off) is true.
+func recMarkerMillis(b []byte, off uint32) uint64 {
+	return binary.LittleEndian.Uint64(recAd(b, off))
+}
+
 func recKey(b []byte, off uint32) []byte {
-	kl := binary.LittleEndian.Uint32(b[off+recKeyLenOff:])
+	kl := recKeyLen(b, off)
 	start := off + recKeyOff
 	return b[start : start+kl]
 }
 
 func recAd(b []byte, off uint32) []byte {
-	kl := binary.LittleEndian.Uint32(b[off+recKeyLenOff:])
+	kl := recKeyLen(b, off)
 	adLenOff := off + recKeyOff + kl
 	adLen := binary.LittleEndian.Uint32(b[adLenOff:])
 	start := adLenOff + 4

--- a/collections/segment.go
+++ b/collections/segment.go
@@ -86,21 +86,16 @@ type segment struct {
 	// Time-travel scan pruning (guarded by the shard lock; recomputed on recovery).
 	// A scan at snapshot S0 can skip this segment entirely when no record in it is
 	// visible at S0 -- either every record was born after S0 (minSeq > S0) or every
-	// record was already superseded by S0 (effectiveMaxSup() <= S0). This keeps
-	// current-time scans O(live) even when time travel retains a large history in
-	// separate (history-only) segments. minSeq is the smallest seq written here (0 =
-	// none yet); liveCount is the number of current (non-superseded, non-marker)
-	// records; maxSup is the largest finite supersededBySeq stamped here.
-	minSeq    uint64
-	liveCount int
-	maxSup    uint64
-	// metaReady is true once minSeq/liveCount/maxSup are known-good: for a segment
-	// built by appends from empty (its counters are maintained from birth) or one
-	// whose records were walked by recovery (rebuildDir). A segment reopened via the
-	// fast directory-snapshot path has NOT been walked, so it stays false and is never
-	// skipped by a scan -- correctness over the optimization. Compaction produces fresh
-	// segments (metaReady true), so time travel's history-segment skipping still applies.
-	metaReady bool
+	// record was superseded by S0 with none current (dead >= used, so no live record,
+	// AND maxSup <= S0). This keeps current-time scans O(live) even when time travel
+	// retains a large history in separate (history-only) segments. minSeq is the
+	// smallest seq written here (0 = none yet, or a fast-reopened segment not walked --
+	// which is then never skipped, conservatively); maxSup is the largest finite
+	// supersededBySeq stamped here. "no current record" is read from the byte counters
+	// (dead >= used, markers counting as dead) rather than a separate live tally, so it
+	// cannot drift out of sync with the arena.
+	minSeq uint64
+	maxSup uint64
 
 	codec Codec // the codec that compressed this segment's records (immutable)
 
@@ -318,7 +313,7 @@ func newSegment(id uint32, size int, codec Codec) *segment {
 	}
 	raw := make([]uint64, size/8)
 	data := unsafe.Slice((*byte)(unsafe.Pointer(&raw[0])), size)
-	return &segment{id: id, raw: raw, data: data, codec: codec, metaReady: true}
+	return &segment{id: id, raw: raw, data: data, codec: codec}
 }
 
 func recAlign(n int) int { return (n + 7) &^ 7 }
@@ -373,7 +368,6 @@ func (s *segment) append(seq uint64, next loc, key, ad []byte) (uint32, bool) {
 	if s.minSeq == 0 || seq < s.minSeq {
 		s.minSeq = seq
 	}
-	s.liveCount++ // born current; drops in supersedeRec
 	return uint32(off), true
 }
 
@@ -409,42 +403,42 @@ func (s *segment) appendMarker(seq uint64, millis uint64) (uint32, bool) {
 	if s.minSeq == 0 || seq < s.minSeq {
 		s.minSeq = seq
 	}
-	// A marker is not a data record: it does NOT count toward liveCount, so a
-	// history-only segment that still carries checkpoints stays skippable.
+	// A marker is not live data: count its bytes as dead so a history-only segment that
+	// carries only superseded records plus checkpoints still reaches dead >= used (and
+	// is thus recognized as fully dead / skippable / reclaimable once aged out).
+	s.dead += int64(rl)
 	return uint32(off), true
 }
 
 // supersedeRec marks the record at off superseded at seq: it stamps the field, adds
-// its bytes to the dead total, drops the live count, and advances maxSup. Caller holds
-// the shard write lock. This is the one place a record leaves the "current" set, so the
-// scan-pruning metadata stays consistent.
+// its bytes to the dead total, and advances maxSup. Caller holds the shard write lock.
+// This is the one place a record leaves the "current" set, so the scan-pruning
+// metadata stays consistent with the arena.
 func (s *segment) supersedeRec(off uint32, seq uint64) {
 	setRecSuperseded(s.data, off, seq)
 	s.dead += int64(recTotalLen(s.data, off))
-	s.liveCount--
 	if seq > s.maxSup {
 		s.maxSup = seq
 	}
 }
 
-// effectiveMaxSup is the highest snapshot S0 at which some record here is still
-// visible: seqMax while any current record remains, else the largest finite
-// supersededBySeq. A scan at S0 >= this can skip the segment (nothing visible).
-func (s *segment) effectiveMaxSup() uint64 {
-	if s.liveCount > 0 {
-		return seqMax
-	}
-	return s.maxSup
-}
-
-// visibleAt reports whether any record in the segment is visible at snapshot s0
-// (seq <= s0 < sup for some record). It is a conservative skip test for scans: false
-// means definitely nothing visible; true means scan the segment.
+// visibleAt reports whether any record in the segment MIGHT be visible at snapshot s0
+// (some record with seq <= s0 < sup). It is a conservative skip test for scans: false
+// means definitely nothing visible; true means scan the segment. It reads only the
+// byte counters, so it cannot drift out of sync with the arena, and a fast-reopened
+// segment whose counters were not rebuilt (minSeq == 0, dead == 0) is never skipped.
+//
+//   - minSeq > s0: every record here was born after s0 -> nothing visible.
+//   - dead >= used (no current record, markers counted as dead) AND maxSup <= s0:
+//     every record was superseded at or before s0 -> nothing visible.
 func (s *segment) visibleAt(s0 uint64) bool {
-	if !s.metaReady {
-		return true // counters not computed (fast reopen); never skip
+	if s.minSeq > s0 {
+		return false
 	}
-	return s.minSeq <= s0 && s.effectiveMaxSup() > s0
+	if s.dead >= int64(s.used) && s.maxSup <= s0 {
+		return false
+	}
+	return true
 }
 
 // recVerifyCRC reports whether the record at off has a valid trailing CRC (i.e. it

--- a/collections/shard.go
+++ b/collections/shard.go
@@ -3,6 +3,7 @@ package collections
 import (
 	"bytes"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -72,6 +73,13 @@ type shard struct {
 	// hashing to h has zero children, so this parent does too. Guarded by mu.
 	childParentHash func(key []byte) (uint64, bool)
 	childCount      map[uint64]int
+
+	// tseq is this shard's time->seq checkpoint index for point-in-time queries
+	// (see timeseq.go). Empty and unused unless the collection has TimeTravel enabled.
+	tseq shardTimeIndex
+	// tt points at the collection's time-travel config (shared, swappable at runtime);
+	// nil-config means disabled. Set once at construction.
+	tt *atomic.Pointer[ttConfig]
 
 	// metrics accumulates this shard's operational timings (write-lock wait/hold,
 	// segment allocation, durability sync). See opstats.go.
@@ -169,16 +177,13 @@ func (sh *shard) put(h uint64, key, ad []byte, seq uint64, codec Codec) {
 		return // sh.writeErr is set; surfaced to the caller
 	}
 	if old, ok := sh.findCurrent(head, key); ok {
-		seg := sh.segs[old.seg]
-		setRecSuperseded(seg.data, old.off, seq)
-		seg.dead += int64(recTotalLen(seg.data, old.off))
+		sh.segs[old.seg].supersedeRec(old.off, seq)
 	} else if old, ok := sh.lookupSealed(key, h); ok {
 		// The key's current version lives in a sealed segment (evicted from the
 		// directory). Supersede it there so it does not remain a second live record,
 		// and flush the supersession (it lands in an already-synced region).
 		seg := sh.segs[old.seg]
-		setRecSuperseded(seg.data, old.off, seq)
-		seg.dead += int64(recTotalLen(seg.data, old.off))
+		seg.supersedeRec(old.off, seq)
 		if sh.alloc != nil {
 			sh.dirtySup = append(sh.dirtySup, supRef{seg, old.off})
 		}
@@ -213,8 +218,7 @@ func (sh *shard) del(h uint64, key []byte, seq uint64) (removed, parentEmptied b
 		}
 	}
 	seg := sh.segs[old.seg]
-	setRecSuperseded(seg.data, old.off, seq)
-	seg.dead += int64(recTotalLen(seg.data, old.off))
+	seg.supersedeRec(old.off, seq)
 	if sh.alloc != nil {
 		sh.dirtySup = append(sh.dirtySup, supRef{seg, old.off}) // flush the tombstone
 	}
@@ -255,6 +259,44 @@ func (sh *shard) writeRecord(seq uint64, next loc, key, ad []byte, codec Codec) 
 		sh.dirty = append(sh.dirty, sh.act) // track for msync (persistent)
 	}
 	return loc{seg: sh.act.id, off: off}, true
+}
+
+// maybeCheckpoint records a time->seq checkpoint (see timeseq.go) if time travel is
+// enabled and the checkpoint interval has elapsed. Caller holds the write lock and
+// calls this after the batch's records are written and sh.commitSeq is bumped, so the
+// marker lands in the active segment and rides the batch's msync.
+func (sh *shard) maybeCheckpoint(seq uint64) {
+	if sh.tt == nil {
+		return
+	}
+	cfg := sh.tt.Load()
+	if cfg == nil {
+		return // time travel disabled
+	}
+	nowMs := nowMillis()
+	if !sh.tseq.due(nowMs, cfg.interval) {
+		return
+	}
+	if sh.writeMarker(seq, nowMs) {
+		sh.tseq.record(seq, nowMs)
+	}
+}
+
+// writeMarker appends a time-checkpoint marker to the active segment if there is room,
+// tracking it for msync like a record. It returns false (checkpoint skipped, retried
+// next commit) when the active segment is absent or full -- rather than allocating a
+// whole segment just for a 48-byte marker. Caller holds the write lock.
+func (sh *shard) writeMarker(seq, millis uint64) bool {
+	if sh.act == nil {
+		return false
+	}
+	if _, ok := sh.act.appendMarker(seq, millis); !ok {
+		return false
+	}
+	if sh.alloc != nil && (len(sh.dirty) == 0 || sh.dirty[len(sh.dirty)-1] != sh.act) {
+		sh.dirty = append(sh.dirty, sh.act)
+	}
+	return true
 }
 
 // get returns a private copy of the current ad bytes for key and the codec they
@@ -426,17 +468,36 @@ type segWindow struct {
 // when the scan is done.
 func (sh *shard) snapshot() (s0 uint64, wins []segWindow) {
 	sh.mu.RLock()
+	defer sh.mu.RUnlock()
 	s0 = sh.commitSeq
-	wins = make([]segWindow, 0, len(sh.segs))
+	return s0, sh.buildWindowsLocked(s0)
+}
+
+// snapshotAt is snapshot for a historical snapshot sequence s0 (point-in-time / AS OF
+// queries): it freezes the same window set but for an arbitrary caller-supplied s0
+// instead of the current commit sequence. The caller MUST releaseWindows(wins).
+func (sh *shard) snapshotAt(s0 uint64) []segWindow {
+	sh.mu.RLock()
+	defer sh.mu.RUnlock()
+	return sh.buildWindowsLocked(s0)
+}
+
+// buildWindowsLocked pins and returns a frozen window over each segment that holds at
+// least one record visible at s0, skipping segments with nothing visible (all records
+// born after s0, or all superseded by s0 -- e.g. history-only segments a current-time
+// scan never needs). This keeps a scan's cost proportional to the versions actually
+// visible at s0, so retained time-travel history does not slow current-time scans.
+// Caller holds the read lock.
+func (sh *shard) buildWindowsLocked(s0 uint64) []segWindow {
+	wins := make([]segWindow, 0, len(sh.segs))
 	for _, seg := range sh.segs {
-		if seg == nil || seg.used == 0 {
+		if seg == nil || seg.used == 0 || !seg.visibleAt(s0) {
 			continue
 		}
 		seg.pin() // no-op for RAM segments
 		wins = append(wins, segWindow{data: seg.data, used: seg.used, codec: seg.codec, seg: seg})
 	}
-	sh.mu.RUnlock()
-	return s0, wins
+	return wins
 }
 
 // releaseWindows drops the pins snapshot took, allowing any mmap segment retired
@@ -460,6 +521,10 @@ func forEachVisible(s0 uint64, wins []segWindow, fn func(ad []byte, codec Codec)
 			if total == 0 {
 				break // malformed guard; should not happen
 			}
+			if recIsMarker(w.data, o) {
+				off += int(total) // time-checkpoint marker, not a data record
+				continue
+			}
 			seq := recSeq(w.data, o)
 			sup := recSuperseded(w.data, o)
 			if seq <= s0 && sup > s0 {
@@ -482,6 +547,10 @@ func forEachVisibleKeyed(s0 uint64, wins []segWindow, fn func(key, ad []byte, co
 			total := recTotalLen(w.data, o)
 			if total == 0 {
 				break
+			}
+			if recIsMarker(w.data, o) {
+				off += int(total) // time-checkpoint marker, not a data record
+				continue
 			}
 			seq := recSeq(w.data, o)
 			sup := recSuperseded(w.data, o)

--- a/collections/store.go
+++ b/collections/store.go
@@ -541,6 +541,7 @@ func (c *Collection) Delete(key []byte) bool {
 	ok, parentEmptied := sh.del(h, key, seq)
 	if ok {
 		sh.commitSeq = seq
+		sh.maybeCheckpoint(seq)
 	}
 	sh.unlockWrite(acq, held)
 	if ok {
@@ -762,6 +763,21 @@ func (c *Collection) Query(q *vm.Query) iter.Seq[*classad.ClassAd] {
 func (c *Collection) scanShard(sh *shard, qp queryPlan, emit func(w []byte) bool) bool {
 	s0, wins := sh.snapshot()
 	defer releaseWindows(wins)
+	return c.scanWindows(s0, wins, qp, emit)
+}
+
+// scanShardAt is scanShard for a historical snapshot sequence s0 (point-in-time / AS
+// OF queries): it scans the versions visible at s0 rather than the current commit
+// sequence.
+func (c *Collection) scanShardAt(sh *shard, s0 uint64, qp queryPlan, emit func(w []byte) bool) bool {
+	wins := sh.snapshotAt(s0)
+	defer releaseWindows(wins)
+	return c.scanWindows(s0, wins, qp, emit)
+}
+
+// scanWindows match-tests and emits the visible records of a frozen window set at
+// snapshot s0. Shared by the current-time and AS OF scan paths.
+func (c *Collection) scanWindows(s0 uint64, wins []segWindow, qp queryPlan, emit func(w []byte) bool) bool {
 	cont := true
 	var dbuf []byte // decompression buffer reused across ads (single-threaded scan)
 	forEachVisibleKeyed(s0, wins, func(key, ad []byte, codec Codec) bool {

--- a/collections/store.go
+++ b/collections/store.go
@@ -136,6 +136,28 @@ type Options struct {
 	// opaque at rest. The set can be changed at runtime via the toggle meta-command;
 	// existing records keep their prior form until rewritten.
 	EncryptedAttrs []string
+
+	// TimeTravel, if non-nil, enables point-in-time ("AS OF") queries: superseded
+	// record versions committed within MaxDistance of now are retained (not reclaimed
+	// by compaction), and a sparse time->seq checkpoint is recorded so a wall-clock
+	// time resolves to the commit sequence that was current then. Nil (default)
+	// disables it with zero write-path cost -- retention collapses to the current seq,
+	// exactly as before. See timeseq.go. It can be toggled at runtime.
+	TimeTravel *TimeTravelOptions
+}
+
+// TimeTravelOptions configures point-in-time queries for a collection (see the
+// TimeTravel option and timeseq.go).
+type TimeTravelOptions struct {
+	// MaxDistance is how far back queries may travel: versions superseded more than
+	// this long ago are eligible for reclamation. Larger keeps more history (more
+	// retained dead bytes). Must be > 0.
+	MaxDistance time.Duration
+	// CheckpointInterval is the granularity of the time->seq map: a checkpoint is
+	// recorded at most once per interval, on the first commit that crosses the
+	// boundary, so an AS OF time resolves to within one interval. Default 1 minute;
+	// lower for finer resolution at proportionally more checkpoints.
+	CheckpointInterval time.Duration
 }
 
 // AdUpdate is one insert-or-update in a batch.
@@ -218,6 +240,10 @@ type Collection struct {
 	// opm accumulates the collection-wide maintenance timings (compact/retrain/reindex)
 	// for OpStats; per-shard write/segment/sync timings live on each shard. See opstats.go.
 	opm opMetrics
+
+	// ttCfg is the active time-travel configuration, or nil when disabled (the
+	// default). Swappable at runtime via SetTimeTravel. See timeseq.go.
+	ttCfg atomic.Pointer[ttConfig]
 }
 
 // rootKey returns the key of the family root for key: it follows parentKeyFor to
@@ -349,6 +375,12 @@ func New(opts Options) *Collection {
 		demand: newDemandTracker(),
 	}
 	c.codec.Store(&codecHolder{codec})
+	if cfg := newTTConfig(opts.TimeTravel); cfg != nil {
+		c.ttCfg.Store(cfg)
+	}
+	for _, sh := range shards {
+		sh.tt = &c.ttCfg // share the collection's swappable time-travel config
+	}
 	c.dicts = newDictReg(codec) // base codec is dictionary id 0
 	// Always front-load the configured hot attributes plus the match-critical defaults
 	// (Requirements, Rank). A persistent collection re-installs these inline in Open.

--- a/collections/timeseq.go
+++ b/collections/timeseq.go
@@ -1,0 +1,166 @@
+package collections
+
+import (
+	"sync"
+	"time"
+)
+
+// Time travel: mapping wall-clock time to commit sequences for point-in-time
+// ("AS OF") queries.
+//
+// The store is already multi-version -- every record carries the commit seq at which
+// it became current and the seq at which it was superseded, and forEachVisible yields
+// the version visible at any snapshot seq S0 (seq <= S0 < sup). Two things are missing
+// for time travel, both provided here plus small hooks elsewhere:
+//
+//  1. a time->seq map, so a wall-clock instant resolves to the seq that was current
+//     then. Commit seqs are strictly per-shard, so the map is per-shard too: each
+//     shard records sparse (seq, unixMillis) checkpoints -- at most one per
+//     CheckpointInterval, on the first commit that crosses the boundary. A checkpoint
+//     is written into the segment arena as a marker entry (see segment.go
+//     appendMarker), so it rides the segment's existing msync durability -- no
+//     separate file or fsync -- and is rebuilt into the in-memory index on recovery.
+//
+//  2. retention: compaction must not reclaim a superseded version still within the
+//     travel window. retainFloor(now) is the seq that was current at now-MaxDistance;
+//     compaction keeps any version whose supersededBySeq is beyond it (see compact.go).
+//
+// When a collection has no TimeTravel option the whole mechanism is inert: no
+// checkpoints are written and retainFloor collapses to the current commit seq, so
+// compaction behaves exactly as before with zero write-path cost.
+
+const defaultCheckpointInterval = time.Minute
+
+// ttConfig is a collection's active time-travel configuration; nil (see
+// Collection.ttCfg) means disabled. Held behind an atomic pointer so the feature can
+// be toggled/retuned at runtime.
+type ttConfig struct {
+	maxDistance time.Duration
+	interval    time.Duration
+}
+
+func newTTConfig(o *TimeTravelOptions) *ttConfig {
+	if o == nil || o.MaxDistance <= 0 {
+		return nil
+	}
+	iv := o.CheckpointInterval
+	if iv <= 0 {
+		iv = defaultCheckpointInterval
+	}
+	return &ttConfig{maxDistance: o.MaxDistance, interval: iv}
+}
+
+// nowMillis is the current wall-clock time in unix milliseconds.
+func nowMillis() uint64 { return uint64(time.Now().UnixMilli()) }
+
+// SetTimeTravel enables, retunes, or (with a nil/zero option) disables point-in-time
+// queries at runtime. Enabling starts recording checkpoints and retaining superseded
+// versions from now on (it is not retroactive); disabling lets the next compaction
+// reclaim the retained history. Safe to call concurrently with reads and writes.
+func (c *Collection) SetTimeTravel(o *TimeTravelOptions) {
+	c.ttCfg.Store(newTTConfig(o))
+}
+
+// timeTravel returns the collection's active time-travel config, or nil when disabled.
+func (c *Collection) timeTravel() *ttConfig { return c.ttCfg.Load() }
+
+// timeSeqEntry is one checkpoint: seq was the shard's commit sequence at wall-clock
+// millis. Both fields are non-decreasing along the slice.
+type timeSeqEntry struct {
+	seq    uint64
+	millis uint64
+}
+
+// shardTimeIndex is a shard's in-memory time->seq checkpoint index: a slice of
+// checkpoints sorted ascending (by both seq and millis, which advance together). It is
+// populated from segment markers on recovery and appended to on commit. Guarded by its
+// own lock so query-time resolution does not contend on the shard write lock.
+type shardTimeIndex struct {
+	mu         sync.RWMutex
+	entries    []timeSeqEntry
+	lastMillis uint64 // millis of the most recent checkpoint (0 = none yet)
+}
+
+// due reports whether a checkpoint should be recorded at nowMs given the interval:
+// true if none has been recorded yet or the interval has elapsed since the last one.
+// Callers hold the shard write lock (checkpoints are recorded during commit).
+func (x *shardTimeIndex) due(nowMs uint64, interval time.Duration) bool {
+	x.mu.RLock()
+	last := x.lastMillis
+	x.mu.RUnlock()
+	if last == 0 {
+		return true
+	}
+	return nowMs >= last+uint64(interval/time.Millisecond)
+}
+
+// record appends a checkpoint (seq was current at millis). millis is clamped to be
+// non-decreasing so a backward clock cannot corrupt the ordering.
+func (x *shardTimeIndex) record(seq, millis uint64) {
+	x.mu.Lock()
+	defer x.mu.Unlock()
+	if len(x.entries) > 0 {
+		if last := x.entries[len(x.entries)-1]; millis < last.millis {
+			millis = last.millis
+		}
+	}
+	x.entries = append(x.entries, timeSeqEntry{seq: seq, millis: millis})
+	x.lastMillis = millis
+}
+
+// seqAt returns the largest checkpoint seq whose millis is <= the given millis (the
+// commit sequence that was current at that wall-clock instant), and ok=false if the
+// instant predates the earliest checkpoint (nothing to resolve to).
+func (x *shardTimeIndex) seqAt(millis uint64) (uint64, bool) {
+	x.mu.RLock()
+	defer x.mu.RUnlock()
+	e := x.entries
+	if len(e) == 0 || millis < e[0].millis {
+		return 0, false
+	}
+	// Largest index with e[i].millis <= millis (entries ascending by millis).
+	lo, hi := 0, len(e)
+	for lo < hi {
+		mid := (lo + hi) / 2
+		if e[mid].millis <= millis {
+			lo = mid + 1
+		} else {
+			hi = mid
+		}
+	}
+	return e[lo-1].seq, true
+}
+
+// retainFloor returns the seq below which superseded versions may be reclaimed for a
+// window of maxDistance ending now: the seq that was current at now-maxDistance. If the
+// entire recorded history is younger than maxDistance (the cutoff predates the earliest
+// checkpoint) it returns 0 -- retain everything. Callers pass this to compaction as the
+// gate `keep any version with supersededBySeq > retainFloor`.
+func (x *shardTimeIndex) retainFloor(nowMs uint64, maxDistance time.Duration) uint64 {
+	d := uint64(maxDistance / time.Millisecond)
+	if nowMs < d {
+		return 0
+	}
+	seq, ok := x.seqAt(nowMs - d)
+	if !ok {
+		return 0
+	}
+	return seq
+}
+
+// trim drops checkpoints whose seq is at or below floor (their window has aged out);
+// they are no longer needed once compaction has reclaimed everything below floor. It
+// keeps the last trimmed entry as a sentinel so seqAt for a time just after the floor
+// still resolves. Callers hold no lock.
+func (x *shardTimeIndex) trim(floor uint64) {
+	x.mu.Lock()
+	defer x.mu.Unlock()
+	// Find the first entry with seq > floor; keep one entry before it as the sentinel.
+	cut := 0
+	for cut < len(x.entries) && x.entries[cut].seq <= floor {
+		cut++
+	}
+	if cut > 1 {
+		x.entries = append(x.entries[:0], x.entries[cut-1:]...)
+	}
+}

--- a/collections/timeseq.go
+++ b/collections/timeseq.go
@@ -1,9 +1,19 @@
 package collections
 
 import (
+	"errors"
+	"fmt"
+	"iter"
 	"sync"
 	"time"
+
+	"github.com/PelicanPlatform/classad/classad"
+	"github.com/PelicanPlatform/classad/collections/vm"
 )
+
+// ErrTimeTravelDisabled is returned by the AS OF query paths when the collection has
+// no time-travel configuration.
+var ErrTimeTravelDisabled = errors.New("collections: time travel is not enabled on this collection")
 
 // Time travel: mapping wall-clock time to commit sequences for point-in-time
 // ("AS OF") queries.
@@ -50,8 +60,13 @@ func newTTConfig(o *TimeTravelOptions) *ttConfig {
 	return &ttConfig{maxDistance: o.MaxDistance, interval: iv}
 }
 
+// nowMillisFn supplies the current wall-clock time in unix milliseconds. It is a
+// package var so tests can install a deterministic clock; production uses the wall
+// clock. Set it only from a single-goroutine test setup.
+var nowMillisFn = func() uint64 { return uint64(time.Now().UnixMilli()) }
+
 // nowMillis is the current wall-clock time in unix milliseconds.
-func nowMillis() uint64 { return uint64(time.Now().UnixMilli()) }
+func nowMillis() uint64 { return nowMillisFn() }
 
 // SetTimeTravel enables, retunes, or (with a nil/zero option) disables point-in-time
 // queries at runtime. Enabling starts recording checkpoints and retaining superseded
@@ -63,6 +78,70 @@ func (c *Collection) SetTimeTravel(o *TimeTravelOptions) {
 
 // timeTravel returns the collection's active time-travel config, or nil when disabled.
 func (c *Collection) timeTravel() *ttConfig { return c.ttCfg.Load() }
+
+// resolveAsOf maps wall-clock t to a per-shard commit-sequence vector for a
+// point-in-time scan: for each shard, the sequence that was current at t (the last
+// checkpoint at or before t). It errors if time travel is disabled or t is older than
+// the retained window. A shard with no checkpoint at or before t resolves to seq 0 (it
+// held nothing that early). t in the future is clamped to now.
+func (c *Collection) resolveAsOf(t time.Time) ([]uint64, error) {
+	cfg := c.ttCfg.Load()
+	if cfg == nil {
+		return nil, ErrTimeTravelDisabled
+	}
+	now := nowMillis()
+	ms := now
+	if tm := t.UnixMilli(); tm >= 0 && uint64(tm) < now {
+		ms = uint64(tm)
+	}
+	d := uint64(cfg.maxDistance / time.Millisecond)
+	var horizon uint64
+	if now > d {
+		horizon = now - d
+	}
+	if ms < horizon {
+		return nil, fmt.Errorf("collections: AS OF %s is older than the %s time-travel window",
+			t.UTC().Format(time.RFC3339), cfg.maxDistance)
+	}
+	seqs := make([]uint64, len(c.shards))
+	for i, sh := range c.shards {
+		if s, ok := sh.tseq.seqAt(ms); ok {
+			seqs[i] = s
+		}
+	}
+	return seqs, nil
+}
+
+// QueryAsOf runs q against the point-in-time snapshot at time t: it resolves t to a
+// per-shard commit sequence and scans each shard at that sequence, so the result is
+// exactly the ads that were current at t. It errors if time travel is disabled or t
+// predates the retained window. v1 uses a serial full scan per shard (the index,
+// parallel, and chained fast paths are current-time only); the query constraint is
+// still applied to every candidate.
+func (c *Collection) QueryAsOf(q *vm.Query, t time.Time) (iter.Seq[*classad.ClassAd], error) {
+	seqs, err := c.resolveAsOf(t)
+	if err != nil {
+		return nil, err
+	}
+	return func(yield func(*classad.ClassAd) bool) {
+		plan := q.ReadPlan()
+		ws := &wireScope{ctx: c}
+		qp := queryPlan{
+			q:        q,
+			plan:     plan,
+			m:        q.Matcher(),
+			wireOK:   q.Native() && plan.PartialSafe,
+			ws:       ws,
+			resolver: ws.resolve,
+		}
+		emit := c.yieldAd(yield)
+		for i, sh := range c.shards {
+			if !c.scanShardAt(sh, seqs[i], qp, emit) {
+				return
+			}
+		}
+	}, nil
+}
 
 // retainFloorLocked is the commit sequence below which superseded versions may be
 // reclaimed by compaction: the current commitSeq when time travel is off (reclaim

--- a/collections/timeseq.go
+++ b/collections/timeseq.go
@@ -79,6 +79,15 @@ func (c *Collection) SetTimeTravel(o *TimeTravelOptions) {
 // timeTravel returns the collection's active time-travel config, or nil when disabled.
 func (c *Collection) timeTravel() *ttConfig { return c.ttCfg.Load() }
 
+// TimeTravelConfig reports the collection's current time-travel settings and whether
+// it is enabled (for persisting the runtime toggle; see db.saveIndexConfig).
+func (c *Collection) TimeTravelConfig() (opts TimeTravelOptions, enabled bool) {
+	if cfg := c.ttCfg.Load(); cfg != nil {
+		return TimeTravelOptions{MaxDistance: cfg.maxDistance, CheckpointInterval: cfg.interval}, true
+	}
+	return TimeTravelOptions{}, false
+}
+
 // resolveAsOf maps wall-clock t to a per-shard commit-sequence vector for a
 // point-in-time scan: for each shard, the sequence that was current at t (the last
 // checkpoint at or before t). It errors if time travel is disabled or t is older than

--- a/collections/timeseq.go
+++ b/collections/timeseq.go
@@ -64,6 +64,22 @@ func (c *Collection) SetTimeTravel(o *TimeTravelOptions) {
 // timeTravel returns the collection's active time-travel config, or nil when disabled.
 func (c *Collection) timeTravel() *ttConfig { return c.ttCfg.Load() }
 
+// retainFloorLocked is the commit sequence below which superseded versions may be
+// reclaimed by compaction: the current commitSeq when time travel is off (reclaim
+// every superseded version, exactly as before), else the sequence that was current
+// MaxDistance ago (retain anything newer for AS OF queries). A version is kept iff its
+// supersededBySeq is strictly greater than this. Caller holds at least the read lock.
+func (sh *shard) retainFloorLocked() uint64 {
+	if sh.tt != nil {
+		if cfg := sh.tt.Load(); cfg != nil {
+			if f := sh.tseq.retainFloor(nowMillis(), cfg.maxDistance); f < sh.commitSeq {
+				return f
+			}
+		}
+	}
+	return sh.commitSeq
+}
+
 // timeSeqEntry is one checkpoint: seq was the shard's commit sequence at wall-clock
 // millis. Both fields are non-decreasing along the slice.
 type timeSeqEntry struct {

--- a/collections/timetravel_test.go
+++ b/collections/timetravel_test.go
@@ -1,0 +1,196 @@
+package collections
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/PelicanPlatform/classad/collections/vm"
+)
+
+// fakeClock installs a controllable millisecond clock for deterministic time-travel
+// tests and returns a restore func plus a setter.
+func fakeClock(t *testing.T, start uint64) (set func(uint64)) {
+	t.Helper()
+	var cur = start
+	prev := nowMillisFn
+	nowMillisFn = func() uint64 { return cur }
+	t.Cleanup(func() { nowMillisFn = prev })
+	return func(ms uint64) { cur = ms }
+}
+
+// countAsOf runs q against the AS OF snapshot at t and returns how many ads match.
+func countAsOf(t *testing.T, c *Collection, qs string, at uint64) int {
+	t.Helper()
+	q, err := vm.Parse(qs)
+	if err != nil {
+		t.Fatalf("parse %q: %v", qs, err)
+	}
+	seq, err := c.QueryAsOf(q, time.UnixMilli(int64(at)))
+	if err != nil {
+		t.Fatalf("QueryAsOf(%q, %d): %v", qs, at, err)
+	}
+	n := 0
+	for range seq {
+		n++
+	}
+	return n
+}
+
+// TestTimeTravelRoundTrip: an AS OF query returns the value that was current at that
+// instant, across an update and a delete; a disabled collection refuses.
+func TestTimeTravelRoundTrip(t *testing.T) {
+	set := fakeClock(t, 10_000)
+	c := New(Options{Shards: 2, TimeTravel: &TimeTravelOptions{
+		MaxDistance: time.Hour, CheckpointInterval: time.Second,
+	}})
+
+	set(10_000)
+	if err := c.Put([]byte("k"), mustAd(t, `[Owner="alice"; JobStatus=1]`)); err != nil {
+		t.Fatal(err)
+	}
+	set(20_000) // +10s -> a new checkpoint is due on this commit
+	if err := c.Put([]byte("k"), mustAd(t, `[Owner="alice"; JobStatus=2]`)); err != nil {
+		t.Fatal(err)
+	}
+	set(30_000)
+	if !c.Delete([]byte("k")) {
+		t.Fatal("delete reported nothing removed")
+	}
+	set(40_000) // advance so the delete's checkpoint is distinguishable
+	_ = c.Put([]byte("other"), mustAd(t, `[Owner="bob"]`))
+
+	if n := countAsOf(t, c, `JobStatus == 1`, 15_000); n != 1 {
+		t.Errorf("count(JobStatus==1) AS OF 15s = %d, want 1", n)
+	}
+	if n := countAsOf(t, c, `JobStatus == 2`, 25_000); n != 1 {
+		t.Errorf("count(JobStatus==2) AS OF 25s = %d, want 1 (post-update)", n)
+	}
+	if n := countAsOf(t, c, `JobStatus == 1`, 25_000); n != 0 {
+		t.Errorf("count(JobStatus==1) AS OF 25s = %d, want 0 (superseded by then)", n)
+	}
+	// After the delete, k is gone (only "other" remains).
+	if n := countAsOf(t, c, `JobStatus == 2`, 35_000); n != 0 {
+		t.Errorf("count(JobStatus==2) AS OF 35s = %d, want 0 (k deleted)", n)
+	}
+
+	// Disabled collection refuses AS OF.
+	off := New(Options{Shards: 2})
+	q, _ := vm.Parse(`true`)
+	if _, err := off.QueryAsOf(q, time.UnixMilli(1000)); err != ErrTimeTravelDisabled {
+		t.Errorf("QueryAsOf on a disabled collection = %v, want ErrTimeTravelDisabled", err)
+	}
+}
+
+// TestTimeTravelCompactionRetainsThenReclaims: an in-window superseded version
+// survives compaction (still AS OF-queryable), and once it ages past MaxDistance a
+// later compaction reclaims it (AS OF that far back is refused).
+func TestTimeTravelCompactionRetainsThenReclaims(t *testing.T) {
+	set := fakeClock(t, 1_000_000)
+	c := New(Options{Shards: 1, SegmentSize: 1 << 14, TimeTravel: &TimeTravelOptions{
+		MaxDistance: 10 * time.Minute, CheckpointInterval: time.Second,
+	}})
+
+	// Churn one key across many versions at 1s steps so each gets its own checkpoint.
+	base := uint64(1_000_000)
+	for i := 0; i < 40; i++ {
+		set(base + uint64(i)*1000)
+		if err := c.Put([]byte("k"), mustAd(t, fmt.Sprintf(`[V=%d]`, i))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Also churn filler keys to build dead bytes so compaction triggers.
+	for i := 0; i < 300; i++ {
+		set(base + 40_000 + uint64(i)*10)
+		_ = c.Put([]byte(fmt.Sprintf("f%d", i%20)), mustAd(t, fmt.Sprintf(`[F=%d]`, i)))
+	}
+
+	set(base + 60_000) // still within the 10-minute window
+	c.Compact()
+
+	// The version current at base+5s (V=5) must survive compaction.
+	if n := countAsOf(t, c, `V == 5`, base+5_000); n != 1 {
+		t.Errorf("count(V==5) AS OF +5s after compaction = %d, want 1 (in-window history retained)", n)
+	}
+	if n := countAsOf(t, c, `V == 5`, base+38_000); n != 0 {
+		t.Errorf("count(V==5) AS OF +38s = %d, want 0 (superseded long before)", n)
+	}
+	// Current value is the last write (V=39), visible at a recent AS OF.
+	if n := countAsOf(t, c, `V == 39`, base+55_000); n != 1 {
+		t.Errorf("count(V==39) AS OF +55s = %d, want 1 (current)", n)
+	}
+
+	// Advance well past the window and compact: the old versions age out and are
+	// reclaimed, so an AS OF that far back is refused.
+	set(base + 60_000 + uint64((11 * time.Minute).Milliseconds()))
+	// A write moves the working set forward so compaction has something to do.
+	_ = c.Put([]byte("k"), mustAd(t, `[V=99]`))
+	c.Compact()
+	q, _ := vm.Parse(`true`)
+	if _, err := c.QueryAsOf(q, time.UnixMilli(int64(base+5_000))); err == nil {
+		t.Error("QueryAsOf +5s after the window elapsed should be refused (data reclaimed)")
+	}
+}
+
+// TestTimeTravelRecovery: markers survive a persistent close/reopen -- the time index
+// is rebuilt from the segment markers, so AS OF still resolves after restart.
+func TestTimeTravelRecovery(t *testing.T) {
+	set := fakeClock(t, 5_000)
+	dir := t.TempDir()
+	opts := Options{Dir: dir, Shards: 2, TimeTravel: &TimeTravelOptions{
+		MaxDistance: time.Hour, CheckpointInterval: time.Second,
+	}}
+	c, err := Open(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	set(5_000)
+	_ = c.Put([]byte("k"), mustAd(t, `[V=1]`))
+	set(15_000)
+	_ = c.Put([]byte("k"), mustAd(t, `[V=2]`))
+	set(25_000)
+	_ = c.Put([]byte("k"), mustAd(t, `[V=3]`))
+	if err := c.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	c2, err := Open(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c2.Close()
+	if n := countAsOf(t, c2, `V == 1`, 10_000); n != 1 {
+		t.Errorf("after reopen, count(V==1) AS OF 10s = %d, want 1 (time index rebuilt from markers)", n)
+	}
+	if n := countAsOf(t, c2, `V == 2`, 20_000); n != 1 {
+		t.Errorf("after reopen, count(V==2) AS OF 20s = %d, want 1", n)
+	}
+}
+
+// TestTimeTravelDisabledNoMarkers: with time travel off, no marker entries are written
+// (zero write-path overhead) -- a scan of the raw arena finds none.
+func TestTimeTravelDisabledNoMarkers(t *testing.T) {
+	c := New(Options{Shards: 1})
+	for i := 0; i < 50; i++ {
+		_ = c.Put([]byte(fmt.Sprintf("k%d", i)), mustAd(t, fmt.Sprintf(`[V=%d]`, i)))
+	}
+	sh := c.shards[0]
+	sh.mu.RLock()
+	defer sh.mu.RUnlock()
+	for _, seg := range sh.segs {
+		if seg == nil {
+			continue
+		}
+		for off := 0; off < seg.used; {
+			o := uint32(off)
+			total := recTotalLen(seg.data, o)
+			if total == 0 {
+				break
+			}
+			if recIsMarker(seg.data, o) {
+				t.Fatal("found a time-checkpoint marker with time travel disabled")
+			}
+			off += int(total)
+		}
+	}
+}

--- a/collections/txn.go
+++ b/collections/txn.go
@@ -153,6 +153,7 @@ func (sh *shard) commitTxn(ws []*txnWrite, durable bool) {
 	}
 	if changed {
 		sh.commitSeq = seq
+		sh.maybeCheckpoint(seq)
 	}
 	sh.unlockWrite(acq, held)
 	if changed {

--- a/db/db.go
+++ b/db/db.go
@@ -124,6 +124,10 @@ func OpenConfig(cfg Config) (*DB, error) {
 		Codec:             chooseBaseCodec(cfg.Dir), // ZSTD by default for new stores
 		DataKey:           enc.data(),
 		EncryptedAttrs:    cfg.EncryptedAttrs,
+		// Time travel is a persisted runtime toggle: read it before opening so recovery
+		// rebuilds the time index (and scan-pruning counters) from the segment markers
+		// instead of the directory snapshot. loadIndexConfig below keeps it in sync.
+		TimeTravel: readPersistedTimeTravel(cfg.Dir),
 	}
 	var c *collections.Collection
 	if cfg.Dir == "" {
@@ -470,6 +474,36 @@ func (db *DB) Query(constraint string) (iter.Seq[*classad.ClassAd], error) {
 		return nil, fmt.Errorf("classad-db: bad constraint %q: %w", constraint, err)
 	}
 	return db.c.Query(q), nil
+}
+
+// QueryAsOf runs a point-in-time ("AS OF") query: it returns the ads matching the
+// constraint as they were at time t. It errors on a malformed constraint, when time
+// travel is not enabled on this table, or when t is older than the retained window.
+func (db *DB) QueryAsOf(constraint string, t time.Time) (iter.Seq[*classad.ClassAd], error) {
+	q, err := vm.Parse(constraint)
+	if err != nil {
+		return nil, fmt.Errorf("classad-db: bad constraint %q: %w", constraint, err)
+	}
+	return db.c.QueryAsOf(q, t)
+}
+
+// SetTimeTravel enables (with a positive maxDistance), retunes, or disables (maxDistance
+// <= 0) point-in-time queries for this table, and persists the setting so it survives a
+// restart. A zero checkpoint interval uses the collections default (1 minute). Enabling
+// is not retroactive -- only changes from now on are travelable.
+func (db *DB) SetTimeTravel(maxDistance, checkpoint time.Duration) {
+	if maxDistance <= 0 {
+		db.c.SetTimeTravel(nil)
+	} else {
+		db.c.SetTimeTravel(&collections.TimeTravelOptions{MaxDistance: maxDistance, CheckpointInterval: checkpoint})
+	}
+	db.saveIndexConfig()
+}
+
+// TimeTravel reports the table's current point-in-time settings and whether enabled.
+func (db *DB) TimeTravel() (maxDistance, checkpoint time.Duration, enabled bool) {
+	o, on := db.c.TimeTravelConfig()
+	return o.MaxDistance, o.CheckpointInterval, on
 }
 
 // QueryProject returns, for each ad matching the constraint, just the named

--- a/db/indexpersist.go
+++ b/db/indexpersist.go
@@ -4,6 +4,9 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"time"
+
+	"github.com/PelicanPlatform/classad/collections"
 )
 
 // Runtime index/hot-set configuration is persisted next to the ClassAd log so
@@ -27,6 +30,41 @@ type persistedIndexConfig struct {
 	// change consistent across restarts -- and, in HA, lets a follower converge on the
 	// policy by reloading, since there is no op-stream replication of config.
 	Encrypted []string `json:"encrypted,omitempty"`
+	// Time-travel (point-in-time / AS OF) settings, a runtime-toggled per-table policy
+	// persisted like Encrypted. TimeTravel off (default) leaves the others inert.
+	TimeTravel                bool `json:"timeTravel,omitempty"`
+	TimeTravelMaxSeconds      int  `json:"timeTravelMaxSeconds,omitempty"`
+	TimeTravelCheckpointSeced int  `json:"timeTravelCheckpointSeconds,omitempty"`
+}
+
+// timeTravelOptions converts the persisted seconds to a collections option set, or nil
+// when disabled. The checkpoint interval defaults inside collections if left zero.
+func (p persistedIndexConfig) timeTravelOptions() *collections.TimeTravelOptions {
+	if !p.TimeTravel || p.TimeTravelMaxSeconds <= 0 {
+		return nil
+	}
+	return &collections.TimeTravelOptions{
+		MaxDistance:        time.Duration(p.TimeTravelMaxSeconds) * time.Second,
+		CheckpointInterval: time.Duration(p.TimeTravelCheckpointSeced) * time.Second,
+	}
+}
+
+// readPersistedTimeTravel reads just the time-travel settings from dir's index-config
+// file, before the collection is opened, so recovery can rebuild the time index. Nil
+// when there is no dir, no file, or time travel is off.
+func readPersistedTimeTravel(dir string) *collections.TimeTravelOptions {
+	if dir == "" {
+		return nil
+	}
+	data, err := os.ReadFile(filepath.Join(dir, indexConfigFile))
+	if err != nil {
+		return nil
+	}
+	var cfg persistedIndexConfig
+	if json.Unmarshal(data, &cfg) != nil {
+		return nil
+	}
+	return cfg.timeTravelOptions()
 }
 
 func (db *DB) indexConfigPath() string {
@@ -48,6 +86,11 @@ func (db *DB) saveIndexConfig() {
 	cfg := persistedIndexConfig{
 		Categorical: cat, Value: val, Auto: db.c.AutoIndexNames(), Hot: db.c.HotAttrNames(),
 		Encrypted: db.c.EncryptedAttrNames(),
+	}
+	if o, on := db.c.TimeTravelConfig(); on {
+		cfg.TimeTravel = true
+		cfg.TimeTravelMaxSeconds = int(o.MaxDistance / time.Second)
+		cfg.TimeTravelCheckpointSeced = int(o.CheckpointInterval / time.Second)
 	}
 	data, err := json.MarshalIndent(cfg, "", "  ")
 	if err != nil {

--- a/db/timetravel_test.go
+++ b/db/timetravel_test.go
@@ -1,0 +1,91 @@
+package db
+
+import (
+	"testing"
+	"time"
+
+	"github.com/PelicanPlatform/classad/collections"
+)
+
+func countAsOf(t *testing.T, db *DB, constraint string, at time.Time) int {
+	t.Helper()
+	seq, err := db.QueryAsOf(constraint, at)
+	if err != nil {
+		t.Fatalf("QueryAsOf(%q): %v", constraint, err)
+	}
+	n := 0
+	for range seq {
+		n++
+	}
+	return n
+}
+
+// TestDBTimeTravel exercises the db-layer wiring: enabling persists across a reopen,
+// AS OF resolves the historical value, and disabling is refused + persisted.
+func TestDBTimeTravel(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Disabled by default.
+	if _, err := db.QueryAsOf("true", time.Now()); err != collections.ErrTimeTravelDisabled {
+		t.Fatalf("QueryAsOf before enable = %v, want ErrTimeTravelDisabled", err)
+	}
+
+	// Enable with a fine checkpoint cadence so distinct writes get distinct checkpoints.
+	db.SetTimeTravel(time.Hour, time.Millisecond)
+	if d, _, on := db.TimeTravel(); !on || d != time.Hour {
+		t.Fatalf("TimeTravel() = (%v,_,%v), want (1h,_,true)", d, on)
+	}
+
+	putAd(t, db, "k", "Owner = \"alice\"\nJobStatus = 1")
+	time.Sleep(20 * time.Millisecond)
+	tMid := time.Now()
+	time.Sleep(20 * time.Millisecond)
+	putAd(t, db, "k", "Owner = \"alice\"\nJobStatus = 2")
+
+	if n := countAsOf(t, db, "JobStatus == 1", tMid); n != 1 {
+		t.Errorf("count(JobStatus==1) AS OF mid = %d, want 1", n)
+	}
+	if n := countAsOf(t, db, "JobStatus == 2", tMid); n != 0 {
+		t.Errorf("count(JobStatus==2) AS OF mid = %d, want 0 (not yet written)", n)
+	}
+	if n := countAsOf(t, db, "JobStatus == 2", time.Now()); n != 1 {
+		t.Errorf("count(JobStatus==2) AS OF now = %d, want 1", n)
+	}
+
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Reopen: the setting persisted, and AS OF still resolves (index rebuilt on recovery).
+	db2, err := Open(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, on := db2.TimeTravel(); !on {
+		t.Fatal("time travel not enabled after reopen (setting did not persist)")
+	}
+	if n := countAsOf(t, db2, "JobStatus == 1", tMid); n != 1 {
+		t.Errorf("after reopen, count(JobStatus==1) AS OF mid = %d, want 1", n)
+	}
+
+	// Disable, and confirm it is refused and persists.
+	db2.SetTimeTravel(0, 0)
+	if _, err := db2.QueryAsOf("true", time.Now()); err != collections.ErrTimeTravelDisabled {
+		t.Fatalf("QueryAsOf after disable = %v, want ErrTimeTravelDisabled", err)
+	}
+	if err := db2.Close(); err != nil {
+		t.Fatal(err)
+	}
+	db3, err := Open(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db3.Close()
+	if _, _, on := db3.TimeTravel(); on {
+		t.Fatal("time travel still enabled after disable+reopen")
+	}
+}

--- a/dbrpc/client.go
+++ b/dbrpc/client.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/PelicanPlatform/classad/db"
 )
@@ -374,6 +375,17 @@ func (c *Client) QueryLimit(ctx context.Context, constraint string, limit int) (
 func (c *Client) QueryTable(ctx context.Context, table, constraint string, limit int) ([]string, error) {
 	return c.streamCtx(ctx, func(id uint64) []byte {
 		return putStr(putI32(putStr(req(id, opQuery), table), int32(limit)), constraint)
+	})
+}
+
+// QueryAsOfTable is QueryTable for a point-in-time ("AS OF") query: it returns the ads
+// in the named table matching constraint as they were at asOf. The server errors if
+// time travel is not enabled on the table or asOf is older than the retained window.
+func (c *Client) QueryAsOfTable(ctx context.Context, table, constraint string, limit int, asOf time.Time) ([]string, error) {
+	return c.streamCtx(ctx, func(id uint64) []byte {
+		b := putI32(putStr(req(id, opQueryAsOf), table), int32(limit))
+		b = putU64(b, uint64(asOf.UnixNano()))
+		return putStr(b, constraint)
 	})
 }
 

--- a/dbrpc/diag.go
+++ b/dbrpc/diag.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"time"
 
 	"github.com/PelicanPlatform/classad/db"
 )
@@ -87,6 +88,28 @@ func (s *Server) admin(t *db.DB, action string, args []string, privileged bool) 
 			return "", err
 		}
 		return "encrypted attributes: " + join(t.EncryptedAttrNames()), nil
+	case "timetravel.enable":
+		// Enable/retune point-in-time queries: args = <maxDistanceSeconds>
+		// [checkpointSeconds]. Persisted so it survives a restart.
+		if len(args) < 1 {
+			return "", fmt.Errorf("timetravel.enable needs <maxDistanceSeconds> [checkpointSeconds]")
+		}
+		maxS, err := strconv.Atoi(args[0])
+		if err != nil || maxS <= 0 {
+			return "", fmt.Errorf("timetravel.enable: bad maxDistanceSeconds %q", args[0])
+		}
+		ckpt := 0
+		if len(args) > 1 {
+			if ckpt, err = strconv.Atoi(args[1]); err != nil || ckpt < 0 {
+				return "", fmt.Errorf("timetravel.enable: bad checkpointSeconds %q", args[1])
+			}
+		}
+		t.SetTimeTravel(time.Duration(maxS)*time.Second, time.Duration(ckpt)*time.Second)
+		md, cp, _ := t.TimeTravel()
+		return fmt.Sprintf("time travel enabled: window %s, checkpoint %s", md, cp), nil
+	case "timetravel.disable":
+		t.SetTimeTravel(0, 0)
+		return "time travel disabled", nil
 	case "truncate":
 		// Removing every ad is a destructive, DB-wide-locked operation.
 		t.Truncate()

--- a/dbrpc/proto.go
+++ b/dbrpc/proto.go
@@ -94,6 +94,10 @@ const (
 	opCreateView op = 40 // [name][json db.ViewSpec] -> status; mutating
 	opDropView   op = 41 // [name] -> status; mutating
 	opListViews  op = 42 // -> [n i32]{[name]}
+
+	// Point-in-time query: like opQuery but with a wall-clock instant; the server
+	// resolves it to the per-shard commit sequence current then (time travel).
+	opQueryAsOf op = 43 // [table][limit i32][asOfUnixNanos u64][constraint] -> stream of [adText]
 )
 
 // String names an opcode for diagnostics (e.g. the read-only rejection message).
@@ -119,6 +123,8 @@ func (o op) String() string {
 		return "LookupAttr"
 	case opQuery:
 		return "Query"
+	case opQueryAsOf:
+		return "QueryAsOf"
 	case opMatchSorted:
 		return "MatchSorted"
 	case opWatch:

--- a/dbrpc/server.go
+++ b/dbrpc/server.go
@@ -383,6 +383,8 @@ func (sc *serverConn) dispatch(frame []byte) {
 	switch o {
 	case opQuery:
 		sc.s.streamQuery(sc.ctx, reqID, body, priv, sc.write, sc.opts.QueryLog)
+	case opQueryAsOf:
+		sc.s.streamQueryAsOf(sc.ctx, reqID, body, priv, sc.write, sc.opts.QueryLog)
 	case opQueryRaw:
 		sc.s.streamQueryRaw(sc.ctx, reqID, body, priv, sc.write, sc.opts.QueryLog)
 	case opQueryRawProj:
@@ -511,6 +513,48 @@ func (s *Server) streamQuery(ctx context.Context, reqID uint64, r *reader, inclu
 	for ad := range seq {
 		if cancelled(ctx) {
 			return // client gone: stop the scan
+		}
+		write(putStr(respHead(reqID, stStream), adString(ad, includePrivate)))
+		n++
+		if limit > 0 && n >= limit {
+			break
+		}
+	}
+	write(respHead(reqID, stStreamEnd))
+}
+
+// streamQueryAsOf is streamQuery for a point-in-time ("AS OF") query: it reads a
+// wall-clock instant (unix nanos) and streams the ads that matched the constraint as
+// they were then. It errors cleanly if time travel is disabled or the instant is
+// outside the retained window.
+func (s *Server) streamQueryAsOf(ctx context.Context, reqID uint64, r *reader, includePrivate bool, write func([]byte), qlog func(QueryLog)) {
+	start := time.Now()
+	table := r.str()
+	limit := int(r.i32())
+	asOf := time.Unix(0, int64(r.u64()))
+	constraint := r.str()
+	n := 0
+	if qlog != nil {
+		defer func() {
+			qlog(QueryLog{Op: "QueryAsOf", Table: table, Constraint: constraint, Limit: limit, Rows: n, Duration: time.Since(start)})
+		}()
+	}
+	if r.err != nil {
+		write(respBad(reqID))
+		return
+	}
+	d, ok := s.tableOr(reqID, table, write)
+	if !ok {
+		return
+	}
+	seq, err := d.QueryAsOf(constraint, asOf)
+	if err != nil {
+		write(respErr(reqID, err.Error()))
+		return
+	}
+	for ad := range seq {
+		if cancelled(ctx) {
+			return
 		}
 		write(putStr(respHead(reqID, stStream), adString(ad, includePrivate)))
 		n++

--- a/dbrpc/timetravel_test.go
+++ b/dbrpc/timetravel_test.go
@@ -1,0 +1,85 @@
+package dbrpc
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/PelicanPlatform/classad/db"
+)
+
+// privilegedPair is testPair with a DAEMON-privileged connection (for admin actions).
+func privilegedPair(t *testing.T) (*Client, func()) {
+	t.Helper()
+	d, err := db.Open("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := NewServer(d)
+	cconn, sconn := netPipe()
+	go func() { _ = s.ServeConnOpts(sconn, ServeOptions{Privileged: true}) }()
+	c := NewClient(cconn)
+	return c, func() { c.Close(); s.Close(); d.Close() }
+}
+
+// TestRPCTimeTravel: the timetravel.enable admin action turns on point-in-time queries
+// and opQueryAsOf resolves the historical state over the wire; disabled it is refused.
+func TestRPCTimeTravel(t *testing.T) {
+	c, cleanup := privilegedPair(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	// Disabled by default.
+	if _, err := c.QueryAsOfTable(ctx, DefaultTable, "true", 0, time.Now()); err == nil {
+		t.Fatal("QueryAsOf before enable should error (time travel disabled)")
+	}
+
+	// Enable via the admin channel: 1h window, 1s checkpoint cadence.
+	if msg, err := c.AdminTable(ctx, DefaultTable, "timetravel.enable", "3600", "1"); err != nil {
+		t.Fatalf("timetravel.enable: %v", err)
+	} else {
+		t.Logf("enable -> %s", msg)
+	}
+
+	put := func(state string) {
+		tx, err := c.Begin(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_ = tx.NewClassAd(ctx, "k", `Name = "k"`+"\n"+`State = "`+state+`"`)
+		if err := tx.Commit(ctx); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	put("Idle")
+	time.Sleep(1100 * time.Millisecond) // cross the 1s checkpoint boundary
+	mid := time.Now()
+	time.Sleep(1100 * time.Millisecond)
+	put("Claimed")
+
+	// AS OF mid: the ad was Idle then.
+	rows, err := c.QueryAsOfTable(ctx, DefaultTable, `State == "Idle"`, 0, mid)
+	if err != nil {
+		t.Fatalf("QueryAsOf mid: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Errorf("AS OF mid: State==Idle rows = %d, want 1", len(rows))
+	}
+	// AS OF now: it is Claimed.
+	rows, err = c.QueryAsOfTable(ctx, DefaultTable, `State == "Claimed"`, 0, time.Now())
+	if err != nil {
+		t.Fatalf("QueryAsOf now: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Errorf("AS OF now: State==Claimed rows = %d, want 1", len(rows))
+	}
+
+	// Disable and confirm it is refused again.
+	if _, err := c.AdminTable(ctx, DefaultTable, "timetravel.disable"); err != nil {
+		t.Fatalf("timetravel.disable: %v", err)
+	}
+	if _, err := c.QueryAsOfTable(ctx, DefaultTable, "true", 0, time.Now()); err == nil {
+		t.Fatal("QueryAsOf after disable should error")
+	}
+}


### PR DESCRIPTION
## Time travel: point-in-time (`AS OF`) queries over the MVCC store

Lets an operator ask *"what did the table look like at time T"* — e.g. `SELECT count(*) WHERE JobStatus == 2 AS OF '2026-07-19T10:00:00'`. **Opt-in per table**, zero cost when off, with a configurable max look-back.

The store is already multi-version (each record carries its commit seq and superseded-by seq, and the visibility scan is already `seq ≤ S0 < sup`). This adds the three missing pieces:

### collections (the engine)
- **Time→seq map** as *sparse in-segment checkpoint markers*: a marker (high bit of `keyLen`, payload = `unixMillis`, seq = the shard's commitSeq) is appended to the active segment at most once per `CheckpointInterval`, riding the segment's existing `msync` — no separate file/WAL, rebuilt from the arena on recovery.
- **Retention-aware, segregating compaction**: keeps versions newer than the retain floor (the seq current `MaxDistance` ago). It rewrites only the *working-set* segments, splitting them into fresh **live** segments and separate **history** segments; pure-history segments are left in place (a pass is O(working-set), not O(history)) and reclaimed once aged out. Reclaimable-vs-retained is tracked with per-segment `liveCount`/`maxSup`.
- **Scan pruning**: per-segment `minSeq`/`liveCount`/`maxSup` (+ a `metaReady` correctness guard for fast-reopened segments) let a scan skip any segment with nothing visible at its snapshot — so **current-time scans stay O(live)** even with a large retained history; point lookups/puts are unaffected (current version stays at the bucket-chain head, retained versions are never chained).
- `Collection.QueryAsOf(q, t)` resolves `t` → per-shard seq and scans there; refuses times outside the window or when disabled.

**Off ⇒ retain floor is the current commitSeq**, so nothing is retained, no markers are written, and every path is byte-identical to before (the full pre-existing suite passes unchanged).

### db
`DB.SetTimeTravel(maxDistance, checkpoint)` persists the toggle in `indexcfg.json` (mirroring the `Encrypted` policy); `OpenConfig` pre-reads it so recovery rebuilds the time index from markers. `DB.QueryAsOf(constraint, t)`.

### dbrpc
`opQueryAsOf` (op 43, `[table][limit][asOfUnixNanos][constraint]` → streamed ads) + `Client.QueryAsOfTable`; DAEMON admin actions `timetravel.enable <maxSeconds> [checkpointSeconds]` / `timetravel.disable`.

## Tests
Per-layer time-travel suites (deterministic clock in collections): AS OF round-trip across update+delete; in-window history survives compaction while an aged-out version is reclaimed; markers survive a persistent reopen; disabled ⇒ error + no markers; db persistence across reopen; dbrpc wire round-trip. `collections`, `db`, `dbrpc` suites all green.

## Notes / trade-offs
- Enabling is **not retroactive**; storage grows with write-rate × `MaxDistance`; per-shard resolution can tear a multi-shard txn at cadence granularity near a boundary.
- v1 `QueryAsOf` uses a serial full scan-at-seq per shard (no index/parallel/chained fast paths, and aggregates count client-side); index-pruned AS OF is a possible follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
