### PR TITLE
db: time-bucketed materialized-view grouping (continuous aggregates, part 1)

### DIFF
--- a/db/view.go
+++ b/db/view.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"sort"
@@ -35,10 +36,15 @@ const (
 )
 
 // ViewGroupCol is one GROUP BY column: the base-table attribute and the alias it is stored
-// under in the materialized rows (e.g. attr "Owner", alias "label_owner").
+// under in the materialized rows (e.g. attr "Owner", alias "label_owner"). When BucketWidth
+// > 0, the column is time-bucketed: the (numeric, unix-seconds) attribute is floored to
+// epoch-aligned buckets of that width, turning the view into a time series -- each interval
+// is a distinct, permanent group rather than an overwritten gauge. This is the same shape as
+// dbrpc.GroupCol.
 type ViewGroupCol struct {
-	Attr  string `json:"attr"`
-	Alias string `json:"alias"`
+	Attr        string `json:"attr"`
+	Alias       string `json:"alias"`
+	BucketWidth int64  `json:"bucketWidth,omitempty"` // seconds; 0 = raw value
 }
 
 // ViewMetric is one aggregate output: the function, its argument attribute ("*" for
@@ -68,6 +74,11 @@ func (s ViewSpec) Validate() error {
 	}
 	if len(s.Groups) == 0 {
 		return fmt.Errorf("view: at least one GROUP BY column is required")
+	}
+	for _, g := range s.Groups {
+		if g.BucketWidth < 0 {
+			return fmt.Errorf("view: time_bucket width must be positive, got %d", g.BucketWidth)
+		}
 	}
 	if len(s.Metrics) == 0 {
 		return fmt.Errorf("view: at least one aggregate metric is required")
@@ -125,14 +136,23 @@ type metricInput struct {
 }
 
 // contribution is what one base-table key contributes to the view, remembered so the OLD
-// contribution can be subtracted on update/delete (the stream carries no before-image).
+// contribution can be subtracted on update/delete (the stream carries no before-image). A
+// contribution with valid == false belongs to no group (a time-bucketed column's attribute
+// was non-numeric); such an ad is dropped from the view entirely.
 type contribution struct {
+	valid    bool
 	groupKey string
 	labels   []string
 	inputs   []metricInput
 }
 
 func (c contribution) equal(o contribution) bool {
+	if c.valid != o.valid {
+		return false
+	}
+	if !c.valid {
+		return true
+	}
 	if c.groupKey != o.groupKey || len(c.inputs) != len(o.inputs) {
 		return false
 	}
@@ -213,6 +233,16 @@ func (v *View) SeriesCount() int {
 func (v *View) contributionOf(ad *classad.ClassAd) contribution {
 	labels := make([]string, len(v.spec.Groups))
 	for i, g := range v.spec.Groups {
+		if g.BucketWidth > 0 {
+			num, ok := ad.EvaluateAttrNumber(g.Attr)
+			if !ok {
+				// Non-numeric bucket attribute: this ad has no time bucket, so it
+				// contributes to no group (dropped from the series).
+				return contribution{valid: false}
+			}
+			labels[i] = bucketLabel(num, g.BucketWidth)
+			continue
+		}
 		labels[i] = renderLabel(ad.EvaluateAttr(g.Attr))
 	}
 	inputs := make([]metricInput, len(v.spec.Metrics))
@@ -233,7 +263,13 @@ func (v *View) contributionOf(ad *classad.ClassAd) contribution {
 		num, ok := ad.EvaluateAttrNumber(m.Arg)
 		inputs[i] = metricInput{defined: ok, val: num}
 	}
-	return contribution{groupKey: strings.Join(labels, "\x00"), labels: labels, inputs: inputs}
+	return contribution{valid: true, groupKey: strings.Join(labels, "\x00"), labels: labels, inputs: inputs}
+}
+
+// bucketLabel floors unix-epoch seconds to an epoch-aligned bucket of the given width
+// (seconds) and renders it as the bucket start in decimal seconds.
+func bucketLabel(sec float64, width int64) string {
+	return strconv.FormatInt(int64(math.Floor(sec/float64(width)))*width, 10)
 }
 
 // add folds a key's contribution into its group (+1 member, +metrics). Creates the group if
@@ -287,20 +323,26 @@ func (v *View) applyUpsert(key string, ad *classad.ClassAd) error {
 	}
 	if existed {
 		v.sub(old)
+		delete(v.contrib, key)
 	}
-	if err := v.add(newC); err != nil {
-		// Roll back the subtraction so the accumulators stay consistent, then fail.
-		if existed {
-			_ = v.add(old)
+	if newC.valid {
+		if err := v.add(newC); err != nil {
+			// Roll back the subtraction so the accumulators stay consistent, then fail.
+			if existed {
+				_ = v.add(old)
+				v.contrib[key] = old
+			}
+			return err
 		}
-		return err
+		v.contrib[key] = newC
 	}
-	v.contrib[key] = newC
 	// Re-render the affected groups.
 	if existed && old.groupKey != newC.groupKey {
 		v.renderGroup(old.groupKey)
 	}
-	v.renderGroup(newC.groupKey)
+	if newC.valid {
+		v.renderGroup(newC.groupKey)
+	}
 	return nil
 }
 
@@ -325,6 +367,14 @@ func (v *View) renderGroup(groupKey string) {
 	}
 	ad := classad.New()
 	for i, gc := range v.spec.Groups {
+		// A time-bucketed column is stored as a number (the unix-seconds bucket start)
+		// so downstream time-axis and archive zone-map handling see a number, not text.
+		if gc.BucketWidth > 0 {
+			if n, err := strconv.ParseInt(g.labels[i], 10, 64); err == nil {
+				ad.InsertAttr(gc.Alias, n)
+				continue
+			}
+		}
 		ad.InsertAttrString(gc.Alias, g.labels[i])
 	}
 	for i, m := range v.spec.Metrics {

--- a/db/view_test.go
+++ b/db/view_test.go
@@ -244,3 +244,99 @@ func TestViewSpecValidate(t *testing.T) {
 		}
 	}
 }
+
+// viewJobTS is a base job ad with an Owner, RequestMemory, and a unix-epoch QDate.
+func viewJobTS(t *testing.T, owner string, mem int, qdate int64) *classad.ClassAd {
+	t.Helper()
+	ad, err := classad.ParseOld(fmt.Sprintf("Owner = %q\nRequestMemory = %d\nQDate = %d", owner, mem, qdate))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ad
+}
+
+// timeBucketSpec groups by time_bucket(QDate, 1h) AND Owner: a continuous-aggregate-shaped
+// view (each (bucket, owner) is its own series).
+func timeBucketSpec() ViewSpec {
+	return ViewSpec{
+		BaseTable: "jobs",
+		Groups: []ViewGroupCol{
+			{Attr: "QDate", Alias: "time", BucketWidth: 3600},
+			{Attr: "Owner", Alias: "label_owner"},
+		},
+		Metrics: []ViewMetric{
+			{Func: ViewCount, Arg: "*", Alias: "metric_jobs"},
+			{Func: ViewSum, Arg: "RequestMemory", Alias: "metric_mem"},
+		},
+		Cardinality: 100,
+	}
+}
+
+func TestViewTimeBucket(t *testing.T) {
+	cat, err := OpenCatalog(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cat.Close()
+	base, err := cat.CreateTable("jobs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// 1h buckets align at 3600. bucket 3600: alice x2 (100,300), bob x1 (200);
+	// bucket 7200: alice x1 (50). The no-QDate ad drops out of the series.
+	base.Put("1", viewJobTS(t, "alice", 100, 3600))
+	base.Put("2", viewJobTS(t, "alice", 300, 3700))
+	base.Put("3", viewJobTS(t, "bob", 200, 3800))
+	base.Put("4", viewJobTS(t, "alice", 50, 7200))
+	base.Put("5", viewJob(t, "carol", 10)) // no QDate -> dropped
+
+	if err := cat.CreateView("jobs_ts", timeBucketSpec()); err != nil {
+		t.Fatalf("CreateView: %v", err)
+	}
+	v, _ := cat.View("jobs_ts")
+	if got := v.SeriesCount(); got != 3 {
+		t.Fatalf("series = %d, want 3", got)
+	}
+
+	// (bucket 3600, alice): 2 jobs, mem 400, and time stored as a NUMBER = 3600.
+	g, ok := viewGroup(t, cat, "jobs_ts", "3600\x00alice")
+	if !ok {
+		t.Fatal("missing (3600, alice) group")
+	}
+	if ts, ok := g.EvaluateAttrInt("time"); !ok || ts != 3600 {
+		t.Errorf("time = %d (ok=%v), want numeric 3600", ts, ok)
+	}
+	if n, _ := g.EvaluateAttrInt("metric_jobs"); n != 2 {
+		t.Errorf("(3600,alice) jobs = %d, want 2", n)
+	}
+	if m, _ := g.EvaluateAttrReal("metric_mem"); m != 400 {
+		t.Errorf("(3600,alice) mem = %v, want 400", m)
+	}
+	if o, _ := g.EvaluateAttrString("label_owner"); o != "alice" {
+		t.Errorf("label_owner = %q", o)
+	}
+
+	// Live: a new alice job in bucket 7200 -> that series' count 1 -> 2. (The series
+	// count stays 3 -- same group -- so poll the group's metric, not the series count.)
+	base.Put("6", viewJobTS(t, "alice", 70, 7300))
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		g2, ok := viewGroup(t, cat, "jobs_ts", "7200\x00alice")
+		if ok {
+			if n, _ := g2.EvaluateAttrInt("metric_jobs"); n == 2 {
+				break
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("(7200,alice) jobs did not reach 2 after live add")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	// Dropping a bucket attribute removes the ad from its series: give job "3" no QDate.
+	base.Put("3", viewJob(t, "bob", 200))
+	waitSeries(t, cat, "jobs_ts", 2) // (3600,bob) disappears
+	if _, ok := viewGroup(t, cat, "jobs_ts", "3600\x00bob"); ok {
+		t.Error("(3600,bob) should be gone after QDate removed")
+	}
+}


### PR DESCRIPTION
## Summary

Part 1 of continuous aggregates: let a materialized view **GROUP BY a `time_bucket`**, turning a current-state gauge view into a time series.

`ViewGroupCol` gains `BucketWidth int64` (seconds; `0` = raw value, unchanged behavior — the same shape as `dbrpc.GroupCol` from v0.13.0). When set, the group column floors its numeric unix-seconds attribute to epoch-aligned buckets, so **each interval is a distinct, permanent group** rather than an overwritten row. The bucket value is stored as a **number** (the bucket start) so downstream time-axis and archive zone-map handling see a number, not text. A base ad whose bucket attribute is non-numeric belongs to no bucket and is **dropped** from the view (matching the query-side `time_bucket` semantics).

## Scope

This is the *grouping* half. A follow-up seals aged buckets to an archive and evicts them; **until then a bucketed view accumulates buckets in memory, bounded by the cardinality cap.** Useful on its own for bounded ranges, and it is the foundation the seal/evict work builds on.

No wire change: `ViewSpec` already rides `opCreateView` as JSON, so the new field round-trips automatically.

## Testing

New `TestViewTimeBucket`: a `time_bucket(QDate, 1h)` + `Owner` view — build (one series per bucket×owner), the numeric bucket label, a live add into an existing bucket, and a drop when the bucket attribute is removed. Full `db` suite green; gofmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
