### PR TITLE
db+dbrpc: generic external-sink exporter registry

### DIFF
--- a/db/catalog.go
+++ b/db/catalog.go
@@ -29,14 +29,23 @@ type Catalog struct {
 	tables   map[string]*DB
 	archives map[string]*ArchiveTable
 	views    map[string]*View
+
+	// exporters are external-sink definitions (e.g. a Kafka change-data exporter). The
+	// catalog only persists each one's opaque per-kind config and an opaque resume-state
+	// blob; it never runs an exporter or interprets its config/state. See db/exporter.go.
+	exporters map[string]ExporterDef
+	// memExporterState holds exporter resume-state blobs for an in-memory catalog
+	// (dir == ""), where there is no disk to persist to. Unused when dir is set.
+	memExporterState map[string][]byte
 }
 
 // tablesSubdir / archivesSubdir are where a persistent catalog keeps its per-table
 // directories, split by table type.
 const (
-	tablesSubdir   = "tables"
-	archivesSubdir = "archives"
-	viewsSubdir    = "views"
+	tablesSubdir    = "tables"
+	archivesSubdir  = "archives"
+	viewsSubdir     = "views"
+	exportersSubdir = "exporters"
 )
 
 // CatalogConfig configures a catalog, including encryption at rest applied to every
@@ -62,8 +71,10 @@ func OpenCatalog(dir string) (*Catalog, error) {
 func OpenCatalogConfig(cfg CatalogConfig) (*Catalog, error) {
 	cat := &Catalog{
 		dir: cfg.Dir, tables: map[string]*DB{}, archives: map[string]*ArchiveTable{},
-		views:    map[string]*View{},
-		poolKeys: cfg.PoolKeys, encAttrs: cfg.EncryptedAttrs,
+		views:            map[string]*View{},
+		exporters:        map[string]ExporterDef{},
+		memExporterState: map[string][]byte{},
+		poolKeys:         cfg.PoolKeys, encAttrs: cfg.EncryptedAttrs,
 	}
 	if cfg.Dir == "" {
 		return cat, nil
@@ -115,6 +126,13 @@ func OpenCatalogConfig(cfg CatalogConfig) (*Catalog, error) {
 	// cardinality) or whose base table is absent does NOT fail catalog open -- it loads in
 	// the failed/stale state and can be fixed by the operator.
 	if err := cat.recoverViews(); err != nil {
+		cat.closeAll()
+		return nil, err
+	}
+	// Recover external-sink exporter definitions from <dir>/exporters/. These are inert
+	// records: the catalog holds each definition (and, on disk, its opaque resume state)
+	// but never runs the exporter. A corrupt definition is skipped, not fatal.
+	if err := cat.recoverExporters(); err != nil {
 		cat.closeAll()
 		return nil, err
 	}
@@ -378,6 +396,11 @@ func (cat *Catalog) closeAll() error {
 	for name, v := range cat.views {
 		v.stop() // cancels the live updater and closes the in-memory backing
 		delete(cat.views, name)
+	}
+	// Exporter definitions hold no runtime resources (the catalog never runs them), so
+	// closing just drops the in-memory registry.
+	for name := range cat.exporters {
+		delete(cat.exporters, name)
 	}
 	return first
 }

--- a/db/exporter.go
+++ b/db/exporter.go
@@ -1,0 +1,153 @@
+package db
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+// ExporterDef defines an external sink that mirrors this database's change stream
+// elsewhere (for example, a Kafka change-data exporter that federates several instances
+// through a broker). The catalog is a passive registry: it stores the definition and an
+// opaque resume-state blob and never runs, interprets, or validates Config -- that is the
+// job of the out-of-process exporter (which reads these over dbrpc). Keeping the DB free
+// of any sink-specific dependency is deliberate.
+type ExporterDef struct {
+	Name string `json:"name"`
+	// Kind selects the exporter implementation (e.g. "kafka"). The catalog does not
+	// enumerate valid kinds; an unknown kind is simply ignored by any exporter that does
+	// not recognize it.
+	Kind string `json:"kind"`
+	// Config is the exporter's own configuration, opaque to the catalog. It is stored and
+	// returned verbatim.
+	Config json.RawMessage `json:"config,omitempty"`
+}
+
+// CreateExporter registers a new exporter definition. The name must be a valid identifier
+// and must not already be registered. Exporters occupy their own namespace, so an exporter
+// may share a name with a table (an exporter named "jobs" that mirrors the "jobs" table is
+// expected). On a persistent catalog the definition is written to disk before it is
+// returned; on an in-memory catalog it lives only in memory.
+func (cat *Catalog) CreateExporter(def ExporterDef) error {
+	if !ValidTableName(def.Name) {
+		return fmt.Errorf("invalid exporter name %q", def.Name)
+	}
+	if def.Kind == "" {
+		return fmt.Errorf("exporter %q: kind must be set", def.Name)
+	}
+	cat.mu.Lock()
+	defer cat.mu.Unlock()
+	if _, ok := cat.exporters[def.Name]; ok {
+		return fmt.Errorf("exporter %q already exists", def.Name)
+	}
+	if cat.dir != "" {
+		if err := saveExporterDef(cat.dir, def); err != nil {
+			return fmt.Errorf("exporter %q: persisting definition: %w", def.Name, err)
+		}
+	}
+	cat.exporters[def.Name] = def
+	return nil
+}
+
+// DropExporter removes an exporter's definition and its resume state. It is not an error to
+// drop an exporter that does not exist (idempotent teardown).
+func (cat *Catalog) DropExporter(name string) error {
+	cat.mu.Lock()
+	defer cat.mu.Unlock()
+	if _, ok := cat.exporters[name]; !ok {
+		return nil
+	}
+	if cat.dir != "" {
+		if err := removeExporterDir(cat.dir, name); err != nil {
+			return fmt.Errorf("exporter %q: removing on-disk state: %w", name, err)
+		}
+	}
+	delete(cat.exporters, name)
+	delete(cat.memExporterState, name)
+	return nil
+}
+
+// Exporters returns all registered exporter definitions, sorted by name.
+func (cat *Catalog) Exporters() []ExporterDef {
+	cat.mu.Lock()
+	defer cat.mu.Unlock()
+	out := make([]ExporterDef, 0, len(cat.exporters))
+	for _, def := range cat.exporters {
+		out = append(out, def)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
+// Exporter returns a single exporter definition.
+func (cat *Catalog) Exporter(name string) (ExporterDef, bool) {
+	cat.mu.Lock()
+	defer cat.mu.Unlock()
+	def, ok := cat.exporters[name]
+	return def, ok
+}
+
+// SaveExporterState durably records an exporter's opaque resume-state blob, replacing any
+// prior state. The exporter calls this after its data has been accepted downstream, so that
+// on restart it resumes just past the last delivered change (at-least-once). The exporter
+// must already exist.
+func (cat *Catalog) SaveExporterState(name string, state []byte) error {
+	cat.mu.Lock()
+	defer cat.mu.Unlock()
+	if _, ok := cat.exporters[name]; !ok {
+		return fmt.Errorf("exporter %q does not exist", name)
+	}
+	if cat.dir == "" {
+		cat.memExporterState[name] = append([]byte(nil), state...)
+		return nil
+	}
+	if err := saveExporterStateFile(cat.dir, name, state); err != nil {
+		return fmt.Errorf("exporter %q: persisting state: %w", name, err)
+	}
+	return nil
+}
+
+// LoadExporterState returns an exporter's last checkpointed resume-state blob. The bool is
+// false when the exporter has never checkpointed (a fresh exporter with no state yet),
+// which callers treat as "start from the beginning", not as an error.
+func (cat *Catalog) LoadExporterState(name string) ([]byte, bool, error) {
+	cat.mu.Lock()
+	defer cat.mu.Unlock()
+	if _, ok := cat.exporters[name]; !ok {
+		return nil, false, fmt.Errorf("exporter %q does not exist", name)
+	}
+	if cat.dir == "" {
+		state, ok := cat.memExporterState[name]
+		return state, ok, nil
+	}
+	return loadExporterStateFile(cat.dir, name)
+}
+
+// recoverExporters loads exporter definitions from <dir>/exporters/ on catalog open. A
+// definition that cannot be read or parsed is skipped rather than failing catalog open,
+// mirroring recoverViews; its resume state (if any) stays on disk and is picked up if the
+// definition is later restored. Resume-state blobs are not loaded here -- the exporter
+// reads them on demand via LoadExporterState.
+func (cat *Catalog) recoverExporters() error {
+	root := filepath.Join(cat.dir, exportersSubdir)
+	entries, err := os.ReadDir(root)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("catalog: reading exporters dir: %w", err)
+	}
+	for _, e := range entries {
+		if !e.IsDir() || !ValidTableName(e.Name()) {
+			continue
+		}
+		def, err := loadExporterDef(cat.dir, e.Name())
+		if err != nil {
+			continue // skip a corrupt/unreadable definition rather than fail open
+		}
+		cat.exporters[def.Name] = def
+	}
+	return nil
+}

--- a/db/exporter_test.go
+++ b/db/exporter_test.go
@@ -1,0 +1,132 @@
+package db
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+func TestExporterCRUDAndState(t *testing.T) {
+	dir := t.TempDir()
+	cat, err := OpenCatalog(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	def := ExporterDef{
+		Name:   "jobs",
+		Kind:   "kafka",
+		Config: json.RawMessage(`{"brokers":["b:9092"],"topic":"htc.jobs"}`),
+	}
+	if err := cat.CreateExporter(def); err != nil {
+		t.Fatalf("CreateExporter: %v", err)
+	}
+	// Duplicate is rejected.
+	if err := cat.CreateExporter(def); err == nil {
+		t.Fatal("creating a duplicate exporter should fail")
+	}
+	// Invalid name / missing kind rejected.
+	if err := cat.CreateExporter(ExporterDef{Name: "bad name", Kind: "kafka"}); err == nil {
+		t.Fatal("invalid exporter name should fail")
+	}
+	if err := cat.CreateExporter(ExporterDef{Name: "nokind"}); err == nil {
+		t.Fatal("missing kind should fail")
+	}
+
+	// Listing + single lookup return the definition verbatim.
+	if got := cat.Exporters(); len(got) != 1 || got[0].Name != "jobs" || got[0].Kind != "kafka" {
+		t.Fatalf("Exporters = %+v", got)
+	}
+	got, ok := cat.Exporter("jobs")
+	if !ok || string(got.Config) != string(def.Config) {
+		t.Fatalf("Exporter(jobs) = %+v, %v", got, ok)
+	}
+
+	// No state until the first checkpoint.
+	if _, ok, err := cat.LoadExporterState("jobs"); err != nil || ok {
+		t.Fatalf("fresh exporter should have no state: ok=%v err=%v", ok, err)
+	}
+	// Save then load state round-trips.
+	state := []byte("cursor=abc;seq=42")
+	if err := cat.SaveExporterState("jobs", state); err != nil {
+		t.Fatalf("SaveExporterState: %v", err)
+	}
+	blob, ok, err := cat.LoadExporterState("jobs")
+	if err != nil || !ok || !bytes.Equal(blob, state) {
+		t.Fatalf("LoadExporterState = %q, %v, %v", blob, ok, err)
+	}
+	// Overwrite replaces.
+	if err := cat.SaveExporterState("jobs", []byte("cursor=def;seq=99")); err != nil {
+		t.Fatal(err)
+	}
+	if blob, _, _ := cat.LoadExporterState("jobs"); string(blob) != "cursor=def;seq=99" {
+		t.Fatalf("state after overwrite = %q", blob)
+	}
+	// State on a non-existent exporter is an error.
+	if _, _, err := cat.LoadExporterState("ghost"); err == nil {
+		t.Fatal("state of a non-existent exporter should error")
+	}
+	if err := cat.SaveExporterState("ghost", state); err == nil {
+		t.Fatal("saving state for a non-existent exporter should error")
+	}
+	cat.Close()
+
+	// Reopen: the definition is recovered from disk; the state persists too.
+	cat2, err := OpenCatalog(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cat2.Close()
+	if got := cat2.Exporters(); len(got) != 1 || got[0].Name != "jobs" {
+		t.Fatalf("after reopen, Exporters = %+v", got)
+	}
+	if blob, ok, _ := cat2.LoadExporterState("jobs"); !ok || string(blob) != "cursor=def;seq=99" {
+		t.Fatalf("after reopen, state = %q ok=%v", blob, ok)
+	}
+
+	// Drop removes definition and state from disk.
+	if err := cat2.DropExporter("jobs"); err != nil {
+		t.Fatalf("DropExporter: %v", err)
+	}
+	if got := cat2.Exporters(); len(got) != 0 {
+		t.Fatalf("after drop, Exporters = %+v", got)
+	}
+	// Dropping again is a no-op.
+	if err := cat2.DropExporter("jobs"); err != nil {
+		t.Fatalf("second DropExporter should be a no-op, got %v", err)
+	}
+
+	cat3, err := OpenCatalog(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cat3.Close()
+	if got := cat3.Exporters(); len(got) != 0 {
+		t.Fatalf("dropped exporter reappeared after reopen: %+v", got)
+	}
+}
+
+// TestExporterInMemoryCatalog: an in-memory catalog keeps definitions and state in memory
+// (no disk), so the same API works without a directory.
+func TestExporterInMemoryCatalog(t *testing.T) {
+	cat, err := OpenCatalog("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cat.Close()
+	if err := cat.CreateExporter(ExporterDef{Name: "m", Kind: "kafka"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := cat.SaveExporterState("m", []byte("x")); err != nil {
+		t.Fatal(err)
+	}
+	if blob, ok, _ := cat.LoadExporterState("m"); !ok || string(blob) != "x" {
+		t.Fatalf("in-memory state = %q ok=%v", blob, ok)
+	}
+	if err := cat.DropExporter("m"); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := cat.Exporter("m"); ok {
+		t.Fatal("exporter should be gone after drop")
+	}
+}

--- a/db/exporterpersist.go
+++ b/db/exporterpersist.go
@@ -1,0 +1,92 @@
+package db
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// An exporter persists two things under <dir>/exporters/<name>/:
+//   - def.json  : the ExporterDef (name, kind, opaque per-kind config), written on
+//     create and never mutated afterward.
+//   - state.bin : an opaque resume-state blob the exporter owns (e.g. a watch cursor,
+//     a monotonic export sequence, and a per-key version map for delete detection),
+//     rewritten on every checkpoint.
+//
+// Both are written atomically (tmp+rename), mirroring db/viewpersist.go. The catalog
+// never interprets either payload.
+
+const (
+	exporterDefFile   = "def.json"
+	exporterStateFile = "state.bin"
+)
+
+func exporterDir(dir, name string) string {
+	return filepath.Join(dir, exportersSubdir, name)
+}
+
+// saveExporterDef writes an exporter's definition under <dir>/exporters/<name>/def.json.
+func saveExporterDef(dir string, def ExporterDef) error {
+	edir := exporterDir(dir, def.Name)
+	if err := os.MkdirAll(edir, 0o750); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(def, "", "  ")
+	if err != nil {
+		return err
+	}
+	return writeAtomic(filepath.Join(edir, exporterDefFile), data)
+}
+
+// loadExporterDef reads the persisted definition for an exporter.
+func loadExporterDef(dir, name string) (ExporterDef, error) {
+	path := filepath.Join(exporterDir(dir, name), exporterDefFile)
+	data, err := os.ReadFile(path) //nolint:gosec // G304 - path is catalog-internal
+	if err != nil {
+		return ExporterDef{}, err
+	}
+	var def ExporterDef
+	if err := json.Unmarshal(data, &def); err != nil {
+		return ExporterDef{}, fmt.Errorf("exporter %q: %w", name, err)
+	}
+	return def, nil
+}
+
+// saveExporterStateFile atomically writes an exporter's opaque resume-state blob.
+func saveExporterStateFile(dir, name string, state []byte) error {
+	edir := exporterDir(dir, name)
+	if err := os.MkdirAll(edir, 0o750); err != nil {
+		return err
+	}
+	return writeAtomic(filepath.Join(edir, exporterStateFile), state)
+}
+
+// loadExporterStateFile reads an exporter's opaque resume-state blob. The bool is false
+// when no state has been checkpointed yet (a fresh exporter), which is not an error.
+func loadExporterStateFile(dir, name string) ([]byte, bool, error) {
+	path := filepath.Join(exporterDir(dir, name), exporterStateFile)
+	data, err := os.ReadFile(path) //nolint:gosec // G304 - path is catalog-internal
+	if os.IsNotExist(err) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	return data, true, nil
+}
+
+// removeExporterDir deletes an exporter's on-disk directory (definition + state).
+func removeExporterDir(dir, name string) error {
+	return os.RemoveAll(exporterDir(dir, name))
+}
+
+// writeAtomic writes data to path via a temp file and rename, so a reader never observes
+// a partial write.
+func writeAtomic(path string, data []byte) error {
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil { //nolint:gosec // G306 - catalog metadata, not secret
+		return err
+	}
+	return os.Rename(tmp, path)
+}

--- a/dbrpc/exporter.go
+++ b/dbrpc/exporter.go
@@ -1,0 +1,118 @@
+package dbrpc
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/PelicanPlatform/classad/db"
+)
+
+// ExporterInfo is the name+kind pair returned by ListExporters. It deliberately omits the
+// exporter's Config, which may hold credentials and is only returned by GetExporter to a
+// DAEMON-authorized client.
+type ExporterInfo struct {
+	Name string
+	Kind string
+}
+
+// CreateExporter registers an external-sink exporter definition. DAEMON-only. The server
+// stores the definition (and later its resume state) but never runs the exporter -- an
+// out-of-process exporter reads these back and does the work.
+func (c *Client) CreateExporter(ctx context.Context, def db.ExporterDef) error {
+	data, err := json.Marshal(def)
+	if err != nil {
+		return err
+	}
+	status, body, err := c.callCtx(ctx, func(id uint64) []byte {
+		return putBytes(req(id, opCreateExporter), data)
+	})
+	if err != nil {
+		return err
+	}
+	if status != stOK {
+		return statusErr(status, body)
+	}
+	return nil
+}
+
+// DropExporter removes an exporter's definition and resume state. DAEMON-only.
+func (c *Client) DropExporter(ctx context.Context, name string) error {
+	status, body, err := c.callCtx(ctx, func(id uint64) []byte { return putStr(req(id, opDropExporter), name) })
+	if err != nil {
+		return err
+	}
+	if status != stOK {
+		return statusErr(status, body)
+	}
+	return nil
+}
+
+// ListExporters returns the registered exporters' names and kinds (no config).
+func (c *Client) ListExporters(ctx context.Context) ([]ExporterInfo, error) {
+	status, body, err := c.callCtx(ctx, func(id uint64) []byte { return req(id, opListExporters) })
+	if err != nil {
+		return nil, err
+	}
+	if status != stOK {
+		return nil, statusErr(status, body)
+	}
+	n := int(body.i32())
+	out := make([]ExporterInfo, 0, n)
+	for i := 0; i < n; i++ {
+		info := ExporterInfo{Name: body.str()}
+		info.Kind = body.str()
+		out = append(out, info)
+	}
+	return out, nil
+}
+
+// GetExporter returns a single exporter's full definition (including Config). DAEMON-only.
+// The bool is false when no exporter of that name exists.
+func (c *Client) GetExporter(ctx context.Context, name string) (db.ExporterDef, bool, error) {
+	status, body, err := c.callCtx(ctx, func(id uint64) []byte { return putStr(req(id, opGetExporter), name) })
+	if err != nil {
+		return db.ExporterDef{}, false, err
+	}
+	if status != stOK {
+		return db.ExporterDef{}, false, statusErr(status, body)
+	}
+	if body.u8() == 0 {
+		return db.ExporterDef{}, false, nil
+	}
+	var def db.ExporterDef
+	if err := json.Unmarshal(body.bytesRef(), &def); err != nil {
+		return db.ExporterDef{}, false, err
+	}
+	return def, true, nil
+}
+
+// PutExporterState durably stores an exporter's opaque resume-state blob. DAEMON-only. The
+// exporter calls this after downstream has accepted its data (the at-least-once boundary).
+func (c *Client) PutExporterState(ctx context.Context, name string, state []byte) error {
+	status, body, err := c.callCtx(ctx, func(id uint64) []byte {
+		return putBytes(putStr(req(id, opPutExporterState), name), state)
+	})
+	if err != nil {
+		return err
+	}
+	if status != stOK {
+		return statusErr(status, body)
+	}
+	return nil
+}
+
+// GetExporterState returns an exporter's last checkpointed resume-state blob. DAEMON-only.
+// The bool is false when the exporter has never checkpointed (start from the beginning).
+func (c *Client) GetExporterState(ctx context.Context, name string) ([]byte, bool, error) {
+	status, body, err := c.callCtx(ctx, func(id uint64) []byte { return putStr(req(id, opGetExporterState), name) })
+	if err != nil {
+		return nil, false, err
+	}
+	if status != stOK {
+		return nil, false, statusErr(status, body)
+	}
+	if body.u8() == 0 {
+		return nil, false, nil
+	}
+	return body.bytesRef(), true, nil
+}

--- a/dbrpc/exporter_wire_test.go
+++ b/dbrpc/exporter_wire_test.go
@@ -1,0 +1,122 @@
+package dbrpc
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/db"
+)
+
+// exporterPair starts a catalog-backed server with the given options and returns a client.
+func exporterPair(t *testing.T, cat *db.Catalog, opts ServeOptions) *Client {
+	t.Helper()
+	s := NewServerCatalog(cat)
+	cconn, sconn := netPipe()
+	go func() { _ = s.ServeConnOpts(sconn, opts) }()
+	c := NewClient(cconn)
+	t.Cleanup(func() { c.Close(); s.Close() })
+	return c
+}
+
+func TestExporterWire(t *testing.T) {
+	cat, err := db.OpenCatalog(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cat.Close()
+	ctx := context.Background()
+
+	priv := exporterPair(t, cat, ServeOptions{Privileged: true})
+
+	def := db.ExporterDef{
+		Name:   "jobs",
+		Kind:   "kafka",
+		Config: json.RawMessage(`{"brokers":["b:9092"],"topic":"htc.jobs"}`),
+	}
+	if err := priv.CreateExporter(ctx, def); err != nil {
+		t.Fatalf("CreateExporter: %v", err)
+	}
+
+	// List (name+kind, no config).
+	infos, err := priv.ListExporters(ctx)
+	if err != nil || len(infos) != 1 || infos[0].Name != "jobs" || infos[0].Kind != "kafka" {
+		t.Fatalf("ListExporters = %v, %v", infos, err)
+	}
+
+	// Get returns the full definition including config.
+	got, ok, err := priv.GetExporter(ctx, "jobs")
+	if err != nil || !ok || string(got.Config) != string(def.Config) {
+		t.Fatalf("GetExporter = %+v, %v, %v", got, ok, err)
+	}
+	if _, ok, _ := priv.GetExporter(ctx, "ghost"); ok {
+		t.Fatal("GetExporter of a missing exporter should report not-found")
+	}
+
+	// State: absent, then set, then read back.
+	if _, ok, err := priv.GetExporterState(ctx, "jobs"); err != nil || ok {
+		t.Fatalf("fresh exporter state: ok=%v err=%v", ok, err)
+	}
+	state := []byte{0x00, 0x01, 0xff, 0x2a} // opaque binary blob
+	if err := priv.PutExporterState(ctx, "jobs", state); err != nil {
+		t.Fatalf("PutExporterState: %v", err)
+	}
+	blob, ok, err := priv.GetExporterState(ctx, "jobs")
+	if err != nil || !ok || !bytes.Equal(blob, state) {
+		t.Fatalf("GetExporterState = %v, %v, %v", blob, ok, err)
+	}
+
+	// Drop.
+	if err := priv.DropExporter(ctx, "jobs"); err != nil {
+		t.Fatalf("DropExporter: %v", err)
+	}
+	if infos, _ := priv.ListExporters(ctx); len(infos) != 0 {
+		t.Fatalf("after drop, ListExporters = %v", infos)
+	}
+}
+
+// TestExporterWirePrivilege: an unprivileged (WRITE-level) connection may list exporters
+// but is refused every DAEMON-only op (create/drop/get/state).
+func TestExporterWirePrivilege(t *testing.T) {
+	cat, err := db.OpenCatalog(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cat.Close()
+	ctx := context.Background()
+
+	// Seed one exporter via a privileged connection.
+	priv := exporterPair(t, cat, ServeOptions{Privileged: true})
+	if err := priv.CreateExporter(ctx, db.ExporterDef{Name: "jobs", Kind: "kafka"}); err != nil {
+		t.Fatal(err)
+	}
+
+	unpriv := exporterPair(t, cat, ServeOptions{}) // WRITE-level, not Privileged
+
+	// Listing is allowed (name+kind only).
+	if infos, err := unpriv.ListExporters(ctx); err != nil || len(infos) != 1 {
+		t.Fatalf("unprivileged ListExporters = %v, %v", infos, err)
+	}
+	// Every DAEMON-only op is refused.
+	if err := unpriv.CreateExporter(ctx, db.ExporterDef{Name: "x", Kind: "kafka"}); err == nil {
+		t.Fatal("unprivileged CreateExporter should be refused")
+	}
+	if err := unpriv.DropExporter(ctx, "jobs"); err == nil {
+		t.Fatal("unprivileged DropExporter should be refused")
+	}
+	if _, _, err := unpriv.GetExporter(ctx, "jobs"); err == nil {
+		t.Fatal("unprivileged GetExporter should be refused (config may hold credentials)")
+	}
+	if err := unpriv.PutExporterState(ctx, "jobs", []byte("x")); err == nil {
+		t.Fatal("unprivileged PutExporterState should be refused")
+	}
+	if _, _, err := unpriv.GetExporterState(ctx, "jobs"); err == nil {
+		t.Fatal("unprivileged GetExporterState should be refused")
+	}
+
+	// The privileged client was not disturbed.
+	if _, ok, _ := priv.GetExporter(ctx, "jobs"); !ok {
+		t.Fatal("exporter should still exist")
+	}
+}

--- a/dbrpc/proto.go
+++ b/dbrpc/proto.go
@@ -114,6 +114,16 @@ const (
 	// attribute is not numeric. Lets the server bucket a time series so only the grouped
 	// rows cross the wire.
 	opAggregateBucketed op = 45 // [table][constraint][nGroup]{[attr][width u64]}[nAgg]{[func u8][arg]} -> stream of [group...][agg...]
+
+	// External-sink exporter registry (see db/exporter.go). Create/Drop/Get and the state
+	// ops are DAEMON-only (config/state may hold broker credentials); List returns only
+	// name+kind so it is safe for unprivileged visibility.
+	opCreateExporter   op = 46 // [json db.ExporterDef] -> status; DAEMON-only; mutating
+	opDropExporter     op = 47 // [name] -> status; DAEMON-only; mutating
+	opListExporters    op = 48 // -> [n i32]{[name][kind]}
+	opGetExporter      op = 49 // [name] -> [found u8]([json db.ExporterDef]); DAEMON-only
+	opPutExporterState op = 50 // [name][blob] -> status; DAEMON-only; mutating
+	opGetExporterState op = 51 // [name] -> [found u8]([blob]); DAEMON-only
 )
 
 // String names an opcode for diagnostics (e.g. the read-only rejection message).
@@ -177,6 +187,18 @@ func (o op) String() string {
 		return "DropView"
 	case opListViews:
 		return "ListViews"
+	case opCreateExporter:
+		return "CreateExporter"
+	case opDropExporter:
+		return "DropExporter"
+	case opListExporters:
+		return "ListExporters"
+	case opGetExporter:
+		return "GetExporter"
+	case opPutExporterState:
+		return "PutExporterState"
+	case opGetExporterState:
+		return "GetExporterState"
 	case opDropTable:
 		return "DropTable"
 	case opListTables:

--- a/dbrpc/server.go
+++ b/dbrpc/server.go
@@ -58,6 +58,15 @@ type Catalog interface {
 	DropView(name string) error
 	Views() []string
 	ViewBacking(name string) (*db.DB, bool)
+	// Exporter registry: passive storage of external-sink definitions and their opaque
+	// resume state. The server never runs exporters; it only persists these for the
+	// out-of-process exporter that reads them.
+	CreateExporter(def db.ExporterDef) error
+	DropExporter(name string) error
+	Exporters() []db.ExporterDef
+	Exporter(name string) (db.ExporterDef, bool)
+	SaveExporterState(name string, state []byte) error
+	LoadExporterState(name string) ([]byte, bool, error)
 }
 
 // DefaultTable is the table name a single-DB server serves and the client
@@ -131,6 +140,17 @@ func (s singleCatalog) CreateArchiveTable(string, db.ArchiveConfig) (*db.Archive
 }
 func (s singleCatalog) ArchiveTables() []string { return nil }
 
+func (s singleCatalog) CreateExporter(db.ExporterDef) error {
+	return fmt.Errorf("single-table server: exporters unsupported")
+}
+func (s singleCatalog) DropExporter(string) error              { return nil }
+func (s singleCatalog) Exporters() []db.ExporterDef            { return nil }
+func (s singleCatalog) Exporter(string) (db.ExporterDef, bool) { return db.ExporterDef{}, false }
+func (s singleCatalog) SaveExporterState(string, []byte) error {
+	return fmt.Errorf("single-table server: exporters unsupported")
+}
+func (s singleCatalog) LoadExporterState(string) ([]byte, bool, error) { return nil, false, nil }
+
 // ServeOptions scopes what a single served connection may do. The zero value is
 // full read/write access with private attributes excluded from returned ads
 // (the historical ServeConn behavior). A privilege-scoped front end (e.g. an
@@ -181,6 +201,7 @@ func (o op) isMutating() bool {
 	switch o {
 	case opNewAd, opNewAdBatch, opDestroyAd, opSetAttr, opDeleteAttr, opAdmin, opCreateTable, opDropTable,
 		opCreateTableMem, opTableToMemory, opCreateView, opDropView,
+		opCreateExporter, opDropExporter, opPutExporterState,
 		opArchiveCreate, opArchiveAppend, opArchiveRotate, opDeleteWhere, opCommitIdem:
 		return true
 	}
@@ -721,6 +742,97 @@ func (s *Server) handle(sc *serverConn, reqID uint64, o op, r *reader, includePr
 			b = putStr(b, n)
 		}
 		return b
+
+	case opCreateExporter:
+		defJSON := r.bytesRef()
+		if r.err != nil {
+			return respBad(reqID)
+		}
+		// Registering an exporter is a DAEMON-level administrative action: its config may
+		// carry broker credentials and it drives data off-box.
+		if !privileged {
+			return respErr(reqID, "CreateExporter requires DAEMON authorization")
+		}
+		var def db.ExporterDef
+		if err := json.Unmarshal(defJSON, &def); err != nil {
+			return respErr(reqID, "exporter def: "+err.Error())
+		}
+		if err := s.cat.CreateExporter(def); err != nil {
+			return respErr(reqID, err.Error())
+		}
+		return resp(reqID, stOK)
+
+	case opDropExporter:
+		name := r.str()
+		if r.err != nil {
+			return respBad(reqID)
+		}
+		if !privileged {
+			return respErr(reqID, "DropExporter requires DAEMON authorization")
+		}
+		if err := s.cat.DropExporter(name); err != nil {
+			return respErr(reqID, err.Error())
+		}
+		return resp(reqID, stOK)
+
+	case opListExporters:
+		// Names and kinds only -- no config -- so listing is safe for an unprivileged peer.
+		defs := s.cat.Exporters()
+		b := putI32(resp(reqID, stOK), int32(len(defs)))
+		for _, d := range defs {
+			b = putStr(putStr(b, d.Name), d.Kind)
+		}
+		return b
+
+	case opGetExporter:
+		name := r.str()
+		if r.err != nil {
+			return respBad(reqID)
+		}
+		// The full definition includes Config, which may hold credentials -> DAEMON-only.
+		if !privileged {
+			return respErr(reqID, "GetExporter requires DAEMON authorization")
+		}
+		def, ok := s.cat.Exporter(name)
+		if !ok {
+			return putU8(resp(reqID, stOK), 0)
+		}
+		data, err := json.Marshal(def)
+		if err != nil {
+			return respErr(reqID, err.Error())
+		}
+		return putBytes(putU8(resp(reqID, stOK), 1), data)
+
+	case opPutExporterState:
+		name := r.str()
+		state := r.bytesRef()
+		if r.err != nil {
+			return respBad(reqID)
+		}
+		if !privileged {
+			return respErr(reqID, "PutExporterState requires DAEMON authorization")
+		}
+		if err := s.cat.SaveExporterState(name, state); err != nil {
+			return respErr(reqID, err.Error())
+		}
+		return resp(reqID, stOK)
+
+	case opGetExporterState:
+		name := r.str()
+		if r.err != nil {
+			return respBad(reqID)
+		}
+		if !privileged {
+			return respErr(reqID, "GetExporterState requires DAEMON authorization")
+		}
+		state, ok, err := s.cat.LoadExporterState(name)
+		if err != nil {
+			return respErr(reqID, err.Error())
+		}
+		if !ok {
+			return putU8(resp(reqID, stOK), 0)
+		}
+		return putBytes(putU8(resp(reqID, stOK), 1), state)
 
 	case opWatchHead:
 		table := r.str()


### PR DESCRIPTION
Adds a generic, dependency-free **external-sink exporter registry** to the DB catalog and exposes it over dbrpc, so an out-of-process exporter can persist its definition and checkpoint its resume state without the core DB ever linking a sink-specific client (Kafka, etc.).

## db (Stage 1)
- `ExporterDef{Name, Kind, Config json.RawMessage}` — `Config` is opaque to the catalog.
- `Catalog.CreateExporter/DropExporter/Exporters/Exporter` (own namespace; an exporter may share a name with a table).
- `Catalog.SaveExporterState/LoadExporterState` — opaque blob, no MVCC, atomic tmp+rename, checkpointed by the exporter **after** downstream accepts its data (the at-least-once boundary).
- Persisted at `<dir>/exporters/<name>/{def.json,state.bin}`; recovered by enumeration on open (a corrupt entry is skipped, never fatal). In-memory catalogs keep both in memory.

## dbrpc (Stage 2)
- `opCreateExporter`/`opDropExporter` (DAEMON-only, mutating), `opListExporters` (name+kind only — safe unprivileged), `opGetExporter` (full def incl. `Config` → DAEMON-only, since config may hold broker credentials), `opPutExporterState`/`opGetExporterState` (DAEMON-only).
- Client methods in `dbrpc/exporter.go`; wire tests cover the round-trip and privilege gating.

Consumed by the new `kafkasync` module in htcondordb (separate PR). No behavior change to existing paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
