### PR TITLE
classad: MarshalOld renders values with old-format string escaping

### DIFF
--- a/classad/classad.go
+++ b/classad/classad.go
@@ -420,7 +420,11 @@ func (c *ClassAd) marshalOld(includePrivate bool) string {
 		first = false
 		b.WriteString(unparseAttrName(attr.Name))
 		b.WriteString(" = ")
-		b.WriteString(attr.Value.String())
+		// Render the value in OLD-ClassAd form: string literals escape only the delimiter
+		// (backslashes/control chars verbatim), matching the C++ old-format unparser and the
+		// lenient old-format lexer -- so a value like a path or regex round-trips instead of
+		// gaining a backslash each hop. attr.Value.String() would use new-format escaping.
+		b.WriteString(unparseExprStringOld(attr.Value))
 	}
 	return b.String()
 }

--- a/classad/introspection_test.go
+++ b/classad/introspection_test.go
@@ -161,9 +161,11 @@ func TestMarshalOld(t *testing.T) {
 			expected: "Name = \"worker-01\"",
 		},
 		{
-			name:     "with expressions",
+			name: "with expressions",
+			// The source has no parentheses, so the C++ old-format unparser adds none
+			// (it echoes only source parens); MarshalOld now matches that.
 			input:    "[x = 10; y = x * 2]",
-			expected: "x = 10\ny = (x * 2)",
+			expected: "x = 10\ny = x * 2",
 		},
 		{
 			name:     "empty classad",

--- a/classad/marshalold_escape_test.go
+++ b/classad/marshalold_escape_test.go
@@ -1,0 +1,64 @@
+package classad
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestMarshalOldStringEscaping verifies MarshalOld uses old-ClassAd string escaping
+// (only the delimiter is escaped; backslashes and control characters are emitted verbatim,
+// matching C++ ClassAdUnParser with SetOldClassAd and the lenient old-format lexer). The
+// bug was strict new-format escaping, which grew a backslash on every parse->marshal hop
+// (a Windows path or regex value gaining `\` each time it was served).
+func TestMarshalOldStringEscaping(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+		// wantContains is a substring the MarshalOld output must contain verbatim.
+		wantContains string
+	}{
+		{"windows path", `Path = "C:\bin\condor"`, `Path = "C:\bin\condor"`},
+		{"regex backslash", `Pat = "host\d+\.example"`, `Pat = "host\d+\.example"`},
+		{"escaped quote", `Q = "say \"hi\""`, `Q = "say \"hi\""`},
+		{"nested in expr", `Req = Machine == "C:\slot"`, `Machine == "C:\slot"`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ad, err := ParseOld(tc.src)
+			if err != nil {
+				t.Fatalf("ParseOld(%q): %v", tc.src, err)
+			}
+			out := ad.MarshalOld()
+			if !strings.Contains(out, tc.wantContains) {
+				t.Fatalf("MarshalOld = %q, want it to contain %q (old-format escaping)", out, tc.wantContains)
+			}
+		})
+	}
+}
+
+// TestMarshalOldRoundTripIdempotent checks ParseOld -> MarshalOld is idempotent for values
+// with backslashes and nested string literals -- the escape asymmetry the fuzzer found.
+func TestMarshalOldRoundTripIdempotent(t *testing.T) {
+	srcs := []string{
+		`X = "C:\foo"`,
+		`X = "a\\b"`,
+		`X = "re\d+"`,
+		`Y = "plain"`,
+		`Req = (OpSys == "LINUX") && (Path == "C:\bin")`,
+		`Name = "slot1@h"` + "\n" + `Regexp = "^user\d+$"`,
+	}
+	for _, src := range srcs {
+		ad, err := ParseOld(src)
+		if err != nil {
+			t.Fatalf("ParseOld(%q): %v", src, err)
+		}
+		m1 := ad.MarshalOld()
+		ad2, err := ParseOld(m1)
+		if err != nil {
+			t.Fatalf("re-parse of %q failed: %v", m1, err)
+		}
+		if m2 := ad2.MarshalOld(); m1 != m2 {
+			t.Fatalf("MarshalOld not idempotent:\n  src: %q\n  m1:  %q\n  m2:  %q", src, m1, m2)
+		}
+	}
+}

--- a/classad/unparse.go
+++ b/classad/unparse.go
@@ -30,21 +30,37 @@ var unaryOpUnparse = map[string]string{
 	"-": " -", "+": " +", "!": " !", "~": " ~",
 }
 
-// unparseExprString renders an AST expression in reference (sink) form.
+// unparseExprString renders an AST expression in reference (sink) form (new ClassAd).
 func unparseExprString(e ast.Expr) string {
 	var b strings.Builder
-	unparseExpr(&b, e)
+	unparseExpr(&b, e, false)
 	return b.String()
 }
 
-func unparseExpr(b *strings.Builder, e ast.Expr) {
+// unparseExprStringOld renders an AST expression in OLD-ClassAd form: identical to the
+// reference form EXCEPT string literals use old-format escaping -- only the delimiter is
+// escaped, and backslashes and control characters are emitted verbatim. This matches the
+// C++ ClassAdUnParser with SetOldClassAd (src/classad/sink.cpp: the escape switch is
+// skipped for oldClassAd) and the lenient old-format lexer, so a value like a Windows path
+// or a regex round-trips unchanged instead of gaining a backslash each hop. See marshalOld.
+func unparseExprStringOld(e ast.Expr) string {
+	var b strings.Builder
+	unparseExpr(&b, e, true)
+	return b.String()
+}
+
+func unparseExpr(b *strings.Builder, e ast.Expr, old bool) {
 	switch v := e.(type) {
 	case *ast.IntegerLiteral:
 		b.WriteString(strconv.FormatInt(v.Value, 10))
 	case *ast.RealLiteral:
 		b.WriteString(classadReal(v.Value))
 	case *ast.StringLiteral:
-		b.WriteString(unparseString(v.Value))
+		if old {
+			b.Write(ast.AppendQuoteStringOld(nil, v.Value))
+		} else {
+			b.WriteString(unparseString(v.Value))
+		}
 	case *ast.BooleanLiteral:
 		if v.Value {
 			b.WriteString("true")
@@ -69,31 +85,31 @@ func unparseExpr(b *strings.Builder, e ast.Expr) {
 		// Explicit source parentheses are echoed verbatim (around any
 		// expression, and nested), matching the reference engine.
 		b.WriteByte('(')
-		unparseExpr(b, v.Inner)
+		unparseExpr(b, v.Inner, old)
 		b.WriteByte(')')
 	case *ast.BinaryOp:
-		unparseExpr(b, v.Left)
+		unparseExpr(b, v.Left, old)
 		b.WriteString(binaryOpUnparse[v.Op])
-		unparseExpr(b, v.Right)
+		unparseExpr(b, v.Right, old)
 	case *ast.UnaryOp:
-		unparseUnary(b, v)
+		unparseUnary(b, v, old)
 	case *ast.ConditionalExpr:
-		unparseExpr(b, v.Condition)
+		unparseExpr(b, v.Condition, old)
 		b.WriteString(" ? ")
-		unparseExpr(b, v.TrueExpr)
+		unparseExpr(b, v.TrueExpr, old)
 		b.WriteString(" : ")
-		unparseExpr(b, v.FalseExpr)
+		unparseExpr(b, v.FalseExpr, old)
 	case *ast.ElvisExpr:
-		unparseExpr(b, v.Left)
+		unparseExpr(b, v.Left, old)
 		b.WriteString(" ?: ")
-		unparseExpr(b, v.Right)
+		unparseExpr(b, v.Right, old)
 	case *ast.ListLiteral:
 		b.WriteString("{ ")
 		for i, el := range v.Elements {
 			if i > 0 {
 				b.WriteByte(',')
 			}
-			unparseExpr(b, el)
+			unparseExpr(b, el, old)
 		}
 		b.WriteString(" }")
 	case *ast.FunctionCall:
@@ -103,16 +119,16 @@ func unparseExpr(b *strings.Builder, e ast.Expr) {
 			if i > 0 {
 				b.WriteByte(',')
 			}
-			unparseExpr(b, a)
+			unparseExpr(b, a, old)
 		}
 		b.WriteByte(')')
 	case *ast.SubscriptExpr:
-		unparseExpr(b, v.Container)
+		unparseExpr(b, v.Container, old)
 		b.WriteByte('[')
-		unparseExpr(b, v.Index)
+		unparseExpr(b, v.Index, old)
 		b.WriteByte(']')
 	case *ast.SelectExpr:
-		unparseExpr(b, v.Record)
+		unparseExpr(b, v.Record, old)
 		// A bare numeric literal before '.' would re-lex as a real ("0.A"),
 		// so separate it with a space. The selected attribute is quoted when
 		// it is not a bare identifier (e.g. a keyword like 'true').
@@ -123,7 +139,7 @@ func unparseExpr(b *strings.Builder, e ast.Expr) {
 		b.WriteByte('.')
 		b.WriteString(unparseAttrName(v.Attr))
 	case *ast.RecordLiteral:
-		unparseRecord(b, v.ClassAd)
+		unparseRecord(b, v.ClassAd, old)
 	default:
 		b.WriteString("error")
 	}
@@ -132,7 +148,7 @@ func unparseExpr(b *strings.Builder, e ast.Expr) {
 // unparseUnary handles the reference engine's special-case folding of a unary
 // +/- applied directly to a numeric literal into a signed literal ("(-5)"),
 // while any other unary operand keeps the leading-space operator ("( -a)").
-func unparseUnary(b *strings.Builder, v *ast.UnaryOp) {
+func unparseUnary(b *strings.Builder, v *ast.UnaryOp, old bool) {
 	// Only unary MINUS on a numeric literal folds into a signed literal
 	// ("(-5)"): the reference lexer makes "-5" a negative literal but keeps
 	// "+5" as a unary plus, so unary plus is never folded (and a non-literal
@@ -154,11 +170,11 @@ func unparseUnary(b *strings.Builder, v *ast.UnaryOp) {
 		}
 	}
 	b.WriteString(unaryOpUnparse[v.Op])
-	unparseExpr(b, v.Expr)
+	unparseExpr(b, v.Expr, old)
 }
 
 // unparseRecord renders a nested ClassAd literal as "[ a = x; b = y ]".
-func unparseRecord(b *strings.Builder, ad *ast.ClassAd) {
+func unparseRecord(b *strings.Builder, ad *ast.ClassAd, old bool) {
 	b.WriteString("[ ")
 	for i, attr := range ad.Attributes {
 		if i > 0 {
@@ -166,7 +182,7 @@ func unparseRecord(b *strings.Builder, ad *ast.ClassAd) {
 		}
 		b.WriteString(unparseAttrName(attr.Name))
 		b.WriteString(" = ")
-		unparseExpr(b, attr.Value)
+		unparseExpr(b, attr.Value, old)
 	}
 	b.WriteString(" ]")
 }


### PR DESCRIPTION
## Fix: MarshalOld over-escaped string values (backslashes grew each hop)

`MarshalOld` rendered values via `ast.Expr.String()` (new-ClassAd escaping), so a string
value with a backslash gained one on every parse→marshal hop — a Windows path or regex came
back as `C:\\bin`, `host\\d+`. (Found by the old-format round-trip fuzzer from #68.)

**Fix:** route `MarshalOld`'s value rendering through the classad reference unparser
(`unparse.go`, validated against C++ `string({...})`) with a new old-format flag. String
literals get old-ClassAd escaping — **only the delimiter is escaped; backslashes and control
chars verbatim** — matching C++ `ClassAdUnParser` under `SetOldClassAd` (`sink.cpp` skips
the C-escape switch for old format) and the lenient old-format lexer. Threads through
**nested** string literals too (a path inside a `Requirements` clause).

### Side effect (also toward C++ fidelity)
Because values now render through the C++-reference unparser rather than `ast.String()`,
`MarshalOld` also stops inserting the **spurious parentheses** `ast.String()` added (C++
echoes only source parens): `y = x * 2` no longer becomes `y = (x * 2)`. One introspection
test that captured the old paren-adding output is updated.

### Scope / safety
- **Not the collector's live serving path** — that renders via `collections/rawdecode`
  (already correct with `ast.AppendQuoteStringOld`). `MarshalOld` feeds the CGO C-API and
  tooling, which now get C++-faithful output.
- Composes with #68 (adjacent name-rendering line).
- Fuzzing also confirmed the fix resolves the earlier control-char cases; remaining
  non-idempotencies are inherent C++/old-format traits (embedded newline in a value;
  `--0`→` -0`→`0` double-negative folding — both exactly what C++ does), not escaping bugs.

Tests: `TestMarshalOldStringEscaping`, `TestMarshalOldRoundTripIdempotent`. Full classad +
parser + db suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)