### PR TITLE
dbrpc: per-call timing Observer to localize round-trip stalls

### DIFF
--- a/collections/compact.go
+++ b/collections/compact.go
@@ -192,6 +192,12 @@ func (c *Collection) Rewrite() int {
 // shard so existing records are recompressed under the new dictionary. In-flight
 // scans are unaffected: they decode retired segments with the codec those
 // segments were written under (recorded per segment). Returns the dictionary size.
+// retrainStallHook, when non-nil, is invoked once mid-retrain (after the codec swap,
+// before recompaction) while holding NO collection lock. It is an unexported test seam
+// (see retrain_stall_test.go) for observing how a long-running retrain affects concurrent
+// transactions; production leaves it nil.
+var retrainStallHook func()
+
 func (c *Collection) RetrainDict(sampleMax int) (int, error) {
 	start := time.Now()
 	defer func() { c.opm.retrain.observe(time.Since(start)) }()
@@ -210,6 +216,9 @@ func (c *Collection) RetrainDict(sampleMax int) (int, error) {
 		return 0, err
 	}
 	c.codec.Store(&codecHolder{codec}) // new writes use the new codec
+	if retrainStallHook != nil {
+		retrainStallHook() // test seam: observe concurrent access during a long retrain
+	}
 	for _, sh := range c.shards {
 		c.compactShard(sh, codec) // recompress to the new codec
 	}

--- a/collections/retrain_stall_test.go
+++ b/collections/retrain_stall_test.go
@@ -1,0 +1,85 @@
+package collections
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+// TestRetrainDoesNotBlockConcurrentAccess asserts that a dictionary retrain holds no lock
+// that a concurrent transaction (Begin/Put/Commit) or read (Get) needs. RetrainDict swaps
+// the codec atomically and recompacts shard-by-shard under only brief per-shard locks, so
+// writers and readers must proceed throughout -- the property the store's design relies on.
+//
+// The retrainStallHook makes one retrain observably long (a full second, holding NO
+// collection lock) so a wide, deterministic window overlaps it. If retrain blocked any of
+// these operations via a shared lock, their worst-case latency would approach the stall
+// duration; the assertion is that they stay orders of magnitude below it.
+//
+// This is the regression record for the collector "slow batch-flush during retrain"
+// investigation: the flush stall was NOT a retrain lock (proven here), which redirected the
+// hunt to the RPC round-trip's send/wait phases.
+func TestRetrainDoesNotBlockConcurrentAccess(t *testing.T) {
+	const stall = 1 * time.Second
+
+	sample := loadCorpus(t)
+	c := populate(t, sample, 3000)
+
+	started := make(chan struct{})
+	retrainStallHook = func() {
+		close(started)
+		time.Sleep(stall)
+	}
+	defer func() { retrainStallHook = nil }()
+
+	retrainDone := make(chan struct{})
+	go func() {
+		if _, err := c.RetrainDict(2000); err != nil {
+			t.Errorf("RetrainDict: %v", err)
+		}
+		close(retrainDone)
+	}()
+
+	<-started // retrain is now inside the stalled section
+
+	var maxBegin, maxCommit, maxGet time.Duration
+	probes := 0
+	deadline := time.Now().Add(stall - 100*time.Millisecond)
+	for time.Now().Before(deadline) {
+		t0 := time.Now()
+		tx := c.Begin()
+		if d := time.Since(t0); d > maxBegin {
+			maxBegin = d
+		}
+		tx.Put([]byte(fmt.Sprintf("probe.%d", probes)), mustAd(t, `[ Name = "probe@host"; State = "Claimed" ]`))
+		t1 := time.Now()
+		if res := tx.Commit(); res.Conflicted() {
+			t.Fatalf("probe commit conflicted: %v", res.Conflicts)
+		}
+		if d := time.Since(t1); d > maxCommit {
+			maxCommit = d
+		}
+
+		t2 := time.Now()
+		_, _ = c.Get([]byte("probe.0"))
+		if d := time.Since(t2); d > maxGet {
+			maxGet = d
+		}
+		probes++
+	}
+
+	<-retrainDone
+	t.Logf("during a %v retrain stall: %d probes; max Begin=%v  max Commit=%v  max Get=%v",
+		stall, probes, maxBegin, maxCommit, maxGet)
+
+	limit := stall / 5
+	if maxBegin > limit {
+		t.Errorf("Begin blocked %v during retrain (limit %v) -- retrain holds a lock writers need", maxBegin, limit)
+	}
+	if maxCommit > limit {
+		t.Errorf("Commit blocked %v during retrain (limit %v)", maxCommit, limit)
+	}
+	if maxGet > limit {
+		t.Errorf("Get blocked %v during retrain (limit %v)", maxGet, limit)
+	}
+}

--- a/dbrpc/client.go
+++ b/dbrpc/client.go
@@ -31,6 +31,26 @@ type Client struct {
 	mu       sync.Mutex
 	pending  map[uint64]*pending
 	closeErr error
+
+	// Observer, if set before use, receives a timing breakdown for each completed unary
+	// call. It lets an embedder (e.g. a collector's Prometheus metrics) localize where a
+	// round-trip spends its time -- client-side write-lock contention, the socket write
+	// (TCP backpressure when the server stops reading), or the server+return wait --
+	// without this package depending on any metrics library. Must not block.
+	Observer func(CallStats)
+}
+
+// CallStats is the per-call timing breakdown delivered to Client.Observer. The three
+// durations partition a unary round-trip and pinpoint a stall: a large WriteWait means
+// another sender held the single-writer lock; a large Send means conn.WriteMsg itself
+// blocked (the socket's send buffer filled because the peer was not reading -- comms/server
+// backpressure, not this client); a large Wait means the request left promptly but the
+// server (or return path) was slow.
+type CallStats struct {
+	Op        uint8         // request op byte (see OpName)
+	WriteWait time.Duration // blocked acquiring the write lock (another send ahead)
+	Send      time.Duration // in conn.WriteMsg -- getting the request onto the wire
+	Wait      time.Duration // from send complete to response received
 }
 
 // pending is a waiting call: a unary call's channel receives exactly one frame; a
@@ -46,6 +66,22 @@ func NewClient(conn MsgConn) *Client {
 	c := &Client{conn: conn, pending: make(map[uint64]*pending)}
 	go c.readLoop()
 	return c
+}
+
+// OpName maps a CallStats.Op byte to a short stable label for the write-path ops a
+// collector times (begin/commit/batch); anything else returns "op<N>". Used to label the
+// per-call timing metrics without exposing the op constants.
+func OpName(op uint8) string {
+	switch op {
+	case 1:
+		return "begin"
+	case 2:
+		return "commit"
+	case 44:
+		return "batch"
+	default:
+		return fmt.Sprintf("op%d", op)
+	}
 }
 
 func (c *Client) readLoop() {
@@ -101,15 +137,20 @@ func (c *Client) Close() error { return c.conn.Close() }
 // is no implicit timeout -- the deadline is exactly whatever ctx carries.
 func (c *Client) callCtx(ctx context.Context, build func(reqID uint64) []byte) (int32, *reader, error) {
 	id := c.nextReq.Add(1)
-	ch, err := c.sendID(id, build, false)
+	ch, st, err := c.sendIDTimed(id, build, false)
 	if err != nil {
 		return 0, nil, err
 	}
+	sentAt := time.Now()
 	select {
 	case <-ctx.Done():
 		c.cancelPending(id)
 		return 0, nil, ctx.Err()
 	case frame, ok := <-ch:
+		if obs := c.Observer; obs != nil {
+			st.Wait = time.Since(sentAt)
+			obs(st)
+		}
 		if !ok {
 			return 0, nil, c.closeErr
 		}
@@ -148,6 +189,15 @@ func (c *Client) send(build func(reqID uint64) []byte, stream bool) (chan []byte
 }
 
 func (c *Client) sendID(id uint64, build func(reqID uint64) []byte, stream bool) (chan []byte, error) {
+	ch, _, err := c.sendIDTimed(id, build, stream)
+	return ch, err
+}
+
+// sendIDTimed is sendID with a timing breakdown (write-lock wait + socket write) filled
+// into the returned CallStats. callCtx completes it with the response wait and hands it to
+// the Observer; other callers ignore it. The timing reads are unconditional but trivial
+// (two time.Now calls), so there is no fast path to branch on.
+func (c *Client) sendIDTimed(id uint64, build func(reqID uint64) []byte, stream bool) (chan []byte, CallStats, error) {
 	bufSize := 1
 	if stream {
 		bufSize = 256
@@ -157,23 +207,31 @@ func (c *Client) sendID(id uint64, build func(reqID uint64) []byte, stream bool)
 	if c.closeErr != nil {
 		err := c.closeErr
 		c.mu.Unlock()
-		return nil, err
+		return nil, CallStats{}, err
 	}
 	c.pending[id] = &pending{ch: ch, stream: stream}
 	c.mu.Unlock()
 	// Serialize the actual send: the CEDAR stream is single-writer (shared frame buffer
 	// + AES-GCM nonce), so concurrent multiplexed calls must not interleave WriteMsg.
 	frame := build(id)
+	var st CallStats
+	if o, ok := frameOp(frame); ok {
+		st.Op = uint8(o)
+	}
+	t0 := time.Now()
 	c.writeMu.Lock()
+	st.WriteWait = time.Since(t0)
+	t1 := time.Now()
 	err := c.conn.WriteMsg(frame)
+	st.Send = time.Since(t1)
 	c.writeMu.Unlock()
 	if err != nil {
 		c.mu.Lock()
 		delete(c.pending, id)
 		c.mu.Unlock()
-		return nil, err
+		return nil, st, err
 	}
-	return ch, nil
+	return ch, st, nil
 }
 
 func statusErr(status int32, body *reader) error {

--- a/dbrpc/proto.go
+++ b/dbrpc/proto.go
@@ -259,6 +259,15 @@ func frameReqID(frame []byte) (uint64, bool) {
 	return binary.LittleEndian.Uint64(frame), true
 }
 
+// frameOp reads the op byte of a request frame ([reqID u64][op u8]) without allocating a
+// reader -- cheap enough for the per-call timing seam. Returns false if the frame is short.
+func frameOp(frame []byte) (op, bool) {
+	if len(frame) < 9 {
+		return 0, false
+	}
+	return op(frame[8]), true
+}
+
 func putBytes(b, v []byte) []byte {
 	b = binary.LittleEndian.AppendUint32(b, uint32(len(v)))
 	return append(b, v...)


### PR DESCRIPTION
## Why
Chasing a collector symptom: `batch_flush_seconds` spikes to 3–40s while `rpc_batch_write_seconds` and `rpc_commit_seconds` stay <0.5s and retries/backoff are zero — the stall lives in the **unmeasured `BeginTable` round-trip**, correlating 1:1 with the remote database's dictionary retrain.

A local test in this PR (`TestRetrainDoesNotBlockConcurrentAccess`) **disproves the obvious explanation**: retrain holds no lock a concurrent `Begin`/`Put`/`Commit`/`Get` needs (~19k probes sail through a 1s retrain at µs latency). So the stall is not a server lock — it is somewhere in the round-trip, and we could not see where.

## What
- **`Client.Observer` hook + `CallStats`** — an optional per-call timing breakdown of every unary RPC into three phases that partition a round-trip and localize a stall:
  - `WriteWait` — blocked on the single-writer lock (another send ahead → **client**)
  - `Send` — time in `conn.WriteMsg` (spikes = TCP backpressure because the peer stopped reading → **comms**)
  - `Wait` — send-complete → response received (**server** / return path)
- No Prometheus/metrics dependency enters this library — the embedder supplies the recording func. Adds a cheap `frameOp` accessor and an `OpName` label helper.
- **`TestRetrainDoesNotBlockConcurrentAccess`** (collections) + a nil-guarded `retrainStallHook` seam — the regression record that retrain is non-blocking for writers/readers.

## Consumer
`golang-collector` wires `Observer` on each write lane and exposes `rpc_begin_seconds` + `rpc_call_phase_seconds{op,phase}` (separate PR). Needs a tag + a collector `go.mod` bump to deploy.

## Test
- `dbrpc` builds; `collections` test passes (~19k probes, max Begin=47µs during a 1s retrain).
