### PR TITLE
dbrpc: bulk + pipelined ad writes (opNewAdBatch) to collapse per-ad round-trips

### DIFF
--- a/dbrpc/batchwrite_test.go
+++ b/dbrpc/batchwrite_test.go
@@ -1,0 +1,142 @@
+package dbrpc
+
+import (
+	"context"
+	"fmt"
+	"testing"
+)
+
+// TestNewClassAdBatch: a bulk write applies all valid ads in one round-trip and reports
+// the unparseable ones by index without losing the rest.
+func TestNewClassAdBatch(t *testing.T) {
+	c, cleanup := testPair(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	tx, err := c.Begin(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	items := []AdKV{
+		{Key: "1.0", Ad: "ClusterId = 1\nProcId = 0"},
+		{Key: "2.0", Ad: "this is not a valid classad {{{"}, // rejected
+		{Key: "3.0", Ad: "ClusterId = 3\nProcId = 0"},
+	}
+	rejects, err := tx.NewClassAdBatch(ctx, items)
+	if err != nil {
+		t.Fatalf("NewClassAdBatch: %v", err)
+	}
+	if len(rejects) != 1 || rejects[0].Index != 1 {
+		t.Fatalf("rejects = %+v, want exactly index 1", rejects)
+	}
+	if rejects[0].Err == "" {
+		t.Errorf("reject should carry the server error message")
+	}
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	// The two valid ads are readable; the rejected one is absent.
+	tx2, _ := c.Begin(ctx)
+	defer func() { _ = tx2.Abort(ctx) }()
+	for _, k := range []string{"1.0", "3.0"} {
+		if _, ok, err := tx2.LookupAttr(ctx, k, "ClusterId"); err != nil || !ok {
+			t.Errorf("key %s should be stored (ok=%v err=%v)", k, ok, err)
+		}
+	}
+	if _, ok, _ := tx2.LookupAttr(ctx, "2.0", "ClusterId"); ok {
+		t.Errorf("rejected key 2.0 should not be stored")
+	}
+}
+
+// TestNewClassAdBatchEmpty: an empty batch is a no-op, no round-trip needed.
+func TestNewClassAdBatchEmpty(t *testing.T) {
+	c, cleanup := testPair(t)
+	defer cleanup()
+	ctx := context.Background()
+	tx, _ := c.Begin(ctx)
+	defer func() { _ = tx.Abort(ctx) }()
+	if rejects, err := tx.NewClassAdBatch(ctx, nil); err != nil || rejects != nil {
+		t.Fatalf("empty batch: rejects=%v err=%v", rejects, err)
+	}
+}
+
+// TestNewClassAdBatchLarge: a batch far larger than a per-ad path exercises the loop and
+// confirms all ads land.
+func TestNewClassAdBatchLarge(t *testing.T) {
+	c, cleanup := testPair(t)
+	defer cleanup()
+	ctx := context.Background()
+	tx, _ := c.Begin(ctx)
+	const n = 500
+	items := make([]AdKV, n)
+	for i := range items {
+		items[i] = AdKV{Key: fmt.Sprintf("k%d", i), Ad: fmt.Sprintf("N = %d", i)}
+	}
+	rejects, err := tx.NewClassAdBatch(ctx, items)
+	if err != nil || len(rejects) != 0 {
+		t.Fatalf("large batch: rejects=%v err=%v", rejects, err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatal(err)
+	}
+	tx2, _ := c.Begin(ctx)
+	defer func() { _ = tx2.Abort(ctx) }()
+	if v, ok, err := tx2.LookupAttr(ctx, "k499", "N"); err != nil || !ok || v != "499" {
+		t.Fatalf("k499 N = %q,%v,%v want 499", v, ok, err)
+	}
+}
+
+// TestNewClassAdBatchPipelined: a large batch split into many small chunks applies every
+// valid ad and reports a bad one at its GLOBAL index -- exercising the send-all-then-
+// collect-all path across multiple in-flight chunks.
+func TestNewClassAdBatchPipelined(t *testing.T) {
+	c, cleanup := testPair(t)
+	defer cleanup()
+	ctx := context.Background()
+	tx, _ := c.Begin(ctx)
+
+	const n = 400
+	items := make([]AdKV, n)
+	for i := range items {
+		items[i] = AdKV{Key: fmt.Sprintf("k%d", i), Ad: fmt.Sprintf("N = %d", i)}
+	}
+	// A bad ad at a global index inside a later chunk (chunkSize 32 -> index 100 is chunk 3).
+	items[100] = AdKV{Key: "k100", Ad: "definitely not a classad ]["}
+
+	rejects, err := tx.NewClassAdBatchPipelined(ctx, items, 32)
+	if err != nil {
+		t.Fatalf("pipelined: %v", err)
+	}
+	if len(rejects) != 1 || rejects[0].Index != 100 {
+		t.Fatalf("rejects = %+v, want exactly global index 100", rejects)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	tx2, _ := c.Begin(ctx)
+	defer func() { _ = tx2.Abort(ctx) }()
+	// A spread of good keys landed; the bad one did not.
+	for _, i := range []int{0, 99, 101, 399} {
+		if _, ok, err := tx2.LookupAttr(ctx, fmt.Sprintf("k%d", i), "N"); err != nil || !ok {
+			t.Errorf("k%d should be stored (ok=%v err=%v)", i, ok, err)
+		}
+	}
+	if _, ok, _ := tx2.LookupAttr(ctx, "k100", "N"); ok {
+		t.Errorf("rejected k100 should not be stored")
+	}
+}
+
+// TestNewClassAdBatchPipelinedEmpty: no items is a no-op.
+func TestNewClassAdBatchPipelinedEmpty(t *testing.T) {
+	c, cleanup := testPair(t)
+	defer cleanup()
+	ctx := context.Background()
+	tx, _ := c.Begin(ctx)
+	defer func() { _ = tx.Abort(ctx) }()
+	if r, err := tx.NewClassAdBatchPipelined(ctx, nil, 32); err != nil || r != nil {
+		t.Fatalf("empty pipelined: r=%v err=%v", r, err)
+	}
+}

--- a/dbrpc/client.go
+++ b/dbrpc/client.go
@@ -285,6 +285,155 @@ func (t *Tx) NewClassAd(ctx context.Context, key, adText string) error {
 	return t.simple(ctx, opNewAd, key, adText)
 }
 
+// AdKV is one keyed ad for the batch writers.
+type AdKV struct {
+	Key string
+	Ad  string // old-ClassAd text
+}
+
+// AdReject reports an ad a batch writer could not apply (unparseable text), by its index
+// in the items slice, with the server's error. The other ads were applied; the caller
+// typically logs the rejects and carries on.
+type AdReject struct {
+	Index int
+	Err   string
+}
+
+// newAdBatchFrame builds one opNewAdBatch request over items[base:end].
+func (t *Tx) newAdBatchFrame(id uint64, items []AdKV) []byte {
+	b := putI32(putU64(req(id, opNewAdBatch), t.id), int32(len(items)))
+	for _, it := range items {
+		b = putStr(putStr(b, it.Key), it.Ad)
+	}
+	return b
+}
+
+// parseAdBatchReply reads an opNewAdBatch reply, appending rejects (with indexOffset
+// added so indices point into the original items slice) to out.
+func parseAdBatchReply(body *reader, indexOffset int, out []AdReject) []AdReject {
+	n := body.i32()
+	for i := int32(0); i < n; i++ {
+		idx := body.i32()
+		msg := body.str()
+		out = append(out, AdReject{Index: indexOffset + int(idx), Err: msg})
+	}
+	return out
+}
+
+// NewClassAdBatch stores many ads under one transaction in a single round-trip, instead
+// of one request/ack per ad. It returns the ads the server rejected (bad text) so the
+// caller can log them; the rest are applied. The whole request must fit the stream's max
+// message size, so for a large batch prefer NewClassAdBatchPipelined, which chunks and
+// pipelines automatically.
+func (t *Tx) NewClassAdBatch(ctx context.Context, items []AdKV) ([]AdReject, error) {
+	if len(items) == 0 {
+		return nil, nil
+	}
+	status, body, err := t.c.callCtx(ctx, func(id uint64) []byte {
+		return t.newAdBatchFrame(id, items)
+	})
+	if err != nil {
+		return nil, err
+	}
+	if status != stOK {
+		return nil, statusErr(status, body)
+	}
+	return parseAdBatchReply(body, 0, nil), nil
+}
+
+// NewClassAdBatchPipelined stores many ads under one transaction with the round-trips
+// pipelined: it splits items into chunks of chunkSize ads and sends EVERY chunk frame
+// back-to-back without waiting for any chunk's ack, then collects all the acks. So the
+// chunks flow independently of the acks and the wire cost is ~one round-trip regardless
+// of ad count -- not one per ad, nor one serialized round-trip per chunk -- while each
+// message stays small and the server applies a whole chunk under a single transaction-
+// lock acquisition (chunkSize goroutines/locks for the batch, not one per ad).
+//
+// It returns the ads the server rejected (unparseable), indexed into items. A whole-
+// chunk failure -- a dropped connection, or the transaction gone ("no such transaction")
+// -- is returned as an error so the caller aborts and replays the batch. chunkSize <= 0
+// defaults to 64.
+func (t *Tx) NewClassAdBatchPipelined(ctx context.Context, items []AdKV, chunkSize int) ([]AdReject, error) {
+	if len(items) == 0 {
+		return nil, nil
+	}
+	if chunkSize <= 0 {
+		chunkSize = 64
+	}
+
+	// Send phase: fire every chunk frame; do not wait for any ack here. The frame writes
+	// are ordered by the client's write lock but never block on a response, so all chunks
+	// are in flight before we read the first ack. The mux's reader goroutine drains acks
+	// into the (buffered) pending channels concurrently, so the sends never deadlock
+	// against unread acks.
+	type pending struct {
+		ch   chan []byte
+		id   uint64
+		base int
+	}
+	var pends []pending
+	for base := 0; base < len(items); base += chunkSize {
+		end := base + chunkSize
+		if end > len(items) {
+			end = len(items)
+		}
+		chunk := items[base:end]
+		id := t.c.nextReq.Add(1)
+		ch, err := t.c.sendID(id, func(id uint64) []byte {
+			return t.newAdBatchFrame(id, chunk)
+		}, false)
+		if err != nil {
+			for _, p := range pends {
+				t.c.cancelPending(p.id)
+			}
+			return nil, err
+		}
+		pends = append(pends, pending{ch: ch, id: id, base: base})
+	}
+
+	// Collect phase: await every chunk's ack. Drain all of them even after an error so no
+	// pending entry leaks; return the first hard error (the caller replays the batch).
+	var rejects []AdReject
+	var firstErr error
+	for i, p := range pends {
+		select {
+		case <-ctx.Done():
+			for _, q := range pends[i:] {
+				t.c.cancelPending(q.id)
+			}
+			if firstErr == nil {
+				firstErr = ctx.Err()
+			}
+			return rejects, firstErr
+		case frame, ok := <-p.ch:
+			if !ok {
+				if firstErr == nil {
+					firstErr = t.c.closeErr
+				}
+				continue
+			}
+			_, status, body, okHdr := respHeader(frame)
+			if !okHdr {
+				if firstErr == nil {
+					firstErr = errShort
+				}
+				continue
+			}
+			if status != stOK {
+				if firstErr == nil {
+					firstErr = statusErr(status, body)
+				}
+				continue
+			}
+			rejects = parseAdBatchReply(body, p.base, rejects)
+		}
+	}
+	if firstErr != nil {
+		return rejects, firstErr
+	}
+	return rejects, nil
+}
+
 // DestroyClassAd removes key.
 func (t *Tx) DestroyClassAd(ctx context.Context, key string) error {
 	return t.simple(ctx, opDestroyAd, key)

--- a/dbrpc/proto.go
+++ b/dbrpc/proto.go
@@ -98,6 +98,15 @@ const (
 	// Point-in-time query: like opQuery but with a wall-clock instant; the server
 	// resolves it to the per-shard commit sequence current then (time travel).
 	opQueryAsOf op = 43 // [table][limit i32][asOfUnixNanos u64][constraint] -> stream of [adText]
+
+	// Bulk ad write: apply many NewClassAd in one round-trip within a transaction,
+	// collapsing the per-ad request/ack chatter that makes a large batch a multi-second
+	// flush over the wire. Payload is a count then that many [key][adText] pairs; the
+	// reply lists the ads the server rejected (bad text) by index so the caller can log
+	// them and treat the rest as applied -- mirroring opNewAd's skip-the-bad-ad behavior.
+	// The whole frame must fit MaxMessageSize, so a caller chunks a large batch across
+	// several of these ops on the same transaction (pipelining the chunks).
+	opNewAdBatch op = 44 // [txnID][n i32]{[key][adText]} -> [nReject i32]{[index i32][errMsg]}
 )
 
 // String names an opcode for diagnostics (e.g. the read-only rejection message).
@@ -111,6 +120,8 @@ func (o op) String() string {
 		return "Abort"
 	case opNewAd:
 		return "NewClassAd"
+	case opNewAdBatch:
+		return "NewClassAdBatch"
 	case opDestroyAd:
 		return "DestroyClassAd"
 	case opSetAttr:

--- a/dbrpc/server.go
+++ b/dbrpc/server.go
@@ -179,7 +179,7 @@ type QueryLog struct {
 // read-only connection).
 func (o op) isMutating() bool {
 	switch o {
-	case opNewAd, opDestroyAd, opSetAttr, opDeleteAttr, opAdmin, opCreateTable, opDropTable,
+	case opNewAd, opNewAdBatch, opDestroyAd, opSetAttr, opDeleteAttr, opAdmin, opCreateTable, opDropTable,
 		opCreateTableMem, opTableToMemory, opCreateView, opDropView,
 		opArchiveCreate, opArchiveAppend, opArchiveRotate, opDeleteWhere, opCommitIdem:
 		return true
@@ -844,6 +844,39 @@ func (s *Server) handle(sc *serverConn, reqID uint64, o op, r *reader, includePr
 			st.tx.NewClassAd(key, ad)
 			st.record(s, WriteOp{Kind: WriteNewClassAd, Key: key, Value: adText})
 			return resp(reqID, stOK)
+		})
+
+	case opNewAdBatch:
+		return s.withTxn(reqID, r, func(st *serverTxn) []byte {
+			n := r.i32()
+			if r.err != nil || n < 0 {
+				return respBad(reqID)
+			}
+			// Apply each ad under this one lock acquisition; an unparseable ad is recorded
+			// as a reject (by index) and skipped, exactly as opNewAd's per-ad ServerError
+			// is skipped by the caller, so one bad ad never loses the batch. A truncated
+			// frame is a bad request.
+			var rejIdx []int32
+			var rejMsg []string
+			for i := int32(0); i < n; i++ {
+				key, adText := r.str(), r.str()
+				if r.err != nil {
+					return respBad(reqID)
+				}
+				ad, err := classad.ParseOld(adText)
+				if err != nil {
+					rejIdx = append(rejIdx, i)
+					rejMsg = append(rejMsg, err.Error())
+					continue
+				}
+				st.tx.NewClassAd(key, ad)
+				st.record(s, WriteOp{Kind: WriteNewClassAd, Key: key, Value: adText})
+			}
+			b := putI32(resp(reqID, stOK), int32(len(rejIdx)))
+			for i := range rejIdx {
+				b = putStr(putI32(b, rejIdx[i]), rejMsg[i])
+			}
+			return b
 		})
 
 	case opDestroyAd:


### PR DESCRIPTION
Writing a batch was one request/ack round-trip **per ad** (`Tx.NewClassAd` in a loop), so a large batch became a multi-second flush purely from wire latency even when the DB applied each ad in microseconds — a 1000-ad batch is 1000 serial round-trips (the collector saw a 1032-ad flush take 2.5s while the DB reported single-digit-ms maxima).

## `opNewAdBatch`

Applies many ads to a transaction in a **single round-trip**, under **one transaction-lock acquisition** on the server. The reply lists the ads the server rejected (unparseable) **by index**, so a caller logs those and treats the rest as applied — mirroring `opNewAd`'s existing skip-the-bad-ad behavior so one bad ad never loses the batch. That per-chunk reply is effectively a **windowed ack**: it acknowledges the whole chunk and reports individual failures selectively.

## Two client entry points

- **`NewClassAdBatch`** — one chunk, one round-trip.
- **`NewClassAdBatchPipelined(items, chunkSize)`** — splits into `chunkSize`-ad chunks and sends **every chunk frame back-to-back without waiting for any ack**, then collects them. So chunks flow independently of the acks and the whole batch costs **~one round-trip** (not one per ad, nor one serialized round-trip per chunk), while each message stays small and the server does `~len/chunkSize` goroutine-dispatches/lock-acquisitions for the batch, not one per ad. A dropped connection or a reaped transaction (`no such transaction`) comes back as an error so the caller aborts and replays.

## Semantics preserved

Nothing durably commits until the final `opCommit` (which still does the conflict check). Per-ad skip-the-bad-ad and abort-and-replay both survive — the reject list just arrives per-window instead of per-ad.

## Tests

Mixed valid/rejected, empty, a 500-ad single batch, and a pipelined 400-ad/32-chunk batch that reports a bad ad at its **global** index. Green under `-race`; full `dbrpc` suite green.

The collector will call `NewClassAdBatchPipelined` with a modest chunk size (~32–64) in a follow-up, once this is tagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
