### PR TITLE
db,dbrpc: finish continuous aggregates (time-ordered seal + rotation test + sealed-history read union)

### DIFF
--- a/db/view.go
+++ b/db/view.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"fmt"
+	"iter"
 	"math"
 	"os"
 	"path/filepath"
@@ -710,6 +711,21 @@ func (cat *Catalog) ViewBacking(name string) (*DB, bool) {
 		return nil, false
 	}
 	return v.backing, true
+}
+
+// ViewSealed streams a continuous aggregate's sealed (archived) rows matching the
+// constraint, so a view read can union sealed history with the live backing. ok is false for
+// a plain table or a gauge view (nothing sealed). The returned sequence is empty (not an
+// error) for a continuous aggregate with no archive (in-memory catalog).
+func (cat *Catalog) ViewSealed(name, constraint string) (seq iter.Seq[*classad.ClassAd], ok bool, err error) {
+	cat.mu.Lock()
+	v, found := cat.views[name]
+	cat.mu.Unlock()
+	if !found {
+		return nil, false, nil
+	}
+	seq, err = v.SealedQuery(constraint)
+	return seq, true, err
 }
 
 // recoverViews reconstructs views from <dir>/views on catalog open. Data is not persisted,

--- a/db/viewcontinuous.go
+++ b/db/viewcontinuous.go
@@ -3,12 +3,14 @@ package db
 import (
 	"context"
 	"encoding/json"
+	"iter"
 	"os"
 	"path/filepath"
 	"sort"
 	"strconv"
 	"time"
 
+	"github.com/PelicanPlatform/classad/classad"
 	"github.com/PelicanPlatform/classad/collections"
 )
 
@@ -116,6 +118,15 @@ func (v *View) sealAged(now int64) {
 	}
 }
 
+// Seal appends and evicts every bucket whose window has closed as of now (unix seconds)
+// into the archive, advancing the watermark. It is what the periodic tick invokes; exported
+// so an operator (or a test) can force sealing at a chosen instant.
+func (v *View) Seal(now int64) {
+	v.mu.Lock()
+	v.sealAged(now)
+	v.mu.Unlock()
+}
+
 // tickLoop periodically seals aged buckets until ctx is cancelled. Only continuous
 // aggregates with an archive start one.
 func (v *View) tickLoop(ctx context.Context) {
@@ -134,6 +145,20 @@ func (v *View) tickLoop(ctx context.Context) {
 			v.mu.Unlock()
 		}
 	}
+}
+
+// SealedQuery streams this continuous aggregate's sealed (archived) rows matching the
+// constraint. It returns an empty sequence for a gauge view or an in-memory continuous
+// aggregate (no archive). Reads union this with the live backing so a view read returns the
+// full series, not just the unsealed buckets.
+func (v *View) SealedQuery(constraint string) (iter.Seq[*classad.ClassAd], error) {
+	v.mu.Lock()
+	arch := v.archive // the archive is internally synchronized; don't hold v.mu during the scan
+	v.mu.Unlock()
+	if arch == nil {
+		return func(yield func(*classad.ClassAd) bool) {}, nil
+	}
+	return arch.Query(constraint)
 }
 
 // LateDrops reports how many base rows were dropped because their time bucket was already

--- a/db/viewcontinuous.go
+++ b/db/viewcontinuous.go
@@ -5,11 +5,17 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"time"
 
 	"github.com/PelicanPlatform/classad/collections"
 )
+
+// viewArchiveSegmentSize overrides the sealed-segment size of a continuous aggregate's
+// archive; 0 uses the archive default (8 MiB). Tests set it small to exercise segment
+// rotation with little data.
+var viewArchiveSegmentSize int
 
 // Continuous aggregates: a materialized view whose GROUP BY includes a time_bucket. Recent
 // buckets live in the in-memory backing (updated in place, so late data lands correctly);
@@ -42,7 +48,7 @@ func (v *View) initContinuous(stateDir string) error {
 	v.stateDir = stateDir
 
 	timeAlias := v.spec.Groups[v.bucketIdx].Alias
-	cfg := ArchiveConfig{ZoneAttrs: []string{timeAlias}}
+	cfg := ArchiveConfig{ZoneAttrs: []string{timeAlias}, SegmentSize: viewArchiveSegmentSize}
 	if v.spec.Retention > 0 {
 		cfg.Retention = collections.Retention{MaxAgeAttr: timeAlias, MaxAge: float64(v.spec.Retention)}
 	}
@@ -63,19 +69,32 @@ func (v *View) sealAged(now int64) {
 		return
 	}
 	sealAtOrBelow := now - v.bucketWidth - v.grace // seal buckets whose start <= this
-	advanced := false
+	// Collect the aged buckets and seal them in bucket-start order, so the archive stays
+	// time-ordered: each segment then carries a contiguous time range, which keeps zone-map
+	// pruning and age-based retention (drop a segment whose max time is old) precise.
+	type agedBucket struct {
+		key   string
+		start int64
+	}
+	var toSeal []agedBucket
 	for gk, g := range v.groups {
 		start, err := strconv.ParseInt(g.labels[v.bucketIdx], 10, 64)
 		if err != nil || start > sealAtOrBelow {
 			continue // unparsable, or the bucket window is still open
 		}
-		if err := v.archive.Append(v.renderGroupAd(g)); err != nil {
+		toSeal = append(toSeal, agedBucket{gk, start})
+	}
+	sort.Slice(toSeal, func(i, j int) bool { return toSeal[i].start < toSeal[j].start })
+
+	advanced := false
+	for _, a := range toSeal {
+		if err := v.archive.Append(v.renderGroupAd(v.groups[a.key])); err != nil {
 			continue // keep the bucket live and retry on the next tick
 		}
-		delete(v.groups, gk)
-		_, _ = v.backing.Delete(gk)
-		if start > v.watermark {
-			v.watermark = start
+		delete(v.groups, a.key)
+		_, _ = v.backing.Delete(a.key)
+		if a.start > v.watermark {
+			v.watermark = a.start
 			advanced = true
 		}
 	}

--- a/db/viewcontinuous_test.go
+++ b/db/viewcontinuous_test.go
@@ -148,3 +148,75 @@ func TestContinuousAggregateReloadNoDuplicate(t *testing.T) {
 		t.Fatalf("archive after reload = %d, want 2 (no duplicate append)", got)
 	}
 }
+
+// TestContinuousAggregateRetentionRotation checks that sealed history is age-rotated: with
+// a retention window, sealing buckets across a wide time span drops the oldest sealed
+// segments while keeping the recent ones. Tiny segments make a few buckets roll a segment;
+// the time-ordered seal keeps segments prunable by age.
+func TestContinuousAggregateRetentionRotation(t *testing.T) {
+	old := viewArchiveSegmentSize
+	viewArchiveSegmentSize = 512 // small segments so a handful of sealed buckets roll one
+	defer func() { viewArchiveSegmentSize = old }()
+
+	cat, err := OpenCatalog(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cat.Close()
+	base, _ := cat.CreateTable("jobs")
+
+	const (
+		width = 3600
+		K     = 60
+		base0 = 300 * width // 1,080,000, bucket-aligned
+	)
+	for i := 0; i < K; i++ {
+		base.Put(fmt.Sprintf("j%d", i), jobTS(t, int64(base0+i*width)))
+	}
+	spec := ViewSpec{
+		BaseTable:   "jobs",
+		Groups:      []ViewGroupCol{{Attr: "QDate", Alias: "time", BucketWidth: width}},
+		Metrics:     []ViewMetric{{Func: ViewCount, Arg: "*", Alias: "metric_jobs"}},
+		Cardinality: 1000,
+		Retention:   100000, // keep ~100k seconds of sealed history
+	}
+	if err := cat.CreateView("jobs_ts", spec); err != nil {
+		t.Fatal(err)
+	}
+	waitSeries(t, cat, "jobs_ts", K)
+	v, _ := cat.View("jobs_ts")
+
+	oldest := int64(base0)               // 1,080,000
+	newest := int64(base0 + (K-1)*width) // 1,292,400
+	// now past the newest bucket's window; retention threshold = now-100000 = 1,196,000,
+	// so segments whose max time is older than that are dropped.
+	seal(v, newest+width+100000)
+
+	times := map[int64]int{}
+	var min, max int64 = 1 << 62, -1
+	for _, ad := range archiveAds(t, v) {
+		ts, _ := ad.EvaluateAttrInt("time")
+		times[ts]++
+		if ts < min {
+			min = ts
+		}
+		if ts > max {
+			max = ts
+		}
+	}
+	if len(times) >= K {
+		t.Fatalf("retention kept %d buckets, expected rotation to drop some (< %d)", len(times), K)
+	}
+	if times[oldest] != 0 {
+		t.Errorf("oldest bucket %d should have been rotated out", oldest)
+	}
+	if times[newest] != 1 {
+		t.Errorf("newest bucket %d should be retained (in the active segment)", newest)
+	}
+	if min <= oldest {
+		t.Errorf("min retained time = %d, want > oldest %d (old segment dropped)", min, oldest)
+	}
+	if max != newest {
+		t.Errorf("max retained time = %d, want newest %d", max, newest)
+	}
+}

--- a/db/viewcontinuous_test.go
+++ b/db/viewcontinuous_test.go
@@ -40,11 +40,7 @@ func archiveAds(t *testing.T, v *View) []*classad.ClassAd {
 	return out
 }
 
-func seal(v *View, now int64) {
-	v.mu.Lock()
-	v.sealAged(now)
-	v.mu.Unlock()
-}
+func seal(v *View, now int64) { v.Seal(now) }
 
 func waitLateDrops(t *testing.T, v *View, want int64) {
 	t.Helper()

--- a/dbrpc/server.go
+++ b/dbrpc/server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"iter"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -504,6 +505,14 @@ func (sc *serverConn) stopWatch(watchReqID uint64) {
 	}
 }
 
+// viewSealer is the optional Catalog capability to read a continuous aggregate's sealed
+// (archived) history. A catalog that has it (the multi-table db.Catalog) lets a view read
+// union sealed buckets with the live backing; catalogs without it (single-table) simply
+// don't, so this is additive and non-breaking.
+type viewSealer interface {
+	ViewSealed(name, constraint string) (iter.Seq[*classad.ClassAd], bool, error)
+}
+
 // streamQuery streams the committed ads matching a constraint. Each result is its own
 // frame under reqID, so its frames interleave with other calls' -- no head-of-line
 // blocking -- and end with a terminator.
@@ -531,6 +540,22 @@ func (s *Server) streamQuery(ctx context.Context, reqID uint64, r *reader, inclu
 		write(respErr(reqID, err.Error()))
 		return
 	}
+	// A continuous aggregate's sealed history lives in its archive; resolve it up front
+	// (so a bad constraint errors before any frame) and union it after the live backing, so
+	// a read of the view returns the full series, not just the unsealed buckets.
+	var sealed iter.Seq[*classad.ClassAd]
+	if vs, ok := s.cat.(viewSealer); ok {
+		var serr error
+		if sq, has, e := vs.ViewSealed(table, constraint); e != nil {
+			serr = e
+		} else if has {
+			sealed = sq
+		}
+		if serr != nil {
+			write(respErr(reqID, serr.Error()))
+			return
+		}
+	}
 	// Push LIMIT down: stopping the range stops the underlying scan, so a small
 	// LIMIT does proportionally less work instead of scanning everything.
 	for ad := range seq {
@@ -541,6 +566,18 @@ func (s *Server) streamQuery(ctx context.Context, reqID uint64, r *reader, inclu
 		n++
 		if limit > 0 && n >= limit {
 			break
+		}
+	}
+	if sealed != nil && (limit <= 0 || n < limit) {
+		for ad := range sealed {
+			if cancelled(ctx) {
+				return
+			}
+			write(putStr(respHead(reqID, stStream), adString(ad, includePrivate)))
+			n++
+			if limit > 0 && n >= limit {
+				break
+			}
 		}
 	}
 	write(respHead(reqID, stStreamEnd))

--- a/dbrpc/view_wire_test.go
+++ b/dbrpc/view_wire_test.go
@@ -2,6 +2,7 @@ package dbrpc
 
 import (
 	"context"
+	"strconv"
 	"testing"
 
 	"github.com/PelicanPlatform/classad/classad"
@@ -74,5 +75,68 @@ func TestViewWire(t *testing.T) {
 	}
 	if views, _ := c.ListViews(ctx); len(views) != 0 {
 		t.Fatalf("views after drop = %v, want none", views)
+	}
+}
+
+// TestViewSealedUnionWire: a continuous aggregate's read unions sealed history (archive)
+// with the live backing, so a query returns the full series even after buckets are evicted.
+func TestViewSealedUnionWire(t *testing.T) {
+	cat, err := db.OpenCatalog(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	base, err := cat.CreateTable("jobs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, j := range []struct {
+		key   string
+		qdate int
+	}{{"1", 3600}, {"2", 3700}, {"3", 7200}} { // buckets 3600 (x2), 7200 (x1)
+		ad, _ := classad.ParseOld("QDate = " + strconv.Itoa(j.qdate))
+		if err := base.Put(j.key, ad); err != nil {
+			t.Fatal(err)
+		}
+	}
+	s := NewServerCatalog(cat)
+	cconn, sconn := netPipe()
+	go func() { _ = s.ServeConn(sconn) }()
+	c := NewClient(cconn)
+	defer func() { c.Close(); s.Close(); cat.Close() }()
+	ctx := context.Background()
+
+	spec := db.ViewSpec{
+		BaseTable:   "jobs",
+		Groups:      []db.ViewGroupCol{{Attr: "QDate", Alias: "time", BucketWidth: 3600}},
+		Metrics:     []db.ViewMetric{{Func: db.ViewCount, Arg: "*", Alias: "metric_jobs"}},
+		Cardinality: 100,
+	}
+	if err := c.CreateView(ctx, "jobs_ts", spec); err != nil {
+		t.Fatalf("CreateView: %v", err)
+	}
+
+	// Seal bucket 3600 (now=7200 => seal starts <= 3600); bucket 7200 stays live.
+	v, _ := cat.View("jobs_ts")
+	v.Seal(7200)
+
+	// Query the view: the union returns BOTH the sealed bucket (3600) and the live one (7200).
+	rows, err := c.QueryTable(ctx, "jobs_ts", "true", 0)
+	if err != nil {
+		t.Fatalf("query view: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("union query returned %d rows, want 2 (live + sealed)", len(rows))
+	}
+	times := map[int64]bool{}
+	for _, txt := range rows {
+		ad, perr := classad.Parse(txt)
+		if perr != nil || ad == nil {
+			t.Fatalf("parse row %q: %v", txt, perr)
+		}
+		ts, _ := ad.EvaluateAttrInt("time")
+		times[ts] = true
+	}
+	if !times[3600] || !times[7200] {
+		t.Fatalf("union missing a bucket; got times %v, want {3600, 7200}", times)
 	}
 }


### PR DESCRIPTION
Follow-up to the seal-and-evict engine (v0.15.0), prompted by a gap in retention/rotation coverage.

## Change

`sealAged` now seals aged buckets in **bucket-start order** rather than map order. This keeps the per-view archive time-ordered, so each sealed segment carries a contiguous time range -- which is what makes zone-map pruning and **age-based retention** precise. Before, buckets sealed in random order, so a segment could mix old and new timestamps and its zone max would block age rotation from ever dropping it.

## Test coverage

The underlying archive `Rotate` (segment/age retention) was already covered, but the **continuous-aggregate integration** was not. New `TestContinuousAggregateRetentionRotation`: seal buckets across a wide time span with a retention window and assert the oldest sealed segments are dropped while recent buckets are retained (and the newest, in the active segment, always survives). A `viewArchiveSegmentSize` test hook makes segment rolling reachable with little data.

Full `db` suite green; gofmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)