### PR TITLE
collections: sync a multi-shard commit's shards in parallel

### DIFF
--- a/collections/txn.go
+++ b/collections/txn.go
@@ -2,6 +2,7 @@ package collections
 
 import (
 	"bytes"
+	"sync"
 	"sync/atomic"
 
 	"github.com/PelicanPlatform/classad/classad"
@@ -124,15 +125,32 @@ type txnWrite struct {
 // respect to other committers (first-committer-wins). Conflicting writes are skipped
 // and flagged; the rest commit at one fresh sequence.
 func (sh *shard) commitTxn(ws []*txnWrite, durable bool) {
+	changed, seq := sh.applyTxn(ws)
+	if !changed {
+		return
+	}
+	if durable {
+		sh.sync()
+	}
+	sh.publishTxn(ws, seq)
+}
+
+// applyTxn applies a shard's buffered writes under the write lock, advancing the shard's
+// commit sequence, and sets each write's ok flag. It returns whether anything changed and
+// the sequence used. The durability sync (sh.sync) and the watch-hub publish (publishTxn)
+// are DELIBERATELY left to the caller so a multi-shard commit can sync its shards
+// concurrently -- the msync is a commit's slow part, and distinct shards sync independently
+// (disjoint locks and segments), so Txn.Commit overlaps them instead of paying them in
+// series. See Txn.Commit.
+func (sh *shard) applyTxn(ws []*txnWrite) (changed bool, seq uint64) {
 	acq, held := sh.lockWrite()
-	seq := sh.commitSeq + 1
+	seq = sh.commitSeq + 1
 	// Single-writer fast path: all of a shard's buffered writes share one snapshot
 	// (ws[0].base). If no one has committed to this shard since -- commitSeq is still
 	// that snapshot -- then no key can have changed, so every write succeeds without a
 	// per-key conflict check. This is the schedd's common single-writer case: zero
 	// conflict-detection cost. Under contention it falls to the per-write check.
 	fast := len(ws) > 0 && sh.commitSeq == ws[0].base
-	changed := false
 	for _, w := range ws {
 		if !fast {
 			conflictCheckCount.Add(1)
@@ -156,24 +174,27 @@ func (sh *shard) commitTxn(ws []*txnWrite, durable bool) {
 		sh.maybeCheckpoint(seq)
 	}
 	sh.unlockWrite(acq, held)
-	if changed {
-		if durable {
-			sh.sync()
+	return changed, seq
+}
+
+// publishTxn notifies the watch hub of a committed batch. It must run only after the batch
+// is durable (sh.sync has returned), so watchers never observe an event that a crash could
+// lose.
+func (sh *shard) publishTxn(ws []*txnWrite, seq uint64) {
+	if sh.hub == nil {
+		return
+	}
+	for _, w := range ws {
+		if !w.ok {
+			continue
 		}
-		if sh.hub != nil {
-			for _, w := range ws {
-				if !w.ok {
-					continue
-				}
-				if w.del {
-					if sh.delLog != nil {
-						sh.delLog.record(w.key, seq)
-						sh.hub.publish(sh.idx, seq, w.key, nil, nil, true)
-					}
-				} else {
-					sh.hub.publish(sh.idx, seq, w.key, w.ad, w.codec, false)
-				}
+		if w.del {
+			if sh.delLog != nil {
+				sh.delLog.record(w.key, seq)
+				sh.hub.publish(sh.idx, seq, w.key, nil, nil, true)
 			}
+		} else {
+			sh.hub.publish(sh.idx, seq, w.key, w.ad, w.codec, false)
 		}
 	}
 }
@@ -303,10 +324,53 @@ func (tx *Txn) Commit() CommitResult {
 		}
 		byShard[idx] = append(byShard[idx], w)
 	}
-	var res CommitResult
+	// Phase 1: apply each touched shard's writes under its own lock (fast; disjoint locks).
+	type shardCommit struct {
+		idx     int
+		ws      []*txnWrite
+		seq     uint64
+		changed bool
+	}
+	commits := make([]shardCommit, 0, len(byShard))
 	for idx, ws := range byShard {
-		tx.c.shards[idx].commitTxn(ws, tx.durable)
-		for _, w := range ws {
+		changed, seq := tx.c.shards[idx].applyTxn(ws)
+		commits = append(commits, shardCommit{idx, ws, seq, changed})
+	}
+
+	// Phase 2: sync the changed shards CONCURRENTLY. The durability msync is a commit's
+	// slow part; distinct shards sync independently, so a commit touching N shards pays
+	// ~one msync latency instead of N in series. The parallelism is inherently sized to
+	// the commit -- a small commit touches one shard and syncs inline with no goroutines;
+	// only a large, many-shard commit fans out.
+	if tx.durable {
+		var toSync []int
+		for _, c := range commits {
+			if c.changed {
+				toSync = append(toSync, c.idx)
+			}
+		}
+		switch len(toSync) {
+		case 0:
+		case 1:
+			tx.c.shards[toSync[0]].sync()
+		default:
+			var wg sync.WaitGroup
+			wg.Add(len(toSync))
+			for _, idx := range toSync {
+				go func(sh *shard) { defer wg.Done(); sh.sync() }(tx.c.shards[idx])
+			}
+			wg.Wait()
+		}
+	}
+
+	// Phase 3: publish (now durable) and aggregate the result + ordered-index maintenance.
+	// Kept sequential: publishing and the ordered index touch collection-shared state.
+	var res CommitResult
+	for _, c := range commits {
+		if c.changed {
+			tx.c.shards[c.idx].publishTxn(c.ws, c.seq)
+		}
+		for _, w := range c.ws {
 			if !w.ok {
 				res.Conflicts = append(res.Conflicts, w.key)
 				continue

--- a/collections/txn_parallelsync_test.go
+++ b/collections/txn_parallelsync_test.go
@@ -1,0 +1,63 @@
+package collections
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestTxnCommitParallelSync verifies that a commit touching multiple shards runs their
+// durability syncs CONCURRENTLY rather than one after another: the CommitSync hook (the
+// per-shard durability point) sees more than one shard syncing at once, and the commit's
+// wall time is far below the serial sum of the per-shard syncs.
+func TestTxnCommitParallelSync(t *testing.T) {
+	const hold = 20 * time.Millisecond
+	var mu sync.Mutex
+	var cur, maxConcurrent, calls int
+	hook := func() {
+		mu.Lock()
+		cur++
+		calls++
+		if cur > maxConcurrent {
+			maxConcurrent = cur
+		}
+		mu.Unlock()
+		time.Sleep(hold) // stand in for an fsync so overlaps are observable
+		mu.Lock()
+		cur--
+		mu.Unlock()
+	}
+
+	c := New(Options{Shards: 16, CommitSync: hook})
+	tx := c.Begin()
+	const n = 200 // enough distinct keys to spread across all 16 shards
+	for i := 0; i < n; i++ {
+		tx.Put([]byte(fmt.Sprintf("k%d", i)), mustAd(t, `[ x = 1 ]`))
+	}
+
+	start := time.Now()
+	res := tx.Commit()
+	elapsed := time.Since(start)
+
+	if res.Committed != n {
+		t.Fatalf("committed %d writes, want %d", res.Committed, n)
+	}
+	mu.Lock()
+	mc, nc := maxConcurrent, calls
+	mu.Unlock()
+
+	if nc < 2 {
+		t.Fatalf("CommitSync fired %d times; the writes should have spanned multiple shards", nc)
+	}
+	if mc < 2 {
+		t.Fatalf("max concurrent syncs = %d; the per-shard syncs did not overlap (still serial)", mc)
+	}
+	// Serial execution would take at least nc*hold; concurrent should be a small multiple
+	// of a single hold. Assert well under the serial bound (generous slack for scheduling).
+	if serial := time.Duration(nc) * hold; elapsed >= serial {
+		t.Fatalf("commit took %v to sync %d shards of %v each -- looks serial (serial bound %v)", elapsed, nc, hold, serial)
+	}
+	t.Logf("commit synced %d shards, up to %d concurrently, in %v (serial would be ~%v)",
+		nc, mc, elapsed, time.Duration(nc)*hold)
+}


### PR DESCRIPTION
## Sync a multi-shard commit's shards in parallel

`Txn.Commit` applied and then synced each touched shard **sequentially**, so a commit
spanning N shards paid N `msync` latencies back-to-back. Since a busy table's commit
touches ~all of its shards, that serialized fsync fan-out is the dominant commit cost
(measured elsewhere: a commit's wall time far exceeds the *summed* per-shard sync time —
i.e. they're serializing, not the DB being slow).

**Change:** split `commitTxn` into `applyTxn` (the locked apply — still sequential, fast)
and `publishTxn` (the post-durable watch-hub notify), and have `Txn.Commit` run the
durability `sync()`s **concurrently** across the changed shards: apply all shards → sync
them in parallel → publish + aggregate. Distinct shards sync independently (disjoint
locks, segments, and per-shard metrics), and `CommitSync` is already documented as safe
for concurrent cross-shard use.

**Adaptive by construction:** a single-shard commit syncs inline with no goroutines; only
a many-shard commit fans out — so light commits pay nothing extra (no fsync amplification).

**Ordering/correctness unchanged:** all of a shard's writes still apply under its write
lock before any sync; publish still happens only after the batch is durable; the result
and ordered-index maintenance stay sequential (they touch collection-shared state).

`TestTxnCommitParallelSync` proves the overlap via the `CommitSync` hook: a 16-shard
commit syncs up to 16-way concurrently (~24ms vs a ~320ms serial bound). Full collections
suite + `-race` green.

Once tagged, this flows to htcondordb (via classad/db) and directly shrinks the slow
commits seen in the collector→db write path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
