### PR TITLE
dbrpc: serialize client WriteMsg (fixes AES-GCM stream corruption under concurrency)

### DIFF
--- a/dbrpc/client.go
+++ b/dbrpc/client.go
@@ -18,6 +18,16 @@ type Client struct {
 	conn    MsgConn
 	nextReq atomic.Uint64
 
+	// writeMu serializes conn.WriteMsg so concurrent callers (independent Tx / queries
+	// multiplexed over the one connection) never interleave frame bytes on the wire.
+	// The underlying CEDAR stream is a single-writer object -- it reuses one frame
+	// buffer and advances one AES-GCM nonce per message -- so two goroutines writing at
+	// once corrupt the encrypted stream and the peer drops it on an authentication
+	// failure. Distinct from mu: the read loop takes mu to deliver responses, so holding
+	// mu across a blocking network write would stall demux (and could deadlock). The
+	// server side serializes its writes the same way (serverConn.write).
+	writeMu sync.Mutex
+
 	mu       sync.Mutex
 	pending  map[uint64]*pending
 	closeErr error
@@ -151,7 +161,13 @@ func (c *Client) sendID(id uint64, build func(reqID uint64) []byte, stream bool)
 	}
 	c.pending[id] = &pending{ch: ch, stream: stream}
 	c.mu.Unlock()
-	if err := c.conn.WriteMsg(build(id)); err != nil {
+	// Serialize the actual send: the CEDAR stream is single-writer (shared frame buffer
+	// + AES-GCM nonce), so concurrent multiplexed calls must not interleave WriteMsg.
+	frame := build(id)
+	c.writeMu.Lock()
+	err := c.conn.WriteMsg(frame)
+	c.writeMu.Unlock()
+	if err != nil {
 		c.mu.Lock()
 		delete(c.pending, id)
 		c.mu.Unlock()

--- a/dbrpc/write_serialize_test.go
+++ b/dbrpc/write_serialize_test.go
@@ -1,0 +1,85 @@
+package dbrpc
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/PelicanPlatform/classad/db"
+)
+
+// serialCheckConn wraps a MsgConn and flags any two WriteMsg calls that overlap in
+// time. It deliberately does NOT serialize writes itself (unlike the test pipeConn,
+// whose internal wmu would mask the bug) -- it models the real CEDAR adapter, which is
+// single-writer: it reuses one frame buffer and advances one AES-GCM nonce per message,
+// so two concurrent writers corrupt the encrypted stream and the peer drops it on an
+// authentication failure. The MsgConn contract (see conn.go) requires the mux (Client)
+// to serialize writers; this asserts the Client actually does.
+type serialCheckConn struct {
+	MsgConn
+	inflight   atomic.Int32
+	violations atomic.Int32
+}
+
+func (c *serialCheckConn) WriteMsg(b []byte) error {
+	if c.inflight.Add(1) != 1 {
+		c.violations.Add(1)
+	}
+	// Widen the window so a missing lock reliably produces an overlap.
+	time.Sleep(50 * time.Microsecond)
+	err := c.MsgConn.WriteMsg(b)
+	c.inflight.Add(-1)
+	return err
+}
+
+// TestClientSerializesConcurrentWrites is the regression guard for the AES-GCM
+// "message authentication failed" disconnects: independent transactions multiplexed
+// over one connection must never call WriteMsg concurrently, or an encrypted CEDAR
+// stream corrupts. Fails if the client mux lets two writes overlap.
+func TestClientSerializesConcurrentWrites(t *testing.T) {
+	d, err := db.Open("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cconn, sconn := netPipe()
+	det := &serialCheckConn{MsgConn: cconn}
+	s := NewServer(d)
+	go func() { _ = s.ServeConn(sconn) }()
+	c := NewClient(det)
+	defer func() { c.Close(); s.Close(); d.Close() }()
+
+	const n = 200
+	var wg sync.WaitGroup
+	errs := make([]error, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			ctx := context.Background()
+			tx, err := c.Begin(ctx) // independent transaction, concurrent over the one conn
+			if err != nil {
+				errs[i] = err
+				return
+			}
+			if err := tx.NewClassAd(ctx, fmt.Sprintf("k%d", i), "N = 1"); err != nil {
+				errs[i] = err
+				return
+			}
+			errs[i] = tx.Commit(ctx)
+		}(i)
+	}
+	wg.Wait()
+
+	for i, e := range errs {
+		if e != nil {
+			t.Fatalf("call %d: %v", i, e)
+		}
+	}
+	if v := det.violations.Load(); v != 0 {
+		t.Fatalf("client issued %d concurrent WriteMsg calls; the MsgConn contract requires the mux to serialize writers "+
+			"(unserialized writes corrupt an encrypted CEDAR stream -> peer drops it on AES-GCM auth failure)", v)
+	}
+}


### PR DESCRIPTION
## The bug

`dbrpc.Client` multiplexes independent transactions/queries over a single connection (monotonic req ids; one reader goroutine demuxes responses by id). But `sendID` called `conn.WriteMsg` with **no lock held**. The `MsgConn` contract states the mux must serialize writers, and the real CEDAR adapter is single-writer — it reuses one frame buffer and advances one AES-GCM nonce per message.

So two concurrent callers interleaved frame bytes and desynced the nonce. The peer then failed to authenticate the frame:

```
failed to decrypt message: AES-GCM decryption failed: cipher: message authentication failed
```

and dropped the connection. In production this presented as: connection resets / broken pipe, `no such transaction` (the txn died with its connection), and **multi-second stalls** from the redial + full re-auth + replay storm after each drop — all while the server process stayed healthy (10h+ uptime, one connection dropped at a time).

The test `pipeConn` has its **own** internal write mutex, so every existing test — including `TestRPCConcurrentCalls` — passed, and the bug only ever manifested against a real encrypted connection.

## The fix

A dedicated `writeMu` around `conn.WriteMsg` in `sendID` (the sole write path), mirroring the serialization the **server** side already had (`serverConn.write`). It is deliberately separate from `mu` so the response-demux reader is never blocked behind a network write.

## Test

`TestClientSerializesConcurrentWrites` uses a contract-faithful `MsgConn` that *detects* overlapping `WriteMsg` (rather than hiding them like `pipeConn`). Without the lock it records **599 concurrent writes** and fails; with it, zero. Full `dbrpc` suite passes under `-race`.

Patch-level correctness fix; no API change. Intended for a `dbrpc/v0.12.1` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
