### PR TITLE
collections: record per-commit durability wall time (commitSync)

### DIFF
--- a/collections/opstats.go
+++ b/collections/opstats.go
@@ -107,9 +107,10 @@ type shardMetrics struct {
 // live on each shard's shardMetrics. (The collection-wide snapshot lock lives in the
 // db package, which keeps its own counter -- see db.OpStats.)
 type opMetrics struct {
-	compact opCounter // Compact() reclaiming dead space
-	retrain opCounter // dictionary retrain + rewrite
-	reindex opCounter // index rebuild
+	compact    opCounter // Compact() reclaiming dead space
+	retrain    opCounter // dictionary retrain + rewrite
+	reindex    opCounter // index rebuild
+	commitSync opCounter // per-commit durability wall time (the parallel shard-sync phase)
 }
 
 // OpStat is one operation's cumulative call count and total wall-nanoseconds. Both
@@ -137,9 +138,15 @@ type OpStats struct {
 	ShardWriteHold OpStat `json:"shardWriteHold"`
 	SegmentAlloc   OpStat `json:"segmentAlloc"`
 	Sync           OpStat `json:"sync"`
-	Compact        OpStat `json:"compact"`
-	Retrain        OpStat `json:"retrain"`
-	Reindex        OpStat `json:"reindex"`
+	// CommitSync is the per-commit durability wall time: how long a Txn.Commit blocked
+	// flushing all of its shards to disk. Since those shard flushes now run in parallel,
+	// this is the commit's critical path (≈ the slowest shard), which the per-shard Sync
+	// total -- now the summed fsync WORK, not the latency -- no longer reveals. Count is
+	// the number of durable commits; Nanos/Count is mean commit durability latency.
+	CommitSync OpStat `json:"commitSync,omitempty"`
+	Compact    OpStat `json:"compact"`
+	Retrain    OpStat `json:"retrain"`
+	Reindex    OpStat `json:"reindex"`
 }
 
 // add accumulates one shard's counters into the snapshot.

--- a/collections/stats.go
+++ b/collections/stats.go
@@ -56,6 +56,7 @@ func (c *Collection) OpStats() OpStats {
 	for _, sh := range c.shards {
 		s.add(&sh.metrics)
 	}
+	s.CommitSync = c.opm.commitSync.snapshot()
 	s.Compact = c.opm.compact.snapshot()
 	s.Retrain = c.opm.retrain.snapshot()
 	s.Reindex = c.opm.reindex.snapshot()

--- a/collections/txn.go
+++ b/collections/txn.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/PelicanPlatform/classad/classad"
 )
@@ -349,17 +350,24 @@ func (tx *Txn) Commit() CommitResult {
 				toSync = append(toSync, c.idx)
 			}
 		}
-		switch len(toSync) {
-		case 0:
-		case 1:
-			tx.c.shards[toSync[0]].sync()
-		default:
-			var wg sync.WaitGroup
-			wg.Add(len(toSync))
-			for _, idx := range toSync {
-				go func(sh *shard) { defer wg.Done(); sh.sync() }(tx.c.shards[idx])
+		if len(toSync) > 0 {
+			// Time the whole durability phase as ONE observation: with the shard syncs
+			// running in parallel this is the commit's critical path (≈ the slowest shard),
+			// the true commit durability latency. The per-shard Sync counter still records
+			// each msync, but its total is now fsync WORK, not this latency -- so measure
+			// the wall time here explicitly (commitSync).
+			syncStart := time.Now()
+			if len(toSync) == 1 {
+				tx.c.shards[toSync[0]].sync()
+			} else {
+				var wg sync.WaitGroup
+				wg.Add(len(toSync))
+				for _, idx := range toSync {
+					go func(sh *shard) { defer wg.Done(); sh.sync() }(tx.c.shards[idx])
+				}
+				wg.Wait()
 			}
-			wg.Wait()
+			tx.c.opm.commitSync.observe(time.Since(syncStart))
 		}
 	}
 

--- a/collections/txn_parallelsync_test.go
+++ b/collections/txn_parallelsync_test.go
@@ -60,4 +60,18 @@ func TestTxnCommitParallelSync(t *testing.T) {
 	}
 	t.Logf("commit synced %d shards, up to %d concurrently, in %v (serial would be ~%v)",
 		nc, mc, elapsed, time.Duration(nc)*hold)
+
+	// The per-commit durability wall time (commitSync) is recorded once for this commit,
+	// and reflects the CRITICAL PATH (~one hold), not the summed per-shard sync work.
+	cs := c.OpStats().CommitSync
+	if cs.Count != 1 {
+		t.Fatalf("CommitSync.Count = %d, want 1 (one durable commit)", cs.Count)
+	}
+	if cs.Nanos < int64(hold) {
+		t.Fatalf("CommitSync.Nanos = %dns, want >= one hold (%v)", cs.Nanos, hold)
+	}
+	// It is the critical path, not the sum: far below nc parallel holds run serially.
+	if cs.Nanos >= int64(time.Duration(nc)*hold) {
+		t.Fatalf("CommitSync.Nanos = %dns (~%v); expected the parallel critical path, not the serial sum", cs.Nanos, time.Duration(cs.Nanos))
+	}
 }


### PR DESCRIPTION
## Make commit durability latency visible again after parallel fsync

Parallelizing a commit's shard syncs (v0.16.1) had a side effect on observability: the
per-shard `Sync` counter's total is now the summed fsync **work**, not the commit
**latency**. A commit blocks for its **critical path** (~the slowest shard), but `Sync`
sums every shard's msync -- so the actual durability latency (what the collector's
`rpc_commit_seconds` is chasing) disappeared from the store's own stats. (You flagged
exactly this: "some of the fsync issue got hidden behind doing several in sequence.")

**Change:** add a collection-wide `commitSync` counter, observed **once per durable
`Txn.Commit`** around the whole parallel-sync phase. `Count` = durable commits;
`Nanos/Count` = mean durability latency; `MaxNanos`+buckets = the tail. Exposed as
`OpStats.CommitSync` (`db.OpStats` gets it via embedding). `TestTxnCommitParallelSync`
now also asserts `CommitSync` is the critical path, well under the serial sum.

**Follow-up (with the htcondordb classad bump):** add `{"commit_sync", o.CommitSync}` to
`opStatList` in `htcondordb/metrics/metrics.go` so it appears on `/metrics` as
`op="commit_sync"` -- then it can be compared directly against `rpc_commit_seconds`.

Full collections suite + `-race` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)