### PR TITLE
classad: accept & preserve non-bare attribute names in old ClassAd format

### DIFF
--- a/classad/classad.go
+++ b/classad/classad.go
@@ -418,7 +418,11 @@ func (c *ClassAd) marshalOld(includePrivate bool) string {
 			b.WriteByte('\n')
 		}
 		first = false
-		b.WriteString(unparseAttrName(attr.Name))
+		// Old-ClassAd wire format takes the attribute name VERBATIM (name before '='), as
+		// the C++ serializer does -- do NOT quote non-bare names here. A name like
+		// "user:condor_tail_X" must round-trip as itself so C++ clients (condor_status, the
+		// negotiator) read the same attribute; the new-format String() path still quotes.
+		b.WriteString(attr.Name)
 		b.WriteString(" = ")
 		b.WriteString(attr.Value.String())
 	}

--- a/classad/parser_old_fuzz_test.go
+++ b/classad/parser_old_fuzz_test.go
@@ -1,0 +1,85 @@
+package classad
+
+import (
+	"sort"
+	"strings"
+	"testing"
+)
+
+// oldFormatFuzzSeeds are old-ClassAd sources (newline-separated `Name = Expr`, no
+// brackets) exercising the ParseOld -> MarshalOld path -- including attribute names that
+// are NOT bare identifiers, which real ads carry (per-user schedd stats like
+// "user:condor_tail_X") and which the new-format lexer would reject unless quoted. This
+// path was previously unfuzzed, so the colon-name rejection slipped through.
+var oldFormatFuzzSeeds = []string{
+	"",
+	"Name = \"login06\"\nCpus = 8",
+	"MyType = \"Machine\"\nRequirements = Cpus > 4 && Memory > 1024",
+	// Non-bare attribute names taken verbatim by the old format:
+	"acwarden:condor_tail_FileTransferDownloadBytes = 984.0\nName = \"login06\"",
+	"acwarden:condor_tail_FileTransferDownloadBytesPerSecond_1h = 0.002624417388097289",
+	"a.b.c = 1\nName = \"x\"",
+	"Weird-Name = 2\nOk = 3",
+	"'already quoted' = 1",
+}
+
+// FuzzParseOldRoundTrip checks the old-format ATTRIBUTE-NAME round trip -- the dimension
+// that regressed in the field. On any input ParseOld must not panic/hang; when it parses,
+// its MarshalOld rendering must (a) re-parse via ParseOld and (b) preserve the exact set of
+// attribute names. That catches both a name the parser wrongly rejects and a name MarshalOld
+// wrongly quotes (which the C++ old-format never does, and which would come back changed).
+//
+// It deliberately does NOT assert byte-exact value round-tripping: string-VALUE escaping
+// (control bytes, backslashes) round-trips asymmetrically between MarshalOld's strict
+// escaping and the lexer's lenient old-format escaping -- a separate, pre-existing issue
+// tracked on its own, out of scope for the attribute-name path.
+func FuzzParseOldRoundTrip(f *testing.F) {
+	for _, s := range oldFormatFuzzSeeds {
+		f.Add(s)
+	}
+	f.Fuzz(func(t *testing.T, src string) {
+		ad1, err := ParseOld(src)
+		if err != nil {
+			return // rejecting malformed input is fine; the point is it must not panic
+		}
+		if ad1 == nil {
+			t.Fatalf("ParseOld returned nil ad and nil error for %q", src)
+		}
+		m1 := ad1.MarshalOld()
+		ad2, err := ParseOld(m1)
+		if err != nil {
+			t.Fatalf("MarshalOld output does not re-parse via ParseOld:\n  src: %q\n  m1:  %q\n  err: %v", src, m1, err)
+		}
+		n1, n2 := sortedAttrNames(ad1), sortedAttrNames(ad2)
+		if strings.Join(n1, "\x00") != strings.Join(n2, "\x00") {
+			t.Fatalf("attribute names not preserved through MarshalOld:\n  src: %q\n  m1:  %q\n  before: %q\n  after:  %q", src, m1, n1, n2)
+		}
+	})
+}
+
+func sortedAttrNames(ad *ClassAd) []string {
+	names := ad.GetAttributes()
+	sort.Strings(names)
+	return names
+}
+
+// TestParseOldColonAttrName is the direct regression for the field report: a Schedd ad
+// with per-user stat attributes whose names contain ':' must parse (not be dropped), keep
+// their values, and re-serialize verbatim so C++ clients read the same attribute.
+func TestParseOldColonAttrName(t *testing.T) {
+	const attr = "acwarden:condor_tail_FileTransferDownloadBytes"
+	ad, err := ParseOld("Name = \"login06.hep.wisc.edu\"\n" + attr + " = 984.0\nOther = 3")
+	if err != nil {
+		t.Fatalf("ParseOld rejected a colon attribute name (the reported failure): %v", err)
+	}
+	if v, ok := ad.EvaluateAttrReal(attr); !ok || v != 984.0 {
+		t.Fatalf("%s = %v (ok=%v), want 984.0", attr, v, ok)
+	}
+	out := ad.MarshalOld()
+	if !strings.Contains(out, attr+" = ") {
+		t.Fatalf("MarshalOld did not emit the colon name verbatim:\n%s", out)
+	}
+	if strings.Contains(out, "'"+attr) {
+		t.Fatalf("MarshalOld quoted the colon name, which breaks C++ old-format wire clients:\n%s", out)
+	}
+}

--- a/parser/old_classad_parser.go
+++ b/parser/old_classad_parser.go
@@ -92,12 +92,24 @@ func convertOldToNewFormat(input string) string {
 		// Check if line has an assignment operator
 		// Old ClassAd lines should be: AttributeName = Expression
 		if strings.Contains(trimmed, "=") {
+			// The old format takes the attribute name verbatim (everything before the
+			// first '='), so it can contain characters -- ':', '.', etc. -- that are not
+			// valid BARE attribute names in the new-format grammar the lexer below uses.
+			// Real ads carry these: per-user schedd stats like "user:condor_tail_X".
+			// Quote such a name so it lexes as a quoted attribute name (matching the C++
+			// parser, which stores the literal name). A bare name is returned unchanged, so
+			// this is byte-identical for the common case.
+			stmt := trimmed
+			if eq := strings.IndexByte(trimmed, '='); eq > 0 {
+				name := strings.TrimSpace(trimmed[:eq])
+				stmt = ast.QuoteAttributeName(name) + " " + trimmed[eq:]
+			}
 			// Add the line with a semicolon if it doesn't already have one
-			if !strings.HasSuffix(trimmed, ";") {
-				result.WriteString(trimmed)
+			if !strings.HasSuffix(stmt, ";") {
+				result.WriteString(stmt)
 				result.WriteString(";\n")
 			} else {
-				result.WriteString(trimmed)
+				result.WriteString(stmt)
 				result.WriteString("\n")
 			}
 		} else {


### PR DESCRIPTION
## Field report: htc-collector drops Schedd ads with `:` in an attribute name

```
err="error parsing old ClassAd format: parse error at line 226, col 9: syntax error
acwarden:
        ^"
```

Real schedd ads carry per-user stat attributes like `acwarden:condor_tail_FileTransferDownloadBytes`.
`ParseOld` converts old→new format and lexes, so it imposed the new grammar's strict
**bare-identifier** rule on attribute names — a name with `:` (or `.`, etc.) was a syntax
error, and the collector dropped the **entire** Schedd ad over one such attribute.

The old format takes the attribute name **verbatim** (everything before `=`), like the C++
parser. Two fixes to match:
- `convertOldToNewFormat` quotes a name that isn't a bare identifier (`ast.QuoteAttributeName`)
  so it lexes as a quoted name. Bare names are byte-identical — pure widening, no effect on
  the common case.
- `marshalOld` emits the attribute name **verbatim** (not via new-format quoting), so
  `user:stat` round-trips as itself and C++ wire clients read the same attribute (it was
  re-serializing as `'user:stat'`, which old format never does).

## Fuzzing (you were right — a gap)
The old-format parse/serialize path was **unfuzzed** (only the new format was). Added
`FuzzParseOldRoundTrip`, whose invariant is attribute-**name** preservation across
`ParseOld → MarshalOld → ParseOld`. `TestParseOldColonAttrName` is the direct regression.

**⚠️ The new fuzzer also surfaced a separate, pre-existing bug** it's scoped around: string
**VALUE** escaping round-trips asymmetrically in old format — `MarshalOld` strict-escapes
(e.g. a backslash `\` → `\\`) while the old lexer decodes leniently, so `Foo = "\0"`
is not idempotent (`\0 → \\0 → \\\\0`). That's **production-relevant** (Windows paths,
regexes in ad values) and worth its own fix — flagging for prioritization, out of scope here.

Full classad + parser suites green; 40s of `FuzzParseOldRoundTrip` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)