### PR TITLE
Wire-form row relay: batched subset streaming, parallel ZSTD scan, hot-prefix decode

### DIFF
--- a/collections/codec.go
+++ b/collections/codec.go
@@ -1,8 +1,11 @@
 package collections
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
+	"io"
+	"sync"
 
 	"github.com/klauspost/compress/zstd"
 )
@@ -44,6 +47,8 @@ type zstdCodec struct {
 	enc     *zstd.Encoder
 	dec     *zstd.Decoder
 	hasDict bool
+	dopts   []zstd.DOption // decoder options, for pooled streaming (prefix) decoders
+	spool   sync.Pool      // *streamDec, one per concurrent prefix read
 }
 
 // NewZSTDCodec returns a ZSTD codec. If dict is non-empty it is used as a shared
@@ -63,7 +68,7 @@ func NewZSTDCodec(dict []byte) (Codec, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &zstdCodec{enc: enc, dec: dec, hasDict: len(dict) > 0}, nil
+	return &zstdCodec{enc: enc, dec: dec, hasDict: len(dict) > 0, dopts: dopts}, nil
 }
 
 func (z *zstdCodec) Compress(dst, src []byte) []byte { return z.enc.EncodeAll(src, dst) }
@@ -141,4 +146,56 @@ func TrainDictSize(samples [][]byte, dictSize int) (dict []byte, err error) {
 		// dictionary ("invalid offset in dictionary").
 		Offsets: [3]int{1, 4, 8},
 	})
+}
+
+// PrefixDecompressor is an optional Codec capability: decompress only
+// (approximately) the first want bytes of a record. With the hot region encoded
+// as a physical prefix (see wire.EncodeInlineWithHotEnc), a hot-covered
+// projected read decompresses a couple of KB instead of the whole record. The
+// result may be shorter than want (the record ends first -- then it is the
+// complete record) and is otherwise a TRUNCATED record: the caller must be
+// prepared for parses to run off the end and fall back to a full Decompress.
+type PrefixDecompressor interface {
+	DecompressPrefix(dst, src []byte, want int) ([]byte, error)
+}
+
+// streamDec is one pooled streaming decoder (Reset-per-record) plus its reader.
+// zstd's DecodeAll is concurrency-safe but streaming decode is not, so each
+// concurrent prefix read takes its own decoder from the pool.
+type streamDec struct {
+	dec *zstd.Decoder
+	br  *bytes.Reader
+}
+
+func (z *zstdCodec) DecompressPrefix(dst, src []byte, want int) ([]byte, error) {
+	v := z.spool.Get()
+	var sd *streamDec
+	if v == nil {
+		dopts := append([]zstd.DOption{zstd.WithDecoderConcurrency(1)}, z.dopts...)
+		dec, err := zstd.NewReader(nil, dopts...)
+		if err != nil {
+			return dst, err
+		}
+		sd = &streamDec{dec: dec, br: new(bytes.Reader)}
+	} else {
+		sd = v.(*streamDec)
+	}
+	sd.br.Reset(src)
+	if err := sd.dec.Reset(sd.br); err != nil {
+		z.spool.Put(sd)
+		return dst, err
+	}
+	off := len(dst)
+	if cap(dst)-off < want {
+		dst = append(dst, make([]byte, want)...)
+	} else {
+		dst = dst[:off+want]
+	}
+	n, err := io.ReadFull(sd.dec, dst[off:])
+	dst = dst[:off+n]
+	z.spool.Put(sd)
+	if err == io.EOF || err == io.ErrUnexpectedEOF {
+		err = nil // the whole record was shorter than want: dst holds all of it
+	}
+	return dst, err
 }

--- a/collections/rawwire_parallel.go
+++ b/collections/rawwire_parallel.go
@@ -1,0 +1,195 @@
+package collections
+
+import (
+	"sync"
+	"sync/atomic"
+
+	"github.com/PelicanPlatform/classad/collections/wire"
+)
+
+// wireRowBatch is one worker's assembled wire-form rows: row i occupies
+// buf[offs[i]:offs[i+1]] (offs always starts with 0). Rows build DIRECTLY into
+// the arena -- the subset assembler appends to it -- so a row is copied exactly
+// once between the decompressed record and the consumer.
+type wireRowBatch struct {
+	buf  []byte
+	offs []int
+}
+
+// wireBatchArena is a worker's target arena size before handing rows to the
+// yielding goroutine -- large enough to amortize channel handoffs, small enough
+// that W workers' in-flight arenas stay a few hundred KB total.
+const wireBatchArena = 64 << 10
+
+// wirePrefixBytes is how much of a compressed record a projected scan
+// decompresses first: the hot region is encoded as a physical prefix (hot
+// header + hot entries, typically ~1-2KB for a monitoring hot set), so this
+// covers it with margin. A subset that the prefix cannot satisfy -- offsets
+// beyond it, a projected attribute that is cold -- falls back to a full
+// decompress of that record.
+const wirePrefixBytes = 3 << 10
+
+// runParallelWireScan fans the wire-row subset scan across the collection's
+// segment windows, using the same worker budget, work-size gate and
+// work-stealing pattern as runParallelQuery: per-record ZSTD decompression is
+// the scan's dominant cost and is embarrassingly parallel across segments.
+// Rows arrive at yield in arbitrary order (queries do not order rows).
+//
+// Returns false without consuming the yield when parallelism is not engaged --
+// too little work, no budget, or an at-rest-encrypted collection (the Sealer
+// contract is single-goroutine per pass, so encrypted stores stay serial) --
+// and the caller runs the serial path.
+func (c *Collection) runParallelWireScan(sel *wireSubsetSelector, needed int, yield func([]byte) bool) bool {
+	if c.sealer != nil {
+		return false
+	}
+	tasks, totalBytes, release := c.gatherTasks()
+	W := 0
+	if c.qsem != nil && len(tasks) >= 2 && totalBytes >= c.parallelMinBytes {
+		want := c.queryPar
+		if want > len(tasks) {
+			want = len(tasks)
+		}
+		W = tryAcquire(c.qsem, want)
+	}
+	if W < 2 {
+		for i := 0; i < W; i++ {
+			<-c.qsem
+		}
+		release()
+		return false
+	}
+	defer release()
+	defer func() {
+		for i := 0; i < W; i++ {
+			<-c.qsem
+		}
+	}()
+
+	results := make(chan wireRowBatch, W)
+	// Arena free-list: the consumer recycles drained batches back to the workers,
+	// so a steady scan reuses ~2W arenas total instead of allocating one per 64KB
+	// of result (a whole-pool unprojected scan would otherwise churn tens of MB of
+	// garbage per query). getBatch falls back to allocation only until the pool
+	// warms.
+	recycle := make(chan wireRowBatch, 2*W+2)
+	getBatch := func() wireRowBatch {
+		select {
+		case b := <-recycle:
+			b.buf = b.buf[:0]
+			b.offs = append(b.offs[:0], 0)
+			return b
+		default:
+			return wireRowBatch{buf: make([]byte, 0, wireBatchArena), offs: []int{0}}
+		}
+	}
+	var next int64
+	var stopped atomic.Bool
+	var wg sync.WaitGroup
+	for i := 0; i < W; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			var dbuf []byte
+			var sc wire.SubsetScratch
+			// Adaptive prefix gate: a stretch of records that cannot be served from
+			// their prefix (not yet re-encoded hot-first, or the projection is not
+			// hot-covered) would pay a wasted prefix decompress each -- so after
+			// eight consecutive fallbacks the worker stops trying for the rest of
+			// its scan. Any success re-arms it.
+			usePrefix := true
+			consecFail := 0
+			batch := getBatch()
+			flush := func() {
+				if len(batch.offs) > 1 {
+					results <- batch
+					batch = getBatch()
+				}
+			}
+			for {
+				if stopped.Load() {
+					return
+				}
+				idx := int(atomic.AddInt64(&next, 1)) - 1
+				if idx >= len(tasks) {
+					flush()
+					return
+				}
+				forEachVisibleWindowKeyed(tasks[idx].s0, tasks[idx].win, func(key, ad []byte, codec Codec) bool {
+					if stopped.Load() {
+						return false
+					}
+					if isSystemKeyBytes(key) {
+						return true
+					}
+					start := len(batch.buf)
+					// Projected reads try a PREFIX decompress first: the hot region is
+					// a physical prefix of the record, so a hot-covered projection
+					// never decompresses the rest. A truncated parse (or an unmet
+					// selection) falls back to the full record.
+					if pd, canPrefix := codec.(PrefixDecompressor); canPrefix && usePrefix && needed > 0 {
+						w, perr := pd.DecompressPrefix(dbuf[:0], ad, wirePrefixBytes)
+						dbuf = w
+						if perr == nil {
+							if out, ok := wire.AppendAdSubsetInlineHotFirst(batch.buf, wire.Ad(w), sel.keep, needed, nil, &sc); ok {
+								consecFail = 0
+								batch.buf = out
+								batch.offs = append(batch.offs, len(out))
+								if len(batch.buf) >= wireBatchArena {
+									flush()
+								}
+								return true
+							} else {
+								batch.buf = out[:start]
+							}
+						}
+						if consecFail++; consecFail >= 8 {
+							usePrefix = false
+						}
+					}
+					w, err := codec.Decompress(dbuf[:0], ad)
+					dbuf = w
+					if err != nil {
+						return true // undecodable record: skip, matching the serial scan
+					}
+					out, ok := wire.AppendAdSubsetInlineHotFirst(batch.buf, wire.Ad(w), sel.keep, needed, nil, &sc)
+					if !ok {
+						batch.buf = out[:start] // discard the partial append
+						return true
+					}
+					batch.buf = out
+					batch.offs = append(batch.offs, len(out))
+					if len(batch.buf) >= wireBatchArena {
+						flush()
+					}
+					return true
+				})
+			}
+		}()
+	}
+	go func() {
+		wg.Wait()
+		close(results)
+	}()
+	for b := range results {
+		stop := false
+		for i := 0; i+1 < len(b.offs); i++ {
+			if !yield(b.buf[b.offs[i]:b.offs[i+1]]) {
+				stop = true
+				break
+			}
+		}
+		select {
+		case recycle <- b:
+		default: // free-list full; let the arena be collected
+		}
+		if stop {
+			stopped.Store(true)
+			for range results {
+				// drain so the workers and closer finish
+			}
+			return true
+		}
+	}
+	return true
+}

--- a/collections/rawwire_subset.go
+++ b/collections/rawwire_subset.go
@@ -1,0 +1,197 @@
+package collections
+
+import (
+	"iter"
+	"strings"
+
+	"github.com/PelicanPlatform/classad/classad"
+	"github.com/PelicanPlatform/classad/collections/vm"
+	"github.com/PelicanPlatform/classad/collections/wire"
+)
+
+// ScanRawWire yields each ad as a WIRE-FORM ROW: a self-contained inline-names
+// ad holding only the selected entries, assembled by slice copies from the
+// stored bytes (see wire.AppendAdSubsetInline) -- nothing is decoded or
+// rendered here. It is the relay scan for shipping a persistent table's ads
+// across a process boundary (dbrpc) with the old-ClassAd render deferred to the
+// far edge (RenderRawAdInline); the consumer needs no intern table and no data
+// key (at-rest-encrypted values are opened during assembly).
+//
+// projection restricts the entries to the named attributes (case-insensitive;
+// MyType/TargetType always ship so the ad stays typed); empty means every
+// entry. redact drops private attributes -- pre-pruned from a projection, or
+// tested per entry with a byte-gated predicate for the whole-ad case. The
+// yielded row aliases a buffer reused across the iteration. Non-inline (RAM)
+// collections yield nothing: their ads are not self-contained, and an
+// in-process consumer reads them through the collection directly.
+func (c *Collection) ScanRawWire(projection []string, redact bool) iter.Seq[[]byte] {
+	return func(yield func([]byte) bool) {
+		if !c.inline {
+			return
+		}
+		sel := c.newWireSubsetSelector(projection, redact)
+		// Decompression dominates a compressed scan and parallelizes across
+		// segments; the serial path below is the fallback (small scans, no budget,
+		// encrypted stores).
+		if c.runParallelWireScan(sel, sel.neededCount(), yield) {
+			return
+		}
+		emit := c.yieldWireRow(yield, sel)
+		q := queryPlan{}
+		for _, sh := range c.shards {
+			if !c.scanShard(sh, q, emit) {
+				return
+			}
+		}
+	}
+}
+
+// QueryRawWire is ScanRawWire restricted to ads matching q.
+func (c *Collection) QueryRawWire(q *vm.Query, projection []string, redact bool) iter.Seq[[]byte] {
+	return func(yield func([]byte) bool) {
+		if !c.inline {
+			return
+		}
+		sel := c.newWireSubsetSelector(projection, redact)
+		emit := c.yieldWireRow(yield, sel)
+		plan := q.ReadPlan()
+		ws := &wireScope{ctx: c}
+		qp := queryPlan{
+			q:        q,
+			plan:     plan,
+			m:        q.Matcher(),
+			wireOK:   q.Native() && plan.PartialSafe,
+			ws:       ws,
+			resolver: ws.resolve,
+		}
+		probes := q.Probes()
+		c.demand.record(probes)
+		usable := c.planIndex(probes)
+		for _, sh := range c.shards {
+			var cont bool
+			if len(usable) > 0 {
+				cont = c.scanShardIndexed(sh, usable, qp, emit)
+			} else {
+				cont = c.scanShard(sh, qp, emit)
+			}
+			if !cont {
+				return
+			}
+		}
+	}
+}
+
+// neededCount is the hot fast path's early-exit target: the projected names
+// plus the two type fields. 0 (whole-ad) disables the shortcut.
+func (sel *wireSubsetSelector) neededCount() int {
+	if sel.wantAll {
+		return 0
+	}
+	return len(sel.names) + 2
+}
+
+func (c *Collection) yieldWireRow(yield func([]byte) bool, sel *wireSubsetSelector) func(w []byte) bool {
+	var scratch []byte
+	var sc wire.SubsetScratch
+	needed := sel.neededCount()
+	return func(w []byte) bool {
+		out, ok := wire.AppendAdSubsetInlineHotFirst(scratch[:0], wire.Ad(w), sel.keep, needed, c.sealer, &sc)
+		scratch = out
+		if !ok {
+			return true // not an inline ad / malformed: skip, keep scanning
+		}
+		return yield(out)
+	}
+}
+
+// wireSubsetSelector decides, per entry, whether a wire-form row keeps it: the
+// same name-hash-first matching the projected text scans use, with private
+// names pre-pruned from a redacted projection so redaction costs nothing per
+// entry on the projected path.
+type wireSubsetSelector struct {
+	wantAll bool
+	redact  bool
+	names   []string
+	hashes  []uint32
+}
+
+func (c *Collection) newWireSubsetSelector(projection []string, redact bool) *wireSubsetSelector {
+	sel := &wireSubsetSelector{wantAll: len(projection) == 0, redact: redact}
+	seen := make(map[string]struct{}, len(projection))
+	for _, name := range projection {
+		fold := strings.ToLower(name)
+		if _, dup := seen[fold]; dup {
+			continue
+		}
+		seen[fold] = struct{}{}
+		if redact && classad.IsPrivateAttribute(name) {
+			continue
+		}
+		sel.names = append(sel.names, name)
+		sel.hashes = append(sel.hashes, wire.NameHash32(name))
+	}
+	if len(projection) > 0 {
+		// Projection demand steers RefreshHotSet exactly as the text scans do.
+		c.demand.recordReads(projection)
+		c.demand.recordReads(rawTypeFieldNames)
+	}
+	return sel
+}
+
+func (sel *wireSubsetSelector) keep(name, _ []byte) bool {
+	// The type fields always ship so the row stays typed (never private).
+	if wire.FoldEqualBytes(name, "MyType") || wire.FoldEqualBytes(name, "TargetType") {
+		return true
+	}
+	if sel.wantAll {
+		return !(sel.redact && isPrivateNameBytes(name))
+	}
+	h := wire.NameHash32Bytes(name)
+	for i, wh := range sel.hashes {
+		if wh == h && wire.FoldEqualBytes(name, sel.names[i]) {
+			return true
+		}
+	}
+	return false
+}
+
+// RenderRawAdInline renders a wire-form row (a self-contained inline-names ad,
+// e.g. one shipped by ScanRawWire over dbrpc) to old-ClassAd "Name = Value"
+// expression text: each expression is buf[offs[i]:offs[i+1]], with
+// MyType/TargetType lifted out exactly as the collection scans do -- the shape
+// message.PutClassAdRawBytes consumes. This is the LAST-MINUTE conversion at
+// the client edge; everything upstream of it stays in wire form. buf/offs are
+// reset and reused (pass the previous call's returns to avoid allocation).
+func RenderRawAdInline(w []byte, buf []byte, offs []int) (outBuf []byte, outOffs []int, myType, targetType string, ok bool) {
+	buf = buf[:0]
+	offs = append(offs[:0], 0)
+	good := true
+	walked := wire.Ad(w).ForEachNameNode(func(name, node []byte) bool {
+		if wire.FoldEqualBytes(name, "MyType") {
+			if lit, lok := wire.LiteralValue(node); lok && lit.Kind == wire.LitString {
+				myType = lit.Str
+				return true
+			}
+		}
+		if wire.FoldEqualBytes(name, "TargetType") {
+			if lit, lok := wire.LiteralValue(node); lok && lit.Kind == wire.LitString {
+				targetType = lit.Str
+				return true
+			}
+		}
+		buf = append(buf, name...)
+		buf = append(buf, ' ', '=', ' ')
+		var aerr error
+		buf, aerr = wire.AppendNodeTextInline(buf, node)
+		if aerr != nil {
+			good = false
+			return false
+		}
+		offs = append(offs, len(buf))
+		return true
+	})
+	if !walked || !good {
+		return buf, offs, "", "", false
+	}
+	return buf, offs, myType, targetType, true
+}

--- a/collections/rawwire_subset_test.go
+++ b/collections/rawwire_subset_test.go
@@ -1,0 +1,178 @@
+package collections
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/classad"
+	"github.com/PelicanPlatform/classad/collections/wire"
+)
+
+// collectWireRendered runs the wire-form relay end-to-end in miniature:
+// ScanRawWire rows (assembled subsets) rendered at the "edge" by
+// RenderRawAdInline, materialized into copies.
+func collectWireRendered(t *testing.T, c *Collection, projection []string, redact bool) []RawAd {
+	t.Helper()
+	var out []RawAd
+	var buf []byte
+	var offs []int
+	for row := range c.ScanRawWire(projection, redact) {
+		var mt, tt string
+		var ok bool
+		buf, offs, mt, tt, ok = RenderRawAdInline(row, buf, offs)
+		if !ok {
+			t.Fatal("RenderRawAdInline failed on a shipped row")
+		}
+		cp := RawAd{MyType: mt, TargetType: tt}
+		for i := 0; i+1 < len(offs); i++ {
+			cp.Exprs = append(cp.Exprs, append([]byte(nil), buf[offs[i]:offs[i+1]]...))
+		}
+		out = append(out, cp)
+	}
+	return out
+}
+
+// TestScanRawWireRoundTrip verifies the relay path -- subset assembly at the
+// store, old-ClassAd render at the far edge -- produces exactly what the
+// direct projected/redacted text scans produce, for a projected, a redacted
+// and a whole-ad selection on a persistent (inline) collection.
+func TestScanRawWireRoundTrip(t *testing.T) {
+	t.Parallel()
+	c := projTestCollectionInline(t)
+
+	cases := []struct {
+		name   string
+		proj   []string
+		redact bool
+	}{
+		{"projected", []string{"Name", "State", "Cpus", "NoSuchAttr"}, false},
+		{"projected-redacted", []string{"Name", "ClaimId"}, true},
+		{"whole-ad", nil, false},
+		{"whole-ad-redacted", nil, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			want := adsByName(t, collectProjected(c, tc.proj, false, tc.redact))
+			got := adsByName(t, collectWireRendered(t, c, tc.proj, tc.redact))
+			if len(got) != len(want) {
+				t.Fatalf("wire relay returned %d ads, direct scan %d", len(got), len(want))
+			}
+			for name, attrs := range want {
+				g := got[name]
+				if len(g) != len(attrs) {
+					t.Errorf("%s: wire %v != direct %v", name, g, attrs)
+					continue
+				}
+				for a, v := range attrs {
+					if g[a] != v {
+						t.Errorf("%s.%s: wire %q != direct %q", name, a, g[a], v)
+					}
+				}
+			}
+		})
+	}
+
+	// The redacted whole-ad row must not leak ClaimId even before rendering:
+	// scan the raw row bytes for the secret value.
+	for row := range c.ScanRawWire(nil, true) {
+		if strings.Contains(string(row), "<secret>") {
+			t.Fatal("redacted wire row carries the private value bytes")
+		}
+	}
+}
+
+// BenchmarkScanRawWireZSTD isolates the db-side wire-subset scan on a
+// ZSTD-compressed persistent store (the htcondordb production configuration):
+// the per-record decompress dominates, bounding what any relay above it can see.
+func BenchmarkScanRawWireZSTD(b *testing.B) {
+	sample := loadCorpus(b)
+	const n = 2000
+	c := populatePersistent(b, sample, n, b.TempDir())
+	defer c.Close()
+	if _, err := c.RetrainDict(n); err != nil {
+		b.Fatal(err)
+	}
+	proj := []string{"Name", "Machine", "OpSys", "Arch", "State", "Activity",
+		"LoadAvg", "Memory", "Cpus", "EnteredCurrentActivity", "MyCurrentTime", "TotalSlots"}
+	c.AddHotAttrs(append(append([]string{}, proj...), "MyType", "TargetType")...)
+	keys := c.Keys()
+	for _, k := range keys {
+		if ad, ok := c.Get([]byte(k)); ok {
+			if err := c.Put([]byte(k), ad); err != nil {
+				b.Fatal(err)
+			}
+		}
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		cnt := 0
+		for range c.ScanRawWire(proj, true) {
+			cnt++
+		}
+	}
+	b.ReportMetric(float64(n)*float64(b.N)/b.Elapsed().Seconds(), "ads/sec")
+}
+
+// TestHotPrefixDecodable verifies the hot-first physical layout end to end: a
+// record encoded with a hot set can be TRUNCATED to a small prefix and still
+// serve a hot-covered subset, identical to the subset from the full record --
+// through both the AST encoder (Put) and the text-ingest StreamEncoder
+// (UpdateOld), the path most records arrive through.
+func TestHotPrefixDecodable(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	c, err := Open(Options{Dir: dir, HotAttrs: []string{"Name", "State", "Cpus", "MyType", "TargetType"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+
+	// AST path.
+	ad, err := classad.Parse(projTestAdTexts[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Put([]byte("ast"), ad); err != nil {
+		t.Fatal(err)
+	}
+	// Text-ingest (StreamEncoder) path.
+	if err := c.UpdateOld([]OldAdUpdate{{Key: []byte("txt"),
+		Text: "MyType = \"Machine\"\nTargetType = \"Job\"\nName = \"slot1@txt\"\nState = \"Claimed\"\nCpus = 4\nMemory = 8192\nLoadAvg = 0.5\nArch = \"X86_64\"\nOpSys = \"LINUX\"\n"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	sel := c.newWireSubsetSelector([]string{"Name", "State", "Cpus"}, false)
+	needed := sel.neededCount()
+	var sc wire.SubsetScratch
+	checked := 0
+	for _, sh := range c.shards {
+		s0, wins := sh.snapshot()
+		forEachVisible(s0, wins, func(rec []byte, codec Codec) bool {
+			full, ferr := codec.Decompress(nil, rec)
+			if ferr != nil {
+				t.Fatal(ferr)
+			}
+			want, ok := wire.AppendAdSubsetInlineHotFirst(nil, wire.Ad(full), sel.keep, needed, nil, &sc)
+			if !ok {
+				t.Fatal("subset failed on the full record")
+			}
+			// The whole selection must be servable from a small physical prefix.
+			const prefix = 512
+			if len(full) > prefix {
+				got, gok := wire.AppendAdSubsetInlineHotFirst(nil, wire.Ad(full[:prefix]), sel.keep, needed, nil, &sc)
+				if !gok {
+					t.Fatalf("subset not servable from a %dB prefix (hot region not front-loaded?)", prefix)
+				}
+				if string(got) != string(want) {
+					t.Fatal("prefix-served subset differs from full-record subset")
+				}
+			}
+			checked++
+			return true
+		})
+		releaseWindows(wins)
+	}
+	if checked < 2 {
+		t.Fatalf("checked %d records, want both encode paths", checked)
+	}
+}

--- a/collections/wire/encode.go
+++ b/collections/wire/encode.go
@@ -111,17 +111,37 @@ func EncodeInlineWithHotEnc(dst []byte, ad *ast.ClassAd, hot map[string]struct{}
 	e := encoder{inline: true, seal: seal}
 	var hots []hotPair
 	if ad != nil {
+		// Hot entries are written FIRST, so the hot region occupies a physical
+		// prefix of the record: a compressed store can then decompress only that
+		// prefix to serve a hot-covered projection (see Codec.DecompressPrefix).
+		// The partition is stable within each class, so among same-named
+		// duplicates the first still comes first.
+		isHot := func(attr *ast.AttributeAssignment) bool {
+			if seal != nil && encrypt != nil && encrypt(attr.Name) {
+				return false // encrypted attributes are never indexed / hot
+			}
+			_, ok := hot[foldASCII(attr.Name)]
+			return ok
+		}
 		for _, attr := range ad.Attributes {
-			entryOff := len(e.buf) // offset of the (name, node) entry within the region
+			if !isHot(attr) {
+				continue
+			}
+			entryOff := len(e.buf)
+			e.putString(attr.Name)
+			e.node(attr.Value)
+			hots = append(hots, hotPair{nameHash32(attr.Name), uint32(entryOff)})
+		}
+		for _, attr := range ad.Attributes {
+			if isHot(attr) {
+				continue
+			}
 			e.putString(attr.Name)
 			if seal != nil && encrypt != nil && encrypt(attr.Name) {
 				e.encNode(attr.Value)
-				continue // encrypted attributes are never indexed / hot
+				continue
 			}
 			e.node(attr.Value)
-			if _, ok := hot[foldASCII(attr.Name)]; ok {
-				hots = append(hots, hotPair{nameHash32(attr.Name), uint32(entryOff)})
-			}
 		}
 	}
 	out := append(dst, magicByte, formatVer, flagInlineNames)

--- a/collections/wire/encrypt.go
+++ b/collections/wire/encrypt.go
@@ -37,6 +37,39 @@ func (e *encoder) encNode(v ast.Expr) {
 	e.buf = append(e.buf, ct...)
 }
 
+// OpenEncryptedNode returns the plain node bytes sealed inside an nEncrypted
+// node -- the sealed payload IS the value's ordinary node encoding, so opening
+// it needs no re-encode. Returns (nil, false) if node is not an nEncrypted
+// node, open is nil, or authentication fails. A relay that ships wire-form
+// rows to a consumer without the data key uses this to emit the entry with its
+// value in the clear (the consumer cannot open it).
+func OpenEncryptedNode(node []byte, open Sealer) ([]byte, bool) {
+	if open == nil || len(node) == 0 || node[0] != nEncrypted {
+		return nil, false
+	}
+	c := &cursor{b: node, pos: 1, ok: true}
+	nl := int(c.uvarint())
+	if !c.ok || c.pos+nl > len(node) {
+		return nil, false
+	}
+	nonce := node[c.pos : c.pos+nl]
+	c.pos += nl
+	cl := int(c.uvarint())
+	if !c.ok || c.pos+cl > len(node) {
+		return nil, false
+	}
+	plain, err := open.Open(nonce, node[c.pos:c.pos+cl])
+	if err != nil {
+		return nil, false
+	}
+	return plain, true
+}
+
+// IsEncryptedNode reports whether node is an nEncrypted (at-rest sealed) node.
+func IsEncryptedNode(node []byte) bool {
+	return len(node) > 0 && node[0] == nEncrypted
+}
+
 // DecodeNodeInlineEnc decodes raw node bytes from an inline-names ad (as returned by
 // LookupByName), opening an nEncrypted node with open. A nil open leaves an encrypted
 // node an error (the fast path treats that as absent).

--- a/collections/wire/stream.go
+++ b/collections/wire/stream.go
@@ -188,6 +188,13 @@ func (s *StreamEncoder) Bytes(dst []byte) []byte {
 	var flags byte
 	if s.inline {
 		flags = flagInlineNames
+		// Reorder the entries region hot-first so the hot region is a physical
+		// prefix of the record (prefix-decompressable; see EncodeInlineWithHotEnc).
+		// Entries were streamed in arrival order, so the hot entries' extents are
+		// parsed out and moved to the front here, with their header offsets
+		// recomputed. Order within each class is preserved (stable), keeping
+		// first-occurrence-wins duplicate semantics intact.
+		s.reorderHotFirstInline()
 	}
 	out := append(dst, magicByte, formatVer, flags)
 	out = binary.AppendUvarint(out, uint64(len(s.hots)))
@@ -198,4 +205,48 @@ func (s *StreamEncoder) Bytes(dst []byte) []byte {
 	out = binary.AppendUvarint(out, uint64(s.count))
 	out = append(out, s.entries...)
 	return out
+}
+
+// reorderHotFirstInline rewrites s.entries with the hot entries first and
+// updates s.hots' offsets. A no-op when nothing is hot or everything already
+// sits at the front. Hot pairs are recorded in write order, so their extents
+// are ascending and the cold remainder is the gaps between them, emitted in
+// order.
+func (s *StreamEncoder) reorderHotFirstInline() {
+	if len(s.hots) == 0 {
+		return
+	}
+	// Parse each hot entry's extent from its recorded start.
+	type extent struct{ start, end int }
+	exts := make([]extent, len(s.hots))
+	contiguousPrefix := true
+	prevEnd := 0
+	for i, h := range s.hots {
+		c := &cursor{b: s.entries, pos: int(h.off), ok: true, inline: true}
+		c.skip(int(c.uvarint())) // name
+		skipNode(c, 0)
+		if !c.ok {
+			return // malformed entry: leave the region untouched
+		}
+		exts[i] = extent{int(h.off), c.pos}
+		if int(h.off) != prevEnd {
+			contiguousPrefix = false
+		}
+		prevEnd = c.pos
+	}
+	if contiguousPrefix {
+		return // hot entries already occupy the front, in order
+	}
+	reordered := make([]byte, 0, len(s.entries))
+	for i := range exts {
+		s.hots[i].off = uint32(len(reordered))
+		reordered = append(reordered, s.entries[exts[i].start:exts[i].end]...)
+	}
+	prev := 0
+	for _, ex := range exts {
+		reordered = append(reordered, s.entries[prev:ex.start]...)
+		prev = ex.end
+	}
+	reordered = append(reordered, s.entries[prev:]...)
+	s.entries = reordered
 }

--- a/collections/wire/subset.go
+++ b/collections/wire/subset.go
@@ -1,0 +1,218 @@
+package wire
+
+// AppendAdSubsetInline assembles a self-contained inline-names ad holding the
+// subset of src's attribute entries keep selects, appending it to dst and
+// returning the extended slice. It is the relay primitive for shipping stored
+// ads across a trust/process boundary in wire form: an inline entry is a
+// contiguous (name, node) byte range, so the subset is assembled by slice
+// copies -- no value is decoded, rendered or re-encoded.
+//
+// An entry whose node is at-rest encrypted (nEncrypted) is emitted with its
+// value OPENED via open when non-nil -- the consumer holds no data key -- and
+// skipped entirely when open is nil or fails (matching the fast paths, which
+// treat an unopenable value as absent). The emitted ad carries no hot header
+// (its consumer renders linearly). Returns ok=false when src is not a
+// well-formed inline-names ad; keep=nil keeps every entry.
+func AppendAdSubsetInline(dst []byte, src Ad, keep func(name, node []byte) bool, open Sealer) ([]byte, bool) {
+	c, ok := src.bodyStart()
+	if !ok || !c.inline {
+		return dst, false
+	}
+	hotCount := c.uvarint()
+	for i := uint64(0); i < hotCount && c.ok; i++ {
+		c.uvarint()
+		c.uvarint()
+	}
+	attrCount := c.uvarint()
+	if !c.ok {
+		return dst, false
+	}
+
+	// Reserve the header now; the entry count is back-patched as a fixed-width
+	// uvarint so entries can stream directly into dst with no second buffer.
+	dst = append(dst, magicByte, formatVer, flagInlineNames)
+	dst = append(dst, 0) // hotCount = 0
+	countAt := len(dst)
+	dst = append(dst, 0x80, 0x80, 0x80, 0x80, 0x00) // 5-byte uvarint placeholder (value patched below)
+	kept := uint64(0)
+
+	for i := uint64(0); i < attrCount && c.ok; i++ {
+		nameStart := c.pos
+		name := c.readNameBytes()
+		if !c.ok {
+			return dst, false
+		}
+		nodeStart := c.pos
+		skipNode(c, 0)
+		if !c.ok {
+			return dst, false
+		}
+		node := src[nodeStart:c.pos]
+		if keep != nil && !keep(name, node) {
+			continue
+		}
+		if IsEncryptedNode(node) {
+			plain, opened := OpenEncryptedNode(node, open)
+			if !opened {
+				continue // no key (or tampered): the value is absent to this consumer
+			}
+			// Re-emit as name + plain node (the one case a copy substitutes bytes).
+			dst = append(dst, src[nameStart:nodeStart]...)
+			dst = append(dst, plain...)
+			kept++
+			continue
+		}
+		dst = append(dst, src[nameStart:c.pos]...) // contiguous (name, node) entry
+		kept++
+	}
+	if !c.ok {
+		return dst, false
+	}
+	patchUvarint5(dst[countAt:countAt+5], kept)
+	return dst, true
+}
+
+// patchUvarint5 writes v into a fixed 5-byte uvarint slot (continuation bits on
+// the first four bytes), enough for any uint32-ranged count. Fixed width lets
+// the encoder reserve the slot before the value is known.
+func patchUvarint5(b []byte, v uint64) {
+	b[0] = byte(v)&0x7f | 0x80
+	b[1] = byte(v>>7)&0x7f | 0x80
+	b[2] = byte(v>>14)&0x7f | 0x80
+	b[3] = byte(v>>21)&0x7f | 0x80
+	b[4] = byte(v >> 28 & 0x7f)
+}
+
+// SubsetScratch holds AppendAdSubsetInlineHotFirst's per-scan scratch (hot
+// pairs, copied-entry offsets), reused across ads so assembly allocates
+// nothing per ad.
+type SubsetScratch struct {
+	hot    []uint32
+	copied []int
+}
+
+// AppendAdSubsetInlineHotFirst is AppendAdSubsetInline with the hot-header
+// shortcut: entries reachable through the ad's hot pairs are copied first via
+// their stored offsets, and when that satisfies the whole selection (kept ==
+// needed) the linear walk is skipped entirely -- the projected relay's fast
+// path, mirroring the projected text scan's. Anything short of full
+// satisfaction falls back to the walk, which skips the entries the hot phase
+// already copied. needed <= 0 disables the shortcut (a whole-ad selection must
+// walk everything).
+func AppendAdSubsetInlineHotFirst(dst []byte, src Ad, keep func(name, node []byte) bool, needed int, open Sealer, sc *SubsetScratch) ([]byte, bool) {
+	if needed <= 0 {
+		return AppendAdSubsetInline(dst, src, keep, open)
+	}
+	c, ok := src.bodyStart()
+	if !ok || !c.inline {
+		return dst, false
+	}
+	hotCount := c.uvarint()
+	sc.hot = sc.hot[:0]
+	for i := uint64(0); i < hotCount && c.ok; i++ {
+		sc.hot = append(sc.hot, uint32(c.uvarint()), uint32(c.uvarint()))
+	}
+	attrCount := c.uvarint()
+	if !c.ok {
+		return dst, false
+	}
+	entriesStart := c.pos
+
+	dst = append(dst, magicByte, formatVer, flagInlineNames)
+	dst = append(dst, 0) // hotCount = 0
+	countAt := len(dst)
+	dst = append(dst, 0x80, 0x80, 0x80, 0x80, 0x00)
+	kept := uint64(0)
+	sc.copied = sc.copied[:0]
+
+	emit := func(entryStart, nameEnd int, name, node []byte) bool {
+		if IsEncryptedNode(node) {
+			plain, opened := OpenEncryptedNode(node, open)
+			if !opened {
+				return false
+			}
+			dst = append(dst, src[entryStart:nameEnd]...)
+			dst = append(dst, plain...)
+			return true
+		}
+		dst = append(dst, src[entryStart:nameEnd]...)
+		dst = append(dst, node...)
+		return true
+	}
+
+	// Hot phase: direct entry offsets, no scanning.
+	for i := 0; i+1 < len(sc.hot); i += 2 {
+		entryStart := entriesStart + int(sc.hot[i+1])
+		ec := &cursor{b: src, pos: entryStart, ok: true, inline: true}
+		name := ec.readNameBytes()
+		if !ec.ok {
+			return dst, false
+		}
+		nameEnd := ec.pos
+		nodeStart := ec.pos
+		skipNode(ec, 0)
+		if !ec.ok {
+			return dst, false
+		}
+		node := src[nodeStart:ec.pos]
+		if keep == nil || !keep(name, node) {
+			continue
+		}
+		dup := false
+		for _, off := range sc.copied {
+			if off == entryStart {
+				dup = true
+				break
+			}
+		}
+		if dup {
+			continue
+		}
+		if emit(entryStart, nameEnd, name, node) {
+			sc.copied = append(sc.copied, entryStart)
+			kept++
+		}
+	}
+	if int(kept) == needed {
+		patchUvarint5(dst[countAt:countAt+5], kept)
+		return dst, true
+	}
+
+	// Fallback walk for whatever the hot header did not cover, skipping entries
+	// the hot phase already copied.
+	for i := uint64(0); i < attrCount && c.ok; i++ {
+		entryStart := c.pos
+		name := c.readNameBytes()
+		if !c.ok {
+			return dst, false
+		}
+		nameEnd := c.pos
+		nodeStart := c.pos
+		skipNode(c, 0)
+		if !c.ok {
+			return dst, false
+		}
+		copiedAlready := false
+		for _, off := range sc.copied {
+			if off == entryStart {
+				copiedAlready = true
+				break
+			}
+		}
+		if copiedAlready {
+			continue
+		}
+		node := src[nodeStart:c.pos]
+		if keep != nil && !keep(name, node) {
+			continue
+		}
+		if emit(entryStart, nameEnd, name, node) {
+			kept++
+		}
+	}
+	if !c.ok {
+		return dst, false
+	}
+	patchUvarint5(dst[countAt:countAt+5], kept)
+	return dst, true
+}

--- a/db/rawwire.go
+++ b/db/rawwire.go
@@ -114,3 +114,22 @@ func (db *DB) QueryRawProjected(constraint string, projection []string, redact b
 	}
 	return db.c.QueryRawProjected(q, projection, false, redact), nil
 }
+
+// QueryRawWire yields each matching ad as a self-contained WIRE-FORM ROW (an
+// inline-names subset ad assembled by slice copies -- see
+// collections.ScanRawWire): the relay form for shipping ads to a remote
+// consumer with the old-ClassAd render deferred to that consumer's client edge.
+// projection restricts the entries (empty = whole ad); redact strips private
+// attributes at the source. At-rest-encrypted values are opened during assembly
+// (the consumer holds no data key). Only meaningful for persistent (inline)
+// stores; an in-memory table yields nothing.
+func (db *DB) QueryRawWire(constraint string, projection []string, redact bool) (iter.Seq[[]byte], error) {
+	if s := strings.TrimSpace(constraint); s == "" || strings.EqualFold(s, "true") {
+		return db.c.ScanRawWire(projection, redact), nil
+	}
+	q, err := vm.Parse(constraint)
+	if err != nil {
+		return nil, fmt.Errorf("classad-db: bad constraint %q: %w", constraint, err)
+	}
+	return db.c.QueryRawWire(q, projection, redact), nil
+}

--- a/dbrpc/proto.go
+++ b/dbrpc/proto.go
@@ -124,6 +124,17 @@ const (
 	opGetExporter      op = 49 // [name] -> [found u8]([json db.ExporterDef]); DAEMON-only
 	opPutExporterState op = 50 // [name][blob] -> status; DAEMON-only; mutating
 	opGetExporterState op = 51 // [name] -> [found u8]([blob]); DAEMON-only
+
+	// opQueryRawWire streams matching ads as WIRE-FORM ROWS -- self-contained
+	// inline-names subset ads assembled by slice copies at the store (see
+	// collections.ScanRawWire) -- batched many rows per frame, so a large result
+	// costs ~payload/WireBatchBudget frames instead of one frame per ad and the
+	// old-ClassAd render happens once, at the consumer's client edge.
+	// [table][limit i32][redact u8][constraint][nattrs i32]{[attr]}
+	//   -> stream of [nRows i32]{[len u32][row bytes]}, then stStreamEnd.
+	// redact requests source-side private-attribute stripping even on a
+	// privileged connection; an unprivileged connection is always redacted.
+	opQueryRawWire op = 52
 )
 
 // String names an opcode for diagnostics (e.g. the read-only rejection message).

--- a/dbrpc/queryraw.go
+++ b/dbrpc/queryraw.go
@@ -2,6 +2,7 @@ package dbrpc
 
 import (
 	"context"
+	"encoding/binary"
 	"iter"
 	"strings"
 	"time"
@@ -183,5 +184,155 @@ func (s *Server) streamQueryRawProject(ctx context.Context, reqID uint64, r *rea
 			break
 		}
 	}
+	write(respHead(reqID, stStreamEnd))
+}
+
+// WireBatchBudget caps one wire-row batch frame's payload bytes. It bounds the
+// per-stream buffer on BOTH sides (each holds ~one frame), amortizes the
+// per-frame syscall/wakeup cost, and stays well under the transport's 1MB
+// message ceiling. Measured sensitivity (2000x21KB-ad scans over TCP loopback):
+// 16KB->64KB gains ~6%, 64KB->256KB ~4%, beyond 256KB flat -- so the default
+// stays memory-lean at 64KB (~128KB per active stream across both sides) and a
+// deployment can raise it for the last few percent on whole-ad scans (projected
+// streams are insensitive: their rows are small enough that every budget
+// batches deeply).
+var WireBatchBudget = 64 << 10
+
+// QueryRawWireStream streams matching ads as wire-form rows (self-contained
+// inline-names subset ads -- render them with collections.RenderRawAdInline),
+// batched many rows per frame (WireBatchBudget on the server side). The row
+// slice passed to yield aliases the frame buffer and is valid only until yield
+// returns; redact requests source-side private-attribute stripping even on a
+// privileged connection. Requires a server with opQueryRawWire; an older server
+// answers respBad and the error surfaces here (callers fall back to the text
+// row stream).
+func (c *Client) QueryRawWireStream(ctx context.Context, table, constraint string, attrs []string, limit int, redact bool, yield func(row []byte) bool) error {
+	build := func(id uint64) []byte {
+		b := putStr(req(id, opQueryRawWire), table)
+		b = putI32(b, int32(limit))
+		r := byte(0)
+		if redact {
+			r = 1
+		}
+		b = append(b, r)
+		b = putStr(b, constraint)
+		b = putI32(b, int32(len(attrs)))
+		for _, a := range attrs {
+			b = putStr(b, a)
+		}
+		return b
+	}
+	_, ch, err := c.callStream(build)
+	if err != nil {
+		return err
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			drain(ch)
+			return ctx.Err()
+		case frame, ok := <-ch:
+			if !ok {
+				return nil // stStreamEnd
+			}
+			_, status, body, ok := respHeader(frame)
+			if !ok {
+				return errShort
+			}
+			switch status {
+			case stStream:
+				n := int(body.i32())
+				for i := 0; i < n; i++ {
+					row := body.bytesRef()
+					if body.err != nil {
+						return errShort
+					}
+					if !yield(row) {
+						drain(ch)
+						return nil
+					}
+				}
+			case stErr:
+				return statusErr(status, body)
+			default:
+				return statusErr(status, body)
+			}
+		}
+	}
+}
+
+// streamQueryRawWire serves opQueryRawWire: wire-form rows from the db's
+// slice-copy subset scan, batched into frames of up to WireBatchBudget payload
+// bytes (a single over-budget row still gets its own frame -- exactly the old
+// one-frame-per-ad behavior, so a jumbo ad is never unshippable).
+func (s *Server) streamQueryRawWire(ctx context.Context, reqID uint64, r *reader, includePrivate bool, write func([]byte), qlog func(QueryLog)) {
+	start := time.Now()
+	table := r.str()
+	limit := int(r.i32())
+	redact := r.u8() != 0 || !includePrivate
+	constraint := r.str()
+	nattrs := int(r.i32())
+	attrs := make([]string, 0, nattrs)
+	for i := 0; i < nattrs; i++ {
+		attrs = append(attrs, r.str())
+	}
+	n := 0
+	if qlog != nil {
+		defer func() {
+			qlog(QueryLog{Op: "QueryRawWire", Table: table, Constraint: constraint, Limit: limit, Rows: n, Duration: time.Since(start)})
+		}()
+	}
+	if r.err != nil {
+		write(respBad(reqID))
+		return
+	}
+	d, ok := s.tableOr(reqID, table, write)
+	if !ok {
+		return
+	}
+	seq, err := d.QueryRawWire(constraint, attrs, redact)
+	if err != nil {
+		write(respErr(reqID, err.Error()))
+		return
+	}
+
+	// Rows build DIRECTLY into one reused frame buffer behind a reserved header
+	// (the row count is patched at flush), so a steady stream allocates nothing
+	// and copies each row exactly once -- write() hands the buffer to a
+	// synchronous, non-retaining WriteMsg, making reuse safe.
+	head := respHead(reqID, stStream)
+	countAt := len(head)
+	frame := make([]byte, 0, WireBatchBudget+countAt+64)
+	begin := func() {
+		frame = append(frame[:0], head...)
+		frame = putI32(frame, 0) // row count, patched by flush
+	}
+	begin()
+	rows := 0
+	flush := func() {
+		if rows == 0 {
+			return
+		}
+		binary.LittleEndian.PutUint32(frame[countAt:countAt+4], uint32(rows))
+		write(frame)
+		begin()
+		rows = 0
+	}
+	payloadLen := func() int { return len(frame) - countAt - 4 }
+	for row := range seq {
+		if cancelled(ctx) {
+			return
+		}
+		if rows > 0 && payloadLen()+4+len(row) > WireBatchBudget {
+			flush()
+		}
+		frame = putBytes(frame, row)
+		rows++
+		n++
+		if limit > 0 && n >= limit {
+			break
+		}
+	}
+	flush()
 	write(respHead(reqID, stStreamEnd))
 }

--- a/dbrpc/queryrawwire_test.go
+++ b/dbrpc/queryrawwire_test.go
@@ -1,0 +1,138 @@
+package dbrpc
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/collections"
+	"github.com/PelicanPlatform/classad/db"
+)
+
+// testPairPersistent is testPair over a PERSISTENT (inline-names) db -- the
+// mode wire-form rows exist for -- with the connection's privilege selectable.
+func testPairPersistent(t *testing.T, includePrivate bool) (*Client, func()) {
+	t.Helper()
+	d, err := db.Open(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := NewServer(d)
+	cconn, sconn := netPipe()
+	go func() { _ = s.ServeConnOpts(sconn, ServeOptions{IncludePrivate: includePrivate}) }()
+	c := NewClient(cconn)
+	return c, func() { c.Close(); s.Close(); d.Close() }
+}
+
+func seedWireAds(t *testing.T, c *Client, n int) {
+	t.Helper()
+	ctx := context.Background()
+	tx, err := c.Begin(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < n; i++ {
+		key := "slot" + string(rune('a'+i%26)) + "." + string(rune('0'+i/26))
+		if err := tx.NewClassAd(ctx, key,
+			"MyType = \"Machine\"\nName = \""+key+"\"\nState = \"Unclaimed\"\nCpus = 8\nMemory = 16384\nClaimId = \"<secret-"+key+">\""); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// renderRows collects a QueryRawWireStream result rendered at the edge, as
+// name->value maps keyed by Name.
+func renderRows(t *testing.T, c *Client, table, constraint string, attrs []string, redact bool) map[string]map[string]string {
+	t.Helper()
+	out := map[string]map[string]string{}
+	var buf []byte
+	var offs []int
+	err := c.QueryRawWireStream(context.Background(), table, constraint, attrs, 0, redact, func(row []byte) bool {
+		var ok bool
+		buf, offs, _, _, ok = collections.RenderRawAdInline(row, buf, offs)
+		if !ok {
+			t.Fatal("render failed on a wire row")
+		}
+		m := map[string]string{}
+		for i := 0; i+1 < len(offs); i++ {
+			name, val, found := strings.Cut(string(buf[offs[i]:offs[i+1]]), " = ")
+			if !found {
+				t.Fatalf("malformed expr %q", buf[offs[i]:offs[i+1]])
+			}
+			m[name] = val
+		}
+		out[strings.Trim(m["Name"], `"`)] = m
+		return true
+	})
+	if err != nil {
+		t.Fatalf("QueryRawWireStream: %v", err)
+	}
+	return out
+}
+
+// TestQueryRawWireStream verifies the batched wire-row stream end to end:
+// projection, source-side redaction (both requested and privilege-forced), and
+// multi-frame batching under a tiny budget.
+func TestQueryRawWireStream(t *testing.T) {
+	c, cleanup := testPairPersistent(t, true) // privileged, like the collector
+	defer cleanup()
+	const n = 60
+	seedWireAds(t, c, n)
+
+	// Force many small frames so batch reassembly is exercised.
+	old := WireBatchBudget
+	WireBatchBudget = 512
+	defer func() { WireBatchBudget = old }()
+
+	proj := renderRows(t, c, DefaultTable, "", []string{"Name", "Cpus"}, false)
+	if len(proj) != n {
+		t.Fatalf("projected wire stream returned %d ads, want %d", len(proj), n)
+	}
+	for name, m := range proj {
+		// Name, Cpus projected; MyType always ships (lifted by the renderer, so
+		// not in the expr map).
+		if m["Cpus"] != "8" || len(m) != 2 {
+			t.Fatalf("%s: projected row %v, want exactly Name+Cpus", name, m)
+		}
+	}
+
+	// Privileged + redact requested: ClaimId stripped at the source.
+	red := renderRows(t, c, DefaultTable, "", nil, true)
+	for name, m := range red {
+		if _, leak := m["ClaimId"]; leak {
+			t.Fatalf("%s: redact-requested wire row leaked ClaimId", name)
+		}
+		if m["Memory"] != "16384" {
+			t.Fatalf("%s: whole-ad redacted row lost Memory: %v", name, m)
+		}
+	}
+
+	// Privileged, no redact: private attributes flow (the collector's PVT path).
+	full := renderRows(t, c, DefaultTable, "", nil, false)
+	if _, ok := full["slota.0"]["ClaimId"]; !ok {
+		t.Fatal("privileged unredacted wire row missing ClaimId")
+	}
+
+	// Constraint pushdown still applies.
+	some := renderRows(t, c, DefaultTable, `Cpus == 8 && Name == "slota.0"`, []string{"Name"}, false)
+	if len(some) != 1 {
+		t.Fatalf("constrained wire stream returned %d ads, want 1", len(some))
+	}
+}
+
+// TestQueryRawWireUnprivilegedAlwaysRedacts: a connection served without
+// IncludePrivate is redacted regardless of what the client requests.
+func TestQueryRawWireUnprivilegedAlwaysRedacts(t *testing.T) {
+	c, cleanup := testPairPersistent(t, false)
+	defer cleanup()
+	seedWireAds(t, c, 3)
+	full := renderRows(t, c, DefaultTable, "", nil, false) // redact NOT requested
+	for name, m := range full {
+		if _, leak := m["ClaimId"]; leak {
+			t.Fatalf("%s: unprivileged wire row leaked ClaimId", name)
+		}
+	}
+}

--- a/dbrpc/server.go
+++ b/dbrpc/server.go
@@ -411,6 +411,8 @@ func (sc *serverConn) dispatch(frame []byte) {
 		sc.s.streamQueryRaw(sc.ctx, reqID, body, priv, sc.write, sc.opts.QueryLog)
 	case opQueryRawProj:
 		sc.s.streamQueryRawProject(sc.ctx, reqID, body, priv, sc.write, sc.opts.QueryLog)
+	case opQueryRawWire:
+		sc.s.streamQueryRawWire(sc.ctx, reqID, body, priv, sc.write, sc.opts.QueryLog)
 	case opMatchSorted:
 		sc.s.streamMatchSorted(sc.ctx, reqID, body, priv, sc.write)
 	case opOrdered:


### PR DESCRIPTION
Second performance series for the query-serving spine, targeting the **two-hop topology** (collector ← dbrpc → htcondordb) that was still ~2x slower than a single-hop C++ collector after #72. Three coupled pieces (details in the commit message):

1. **Wire-form rows** — new `opQueryRawWire` (52): self-contained inline-names *subset* ads assembled by slice copies at the store (projection + redaction applied there; sealed values opened; redaction requestable by privileged connections), batched many-per-frame under a measured 64KB budget into one reused frame buffer. The old-ClassAd render happens once, at the consumer's client edge (`collections.RenderRawAdInline`). Old servers reject the op before any row flows → automatic fallback to the text streams.
2. **Parallel wire scan** — per-record ZSTD decompress fanned across segment windows on the existing parallel-query framework, rows built into free-listed 64KB batch arenas (the free-list is load-bearing: without it a whole-pool scan churned tens of MB per query). Encrypted stores stay serial per the Sealer contract. **60.7k → 223.9k ads/sec** on a ZSTD store.
3. **Hot-first layout + prefix decode** — both encoders (AST + StreamEncoder text-ingest) write hot entries as a physical prefix (stable partition, duplicate semantics preserved, no format bump); the zstd codec gains pooled streaming `DecompressPrefix`, so hot-covered projections decompress ~3KB instead of the record, with a bounds-safe fallback and an adaptive gate for unconverged records. **223.9k → 265.3k** — above the uncompressed store's 232k — zstd decode 10% → 2.6% of scan CPU.

**End-to-end at the collector (two-hop over TCP): projected monitoring 20.9k → 112.5k ads/sec** — past a single-hop C++ condor_collector at conc=1 — with ZSTD storage savings fully intact.

Tests: dbrpc wire-stream round-trip (projection / requested + privilege-forced redaction / multi-frame batching at a 512B budget / constraint pushdown / unprivileged-always-redacts), collections subset round-trip + bytes-level no-leak, prefix-decodability through both encode paths (512B prefix ≡ full record), and the existing suites green across collections/wire/db/dbrpc. Downstream (bbockelm/golang-collector) follows with the `WireRowStreamer` relay once this tags.