### PR TITLE
dbrpc: chunk batch writes by bytes (fix message too large)

### DIFF
--- a/dbrpc/batchwrite_framesize_test.go
+++ b/dbrpc/batchwrite_framesize_test.go
@@ -1,0 +1,83 @@
+package dbrpc
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/db"
+)
+
+// sizeCappedConn rejects an outgoing frame larger than limit, exactly as the CEDAR stream
+// does at MaxMessageSize -- so this test reproduces the "message too large" write failure
+// that the byte-aware batch chunker must avoid. (The test pipe conn has no such cap.)
+type sizeCappedConn struct {
+	MsgConn
+	limit int
+	over  atomic.Int64 // frames written over the limit
+}
+
+func (c *sizeCappedConn) WriteMsg(b []byte) error {
+	if len(b) > c.limit {
+		c.over.Add(1)
+		return fmt.Errorf("message too large: %d bytes (max %d)", len(b), c.limit)
+	}
+	return c.MsgConn.WriteMsg(b)
+}
+
+// TestNewClassAdBatchPipelinedFrameSize is the regression for the "message too large"
+// write failures: a batch of large ads whose count-based chunk (64) would build a frame
+// over the 1 MiB message limit must instead be chunked by BYTES, so every frame fits and
+// all ads commit.
+func TestNewClassAdBatchPipelinedFrameSize(t *testing.T) {
+	d, err := db.Open("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := NewServer(d)
+	cconn, sconn := netPipe()
+	go func() { _ = s.ServeConn(sconn) }()
+	capped := &sizeCappedConn{MsgConn: cconn, limit: 1 << 20} // 1 MiB, matching the CEDAR stream
+	c := NewClient(capped)
+	defer func() { c.Close(); s.Close(); d.Close() }()
+	ctx := context.Background()
+
+	// 128 ads of ~30 KiB each. A count-64 chunk would be ~1.9 MiB -- well over the cap;
+	// byte-aware chunking must cut it into smaller frames.
+	const n = 128
+	big := strings.Repeat("x", 30000)
+	items := make([]AdKV, n)
+	for i := range items {
+		items[i] = AdKV{Key: fmt.Sprintf("k%d", i), Ad: fmt.Sprintf("N = %d\nBig = %q", i, big)}
+	}
+
+	tx, err := c.Begin(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rejects, err := tx.NewClassAdBatchPipelined(ctx, items, 64)
+	if err != nil {
+		t.Fatalf("pipelined batch of large ads failed (over-size frame?): %v", err)
+	}
+	if len(rejects) != 0 {
+		t.Fatalf("unexpected rejects: %v", rejects)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if over := capped.over.Load(); over != 0 {
+		t.Fatalf("%d frame(s) exceeded the %d-byte cap; byte-aware chunking failed", over, capped.limit)
+	}
+
+	// Every ad landed.
+	tx2, _ := c.Begin(ctx)
+	defer func() { _ = tx2.Abort(ctx) }()
+	for _, i := range []int{0, n / 2, n - 1} {
+		v, ok, err := tx2.LookupAttr(ctx, fmt.Sprintf("k%d", i), "N")
+		if err != nil || !ok || v != fmt.Sprintf("%d", i) {
+			t.Fatalf("k%d N = %q,%v,%v want %d", i, v, ok, err, i)
+		}
+	}
+}

--- a/dbrpc/client.go
+++ b/dbrpc/client.go
@@ -299,6 +299,21 @@ type AdReject struct {
 	Err   string
 }
 
+const (
+	// maxBatchFrameBytes bounds one opNewAdBatch frame so it stays under the CEDAR stream's
+	// MaxMessageSize (1 MiB); the margin covers the frame header, per-message framing, and
+	// safety. A batch chunk is cut before a frame would exceed this, so a run of large ads
+	// can never build an over-size frame (which the stream rejects as "message too large",
+	// failing the whole write and -- after retries replay the same too-big frame -- dropping
+	// the ads).
+	maxBatchFrameBytes = (1 << 20) - 4096
+	// adBatchFrameOverhead is the fixed opNewAdBatch header: reqID(8) + op(1) + txnID(8) +
+	// count(4). adBatchItemOverhead is the two length prefixes putStr writes per item
+	// (key + ad), 4 bytes each.
+	adBatchFrameOverhead = 8 + 1 + 8 + 4
+	adBatchItemOverhead  = 4 + 4
+)
+
 // newAdBatchFrame builds one opNewAdBatch request over items[base:end].
 func (t *Tx) newAdBatchFrame(id uint64, items []AdKV) []byte {
 	b := putI32(putU64(req(id, opNewAdBatch), t.id), int32(len(items)))
@@ -372,12 +387,25 @@ func (t *Tx) NewClassAdBatchPipelined(ctx context.Context, items []AdKV, chunkSi
 		base int
 	}
 	var pends []pending
-	for base := 0; base < len(items); base += chunkSize {
-		end := base + chunkSize
-		if end > len(items) {
-			end = len(items)
+	for base := 0; base < len(items); {
+		// Cut a chunk at whichever comes first: chunkSize ads, or the byte budget that keeps
+		// the frame under the stream's max message size. Chunking by COUNT alone lets a run
+		// of large ads build an over-size frame that the stream rejects ("message too
+		// large"), failing the whole write; the byte guard prevents that. At least one ad
+		// always goes in a chunk (a single ad larger than the budget is sent alone -- the
+		// smallest possible frame -- rather than silently dropped).
+		end := base
+		frameBytes := adBatchFrameOverhead
+		for end < len(items) {
+			need := adBatchItemOverhead + len(items[end].Key) + len(items[end].Ad)
+			if end > base && (end-base >= chunkSize || frameBytes+need > maxBatchFrameBytes) {
+				break
+			}
+			frameBytes += need
+			end++
 		}
 		chunk := items[base:end]
+		chunkBase := base
 		id := t.c.nextReq.Add(1)
 		ch, err := t.c.sendID(id, func(id uint64) []byte {
 			return t.newAdBatchFrame(id, chunk)
@@ -388,7 +416,8 @@ func (t *Tx) NewClassAdBatchPipelined(ctx context.Context, items []AdKV, chunkSi
 			}
 			return nil, err
 		}
-		pends = append(pends, pending{ch: ch, id: id, base: base})
+		pends = append(pends, pending{ch: ch, id: id, base: chunkBase})
+		base = end
 	}
 
 	// Collect phase: await every chunk's ack. Drain all of them even after an error so no


### PR DESCRIPTION
## Fix: `message too large` write failures (production regression after upgrade)

`NewClassAdBatchPipelined` chunked items by **ad count** only (`chunkSize`, default 64). A
run of large ads then built an `opNewAdBatch` frame over the CEDAR stream's 1 MiB
`MaxMessageSize`, which the stream rejects:

```
message too large: 1052168 bytes (max 1048576)
```

That fails the whole write; `withRetry` replays the identical too-big frame, so it never
succeeds and the ads are **dropped**. It surfaced in production as `retries_total{cause=transport}`
churn once ads grew large enough that 64 of them exceed 1 MiB. (Latent since the batch
writer landed; not caused by the recent write-path changes, but exposed by them driving
larger batches.)

**Fix:** cut each chunk at whichever comes first — `chunkSize` ads **or** a byte budget
(`maxBatchFrameBytes` = 1 MiB − 4 KiB margin) that keeps the frame under `MaxMessageSize`.
A single ad larger than the budget is still sent alone (smallest possible frame) rather
than dropped.

`TestNewClassAdBatchPipelinedFrameSize` wraps the client conn with a 1 MiB cap (the test
pipe has none, so it couldn't catch this before) and commits 128 ads of ~30 KiB: pre-fix a
count-64 chunk (~1.9 MiB) trips the cap; now every frame fits and all ads land. Full dbrpc
suite + `-race` green.

**Recommend a fast patch release** (dbrpc v0.16.2) so the collector/htcondordb can pick it
up — this is dropping ads in the field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)