### PR TITLE
Raw read path: source-side redaction + in-walk projection with a hot fast path

### DIFF
--- a/classad/private.go
+++ b/classad/private.go
@@ -38,7 +38,30 @@ const privateV2Prefix = "_condor_priv"
 // IsPrivateAttributeV1 reports whether name is one of HTCondor's fixed private
 // attributes (a claim capability or transfer key).
 func IsPrivateAttributeV1(name string) bool {
-	_, ok := privateAttrsV1[strings.ToLower(name)]
+	// This predicate runs on every attribute of every ad a collector serves, so it
+	// avoids the strings.ToLower allocation (attribute names are usually mixed-case,
+	// so ToLower would allocate a fresh lower-case string each call). Every V1
+	// private name is 7-13 bytes and begins with c/C or t/T; the vast majority of
+	// attributes fail that gate and never reach the map lookup.
+	if len(name) < 7 || len(name) > 13 {
+		return false
+	}
+	switch name[0] {
+	case 'c', 'C', 't', 'T':
+	default:
+		return false
+	}
+	// Case-fold into a stack buffer; a map lookup keyed by string(buf[:n]) is
+	// special-cased by the compiler to avoid a heap allocation.
+	var buf [13]byte
+	for i := 0; i < len(name); i++ {
+		b := name[i]
+		if b >= 'A' && b <= 'Z' {
+			b += 'a' - 'A'
+		}
+		buf[i] = b
+	}
+	_, ok := privateAttrsV1[string(buf[:len(name)])]
 	return ok
 }
 

--- a/collections/archive.go
+++ b/collections/archive.go
@@ -160,7 +160,7 @@ func newArchiveShell(opts ArchiveOptions) (*Archive, error) {
 		dir:     opts.Dir,
 		segSize: recAlign(segSize),
 		codec:   codec,
-		intern:  wire.NewInternTable(),
+		intern:  wire.NewInternTableWithPrivacy(classad.IsPrivateAttribute),
 		ret:     opts.Retention,
 		hub:     newArchiveWatchHub(),
 	}, nil

--- a/collections/rawdecode.go
+++ b/collections/rawdecode.go
@@ -29,6 +29,20 @@ type RawAd struct {
 // Inline-name (persistent) collections have no intern table, so QueryRaw yields
 // nothing for them; callers that must support those should use Query.
 func (c *Collection) QueryRaw(q *vm.Query) iter.Seq[RawAd] {
+	return c.queryRaw(q, false)
+}
+
+// QueryRawRedacted is QueryRaw with private (secret) attributes stripped from
+// every yielded ad, using the intern table's precomputed per-id private flags
+// (see wire.NewInternTableWithPrivacy): the redaction costs one bool check per
+// attribute and private nodes are never rendered at all. Use it to serve a
+// public query; QueryRaw preserves private attributes for trusted consumers
+// (e.g. the negotiator's private-ad query).
+func (c *Collection) QueryRawRedacted(q *vm.Query) iter.Seq[RawAd] {
+	return c.queryRaw(q, true)
+}
+
+func (c *Collection) queryRaw(q *vm.Query, redact bool) iter.Seq[RawAd] {
 	return func(yield func(RawAd) bool) {
 		plan := q.ReadPlan()
 		ws := &wireScope{ctx: c}
@@ -43,7 +57,7 @@ func (c *Collection) QueryRaw(q *vm.Query) iter.Seq[RawAd] {
 		probes := q.Probes()
 		c.demand.record(probes)
 		usable := c.planIndex(probes)
-		emit := c.yieldRaw(yield)
+		emit := c.yieldRaw(yield, redact)
 		for _, sh := range c.shards {
 			var cont bool
 			if len(usable) > 0 {
@@ -60,9 +74,19 @@ func (c *Collection) QueryRaw(q *vm.Query) iter.Seq[RawAd] {
 
 // ScanRaw is Scan, yielding every ad as RawAd (AST-free).
 func (c *Collection) ScanRaw() iter.Seq[RawAd] {
+	return c.scanRaw(false)
+}
+
+// ScanRawRedacted is ScanRaw with private attributes stripped (see
+// QueryRawRedacted).
+func (c *Collection) ScanRawRedacted() iter.Seq[RawAd] {
+	return c.scanRaw(true)
+}
+
+func (c *Collection) scanRaw(redact bool) iter.Seq[RawAd] {
 	return func(yield func(RawAd) bool) {
 		q := queryPlan{}
-		emit := c.yieldRaw(yield)
+		emit := c.yieldRaw(yield, redact)
 		for _, sh := range c.shards {
 			if !c.scanShard(sh, q, emit) {
 				return
@@ -75,14 +99,14 @@ func (c *Collection) ScanRaw() iter.Seq[RawAd] {
 // wire bytes straight to old-ClassAd text and yield them. The buf/offs/exprs
 // scratch is reused across the whole scan (single-threaded), so no per-ad
 // expression bytes are allocated.
-func (c *Collection) yieldRaw(yield func(RawAd) bool) func(w []byte) bool {
+func (c *Collection) yieldRaw(yield func(RawAd) bool, redact bool) func(w []byte) bool {
 	var buf []byte
 	var offs []int
 	var exprs [][]byte
 	return func(w []byte) bool {
 		var mt, tt string
 		var ok bool
-		buf, offs, mt, tt, ok = c.appendWireAd(w, buf, offs)
+		buf, offs, mt, tt, ok = c.appendWireAd(w, buf, offs, redact)
 		if !ok {
 			return true // undecodable record: skip, keep scanning
 		}
@@ -112,7 +136,7 @@ func (c *Collection) decodeAdRaw(stored []byte, codec Codec, dst []byte) (exprs 
 	if err != nil {
 		return nil, "", "", false
 	}
-	buf, offs, mt, tt, ok := c.appendWireAd(wireBytes, nil, nil)
+	buf, offs, mt, tt, ok := c.appendWireAd(wireBytes, nil, nil, false)
 	if !ok {
 		return nil, "", "", false
 	}
@@ -130,15 +154,17 @@ func (c *Collection) decodeAdRaw(stored []byte, codec Codec, dst []byte) (exprs 
 // as trailing fields, not numbered expressions). Passing the previous ad's buf/offs
 // reuses their backing, so a streaming scan allocates no per-ad expression strings.
 // Returns ok=false for inline-name ads (no intern table).
-func (c *Collection) appendWireAd(wireBytes []byte, buf []byte, offs []int) (outBuf []byte, outOffs []int, myType, targetType string, ok bool) {
+func (c *Collection) appendWireAd(wireBytes []byte, buf []byte, offs []int, redact bool) (outBuf []byte, outOffs []int, myType, targetType string, ok bool) {
 	buf = buf[:0]
 	offs = append(offs[:0], 0)
 	// ForEachNamed handles both encodings: an inline (persistent) ad yields its
 	// stored names and the intern table is ignored; an interned ad resolves ids
 	// through it. Values render with the matching decoder (inline nodes carry
-	// inline names too).
+	// inline names too). The redacting variant strips private attributes as it
+	// de-interns -- a per-id flag check, so the redacted response costs no
+	// name re-classification and private values are never rendered.
 	good := true
-	wire.Ad(wireBytes).ForEachNamed(c.intern, func(name string, node []byte) bool {
+	emit := func(name string, node []byte) bool {
 		if name == "MyType" || name == "TargetType" {
 			if lit, lok := wire.LiteralValue(node); lok && lit.Kind == wire.LitString {
 				if name == "MyType" {
@@ -163,7 +189,12 @@ func (c *Collection) appendWireAd(wireBytes []byte, buf []byte, offs []int) (out
 		}
 		offs = append(offs, len(buf))
 		return true
-	})
+	}
+	if redact {
+		wire.Ad(wireBytes).ForEachNamedRedact(c.intern, emit)
+	} else {
+		wire.Ad(wireBytes).ForEachNamed(c.intern, emit)
+	}
 	if !good {
 		return buf, offs, "", "", false
 	}

--- a/collections/rawprojected.go
+++ b/collections/rawprojected.go
@@ -1,0 +1,431 @@
+package collections
+
+import (
+	"iter"
+	"strings"
+
+	"github.com/PelicanPlatform/classad/classad"
+	"github.com/PelicanPlatform/classad/collections/vm"
+	"github.com/PelicanPlatform/classad/collections/wire"
+)
+
+// ScanRawProjected is ScanRaw restricted to the projected attribute names,
+// applied INSIDE the wire walk: the projection is resolved to interned ids once
+// per scan, and each ad is walked as raw (id, node) pairs -- a non-projected
+// attribute costs one id comparison and a TLV length hop, and is never name-
+// resolved or rendered. For a typical monitoring projection (10-20 attributes of
+// a several-hundred-attribute ad) this skips the overwhelming majority of the
+// per-ad decode work that a decode-everything-then-filter projection pays.
+//
+// chaseRefs additionally resolves each emitted expression's attribute
+// references against the same ad (transitively, per ad -- an "elevator" of
+// linear passes that repeats only while new references surface), so a projected
+// ad evaluates self-contained. HTCondor's query protocol sends exactly the
+// requested attributes, so a protocol-compatible server passes false.
+//
+// redact strips private attributes exactly as ScanRawRedacted does. An empty
+// projection means no attribute filter (the whole ad, matching QueryRawProject
+// semantics upstream). Inline-name collections yield nothing, as with ScanRaw.
+func (c *Collection) ScanRawProjected(projection []string, chaseRefs, redact bool) iter.Seq[RawAd] {
+	return func(yield func(RawAd) bool) {
+		p := c.newRawProjector(projection, chaseRefs, redact)
+		emit := c.yieldRawProjected(yield, p)
+		q := queryPlan{}
+		for _, sh := range c.shards {
+			if !c.scanShard(sh, q, emit) {
+				return
+			}
+		}
+	}
+}
+
+// QueryRawProjected is QueryRaw with the same in-walk projection as
+// ScanRawProjected (see there for chaseRefs/redact).
+func (c *Collection) QueryRawProjected(q *vm.Query, projection []string, chaseRefs, redact bool) iter.Seq[RawAd] {
+	return func(yield func(RawAd) bool) {
+		p := c.newRawProjector(projection, chaseRefs, redact)
+		emit := c.yieldRawProjected(yield, p)
+		plan := q.ReadPlan()
+		ws := &wireScope{ctx: c}
+		qp := queryPlan{
+			q:        q,
+			plan:     plan,
+			m:        q.Matcher(),
+			wireOK:   q.Native() && plan.PartialSafe,
+			ws:       ws,
+			resolver: ws.resolve,
+		}
+		probes := q.Probes()
+		c.demand.record(probes)
+		usable := c.planIndex(probes)
+		for _, sh := range c.shards {
+			var cont bool
+			if len(usable) > 0 {
+				cont = c.scanShardIndexed(sh, usable, qp, emit)
+			} else {
+				cont = c.scanShard(sh, qp, emit)
+			}
+			if !cont {
+				return
+			}
+		}
+	}
+}
+
+// rawTypeFieldNames are the type fields every raw response lifts into RawAd;
+// recorded as read demand so the hot set learns to front-load them.
+var rawTypeFieldNames = []string{"MyType", "TargetType"}
+
+// rawProjector is one projected scan's state: the base wanted-id set (resolved
+// from the projection once) plus per-ad scratch recycled across every ad of the
+// scan. Per-ad membership uses a generation counter (gen bumps each ad; slot ==
+// gen means "this ad") so nothing is cleared between ads.
+type rawProjector struct {
+	c         *Collection
+	chaseRefs bool
+	redact    bool
+
+	wantAll   bool   // empty projection: no attribute filter (redaction still applies)
+	want      []bool // base wanted set, indexed by intern id; immutable during the scan
+	wantCount int    // number of distinct resolved wanted ids (the hot fast path's target)
+
+	// Inline (persistent) collections store attribute names in the ad body, not
+	// interned ids, so their wanted set is name-based: the projected names (deduped
+	// case-insensitively, private ones pre-dropped under redact) with precomputed
+	// fold hashes -- matched hash-first against entries and hot pairs, then
+	// verified with a case-insensitive byte compare (hashes can collide).
+	inline   bool
+	inNames  []string
+	inHashes []uint32
+	inDone   []uint32 // gen-marked per projected name (see gen)
+
+	haveMyType, haveTargetType bool
+	myTypeID, targetTypeID     uint32
+
+	gen        uint32
+	wantGen    []uint32 // ref-closure additions for the current ad (slot == gen)
+	doneGen    []uint32 // ids already emitted for the current ad (slot == gen)
+	refs       []uint32 // per-node reference-id scratch
+	hotScratch []uint32 // hot-header pair scratch (ForEachHotBuf), reused across ads
+
+	buf   []byte
+	offs  []int
+	exprs [][]byte
+}
+
+func (c *Collection) newRawProjector(projection []string, chaseRefs, redact bool) *rawProjector {
+	p := &rawProjector{c: c, chaseRefs: chaseRefs, redact: redact, inline: c.inline}
+	if p.inline {
+		p.wantAll = len(projection) == 0
+		seen := make(map[string]struct{}, len(projection))
+		for _, name := range projection {
+			fold := strings.ToLower(name)
+			if _, dup := seen[fold]; dup {
+				continue
+			}
+			seen[fold] = struct{}{}
+			// Private names never leave a redacted response; dropping them from the
+			// wanted set here makes redaction free per ad.
+			if redact && classad.IsPrivateAttribute(name) {
+				continue
+			}
+			p.inNames = append(p.inNames, name)
+			p.inHashes = append(p.inHashes, wire.NameHash32(name))
+		}
+		p.inDone = make([]uint32, len(p.inNames))
+		if len(projection) > 0 {
+			c.demand.recordReads(projection)
+			c.demand.recordReads(rawTypeFieldNames)
+		}
+		return p
+	}
+	n := c.intern.Len()
+	p.want = make([]bool, n)
+	// No filter: want everything (QueryRawProject treats an empty projection as
+	// "whole ad"; a flag rather than a filled slice, so attributes interned after
+	// this point are still emitted). Redaction still applies below.
+	p.wantAll = len(projection) == 0
+	for _, name := range projection {
+		// A name that was never interned exists in no stored ad; there is nothing
+		// to project for it.
+		if id, ok := c.intern.LookupID(name); ok && int(id) < n && !p.want[id] {
+			p.want[id] = true
+			p.wantCount++
+		}
+	}
+	if len(projection) > 0 {
+		// Register projection demand: RefreshHotSet ranks attributes by how often
+		// queries read them, so the attributes monitoring keeps projecting (plus the
+		// type fields every raw response lifts) migrate into the hot set and future
+		// writes front-load them -- which is what lets the hot fast path in render
+		// satisfy the whole projection without walking the ad.
+		c.demand.recordReads(projection)
+		c.demand.recordReads(rawTypeFieldNames)
+	}
+	// MyType/TargetType travel as RawAd fields (trailing type info on the wire),
+	// not as projected expressions; they are lifted whenever present.
+	if id, ok := c.intern.LookupID("MyType"); ok {
+		p.myTypeID, p.haveMyType = id, true
+	}
+	if id, ok := c.intern.LookupID("TargetType"); ok {
+		p.targetTypeID, p.haveTargetType = id, true
+	}
+	p.wantGen = make([]uint32, n)
+	p.doneGen = make([]uint32, n)
+	return p
+}
+
+func (c *Collection) yieldRawProjected(yield func(RawAd) bool, p *rawProjector) func(w []byte) bool {
+	return func(w []byte) bool {
+		ra, ok := p.render(w)
+		if !ok {
+			return true // inline-name or undecodable record: skip, keep scanning
+		}
+		return yield(ra)
+	}
+}
+
+// render emits one ad's projected (and, with chaseRefs, transitively
+// referenced) attributes as "Name = Value" expression slices.
+//
+// Fast path: the whole projection is satisfied from the HOT HEADER alone --
+// O(hotCount) with direct node offsets, never touching the ad's other
+// attributes. It applies when every resolved projected id (and both type
+// fields) was found hot; the projection demand recorded at construction steers
+// RefreshHotSet toward exactly that state. Anything short of full satisfaction
+// (an attribute that is cold, or absent from the ad) falls back to the linear
+// walk, which skips already-emitted ids via doneGen.
+//
+// The walk repeats only when chaseRefs surfaced references to ids not yet
+// wanted for this ad (an earlier entry may hold a newly wanted attribute).
+// Passes are bounded: each repeat strictly grows the per-ad wanted set, which
+// is capped by the ad's own attribute count.
+func (p *rawProjector) render(w []byte) (RawAd, bool) {
+	if p.inline {
+		return p.renderInline(w)
+	}
+	p.gen++
+	gen := p.gen
+	p.buf = p.buf[:0]
+	p.offs = append(p.offs[:0], 0)
+	var myType, targetType string
+	var mtDone, ttDone bool
+	ad := wire.Ad(w)
+	intern := p.c.intern
+
+	good := true
+	again := false
+	// handle processes one (id, node) entry -- shared by the hot fast path and
+	// the linear walk. Returns false only on a render error (good is cleared).
+	handle := func(id uint32, node []byte) bool {
+		if !mtDone && p.haveMyType && id == p.myTypeID {
+			if lit, ok := wire.LiteralValue(node); ok && lit.Kind == wire.LitString {
+				myType = lit.Str
+				mtDone = true
+				return true
+			}
+		}
+		if !ttDone && p.haveTargetType && id == p.targetTypeID {
+			if lit, ok := wire.LiteralValue(node); ok && lit.Kind == wire.LitString {
+				targetType = lit.Str
+				ttDone = true
+				return true
+			}
+		}
+		wanted := p.wantAll || (int(id) < len(p.want) && p.want[id]) ||
+			(int(id) < len(p.wantGen) && p.wantGen[id] == gen)
+		if !wanted || (int(id) < len(p.doneGen) && p.doneGen[id] == gen) {
+			return true
+		}
+		if p.redact && intern.IsPrivate(id) {
+			return true
+		}
+		name, ok := intern.Name(id)
+		if !ok {
+			return true // unresolved id: skip (matches ForEachNamed)
+		}
+		p.buf = append(p.buf, name...)
+		p.buf = append(p.buf, ' ', '=', ' ')
+		var aerr error
+		p.buf, aerr = appendWireValue(p.buf, node, intern)
+		if aerr != nil {
+			good = false
+			return false
+		}
+		p.offs = append(p.offs, len(p.buf))
+		if int(id) < len(p.doneGen) {
+			p.doneGen[id] = gen
+		}
+		if p.chaseRefs {
+			p.refs = wire.AppendNodeRefIDs(node, p.refs[:0])
+			for _, rid := range p.refs {
+				if int(rid) < len(p.wantGen) && !p.want[rid] && p.wantGen[rid] != gen {
+					p.wantGen[rid] = gen
+					again = true
+				}
+			}
+		}
+		return true
+	}
+
+	// Hot fast path (real projections only -- wantAll must walk everything).
+	if !p.wantAll {
+		needed := p.wantCount
+		if p.haveMyType {
+			needed++
+		}
+		if p.haveTargetType {
+			needed++
+		}
+		before := len(p.offs)
+		var hotOK bool
+		p.hotScratch, hotOK = ad.ForEachHotBuf(p.hotScratch, handle)
+		if !good {
+			return RawAd{}, false
+		}
+		satisfied := (len(p.offs) - before) + boolInt(mtDone) + boolInt(ttDone)
+		if hotOK && satisfied == needed && !again {
+			p.exprs = p.exprs[:0]
+			for i := 0; i+1 < len(p.offs); i++ {
+				p.exprs = append(p.exprs, p.buf[p.offs[i]:p.offs[i+1]])
+			}
+			return RawAd{Exprs: p.exprs, MyType: myType, TargetType: targetType}, true
+		}
+		// Fall through: something projected was cold or absent (or references are
+		// pending); the walk fills in the rest, doneGen skipping what hot emitted.
+	}
+
+	for {
+		again = false
+		walked := ad.ForEachIDNode(handle)
+		if !walked || !good {
+			return RawAd{}, false
+		}
+		if !again {
+			break
+		}
+		// A new reference id may name an attribute stored EARLIER in the ad than
+		// where it was discovered; restart the linear walk. doneGen keeps already-
+		// emitted ids from duplicating.
+	}
+
+	p.exprs = p.exprs[:0]
+	for i := 0; i+1 < len(p.offs); i++ {
+		p.exprs = append(p.exprs, p.buf[p.offs[i]:p.offs[i+1]])
+	}
+	return RawAd{Exprs: p.exprs, MyType: myType, TargetType: targetType}, true
+}
+
+func boolInt(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
+}
+
+// renderInline is render for a persistent (inline-names) collection: entries
+// carry their names in the ad body, so the wanted test is hash-first (the same
+// folded hash the inline hot header uses) verified by a case-insensitive byte
+// compare. The hot fast path resolves (hash, entry-offset) pairs and early-exits
+// when the whole projection plus both type fields were found hot. chaseRefs is
+// not supported for inline ads (their expressions reference attributes by
+// inline name, not id); the projection is served exactly.
+func (p *rawProjector) renderInline(w []byte) (RawAd, bool) {
+	p.gen++
+	gen := p.gen
+	p.buf = p.buf[:0]
+	p.offs = append(p.offs[:0], 0)
+	var myType, targetType string
+	var mtDone, ttDone bool
+	ad := wire.Ad(w)
+
+	good := true
+	handle := func(name, node []byte) bool {
+		if !mtDone && wire.FoldEqualBytes(name, "MyType") {
+			if lit, ok := wire.LiteralValue(node); ok && lit.Kind == wire.LitString {
+				myType = lit.Str
+				mtDone = true
+				return true
+			}
+		}
+		if !ttDone && wire.FoldEqualBytes(name, "TargetType") {
+			if lit, ok := wire.LiteralValue(node); ok && lit.Kind == wire.LitString {
+				targetType = lit.Str
+				ttDone = true
+				return true
+			}
+		}
+		if p.wantAll {
+			if p.redact && isPrivateNameBytes(name) {
+				return true
+			}
+		} else {
+			h := wire.NameHash32Bytes(name)
+			hit := false
+			for i, wh := range p.inHashes {
+				if wh == h && p.inDone[i] != gen && wire.FoldEqualBytes(name, p.inNames[i]) {
+					p.inDone[i] = gen
+					hit = true
+					break
+				}
+			}
+			if !hit {
+				return true
+			}
+		}
+		p.buf = append(p.buf, name...)
+		p.buf = append(p.buf, ' ', '=', ' ')
+		var aerr error
+		p.buf, aerr = wire.AppendNodeTextInline(p.buf, node)
+		if aerr != nil {
+			good = false
+			return false
+		}
+		p.offs = append(p.offs, len(p.buf))
+		return true
+	}
+
+	// Hot fast path (real projections only): the projection was pre-pruned of
+	// private names, so redaction costs nothing here either.
+	if !p.wantAll {
+		needed := len(p.inNames) + 2 // + MyType and TargetType, lifted by name
+		var hotOK bool
+		p.hotScratch, hotOK = ad.ForEachHotInlineBuf(p.hotScratch, func(_ uint32, name, node []byte) bool {
+			return handle(name, node)
+		})
+		if !good {
+			return RawAd{}, false
+		}
+		satisfied := (len(p.offs) - 1) + boolInt(mtDone) + boolInt(ttDone)
+		if hotOK && satisfied == needed {
+			p.exprs = p.exprs[:0]
+			for i := 0; i+1 < len(p.offs); i++ {
+				p.exprs = append(p.exprs, p.buf[p.offs[i]:p.offs[i+1]])
+			}
+			return RawAd{Exprs: p.exprs, MyType: myType, TargetType: targetType}, true
+		}
+	}
+
+	if !ad.ForEachNameNode(handle) || !good {
+		return RawAd{}, false
+	}
+	p.exprs = p.exprs[:0]
+	for i := 0; i+1 < len(p.offs); i++ {
+		p.exprs = append(p.exprs, p.buf[p.offs[i]:p.offs[i+1]])
+	}
+	return RawAd{Exprs: p.exprs, MyType: myType, TargetType: targetType}, true
+}
+
+// isPrivateNameBytes is classad.IsPrivateAttribute for raw name bytes, gated so
+// the string conversion (an allocation) happens only for the few names that
+// could possibly be private (V1 names start with c/t; V2 with '_').
+func isPrivateNameBytes(nm []byte) bool {
+	if len(nm) == 0 {
+		return false
+	}
+	switch nm[0] {
+	case 'c', 'C', 't', 'T', '_':
+		return classad.IsPrivateAttribute(string(nm))
+	}
+	return false
+}

--- a/collections/rawprojected_bench_test.go
+++ b/collections/rawprojected_bench_test.go
@@ -1,0 +1,57 @@
+package collections
+
+import (
+	"testing"
+)
+
+// BenchmarkScanRawProjectedInline measures the projected raw scan on a
+// PERSISTENT (inline-names) collection -- the mode htcondordb tables run in --
+// with the projection pinned hot and the ads re-encoded (the converged state),
+// against the unprojected raw scan of the same store.
+func BenchmarkScanRawProjectedInline(b *testing.B) {
+	sample := loadCorpus(b)
+	const n = 2000
+	c := populatePersistent(b, sample, n, b.TempDir())
+	defer c.Close()
+	proj := []string{
+		"Name", "Machine", "OpSys", "Arch", "State", "Activity",
+		"LoadAvg", "Memory", "Cpus", "EnteredCurrentActivity", "MyCurrentTime", "TotalSlots",
+	}
+	b.Run("unprojected", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			cnt := 0
+			for range c.ScanRaw() {
+				cnt++
+			}
+		}
+		b.ReportMetric(float64(n)*float64(b.N)/b.Elapsed().Seconds(), "ads/sec")
+	})
+	b.Run("projected-cold", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			cnt := 0
+			for range c.ScanRawProjected(proj, false, true) {
+				cnt++
+			}
+		}
+		b.ReportMetric(float64(n)*float64(b.N)/b.Elapsed().Seconds(), "ads/sec")
+	})
+	// Converge: pin the projection + type fields hot, re-encode every ad.
+	c.AddHotAttrs(append(append([]string{}, proj...), "MyType", "TargetType")...)
+	keys := c.Keys()
+	for _, k := range keys {
+		if ad, ok := c.Get([]byte(k)); ok {
+			if err := c.Put([]byte(k), ad); err != nil {
+				b.Fatal(err)
+			}
+		}
+	}
+	b.Run("projected-hot", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			cnt := 0
+			for range c.ScanRawProjected(proj, false, true) {
+				cnt++
+			}
+		}
+		b.ReportMetric(float64(n)*float64(b.N)/b.Elapsed().Seconds(), "ads/sec")
+	})
+}

--- a/collections/rawprojected_test.go
+++ b/collections/rawprojected_test.go
@@ -1,0 +1,303 @@
+package collections
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/classad"
+)
+
+var projTestAdTexts = []string{
+	`[MyType = "Machine"; TargetType = "Job"; Name = "slot1@a"; State = "Unclaimed";
+	  Cpus = 8; Memory = 16384; OpSys = "LINUX"; Arch = "X86_64";
+	  ClaimId = "<secret>";
+	  Start = (LoadAvg < 0.5) && (KeyboardIdle > 900); LoadAvg = 0.25; KeyboardIdle = 1200;
+	  Requirements = MY.Start && (TARGET.RequestCpus <= Cpus)]`,
+	`[MyType = "Machine"; TargetType = "Job"; Name = "slot1@b"; State = "Claimed";
+	  Cpus = 4; Memory = 8192; OpSys = "LINUX"; Arch = "ARM64";
+	  Start = SuspendReason isnt undefined; SuspendReason = undefined]`,
+}
+
+func projTestCollection(t *testing.T) *Collection {
+	t.Helper()
+	c := New(Options{})
+	t.Cleanup(func() { c.Close() })
+	for i, text := range projTestAdTexts {
+		ad, err := classad.Parse(text)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := c.Put([]byte{byte('a' + i)}, ad); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return c
+}
+
+func adsByName(t *testing.T, ras []RawAd) map[string]map[string]string {
+	t.Helper()
+	out := map[string]map[string]string{}
+	for _, ra := range ras {
+		m := map[string]string{}
+		for _, e := range ra.Exprs {
+			name, val, ok := strings.Cut(string(e), " = ")
+			if !ok {
+				t.Fatalf("malformed expr %q", e)
+			}
+			m[name] = val
+		}
+		key, ok := m["Name"]
+		if !ok {
+			t.Fatalf("ad missing Name: %v", m)
+		}
+		key = strings.Trim(key, `"`) // rendered value text carries its quotes
+		if ra.MyType != "Machine" || ra.TargetType != "Job" {
+			t.Fatalf("MyType/TargetType not lifted: %q/%q", ra.MyType, ra.TargetType)
+		}
+		out[key] = m
+	}
+	return out
+}
+
+// collectProjected materializes a projected scan (copying the reused buffers).
+func collectProjected(c *Collection, projection []string, chase, redact bool) []RawAd {
+	var out []RawAd
+	for ra := range c.ScanRawProjected(projection, chase, redact) {
+		cp := RawAd{MyType: ra.MyType, TargetType: ra.TargetType}
+		for _, e := range ra.Exprs {
+			cp.Exprs = append(cp.Exprs, append([]byte(nil), e...))
+		}
+		out = append(out, cp)
+	}
+	return out
+}
+
+// TestScanRawProjected verifies the in-walk projection emits exactly the
+// projected attributes with the same rendered values as the unprojected scan,
+// respects redaction, and never emits unprojected attributes.
+func TestScanRawProjected(t *testing.T) {
+	t.Parallel()
+	c := projTestCollection(t)
+
+	// Reference values from the unprojected scan.
+	var full []RawAd
+	for ra := range c.ScanRaw() {
+		cp := RawAd{MyType: ra.MyType, TargetType: ra.TargetType}
+		for _, e := range ra.Exprs {
+			cp.Exprs = append(cp.Exprs, append([]byte(nil), e...))
+		}
+		full = append(full, cp)
+	}
+	want := adsByName(t, full)
+
+	proj := []string{"Name", "State", "Cpus", "NoSuchAttr"}
+	got := adsByName(t, collectProjected(c, proj, false, false))
+	if len(got) != 2 {
+		t.Fatalf("projected scan returned %d ads, want 2", len(got))
+	}
+	for name, attrs := range got {
+		if len(attrs) != 3 { // Name, State, Cpus; NoSuchAttr matches nothing
+			t.Errorf("%s: got %d attrs (%v), want exactly Name/State/Cpus", name, len(attrs), attrs)
+		}
+		for a, v := range attrs {
+			if wv := want[name][a]; v != wv {
+				t.Errorf("%s.%s: projected %q != unprojected %q", name, a, v, wv)
+			}
+		}
+	}
+
+	// Redaction: ClaimId projected explicitly must still be stripped.
+	red := adsByName(t, collectProjected(c, []string{"Name", "ClaimId"}, false, true))
+	for name, attrs := range red {
+		if _, leak := attrs["ClaimId"]; leak {
+			t.Errorf("%s: redacted projection leaked ClaimId", name)
+		}
+	}
+	unred := adsByName(t, collectProjected(c, []string{"Name", "ClaimId"}, false, false))
+	if _, ok := unred["slot1@a"]["ClaimId"]; !ok {
+		t.Error("unredacted projection dropped ClaimId (should only be stripped when redact=true)")
+	}
+}
+
+// TestScanRawProjectedChasesRefs verifies the reference-closure "elevator":
+// projecting Start must pull in the attributes Start references (transitively,
+// per ad), including ones stored EARLIER in the ad than the reference, while
+// TARGET.-scoped references are not chased.
+func TestScanRawProjectedChasesRefs(t *testing.T) {
+	t.Parallel()
+	c := projTestCollection(t)
+
+	got := adsByName(t, collectProjected(c, []string{"Name", "Requirements"}, true, false))
+	a := got["slot1@a"]
+	// Requirements references MY.Start and Cpus; Start references LoadAvg and
+	// KeyboardIdle (a second elevator pass); TARGET.RequestCpus must NOT appear.
+	for _, needed := range []string{"Requirements", "Start", "Cpus", "LoadAvg", "KeyboardIdle"} {
+		if _, ok := a[needed]; !ok {
+			t.Errorf("slot1@a: closure missing %s (have %v)", needed, a)
+		}
+	}
+	if _, ok := a["RequestCpus"]; ok {
+		t.Error("slot1@a: TARGET.RequestCpus was chased into the closure")
+	}
+	if _, ok := a["Memory"]; ok {
+		t.Error("slot1@a: unreferenced Memory leaked into the closure")
+	}
+	// slot1@b has no Requirements; only Name should appear.
+	if b := got["slot1@b"]; len(b) != 1 {
+		t.Errorf("slot1@b: got %v, want only Name", b)
+	}
+}
+
+// TestScanRawProjectedHotFastPath pins the projected attributes (and the type
+// fields) into the hot set, re-encodes the ads, and verifies the hot fast path
+// produces exactly the walk path's output -- including when one projected
+// attribute is absent from an ad (forcing that ad back onto the walk).
+func TestScanRawProjectedHotFastPath(t *testing.T) {
+	t.Parallel()
+	c := projTestCollection(t)
+
+	proj := []string{"Name", "State", "Cpus", "SuspendReason"} // SuspendReason absent from slot1@a
+	before := adsByName(t, collectProjected(c, proj, false, false))
+
+	c.AddHotAttrs("Name", "State", "Cpus", "SuspendReason", "MyType", "TargetType")
+	// Re-put the ads so their hot headers carry the pinned attributes (production
+	// converges the same way: daemons re-advertise and rewrite their ads).
+	for i, key := range []string{"a", "b"} {
+		_ = i
+		ad, ok := c.Get([]byte(key))
+		if !ok {
+			t.Fatalf("ad %s missing", key)
+		}
+		if err := c.Put([]byte(key), ad); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	after := adsByName(t, collectProjected(c, proj, false, false))
+	if len(after) != len(before) {
+		t.Fatalf("hot path returned %d ads, walk returned %d", len(after), len(before))
+	}
+	for name, attrs := range before {
+		got := after[name]
+		if len(got) != len(attrs) {
+			t.Errorf("%s: hot path %v != walk %v", name, got, attrs)
+			continue
+		}
+		for a, v := range attrs {
+			if got[a] != v {
+				t.Errorf("%s.%s: hot %q != walk %q", name, a, got[a], v)
+			}
+		}
+	}
+	// Redaction still composes on the hot path.
+	c.AddHotAttrs("ClaimId")
+	ad, _ := c.Get([]byte("a"))
+	if err := c.Put([]byte("a"), ad); err != nil {
+		t.Fatal(err)
+	}
+	red := adsByName(t, collectProjected(c, []string{"Name", "ClaimId"}, false, true))
+	if _, leak := red["slot1@a"]["ClaimId"]; leak {
+		t.Error("hot fast path leaked ClaimId under redaction")
+	}
+}
+
+// projTestCollectionInline is projTestCollection persisted to disk -- an
+// inline-names collection, the mode htcondordb tables run in.
+func projTestCollectionInline(t *testing.T) *Collection {
+	t.Helper()
+	c, err := Open(Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { c.Close() })
+	for i, text := range projTestAdTexts {
+		ad, err := classad.Parse(text)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := c.Put([]byte{byte('a' + i)}, ad); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return c
+}
+
+// TestScanRawProjectedInline verifies the projected scan on a persistent
+// (inline-names) collection: exact projected attributes, values identical to
+// the unprojected scan, redaction (both projected-private and wantAll), and the
+// inline hot fast path after pinning + re-encoding.
+func TestScanRawProjectedInline(t *testing.T) {
+	t.Parallel()
+	c := projTestCollectionInline(t)
+
+	var full []RawAd
+	for ra := range c.ScanRaw() {
+		cp := RawAd{MyType: ra.MyType, TargetType: ra.TargetType}
+		for _, e := range ra.Exprs {
+			cp.Exprs = append(cp.Exprs, append([]byte(nil), e...))
+		}
+		full = append(full, cp)
+	}
+	want := adsByName(t, full)
+
+	proj := []string{"Name", "State", "Cpus", "NoSuchAttr"}
+	got := adsByName(t, collectProjected(c, proj, false, false))
+	if len(got) != 2 {
+		t.Fatalf("inline projected scan returned %d ads, want 2", len(got))
+	}
+	for name, attrs := range got {
+		if len(attrs) != 3 {
+			t.Errorf("%s: got %v, want exactly Name/State/Cpus", name, attrs)
+		}
+		for a, v := range attrs {
+			if wv := want[name][a]; v != wv {
+				t.Errorf("%s.%s: inline projected %q != unprojected %q", name, a, v, wv)
+			}
+		}
+	}
+
+	// Redaction: projected-private stripped; unredacted keeps it.
+	red := adsByName(t, collectProjected(c, []string{"Name", "ClaimId"}, false, true))
+	for name, attrs := range red {
+		if _, leak := attrs["ClaimId"]; leak {
+			t.Errorf("%s: inline redacted projection leaked ClaimId", name)
+		}
+	}
+	unred := adsByName(t, collectProjected(c, []string{"Name", "ClaimId"}, false, false))
+	if _, ok := unred["slot1@a"]["ClaimId"]; !ok {
+		t.Error("inline unredacted projection dropped ClaimId")
+	}
+
+	// wantAll + redact (the dbrpc unprojected-with-redaction shape).
+	all := adsByName(t, collectProjected(c, nil, false, true))
+	if _, leak := all["slot1@a"]["ClaimId"]; leak {
+		t.Error("inline wantAll redaction leaked ClaimId")
+	}
+	if _, ok := all["slot1@a"]["Memory"]; !ok {
+		t.Error("inline wantAll dropped a public attribute")
+	}
+
+	// Hot fast path: pin the projection + type fields, re-encode, same output.
+	before := adsByName(t, collectProjected(c, proj, false, false))
+	c.AddHotAttrs("Name", "State", "Cpus", "NoSuchAttr", "MyType", "TargetType")
+	for _, key := range []string{"a", "b"} {
+		ad, ok := c.Get([]byte(key))
+		if !ok {
+			t.Fatalf("ad %s missing", key)
+		}
+		if err := c.Put([]byte(key), ad); err != nil {
+			t.Fatal(err)
+		}
+	}
+	after := adsByName(t, collectProjected(c, proj, false, false))
+	for name, attrs := range before {
+		for a, v := range attrs {
+			if after[name][a] != v {
+				t.Errorf("%s.%s: inline hot %q != walk %q", name, a, after[name][a], v)
+			}
+		}
+		if len(after[name]) != len(attrs) {
+			t.Errorf("%s: inline hot %v != walk %v", name, after[name], attrs)
+		}
+	}
+}

--- a/collections/rawredact_test.go
+++ b/collections/rawredact_test.go
@@ -1,0 +1,106 @@
+package collections
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/classad"
+)
+
+// TestScanRawRedacted verifies the redacting raw scan strips exactly the private
+// attributes -- flagged once at intern time -- while ScanRaw still returns them,
+// and that near-miss names (Cpus, TotalCpus, ClaimIdea, ...) survive redaction.
+func TestScanRawRedacted(t *testing.T) {
+	t.Parallel()
+	c := New(Options{})
+	defer c.Close()
+
+	ad, err := classad.Parse(`[
+		MyType = "Machine"; TargetType = "Job";
+		Name = "slot1@host";
+		Cpus = 8; TotalCpus = 16;
+		ClaimId = "<secret-claim>";
+		CLAIMID = "casing is irrelevant, same interned id";
+		Capability = "<secret-cap>";
+		ChildClaimIds = { "a", "b" };
+		TransferKey = "<secret-key>";
+		ClaimIdea = "not private, just similar";
+		Transferkeys = "not private either";
+		_condor_privToken = "<secret-v2>";
+		State = "Claimed"
+	]`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Put([]byte("slot1@host"), ad); err != nil {
+		t.Fatal(err)
+	}
+
+	names := func(ras []map[string]struct{}) map[string]struct{} {
+		if len(ras) != 1 {
+			t.Fatalf("got %d ads, want 1", len(ras))
+		}
+		return ras[0]
+	}
+	collect := func(redacted bool) map[string]struct{} {
+		var out []map[string]struct{}
+		it := c.ScanRaw()
+		if redacted {
+			it = c.ScanRawRedacted()
+		}
+		for ra := range it {
+			m := map[string]struct{}{}
+			for _, e := range ra.Exprs {
+				name, _, ok := strings.Cut(string(e), " = ")
+				if !ok {
+					t.Fatalf("malformed expr %q", e)
+				}
+				m[name] = struct{}{}
+			}
+			out = append(out, m)
+		}
+		return names(out)
+	}
+
+	private := []string{"ClaimId", "CLAIMID", "Capability", "ChildClaimIds", "TransferKey", "_condor_privToken"}
+	public := []string{"Name", "Cpus", "TotalCpus", "ClaimIdea", "Transferkeys", "State"}
+
+	full := collect(false)
+	for _, n := range append(append([]string{}, private...), public...) {
+		// CLAIMID interns to ClaimId's id; the unredacted scan surfaces the stored
+		// attribute under one canonical casing, so only require the fold to exist.
+		if _, ok := full[n]; !ok {
+			found := false
+			for got := range full {
+				if strings.EqualFold(got, n) {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("unredacted scan missing %s", n)
+			}
+		}
+	}
+
+	red := collect(true)
+	for _, n := range private {
+		for got := range red {
+			if strings.EqualFold(got, n) {
+				t.Errorf("redacted scan leaked private attribute %s (as %s)", n, got)
+			}
+		}
+	}
+	for _, n := range public {
+		found := false
+		for got := range red {
+			if strings.EqualFold(got, n) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("redacted scan dropped public attribute %s", n)
+		}
+	}
+}

--- a/collections/store.go
+++ b/collections/store.go
@@ -371,7 +371,10 @@ func New(opts Options) *Collection {
 		shards: shards,
 		mask:   uint64(n - 1),
 		h:      h,
-		intern: wire.NewInternTable(),
+		// Private attributes are flagged once per unique name at intern time, so a
+		// redacted query (ScanRawRedacted/QueryRawRedacted) strips them with a per-id
+		// bool check instead of re-classifying every attribute of every ad.
+		intern: wire.NewInternTableWithPrivacy(classad.IsPrivateAttribute),
 		demand: newDemandTracker(),
 	}
 	c.codec.Store(&codecHolder{codec})

--- a/collections/wire/accessor.go
+++ b/collections/wire/accessor.go
@@ -165,6 +165,149 @@ func (a Ad) ForEach(fn func(id uint32, node []byte) bool) bool {
 // wrong for inline ads -- this works for both encodings. Returns false if fn stopped
 // early or the ad is malformed.
 func (a Ad) ForEachNamed(t *InternTable, fn func(name string, node []byte) bool) bool {
+	return a.forEachNamed(t, false, fn)
+}
+
+// ForEachNamedRedact is ForEachNamed except attributes whose name the table
+// classified as private (see NewInternTableWithPrivacy) are skipped -- their
+// nodes are never decoded and fn never sees them. Interned attributes are
+// filtered by their precomputed per-id flag (O(1), no name resolution); inline
+// attributes fall back to the table's privacy predicate on the stored name.
+func (a Ad) ForEachNamedRedact(t *InternTable, fn func(name string, node []byte) bool) bool {
+	return a.forEachNamed(t, true, fn)
+}
+
+// ForEachHotInlineBuf is ForEachHotBuf's inline-names counterpart: an inline
+// ad's hot pairs are (nameHash32, offset) where the offset points at the whole
+// attribute ENTRY (inline name, then node). It yields the folded name hash, the
+// raw name bytes and the node bytes; the caller must verify the name (hashes
+// can collide) with foldEqualBytes before trusting a match. scratch as in
+// ForEachHotBuf. Reports false for an interned ad.
+func (a Ad) ForEachHotInlineBuf(scratch []uint32, fn func(hash uint32, name, node []byte) bool) ([]uint32, bool) {
+	c, ok := a.bodyStart()
+	if !ok || !c.inline {
+		return scratch, false
+	}
+	hotCount := c.uvarint()
+	if hotCount == 0 {
+		return scratch, c.ok
+	}
+	scratch = scratch[:0]
+	for i := uint64(0); i < hotCount && c.ok; i++ {
+		scratch = append(scratch, uint32(c.uvarint()), uint32(c.uvarint()))
+	}
+	c.uvarint() // attrCount
+	if !c.ok {
+		return scratch, false
+	}
+	entriesStart := c.pos
+	for i := 0; i+1 < len(scratch); i += 2 {
+		ec := &cursor{b: a, pos: entriesStart + int(scratch[i+1]), ok: true, inline: true}
+		name := ec.readNameBytes()
+		if !ec.ok {
+			return scratch, false
+		}
+		nodeStart := ec.pos
+		skipNode(ec, 0)
+		if !ec.ok {
+			return scratch, false
+		}
+		if !fn(scratch[i], name, a[nodeStart:ec.pos]) {
+			return scratch, true
+		}
+	}
+	return scratch, c.ok
+}
+
+// ForEachNameNode iterates an inline-names ad's attribute entries as raw (name
+// bytes, node bytes) pairs, allocating nothing -- the projection walk for a
+// persistent collection filters on the name bytes before rendering anything.
+// Reports false (calling fn for nothing) for an interned ad.
+func (a Ad) ForEachNameNode(fn func(name, node []byte) bool) bool {
+	c, ok := a.bodyStart()
+	if !ok || !c.inline {
+		return false
+	}
+	hotCount := c.uvarint()
+	for i := uint64(0); i < hotCount && c.ok; i++ {
+		c.uvarint()
+		c.uvarint()
+	}
+	attrCount := c.uvarint()
+	for i := uint64(0); i < attrCount && c.ok; i++ {
+		name := c.readNameBytes()
+		if !c.ok {
+			return false
+		}
+		nodeStart := c.pos
+		skipNode(c, 0)
+		if !c.ok {
+			return false
+		}
+		if !fn(name, a[nodeStart:c.pos]) {
+			return true
+		}
+	}
+	return c.ok
+}
+
+// NameHash32 exposes the case-insensitive 32-bit hash used by inline hot-header
+// pairs, so a projected reader can precompute its wanted-name hashes.
+func NameHash32(name string) uint32 { return nameHash32(name) }
+
+// NameHash32Bytes is NameHash32 over raw name bytes (no string conversion).
+func NameHash32Bytes(name []byte) uint32 {
+	const off, prime = 2166136261, 16777619
+	h := uint32(off)
+	for i := 0; i < len(name); i++ {
+		c := name[i]
+		if c >= 'A' && c <= 'Z' {
+			c += 'a' - 'A'
+		}
+		h = (h ^ uint32(c)) * prime
+	}
+	return h
+}
+
+// FoldEqualBytes reports whether the raw attribute-name bytes equal name
+// case-insensitively (ASCII fold, matching ClassAd attribute-name semantics).
+func FoldEqualBytes(b []byte, name string) bool { return foldEqualBytes(b, name) }
+
+// ForEachIDNode iterates the ad's attribute entries as raw (interned id, node
+// bytes) pairs, resolving nothing: the caller filters by id -- a projection's
+// wanted-set test, a privacy flag -- before paying for name resolution or value
+// rendering. Skipped entries cost one uvarint plus a TLV length hop. Returns
+// false (calling fn for nothing) for an inline-names ad, whose entries carry no
+// interned ids; fn returning false stops the walk early.
+func (a Ad) ForEachIDNode(fn func(id uint32, node []byte) bool) bool {
+	c, ok := a.bodyStart()
+	if !ok || c.inline {
+		return false
+	}
+	hotCount := c.uvarint()
+	for i := uint64(0); i < hotCount && c.ok; i++ {
+		c.uvarint()
+		c.uvarint()
+	}
+	attrCount := c.uvarint()
+	for i := uint64(0); i < attrCount && c.ok; i++ {
+		aid := c.uvarint()
+		if !c.ok {
+			return false
+		}
+		nodeStart := c.pos
+		skipNode(c, 0)
+		if !c.ok {
+			return false
+		}
+		if !fn(uint32(aid), a[nodeStart:c.pos]) {
+			return true
+		}
+	}
+	return c.ok
+}
+
+func (a Ad) forEachNamed(t *InternTable, redact bool, fn func(name string, node []byte) bool) bool {
 	c, ok := a.bodyStart()
 	if !ok {
 		return false
@@ -183,10 +326,24 @@ func (a Ad) ForEachNamed(t *InternTable, fn func(name string, node []byte) bool)
 				return false
 			}
 			name = string(nm)
+			if redact && t.isPrivateName(name) {
+				skipNode(c, 0) // private: never surface its node
+				if !c.ok {
+					return false
+				}
+				continue
+			}
 		} else {
 			aid := c.uvarint()
 			if !c.ok {
 				return false
+			}
+			if redact && t.IsPrivate(uint32(aid)) {
+				skipNode(c, 0) // private: skip before even resolving the name
+				if !c.ok {
+					return false
+				}
+				continue
 			}
 			n, ok := t.Name(uint32(aid))
 			if !ok {
@@ -240,6 +397,42 @@ func (a Ad) AttrCount() int {
 // malformed. Cost is O(hotCount), independent of the total attribute count -- so a
 // collection whose hot set is the match closure can read exactly the match-relevant
 // attributes of a very wide ad without touching the cold ones.
+// ForEachHotBuf is ForEachHot with caller-provided scratch for the header's
+// (id, offset) pairs, grown as needed and returned for reuse -- a scan calling
+// it once per ad performs no per-ad allocation (ForEachHot allocates two slices
+// per call). scratch holds the pairs interleaved: id, offset, id, offset, ...
+// Interned ads only: an inline ad's hot pairs are (nameHash32, offset-to-ENTRY)
+// -- see ForEachHotInlineBuf -- so it reports false rather than mis-parse.
+func (a Ad) ForEachHotBuf(scratch []uint32, fn func(id uint32, node []byte) bool) ([]uint32, bool) {
+	c, ok := a.bodyStart()
+	if !ok || c.inline {
+		return scratch, false
+	}
+	hotCount := c.uvarint()
+	if hotCount == 0 {
+		return scratch, c.ok
+	}
+	scratch = scratch[:0]
+	for i := uint64(0); i < hotCount && c.ok; i++ {
+		scratch = append(scratch, uint32(c.uvarint()), uint32(c.uvarint()))
+	}
+	c.uvarint() // attrCount
+	if !c.ok {
+		return scratch, false
+	}
+	entriesStart := c.pos
+	for i := 0; i+1 < len(scratch); i += 2 {
+		node, ok := nodeBytesAt(a, entriesStart+int(scratch[i+1]))
+		if !ok {
+			return scratch, false
+		}
+		if !fn(scratch[i], node) {
+			return scratch, true
+		}
+	}
+	return scratch, c.ok
+}
+
 func (a Ad) ForEachHot(fn func(id uint32, node []byte) bool) bool {
 	c, ok := a.bodyStart()
 	if !ok {

--- a/collections/wire/intern.go
+++ b/collections/wire/intern.go
@@ -31,24 +31,49 @@ type InternTable struct {
 	// exact names can map to one id (e.g. "Owner", "owner", "OWNER").
 	byExact map[string]uint32
 	byFold  map[string]uint32 // ToLower(name) -> id
-	// canon (id -> first-seen casing) is published as an immutable, append-only
-	// slice behind an atomic pointer so Name resolves an id with no lock. Name is
-	// called for every attribute of every ad during serialization; an RWMutex.RLock
-	// there -- though logically a read -- serializes on its atomic reader counter
-	// across cores, which alone was ~23% of CPU on concurrent large-ad scans.
-	// Writers (Intern, holding mu) copy-append and atomically publish; existing
-	// entries are never mutated, so a lock-free reader always sees a valid snapshot.
-	canon atomic.Pointer[[]string]
+	// canon (id -> entry: first-seen casing + private flag) is published as an
+	// immutable, append-only slice behind an atomic pointer so Name/IsPrivate
+	// resolve an id with no lock. Name is called for every attribute of every ad
+	// during serialization; an RWMutex.RLock there -- though logically a read --
+	// serializes on its atomic reader counter across cores, which alone was ~23%
+	// of CPU on concurrent large-ad scans. Writers (Intern, holding mu) copy-append
+	// and atomically publish; existing entries are never mutated, so a lock-free
+	// reader always sees a valid snapshot. The private flag lives INSIDE the entry
+	// (not a parallel slice under its own atomic) so a single load observes a
+	// consistent name+flag pair.
+	canon atomic.Pointer[[]internEntry]
+	// privacy classifies a name as private (secret) ONCE, when its id is first
+	// allocated; per-attribute consumers then read the precomputed flag by id.
+	// nil means nothing is private. Set at construction only -- flags computed for
+	// already-interned ids are never revisited.
+	privacy func(string) bool
+}
+
+// internEntry is one id's published state: its canonical (first-seen) casing and
+// whether the name is private (per the table's privacy predicate).
+type internEntry struct {
+	name    string
+	private bool
 }
 
 // NewInternTable returns an empty table. Id 0 is a valid id (the first name
 // interned); callers that need a sentinel should track presence separately.
 func NewInternTable() *InternTable {
+	return NewInternTableWithPrivacy(nil)
+}
+
+// NewInternTableWithPrivacy returns an empty table whose entries are flagged
+// private when privacy(name) is true, evaluated once per unique name at intern
+// time. Redacting iterators (Ad.ForEachNamedRedact) skip flagged ids, so a
+// serialization path can strip secrets in O(1) per attribute instead of
+// re-classifying every attribute name of every ad. A nil privacy flags nothing.
+func NewInternTableWithPrivacy(privacy func(string) bool) *InternTable {
 	t := &InternTable{
 		byExact: make(map[string]uint32),
 		byFold:  make(map[string]uint32),
+		privacy: privacy,
 	}
-	empty := []string{}
+	empty := []internEntry{}
 	t.canon.Store(&empty)
 	return t
 }
@@ -76,12 +101,16 @@ func (t *InternTable) Intern(name string) uint32 {
 	id, ok = t.byFold[fold]
 	if !ok {
 		// First time any casing of this name is seen: allocate an id and record
-		// this casing as canonical. Copy-append (cap==len forces a fresh backing
-		// array) so lock-free readers holding the old snapshot are unaffected, then
-		// publish atomically. New names are rare after warmup, so the copy is cheap.
+		// this casing as canonical (classifying it as private exactly once).
+		// Copy-append (cap==len forces a fresh backing array) so lock-free readers
+		// holding the old snapshot are unaffected, then publish atomically. New
+		// names are rare after warmup, so the copy is cheap.
 		old := *t.canon.Load()
 		id = uint32(len(old))
-		next := append(old[:len(old):len(old)], name)
+		next := append(old[:len(old):len(old)], internEntry{
+			name:    name,
+			private: t.privacy != nil && t.privacy(name),
+		})
 		t.canon.Store(&next)
 		t.byFold[fold] = id
 	}
@@ -110,7 +139,23 @@ func (t *InternTable) Name(id uint32) (string, bool) {
 	if int(id) >= len(canon) {
 		return "", false
 	}
-	return canon[id], true
+	return canon[id].name, true
+}
+
+// IsPrivate reports whether id's name was classified private by the table's
+// privacy predicate when it was interned. Lock-free; an unallocated id is not
+// private. O(1) -- this is the point of precomputing the flag: a redacting
+// serializer checks one bool per attribute instead of re-classifying its name.
+func (t *InternTable) IsPrivate(id uint32) bool {
+	canon := *t.canon.Load()
+	return int(id) < len(canon) && canon[id].private
+}
+
+// isPrivateName classifies a (non-interned) name with the table's privacy
+// predicate -- the redacting iterator uses it for inline-encoded ads, whose
+// attribute names are stored in the ad body rather than as interned ids.
+func (t *InternTable) isPrivateName(name string) bool {
+	return t.privacy != nil && t.privacy(name)
 }
 
 // Len returns the number of interned names (== the next id to be allocated).
@@ -123,6 +168,8 @@ func (t *InternTable) Len() int {
 func (t *InternTable) snapshotNames() []string {
 	canon := *t.canon.Load()
 	out := make([]string, len(canon))
-	copy(out, canon)
+	for i, e := range canon {
+		out[i] = e.name
+	}
 	return out
 }

--- a/collections/wire/refs.go
+++ b/collections/wire/refs.go
@@ -1,0 +1,132 @@
+package wire
+
+import (
+	"encoding/binary"
+
+	"github.com/PelicanPlatform/classad/ast"
+)
+
+// AppendNodeRefIDs appends to dst the interned id of every attribute reference
+// inside node that could resolve against the enclosing ad -- unscoped and
+// MY.-scoped references (TARGET./PARENT. refer to a different ad) -- returning
+// the extended slice. It walks the node's TLV structure directly (the same walk
+// as skipNode), so collecting a node's references costs no decode, no name
+// resolution and no allocation beyond dst's growth; a caller building a
+// projection's reference closure recycles dst across nodes and passes.
+//
+// The collection is a superset: references inside nested record literals are
+// included even though record-member resolution could shadow them, and duplicate
+// ids are appended as-is (the caller's wanted-set absorbs both). An encrypted
+// node is opaque and contributes nothing. Returns dst unchanged (beyond any
+// partial appends) with no error indication on a malformed node -- the caller's
+// subsequent render of the same bytes surfaces the corruption.
+func AppendNodeRefIDs(node []byte, dst []uint32) []uint32 {
+	c := &cursor{b: node, ok: true}
+	return refNode(c, 0, dst)
+}
+
+func refNode(c *cursor, depth int, dst []uint32) []uint32 {
+	if !c.ok || depth > maxDepth {
+		c.ok = false
+		return dst
+	}
+	tag := c.byteAt()
+	switch tag {
+	case nUndefined, nError, nBoolFalse, nBoolTrue:
+		// no payload
+	case nInt:
+		_, n := binary.Varint(c.b[c.pos:])
+		if n <= 0 {
+			c.ok = false
+			return dst
+		}
+		c.pos += n
+	case nReal:
+		c.skip(8)
+	case nString:
+		c.skip(int(c.uvarint()))
+	case nAttrRef:
+		scope := c.byteAt()
+		id := c.uvarint()
+		if c.ok && (ast.AttributeScope(scope) == ast.NoScope || ast.AttributeScope(scope) == ast.MyScope) {
+			dst = append(dst, uint32(id))
+		}
+	case nAttrRefStr:
+		c.skip(1)                // scope byte
+		c.skip(int(c.uvarint())) // inline name: not an interned id, nothing to collect
+	case nBinOp:
+		c.skip(1) // op id
+		dst = refNode(c, depth+1, dst)
+		dst = refNode(c, depth+1, dst)
+	case nBinOpStr:
+		c.skip(int(c.uvarint())) // op string
+		dst = refNode(c, depth+1, dst)
+		dst = refNode(c, depth+1, dst)
+	case nUnOp:
+		c.skip(1)
+		dst = refNode(c, depth+1, dst)
+	case nUnOpStr:
+		c.skip(int(c.uvarint()))
+		dst = refNode(c, depth+1, dst)
+	case nList:
+		n := c.uvarint()
+		for i := uint64(0); i < n && c.ok; i++ {
+			dst = refNode(c, depth+1, dst)
+		}
+	case nRecord:
+		dst = refAdBody(c, depth+1, dst)
+	case nFunc:
+		c.uvarint() // function name id: not an attribute reference
+		n := c.uvarint()
+		for i := uint64(0); i < n && c.ok; i++ {
+			dst = refNode(c, depth+1, dst)
+		}
+	case nFuncStr:
+		c.skip(int(c.uvarint())) // inline function name
+		n := c.uvarint()
+		for i := uint64(0); i < n && c.ok; i++ {
+			dst = refNode(c, depth+1, dst)
+		}
+	case nCond:
+		dst = refNode(c, depth+1, dst)
+		dst = refNode(c, depth+1, dst)
+		dst = refNode(c, depth+1, dst)
+	case nElvis, nSubscript:
+		dst = refNode(c, depth+1, dst)
+		dst = refNode(c, depth+1, dst)
+	case nSelect:
+		dst = refNode(c, depth+1, dst)
+		c.uvarint() // selected member id: resolves inside the record, not the ad
+	case nSelectStr:
+		dst = refNode(c, depth+1, dst)
+		c.skip(int(c.uvarint()))
+	case nParen:
+		dst = refNode(c, depth+1, dst)
+	case nEncrypted:
+		c.skip(int(c.uvarint())) // nonce
+		c.skip(int(c.uvarint())) // ciphertext: opaque, no visible references
+	default:
+		c.ok = false
+	}
+	return dst
+}
+
+// refAdBody walks a nested record body ([hotCount][hot][attrCount][key+node]*),
+// collecting references from each member's value node.
+func refAdBody(c *cursor, depth int, dst []uint32) []uint32 {
+	if !c.ok || depth > maxDepth {
+		c.ok = false
+		return dst
+	}
+	hotCount := c.uvarint()
+	for i := uint64(0); i < hotCount && c.ok; i++ {
+		c.uvarint()
+		c.uvarint()
+	}
+	attrCount := c.uvarint()
+	for i := uint64(0); i < attrCount && c.ok; i++ {
+		c.skipKey()
+		dst = refNode(c, depth+1, dst)
+	}
+	return dst
+}

--- a/db/rawwire.go
+++ b/db/rawwire.go
@@ -82,3 +82,35 @@ func (db *DB) QueryRaw(constraint string) (iter.Seq[collections.RawAd], error) {
 	}
 	return db.c.QueryRaw(q), nil
 }
+
+// QueryRawRedacted is QueryRaw with private (secret) attributes stripped inside
+// the collection's decode walk -- an unprivileged consumer's whole-ad query pays
+// no per-attribute re-classification and never renders a private value (see
+// collections.ScanRawRedacted).
+func (db *DB) QueryRawRedacted(constraint string) (iter.Seq[collections.RawAd], error) {
+	if s := strings.TrimSpace(constraint); s == "" || strings.EqualFold(s, "true") {
+		return db.c.ScanRawRedacted(), nil
+	}
+	q, err := vm.Parse(constraint)
+	if err != nil {
+		return nil, fmt.Errorf("classad-db: bad constraint %q: %w", constraint, err)
+	}
+	return db.c.QueryRawRedacted(q), nil
+}
+
+// QueryRawProjected is QueryRaw restricted to the projected attribute names,
+// applied inside the collection's decode walk: a non-projected attribute is
+// skipped before any name resolution or value rendering, and a hot-header-
+// covered projection is served from the hot header alone (see
+// collections.ScanRawProjected). redact additionally strips private attributes.
+// An empty projection means no attribute filter.
+func (db *DB) QueryRawProjected(constraint string, projection []string, redact bool) (iter.Seq[collections.RawAd], error) {
+	if s := strings.TrimSpace(constraint); s == "" || strings.EqualFold(s, "true") {
+		return db.c.ScanRawProjected(projection, false, redact), nil
+	}
+	q, err := vm.Parse(constraint)
+	if err != nil {
+		return nil, fmt.Errorf("classad-db: bad constraint %q: %w", constraint, err)
+	}
+	return db.c.QueryRawProjected(q, projection, false, redact), nil
+}

--- a/dbrpc/queryraw.go
+++ b/dbrpc/queryraw.go
@@ -2,10 +2,10 @@ package dbrpc
 
 import (
 	"context"
+	"iter"
 	"strings"
 	"time"
 
-	"github.com/PelicanPlatform/classad/classad"
 	"github.com/PelicanPlatform/classad/collections"
 )
 
@@ -86,7 +86,16 @@ func (s *Server) streamQueryRaw(ctx context.Context, reqID uint64, r *reader, in
 	if !ok {
 		return
 	}
-	seq, err := d.QueryRaw(constraint)
+	// Redaction is pushed into the collection's decode walk: an unprivileged
+	// stream never renders a private value, and no per-attribute name
+	// re-classification happens here.
+	var seq iter.Seq[collections.RawAd]
+	var err error
+	if includePrivate {
+		seq, err = d.QueryRaw(constraint)
+	} else {
+		seq, err = d.QueryRawRedacted(constraint)
+	}
 	if err != nil {
 		write(respErr(reqID, err.Error()))
 		return
@@ -95,7 +104,7 @@ func (s *Server) streamQueryRaw(ctx context.Context, reqID uint64, r *reader, in
 		if cancelled(ctx) {
 			return
 		}
-		write(putStr(respHead(reqID, stStream), rawAdToOldText(ra, includePrivate)))
+		write(putStr(respHead(reqID, stStream), rawAdText(ra)))
 		n++
 		if limit > 0 && n >= limit {
 			break
@@ -104,11 +113,11 @@ func (s *Server) streamQueryRaw(ctx context.Context, reqID uint64, r *reader, in
 	write(respHead(reqID, stStreamEnd))
 }
 
-// rawAdToOldText renders a RawAd as old-ClassAd wire text: the type tags as their
-// own lines followed by the attribute expression lines, dropping private
-// attributes unless includePrivate. It touches no AST -- the expression bytes are
-// copied straight from the stored form.
-func rawAdToOldText(ra collections.RawAd, includePrivate bool) string {
+// rawAdText renders a RawAd as old-ClassAd wire text: the type tags as their own
+// lines followed by the attribute expression lines verbatim. Filtering -- both
+// projection and private-attribute redaction -- already happened inside the
+// collection's decode walk, so nothing is re-classified here.
+func rawAdText(ra collections.RawAd) string {
 	var b strings.Builder
 	if ra.MyType != "" {
 		b.WriteString("MyType = \"")
@@ -121,27 +130,10 @@ func rawAdToOldText(ra collections.RawAd, includePrivate bool) string {
 		b.WriteString("\"\n")
 	}
 	for _, e := range ra.Exprs {
-		if !includePrivate && classad.IsPrivateAttribute(rawExprName(e)) {
-			continue
-		}
 		b.Write(e)
 		b.WriteByte('\n')
 	}
 	return b.String()
-}
-
-// rawExprName returns the attribute name of a rendered "Name = value" expression
-// line (leading whitespace trimmed, up to the first '=' or space).
-func rawExprName(expr []byte) string {
-	i := 0
-	for i < len(expr) && (expr[i] == ' ' || expr[i] == '\t') {
-		i++
-	}
-	start := i
-	for i < len(expr) && expr[i] != '=' && expr[i] != ' ' && expr[i] != '\t' {
-		i++
-	}
-	return string(expr[start:i])
 }
 
 // streamQueryRawProject is streamQueryRaw with a projection: it streams each
@@ -173,11 +165,10 @@ func (s *Server) streamQueryRawProject(ctx context.Context, reqID uint64, r *rea
 	if !ok {
 		return
 	}
-	proj := make(map[string]struct{}, len(attrs))
-	for _, a := range attrs {
-		proj[strings.ToLower(a)] = struct{}{}
-	}
-	seq, err := d.QueryRaw(constraint)
+	// The projection (and, unprivileged, redaction) is applied inside the
+	// collection's decode walk: non-projected attributes are never rendered, and a
+	// hot-header-covered projection is served from the hot header alone.
+	seq, err := d.QueryRawProjected(constraint, attrs, !includePrivate)
 	if err != nil {
 		write(respErr(reqID, err.Error()))
 		return
@@ -186,40 +177,11 @@ func (s *Server) streamQueryRawProject(ctx context.Context, reqID uint64, r *rea
 		if cancelled(ctx) {
 			return
 		}
-		write(putStr(respHead(reqID, stStream), rawAdToOldTextProjected(ra, proj, includePrivate)))
+		write(putStr(respHead(reqID, stStream), rawAdText(ra)))
 		n++
 		if limit > 0 && n >= limit {
 			break
 		}
 	}
 	write(respHead(reqID, stStreamEnd))
-}
-
-// rawAdToOldTextProjected is rawAdToOldText restricted to the attributes in proj
-// (lowercased names) -- plus MyType/TargetType, always kept so the ad stays
-// identifiable. Private attributes are still dropped unless includePrivate.
-func rawAdToOldTextProjected(ra collections.RawAd, proj map[string]struct{}, includePrivate bool) string {
-	var b strings.Builder
-	if ra.MyType != "" {
-		b.WriteString(`MyType = "`)
-		b.WriteString(ra.MyType)
-		b.WriteString("\"\n")
-	}
-	if ra.TargetType != "" {
-		b.WriteString(`TargetType = "`)
-		b.WriteString(ra.TargetType)
-		b.WriteString("\"\n")
-	}
-	for _, e := range ra.Exprs {
-		name := rawExprName(e)
-		if _, ok := proj[strings.ToLower(name)]; !ok {
-			continue
-		}
-		if !includePrivate && classad.IsPrivateAttribute(name) {
-			continue
-		}
-		b.Write(e)
-		b.WriteByte('\n')
-	}
-	return b.String()
 }

--- a/dbrpc/queryrawproject_test.go
+++ b/dbrpc/queryrawproject_test.go
@@ -1,0 +1,62 @@
+package dbrpc
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/classad"
+)
+
+// TestQueryRawProject verifies server-side projection: each returned ad carries
+// only the requested attributes (matched case-insensitively) plus
+// MyType/TargetType, and nothing else.
+func TestQueryRawProject(t *testing.T) {
+	c, cleanup := testPair(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	tx, err := c.Begin(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = tx.NewClassAd(ctx, "a", `MyType = "Machine"`+"\n"+`Name = "slot1"`+"\n"+`Cpus = 8`+"\n"+`Memory = 4096`+"\n"+`State = "Idle"`)
+	_ = tx.NewClassAd(ctx, "b", `MyType = "Machine"`+"\n"+`Name = "slot2"`+"\n"+`Cpus = 4`+"\n"+`Memory = 2048`+"\n"+`State = "Claimed"`)
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	// Project to Name + Cpus (lowercase on the wire to exercise case-insensitivity).
+	rows, err := c.QueryRawProject(ctx, DefaultTable, "true", []string{"name", "cpus"}, 0)
+	if err != nil {
+		t.Fatalf("QueryRawProject: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("got %d ads, want 2", len(rows))
+	}
+	for _, r := range rows {
+		ad, err := classad.ParseOld(r)
+		if err != nil {
+			t.Fatalf("parse projected ad %q: %v", r, err)
+		}
+		if _, ok := ad.Lookup("Name"); !ok {
+			t.Errorf("projected ad missing Name: %q", r)
+		}
+		if _, ok := ad.Lookup("Cpus"); !ok {
+			t.Errorf("projected ad missing Cpus: %q", r)
+		}
+		if mt, _ := ad.EvaluateAttrString("MyType"); mt != "Machine" {
+			t.Errorf("projected ad lost MyType (got %q): %q", mt, r)
+		}
+		if _, ok := ad.Lookup("Memory"); ok {
+			t.Errorf("projected ad should not carry Memory: %q", r)
+		}
+		if _, ok := ad.Lookup("State"); ok {
+			t.Errorf("projected ad should not carry State: %q", r)
+		}
+		// Belt-and-suspenders: the raw text must not even mention the dropped attrs.
+		if strings.Contains(r, "Memory") || strings.Contains(r, "State") {
+			t.Errorf("projected wire text carries a dropped attribute: %q", r)
+		}
+	}
+}


### PR DESCRIPTION
Performance series for the collector/htcondordb query-serving spine, found profiling `condor_status -totals` against a 20k-startd collector (Go was 2-3s vs C++ 300ms).

**Commit 1 — allocation-free `IsPrivateAttribute`.** `strings.ToLower` allocated per attribute name per ad (~2M allocs per 20k-ad query). Length+first-byte gate, stack-buffer casefold, allocation-free map lookup. **+54%** on the collector's whole-ad serve.

**Commit 2 — redaction and projection move inside the wire walk**, both encodings (interned RAM + inline/persistent):
- **Intern-time private flags** — names classified once at id allocation (predicate injected from `classad.IsPrivateAttribute`); redacting scans skip flagged ids with one bool check. Private values are never rendered at all.
- **In-walk projection** — resolved once per query to ids (RAM) or folded-name hashes (persistent; verified case-insensitively); non-projected attributes cost an id/hash check + TLV hop instead of being rendered and discarded. Optional per-ad reference closure (`chaseRefs`) via `AppendNodeRefIDs` (TLV-level, no decode).
- **Hot fast path** — a projection fully covered by the ad's hot header is served from hot offsets alone; projected queries record read demand so the (already demand-ranked) `RefreshHotSet` converges the hot set onto the monitoring working set.
- **db/dbrpc pushdown** — `db.QueryRawRedacted/QueryRawProjected`; the dbrpc raw streams use them and the decode-everything renderers are deleted. Wire format unchanged (full dbrpc suite passes untouched).

**Measured** (2000 realistic OSPool ads, single-threaded): interned projected serve **22k → 360k ads/sec**; persistent (htcondordb-mode) redacted scans **23.4k unprojected / 51.7k projected-cold / 232k projected-hot**. Downstream (bbockelm/golang-collector wired to these APIs): end-to-end conc=1 vs the C++ condor_collector flipped from -12% to **2.2x faster**.

New tests: intern-flag redaction (case variants, near-miss names, both scan paths), projection equivalence vs the unprojected render, ref-closure semantics (earlier-stored attrs, TARGET. exclusion), hot-fast-path equivalence incl. absent-attr fallback and redaction-on-hot, inline-mode versions of all of the above, and a dbrpc server-side projection test.