### PR TITLE
collections: add max + latency histogram to OpStats (see the tail, not just the mean)

### DIFF
--- a/collections/opstats.go
+++ b/collections/opstats.go
@@ -25,21 +25,71 @@ import (
 // (maintenance, snapshot lock) are infrequent and live on the Collection. All are
 // plain atomics, read locklessly by OpStats().
 
-// opCounter is one instrumented operation: a call count and cumulative nanoseconds.
+// latencyBucketBoundsNanos are the inclusive upper bounds of the latency histogram,
+// log-scale from 100µs to 30s. observe() files each occurrence into the first bucket it
+// fits; anything larger than the last bound lands in a final overflow bucket (so there
+// are len+1 buckets). The mean (Nanos/Count) hides tail stalls -- a slow msync or a
+// long retrain shows up here as a count in the 1s/10s/30s buckets and in MaxNanos.
+var latencyBucketBoundsNanos = [...]int64{
+	100_000,        // 100µs
+	1_000_000,      // 1ms
+	10_000_000,     // 10ms
+	100_000_000,    // 100ms
+	1_000_000_000,  // 1s
+	5_000_000_000,  // 5s
+	10_000_000_000, // 10s
+	30_000_000_000, // 30s
+}
+
+// LatencyBucketBoundsNanos returns a copy of the histogram's inclusive upper bounds (in
+// nanoseconds). An OpStat's Buckets slice has one more entry than this: buckets[i] counts
+// observations <= bound[i], and the final entry counts observations above the last bound.
+func LatencyBucketBoundsNanos() []int64 {
+	return append([]int64(nil), latencyBucketBoundsNanos[:]...)
+}
+
+// bucketIndex maps a duration (nanos) to its histogram bucket.
+func bucketIndex(n int64) int {
+	for i, b := range latencyBucketBoundsNanos {
+		if n <= b {
+			return i
+		}
+	}
+	return len(latencyBucketBoundsNanos) // overflow bucket
+}
+
+// opCounter is one instrumented operation: a call count, cumulative nanoseconds, the
+// max single duration seen, and a latency histogram -- so a caller can see the tail, not
+// just the mean. All fields are plain atomics, read locklessly by snapshot().
 type opCounter struct {
-	count atomic.Int64
-	nanos atomic.Int64
+	count   atomic.Int64
+	nanos   atomic.Int64
+	max     atomic.Int64
+	buckets [len(latencyBucketBoundsNanos) + 1]atomic.Int64
 }
 
 // observe records one occurrence lasting d.
 func (o *opCounter) observe(d time.Duration) {
+	n := int64(d)
 	o.count.Add(1)
-	o.nanos.Add(int64(d))
+	o.nanos.Add(n)
+	for { // lockless max
+		cur := o.max.Load()
+		if n <= cur || o.max.CompareAndSwap(cur, n) {
+			break
+		}
+	}
+	o.buckets[bucketIndex(n)].Add(1)
 }
 
 // snapshot reads the counter locklessly.
 func (o *opCounter) snapshot() OpStat {
-	return OpStat{Count: o.count.Load(), Nanos: o.nanos.Load()}
+	s := OpStat{Count: o.count.Load(), Nanos: o.nanos.Load(), MaxNanos: o.max.Load()}
+	s.Buckets = make([]int64, len(o.buckets))
+	for i := range o.buckets {
+		s.Buckets[i] = o.buckets[i].Load()
+	}
+	return s
 }
 
 // shardMetrics are the per-shard operational counters, kept on each shard to avoid
@@ -67,6 +117,13 @@ type opMetrics struct {
 type OpStat struct {
 	Count int64 `json:"count"`
 	Nanos int64 `json:"nanos"`
+	// MaxNanos is the longest single occurrence seen, and Buckets is the latency
+	// histogram (see LatencyBucketBoundsNanos: buckets[i] counts occurrences <= bound[i],
+	// the last entry counts the overflow above the final bound). Both surface the tail
+	// the mean (Nanos/Count) hides. Omitted from JSON when empty so an older peer that
+	// never populated them stays byte-compatible.
+	MaxNanos int64   `json:"maxNanos,omitempty"`
+	Buckets  []int64 `json:"buckets,omitempty"`
 }
 
 // OpStats is a snapshot of a collection's operational timing counters -- the wall
@@ -96,4 +153,17 @@ func (s *OpStats) add(m *shardMetrics) {
 func addStat(dst *OpStat, v OpStat) {
 	dst.Count += v.Count
 	dst.Nanos += v.Nanos
+	if v.MaxNanos > dst.MaxNanos {
+		dst.MaxNanos = v.MaxNanos
+	}
+	if len(v.Buckets) > 0 {
+		if dst.Buckets == nil {
+			dst.Buckets = make([]int64, len(v.Buckets))
+		}
+		for i := range v.Buckets {
+			if i < len(dst.Buckets) {
+				dst.Buckets[i] += v.Buckets[i]
+			}
+		}
+	}
 }

--- a/collections/opstats_test.go
+++ b/collections/opstats_test.go
@@ -3,7 +3,59 @@ package collections
 import (
 	"fmt"
 	"testing"
+	"time"
 )
+
+// TestOpCounterHistogram: observe() files durations into the right buckets, tracks the
+// max, and addStat sums buckets while taking the max of maxes across shards.
+func TestOpCounterHistogram(t *testing.T) {
+	t.Parallel()
+	var o opCounter
+	// One in the 100µs bucket (bound[0]), one in 10ms (bound[2]), one at 20s (bound[7]),
+	// one at 45s (overflow bucket, index len(bounds)).
+	o.observe(50 * time.Microsecond)
+	o.observe(5 * time.Millisecond)
+	o.observe(20 * time.Second)
+	o.observe(45 * time.Second)
+
+	s := o.snapshot()
+	if s.Count != 4 {
+		t.Fatalf("Count = %d, want 4", s.Count)
+	}
+	if s.MaxNanos != int64(45*time.Second) {
+		t.Errorf("MaxNanos = %d, want %d", s.MaxNanos, int64(45*time.Second))
+	}
+	if len(s.Buckets) != len(latencyBucketBoundsNanos)+1 {
+		t.Fatalf("len(Buckets) = %d, want %d", len(s.Buckets), len(latencyBucketBoundsNanos)+1)
+	}
+	want := map[int]int64{0: 1, 2: 1, 7: 1, len(latencyBucketBoundsNanos): 1}
+	for i, got := range s.Buckets {
+		if got != want[i] {
+			t.Errorf("bucket[%d] = %d, want %d", i, got, want[i])
+		}
+	}
+
+	// addStat: counts and buckets sum; MaxNanos takes the larger.
+	var dst OpStat
+	addStat(&dst, s)
+	addStat(&dst, OpStat{Count: 1, MaxNanos: int64(2 * time.Second), Buckets: mustBuckets(6, 1)})
+	if dst.Count != 5 {
+		t.Errorf("aggregated Count = %d, want 5", dst.Count)
+	}
+	if dst.MaxNanos != int64(45*time.Second) {
+		t.Errorf("aggregated MaxNanos = %d, want %d (max of maxes)", dst.MaxNanos, int64(45*time.Second))
+	}
+	if dst.Buckets[6] != 1 || dst.Buckets[7] != 1 || dst.Buckets[len(latencyBucketBoundsNanos)] != 1 {
+		t.Errorf("aggregated buckets wrong: %v", dst.Buckets)
+	}
+}
+
+// mustBuckets returns a bucket slice with count at index i.
+func mustBuckets(i int, count int64) []int64 {
+	b := make([]int64, len(latencyBucketBoundsNanos)+1)
+	b[i] = count
+	return b
+}
 
 // TestOpStatsWriteAndSegmentCounters: writes count shard write-lock wait/hold and
 // segment allocations.


### PR DESCRIPTION
## Why

The operational counters were `{count, nanos}` only, so the sole latency signal was the mean (`nanos/count`). That hides exactly the tail that matters when hunting stalls: during a real investigation, the biggest table showed `sync (msync)` at a **2.47ms mean** — while the actual client-visible stalls were **12–30s**. The mean can't show a tail; a slow `msync` or a long dictionary `retrain` averages out to milliseconds while its p99 is seconds.

## What

Adds, to every `opCounter`:
- **`MaxNanos`** — the longest single occurrence seen (lockless CAS).
- **`Buckets`** — a fixed log-scale latency histogram (100µs → 30s, plus an overflow bucket).

Both are plain atomics, matching the package's dependency-free design. Exposed on `OpStat` as `MaxNanos` / `Buckets` with `json:",omitempty"` so the JSON diagnostics wire stays byte-compatible with an older peer that never populated them. `LatencyBucketBoundsNanos()` exports the boundaries so a consumer can label each bucket. `addStat` sums buckets across shards and takes the max of maxes.

No code change needed in `db` (embeds `collections.OpStats`) or `dbrpc` (JSON-marshals it) — the fields flow through automatically. Consumers (htcondordb `.stats`, the collector's `db_op_*` metrics) can render the tail in follow-ups.

## Test

`TestOpCounterHistogram` verifies bucket placement, max tracking, and cross-shard aggregation. Full `collections` suite passes under `-race`; `db` and `dbrpc` build and their diag/stats tests pass against the local change.

Feature-level, additive; intended for a coordinated `collections`/`db`/`dbrpc` minor tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
