### PR TITLE
db: seal-and-evict for continuous aggregates (part 2)

### DIFF
--- a/db/view.go
+++ b/db/view.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/PelicanPlatform/classad/classad"
 )
@@ -65,6 +66,31 @@ type ViewSpec struct {
 	Cardinality int `json:"cardinality"`
 	// SelectText is the original SELECT for display (.views); not used for execution.
 	SelectText string `json:"selectText"`
+
+	// Grace is seconds to wait after a time bucket's window closes before sealing it
+	// (so late-arriving base rows still land). Only meaningful for a continuous aggregate
+	// (a spec with a time-bucketed group column). 0 seals as soon as the window closes.
+	Grace int64 `json:"grace,omitempty"`
+	// Retention is seconds of sealed history to keep in the continuous aggregate's archive;
+	// 0 keeps all.
+	Retention int64 `json:"retention,omitempty"`
+}
+
+// bucketCol returns the index and width of the (first) time-bucketed group column, and
+// whether the view has one -- i.e. whether it is a continuous aggregate.
+func (s ViewSpec) bucketCol() (idx int, width int64, ok bool) {
+	for i, g := range s.Groups {
+		if g.BucketWidth > 0 {
+			return i, g.BucketWidth, true
+		}
+	}
+	return 0, 0, false
+}
+
+// IsContinuous reports whether the view is a continuous aggregate (has a time bucket).
+func (s ViewSpec) IsContinuous() bool {
+	_, _, ok := s.bucketCol()
+	return ok
 }
 
 // Validate checks a spec is well-formed and delta-maintainable.
@@ -140,10 +166,11 @@ type metricInput struct {
 // contribution with valid == false belongs to no group (a time-bucketed column's attribute
 // was non-numeric); such an ad is dropped from the view entirely.
 type contribution struct {
-	valid    bool
-	groupKey string
-	labels   []string
-	inputs   []metricInput
+	valid       bool
+	groupKey    string
+	labels      []string
+	inputs      []metricInput
+	bucketStart int64 // floored start of this ad's time bucket (continuous aggregates)
 }
 
 func (c contribution) equal(o contribution) bool {
@@ -193,19 +220,52 @@ type View struct {
 	groups  map[string]*groupAcc    // groupKey -> accumulator
 	cursor  []byte                  // last durable watch cursor (for resume/persist)
 
+	// Continuous-aggregate (time-bucketed) state; zero/nil for a gauge view. A bucket whose
+	// start is <= watermark has been sealed (appended to archive, evicted from memory);
+	// buckets whose window has closed (now past start+width+grace) are sealed on each tick.
+	archive     *ArchiveTable // sealed buckets; nil for a gauge view or an in-memory catalog
+	bucketIdx   int           // index of the time-bucket group column
+	bucketWidth int64         // its width in seconds (0 => not a continuous aggregate)
+	grace       int64         // seconds after a bucket closes before sealing
+	watermark   int64         // highest sealed bucket start; -1 = nothing sealed yet
+	lateDrops   int64         // base rows dropped because their bucket was already sealed
+	stateDir    string        // <catalog>/views/<name>, for persisting the watermark; "" = in-memory
+	nowFn       func() int64  // wall clock (unix seconds); overridable in tests
+	tickEvery   time.Duration // seal cadence
+
 	cancel   context.CancelFunc // stops the live updater
 	stopOnce sync.Once
 }
 
 // newView constructs a view around a spec and an (empty, in-memory) backing DB.
 func newView(spec ViewSpec, backing *DB) *View {
-	return &View{
-		spec:    spec,
-		backing: backing,
-		state:   ViewBuilding,
-		contrib: make(map[string]contribution),
-		groups:  make(map[string]*groupAcc),
+	v := &View{
+		spec:      spec,
+		backing:   backing,
+		state:     ViewBuilding,
+		contrib:   make(map[string]contribution),
+		groups:    make(map[string]*groupAcc),
+		watermark: -1, // nothing sealed yet (bucket starts are >= 0)
+		nowFn:     func() int64 { return time.Now().Unix() },
 	}
+	if idx, width, ok := spec.bucketCol(); ok {
+		v.bucketIdx, v.bucketWidth, v.grace = idx, width, spec.Grace
+		v.tickEvery = sealTickInterval(width)
+	}
+	return v
+}
+
+// sealTickInterval picks how often a continuous aggregate checks for aged buckets: about
+// half the bucket width, clamped so it is neither busy nor sluggish.
+func sealTickInterval(width int64) time.Duration {
+	d := time.Duration(width/2) * time.Second
+	if d < time.Second {
+		d = time.Second
+	}
+	if d > 5*time.Minute {
+		d = 5 * time.Minute
+	}
+	return d
 }
 
 // Spec returns the view's definition.
@@ -232,6 +292,7 @@ func (v *View) SeriesCount() int {
 // inputs.
 func (v *View) contributionOf(ad *classad.ClassAd) contribution {
 	labels := make([]string, len(v.spec.Groups))
+	var bucketStart int64
 	for i, g := range v.spec.Groups {
 		if g.BucketWidth > 0 {
 			num, ok := ad.EvaluateAttrNumber(g.Attr)
@@ -240,7 +301,8 @@ func (v *View) contributionOf(ad *classad.ClassAd) contribution {
 				// contributes to no group (dropped from the series).
 				return contribution{valid: false}
 			}
-			labels[i] = bucketLabel(num, g.BucketWidth)
+			bucketStart = bucketFloorInt(num, g.BucketWidth)
+			labels[i] = strconv.FormatInt(bucketStart, 10)
 			continue
 		}
 		labels[i] = renderLabel(ad.EvaluateAttr(g.Attr))
@@ -263,13 +325,13 @@ func (v *View) contributionOf(ad *classad.ClassAd) contribution {
 		num, ok := ad.EvaluateAttrNumber(m.Arg)
 		inputs[i] = metricInput{defined: ok, val: num}
 	}
-	return contribution{valid: true, groupKey: strings.Join(labels, "\x00"), labels: labels, inputs: inputs}
+	return contribution{valid: true, groupKey: strings.Join(labels, "\x00"), labels: labels, inputs: inputs, bucketStart: bucketStart}
 }
 
-// bucketLabel floors unix-epoch seconds to an epoch-aligned bucket of the given width
-// (seconds) and renders it as the bucket start in decimal seconds.
-func bucketLabel(sec float64, width int64) string {
-	return strconv.FormatInt(int64(math.Floor(sec/float64(width)))*width, 10)
+// bucketFloorInt floors unix-epoch seconds to an epoch-aligned bucket of the given width
+// (seconds), returning the bucket start in seconds.
+func bucketFloorInt(sec float64, width int64) int64 {
+	return int64(math.Floor(sec/float64(width))) * width
 }
 
 // add folds a key's contribution into its group (+1 member, +metrics). Creates the group if
@@ -317,6 +379,12 @@ func (v *View) sub(c contribution) {
 // backing rows. Idempotent: a re-delivered identical ad is a no-op.
 func (v *View) applyUpsert(key string, ad *classad.ClassAd) error {
 	newC := v.contributionOf(ad)
+	// Late data for a continuous aggregate: if this row's bucket was already sealed
+	// (start <= watermark), drop it (and count it) rather than resurrecting the bucket.
+	if newC.valid && v.bucketWidth > 0 && newC.bucketStart <= v.watermark {
+		newC = contribution{valid: false}
+		v.lateDrops++
+	}
 	old, existed := v.contrib[key]
 	if existed && old.equal(newC) {
 		return nil // duplicate delivery
@@ -365,10 +433,16 @@ func (v *View) renderGroup(groupKey string) {
 		_, _ = v.backing.Delete(groupKey)
 		return
 	}
+	_ = v.backing.Put(groupKey, v.renderGroupAd(g))
+}
+
+// renderGroupAd builds the materialized ad for a group: each group column under its alias
+// (a time bucket as a number, so the time axis and archive zone maps see a number) and each
+// metric under its alias. Used both to write the backing row and to seal a bucket to the
+// archive.
+func (v *View) renderGroupAd(g *groupAcc) *classad.ClassAd {
 	ad := classad.New()
 	for i, gc := range v.spec.Groups {
-		// A time-bucketed column is stored as a number (the unix-seconds bucket start)
-		// so downstream time-axis and archive zone-map handling see a number, not text.
 		if gc.BucketWidth > 0 {
 			if n, err := strconv.ParseInt(g.labels[i], 10, 64); err == nil {
 				ad.InsertAttr(gc.Alias, n)
@@ -396,7 +470,7 @@ func (v *View) renderGroup(groupKey string) {
 			ad.InsertAttrFloat(m.Alias, avg)
 		}
 	}
-	_ = v.backing.Put(groupKey, ad)
+	return ad
 }
 
 // reset clears all view state and the backing (WatchReset: a full rebuild follows).
@@ -485,6 +559,9 @@ func (v *View) stop() {
 		if v.backing != nil {
 			_ = v.backing.Close()
 		}
+		if v.archive != nil {
+			_ = v.archive.Close()
+		}
 	})
 }
 
@@ -555,6 +632,17 @@ func (cat *Catalog) CreateView(name string, spec ViewSpec) error {
 	}
 	v := newView(spec, backing)
 
+	// Prepare a continuous aggregate (open its archive, load the watermark) BEFORE the build
+	// so the replay drops already-sealed buckets. A fresh view has an empty archive.
+	stateDir := ""
+	if cat.dir != "" {
+		stateDir = filepath.Join(cat.dir, viewsSubdir, name)
+	}
+	if err := v.initContinuous(stateDir); err != nil {
+		v.stop()
+		return fmt.Errorf("catalog: preparing continuous aggregate %q: %w", name, err)
+	}
+
 	// Start the single build+maintain goroutine and wait for the initial build to finish.
 	// A cardinality/aggregation error during the build fails the create and leaves nothing
 	// behind; on success the goroutine keeps maintaining the view live.
@@ -566,6 +654,7 @@ func (cat *Catalog) CreateView(name string, spec ViewSpec) error {
 		v.stop()
 		return fmt.Errorf("catalog: building view %q: %w", name, err)
 	}
+	go v.tickLoop(ctx) // seals aged buckets (no-op for a gauge view)
 
 	if cat.dir != "" {
 		if err := saveViewDef(cat.dir, name, spec); err != nil {
@@ -658,6 +747,15 @@ func (cat *Catalog) recoverViews() error {
 			cat.views[name] = v
 			continue
 		}
+		// Reopen the continuous aggregate's archive and load its watermark BEFORE the
+		// rebuild, so the replay drops already-sealed buckets (the archive is the durable
+		// sealed history; only the live window is rebuilt from the base).
+		if err := v.initContinuous(filepath.Join(cat.dir, viewsSubdir, name)); err != nil {
+			v.stop()
+			v.state, v.failErr = ViewFailed, err
+			cat.views[name] = v
+			continue
+		}
 		ctx, cancel := context.WithCancel(context.Background())
 		v.cancel = cancel
 		ready := make(chan error, 1)
@@ -668,6 +766,8 @@ func (cat *Catalog) recoverViews() error {
 			// close backing) and register the failed view so the operator can see it.
 			v.stop()
 			v.state, v.failErr = ViewFailed, berr
+		} else {
+			go v.tickLoop(ctx) // resume sealing aged buckets
 		}
 		cat.views[name] = v
 	}

--- a/db/viewcontinuous.go
+++ b/db/viewcontinuous.go
@@ -1,0 +1,160 @@
+package db
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strconv"
+	"time"
+
+	"github.com/PelicanPlatform/classad/collections"
+)
+
+// Continuous aggregates: a materialized view whose GROUP BY includes a time_bucket. Recent
+// buckets live in the in-memory backing (updated in place, so late data lands correctly);
+// once a bucket's window has closed (wall-clock past start+width+grace) it is SEALED --
+// appended once to a per-view append-only archive and evicted from memory -- so history is
+// unbounded and cheap to read while memory stays bounded to recent buckets. The watermark
+// (highest sealed bucket start) makes sealing idempotent across late data and reload: a row
+// whose bucket start is <= watermark is dropped rather than resurrecting a sealed bucket.
+
+const viewArchiveSubdir = "archive"
+
+// initContinuous prepares a continuous-aggregate view before its build goroutine starts: it
+// loads the persisted watermark and opens the per-view archive, so the build's replay drops
+// already-sealed buckets (start <= watermark) instead of re-appending them. stateDir is the
+// view's catalog directory (<catalog>/views/<name>); "" for an in-memory catalog, in which
+// case the view still buckets but never seals (bounded by the cardinality cap). No-op for a
+// gauge view.
+func (v *View) initContinuous(stateDir string) error {
+	if v.bucketWidth == 0 || stateDir == "" {
+		return nil
+	}
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		return err
+	}
+	st, err := loadViewState(stateDir)
+	if err != nil {
+		return err
+	}
+	v.watermark = st.Watermark
+	v.stateDir = stateDir
+
+	timeAlias := v.spec.Groups[v.bucketIdx].Alias
+	cfg := ArchiveConfig{ZoneAttrs: []string{timeAlias}}
+	if v.spec.Retention > 0 {
+		cfg.Retention = collections.Retention{MaxAgeAttr: timeAlias, MaxAge: float64(v.spec.Retention)}
+	}
+	arch, err := openArchiveTable(filepath.Join(stateDir, viewArchiveSubdir), cfg)
+	if err != nil {
+		return err
+	}
+	v.archive = arch
+	return nil
+}
+
+// sealAged appends and evicts every live bucket whose window has closed (now past
+// start+width+grace), advancing the watermark, forgetting the base-key contributions that
+// fed the sealed buckets, applying archive retention, and persisting the watermark. The
+// caller holds v.mu. No-op for a gauge view or an in-memory catalog (no archive).
+func (v *View) sealAged(now int64) {
+	if v.archive == nil {
+		return
+	}
+	sealAtOrBelow := now - v.bucketWidth - v.grace // seal buckets whose start <= this
+	advanced := false
+	for gk, g := range v.groups {
+		start, err := strconv.ParseInt(g.labels[v.bucketIdx], 10, 64)
+		if err != nil || start > sealAtOrBelow {
+			continue // unparsable, or the bucket window is still open
+		}
+		if err := v.archive.Append(v.renderGroupAd(g)); err != nil {
+			continue // keep the bucket live and retry on the next tick
+		}
+		delete(v.groups, gk)
+		_, _ = v.backing.Delete(gk)
+		if start > v.watermark {
+			v.watermark = start
+			advanced = true
+		}
+	}
+	if !advanced {
+		return
+	}
+	// Base keys whose bucket is now sealed will never change it again; forget them so
+	// contrib stays bounded to the live window.
+	for k, c := range v.contrib {
+		if c.bucketStart <= v.watermark {
+			delete(v.contrib, k)
+		}
+	}
+	if v.spec.Retention > 0 {
+		_, _ = v.archive.Rotate(float64(now))
+	}
+	if v.stateDir != "" {
+		_ = saveViewState(v.stateDir, viewState{Watermark: v.watermark})
+	}
+}
+
+// tickLoop periodically seals aged buckets until ctx is cancelled. Only continuous
+// aggregates with an archive start one.
+func (v *View) tickLoop(ctx context.Context) {
+	if v.tickEvery <= 0 {
+		return
+	}
+	t := time.NewTicker(v.tickEvery)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			v.mu.Lock()
+			v.sealAged(v.nowFn())
+			v.mu.Unlock()
+		}
+	}
+}
+
+// LateDrops reports how many base rows were dropped because their time bucket was already
+// sealed (out-of-window late data).
+func (v *View) LateDrops() int64 {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	return v.lateDrops
+}
+
+// viewState is a continuous aggregate's mutable persisted state (the immutable ViewSpec is
+// saved separately). Only the watermark is durable; sealed history lives in the archive and
+// the live window is rebuilt from the base table on reload.
+type viewState struct {
+	Watermark int64 `json:"watermark"`
+}
+
+func saveViewState(stateDir string, st viewState) error {
+	b, err := json.Marshal(st)
+	if err != nil {
+		return err
+	}
+	tmp := filepath.Join(stateDir, "state.json.tmp")
+	if err := os.WriteFile(tmp, b, 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, filepath.Join(stateDir, "state.json"))
+}
+
+func loadViewState(stateDir string) (viewState, error) {
+	b, err := os.ReadFile(filepath.Join(stateDir, "state.json"))
+	if os.IsNotExist(err) {
+		return viewState{Watermark: -1}, nil // nothing sealed yet
+	}
+	if err != nil {
+		return viewState{}, err
+	}
+	var st viewState
+	if err := json.Unmarshal(b, &st); err != nil {
+		return viewState{}, err
+	}
+	return st, nil
+}

--- a/db/viewcontinuous_test.go
+++ b/db/viewcontinuous_test.go
@@ -1,0 +1,150 @@
+package db
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/PelicanPlatform/classad/classad"
+)
+
+func jobTS(t *testing.T, qdate int64) *classad.ClassAd {
+	t.Helper()
+	ad, err := classad.ParseOld(fmt.Sprintf("QDate = %d", qdate))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ad
+}
+
+// continuousSpec: COUNT(*) grouped by time_bucket(QDate, 1h) -- one series per bucket.
+func continuousSpec() ViewSpec {
+	return ViewSpec{
+		BaseTable:   "jobs",
+		Groups:      []ViewGroupCol{{Attr: "QDate", Alias: "time", BucketWidth: 3600}},
+		Metrics:     []ViewMetric{{Func: ViewCount, Arg: "*", Alias: "metric_jobs"}},
+		Cardinality: 100,
+	}
+}
+
+func archiveAds(t *testing.T, v *View) []*classad.ClassAd {
+	t.Helper()
+	seq, err := v.archive.Query("true")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out []*classad.ClassAd
+	for ad := range seq {
+		out = append(out, ad)
+	}
+	return out
+}
+
+func seal(v *View, now int64) {
+	v.mu.Lock()
+	v.sealAged(now)
+	v.mu.Unlock()
+}
+
+func waitLateDrops(t *testing.T, v *View, want int64) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if v.LateDrops() == want {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("lateDrops = %d, want %d (timed out)", v.LateDrops(), want)
+}
+
+func TestContinuousAggregateSealAndEvict(t *testing.T) {
+	cat, err := OpenCatalog(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cat.Close()
+	base, _ := cat.CreateTable("jobs")
+	base.Put("1", jobTS(t, 3600)) // bucket 3600
+	base.Put("2", jobTS(t, 3700)) // bucket 3600
+	base.Put("3", jobTS(t, 7200)) // bucket 7200
+	if err := cat.CreateView("jobs_ts", continuousSpec()); err != nil {
+		t.Fatal(err)
+	}
+	waitSeries(t, cat, "jobs_ts", 2)
+	v, _ := cat.View("jobs_ts")
+
+	// Seal bucket 3600 (now=7200 => seal starts <= 7200-3600-0 = 3600); 7200 stays live.
+	seal(v, 7200)
+	if v.SeriesCount() != 1 {
+		t.Fatalf("series after first seal = %d, want 1", v.SeriesCount())
+	}
+	arch := archiveAds(t, v)
+	if len(arch) != 1 {
+		t.Fatalf("archive = %d, want 1", len(arch))
+	}
+	if ts, _ := arch[0].EvaluateAttrInt("time"); ts != 3600 {
+		t.Errorf("sealed time = %d, want 3600", ts)
+	}
+	if n, _ := arch[0].EvaluateAttrInt("metric_jobs"); n != 2 {
+		t.Errorf("sealed count = %d, want 2", n)
+	}
+
+	// Late data into the sealed bucket is dropped, not resurrected.
+	base.Put("4", jobTS(t, 3650))
+	waitLateDrops(t, v, 1)
+	if v.SeriesCount() != 1 {
+		t.Fatalf("late data resurrected a bucket: series = %d, want 1", v.SeriesCount())
+	}
+
+	// Seal bucket 7200 too.
+	seal(v, 10800)
+	if v.SeriesCount() != 0 {
+		t.Fatalf("series after second seal = %d, want 0", v.SeriesCount())
+	}
+	if got := len(archiveAds(t, v)); got != 2 {
+		t.Fatalf("archive = %d, want 2", got)
+	}
+}
+
+func TestContinuousAggregateReloadNoDuplicate(t *testing.T) {
+	dir := t.TempDir()
+	cat, err := OpenCatalog(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	base, _ := cat.CreateTable("jobs")
+	base.Put("1", jobTS(t, 3600))
+	base.Put("2", jobTS(t, 3700))
+	base.Put("3", jobTS(t, 7200))
+	if err := cat.CreateView("jobs_ts", continuousSpec()); err != nil {
+		t.Fatal(err)
+	}
+	waitSeries(t, cat, "jobs_ts", 2)
+	v, _ := cat.View("jobs_ts")
+	seal(v, 10800) // seal both buckets -> archive 2, watermark 7200
+	if got := len(archiveAds(t, v)); got != 2 {
+		t.Fatalf("archive before reload = %d, want 2", got)
+	}
+	if err := cat.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Reopen: the watermark is loaded, so the rebuild's replay drops both sealed buckets;
+	// the archive keeps exactly the two sealed samples (no duplicate appends).
+	cat2, err := OpenCatalog(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cat2.Close()
+	v2, ok := cat2.View("jobs_ts")
+	if !ok {
+		t.Fatal("view did not survive reload")
+	}
+	if v2.SeriesCount() != 0 {
+		t.Fatalf("reload live series = %d, want 0 (all buckets sealed)", v2.SeriesCount())
+	}
+	if got := len(archiveAds(t, v2)); got != 2 {
+		t.Fatalf("archive after reload = %d, want 2 (no duplicate append)", got)
+	}
+}


### PR DESCRIPTION
## Summary

Phase 2b of continuous aggregates: a time-bucketed materialized view now **seals aged buckets to a per-view append-only archive and evicts them from memory** — so history is unbounded and cheap to read while memory stays bounded to the live window, instead of accumulating every bucket until the cardinality cap (the Phase 2a limitation).

## Mechanics

- **Live window:** recent buckets stay in the in-memory backing, updated in place — so late-arriving base rows still land in the correct bucket.
- **Seal & evict:** once a bucket's window has closed (wall-clock past `start + width + grace`), a per-view tick renders its `(time, label_*, metric_*)` ad, `Append`s it to the archive, and evicts the group plus the base-key contributions that fed it.
- **Watermark (idempotence):** a monotonic high-water mark (highest sealed bucket start) is the single invariant. A base row whose bucket start is `<= watermark` is **dropped and counted** (`LateDrops`) rather than resurrecting a sealed bucket — this covers both out-of-window late data *and* the replay during rebuild-on-reload.
- **Durability:** the watermark is persisted (`state.json`) beside the spec; the archive is the durable sealed history. On reload the archive reopens and only the *live* window is rebuilt from the base — **no duplicate appends**.
- **Knobs:** `ViewSpec` gains `Grace` and `Retention` (seconds); `Retention` drives archive age-rotation. An in-memory catalog has no archive, so a continuous aggregate there still buckets but does not seal (bounded by the cap, as in Phase 2a).

**Gauge views are unchanged** — no bucket column means no archive, no tick, and `sealAged` is a no-op.

## Read path

Each archived sample already carries `time` + `label_*` + `metric_*`, so reading the sealed history is a plain archive query (newest-first, zone-pruned by `time`). The live window is the view backing. (Unioning the two for a gap-free right edge is a follow-up.)

## Testing

- Seal + evict + read-back from the archive (bucket counts correct).
- Late data into a sealed bucket is dropped, not resurrected (`LateDrops` increments, series count stable).
- Reload loads the watermark and keeps exactly the sealed samples — no duplicate appends.
- Full `db` suite green; gofmt clean.

## Follow-up (htcondordb)

A `WITH (grace=…, retention=…)` clause on `CREATE MATERIALIZED VIEW` to set these from SQL; defaults (grace 0, retention keep-all) work today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
