### PR TITLE
collections: group-commit the durability msync (fixes a concurrent-commit durability race)

### DIFF
--- a/collections/commit.go
+++ b/collections/commit.go
@@ -125,7 +125,7 @@ func (sh *shard) applyWrites(writes []pendingPut) {
 	sh.commitSeq = seq
 	sh.maybeCheckpoint(seq)
 	sh.unlockWrite(acq, held)
-	sh.sync()
+	sh.syncFor(seq)
 	if sh.hub != nil {
 		for i := range writes {
 			sh.hub.publish(sh.idx, seq, writes[i].key, writes[i].ad, writes[i].codec, false)
@@ -142,7 +142,7 @@ func (sh *shard) applyOne(p pendingPut) {
 	sh.commitSeq = seq
 	sh.maybeCheckpoint(seq)
 	sh.unlockWrite(acq, held)
-	sh.sync()
+	sh.syncFor(seq)
 	if sh.hub != nil {
 		sh.hub.publish(sh.idx, seq, p.key, p.ad, p.codec, false)
 	}
@@ -161,7 +161,7 @@ func (sh *shard) applyBatch(batch []*commitReq) {
 	sh.commitSeq = seq
 	sh.maybeCheckpoint(seq)
 	sh.unlockWrite(acq, held)
-	sh.sync()
+	sh.syncFor(seq)
 	if sh.hub != nil {
 		for _, r := range batch {
 			for i := range r.writes {
@@ -171,21 +171,62 @@ func (sh *shard) applyBatch(batch []*commitReq) {
 	}
 }
 
-// sync is the durability point: where a future durable collection would fsync or
-// serialize the just-committed batch. It runs once per (possibly coalesced)
-// batch. Today it is a no-op unless a CommitSync hook is configured.
+// sync is the durability point for callers that do not know their commit sequence:
+// it makes everything applied so far durable. Callers that do know (Txn.Commit,
+// applyBatch) use syncFor directly for precise coalescing.
 func (sh *shard) sync() {
+	sh.mu.RLock()
+	need := sh.commitSeq
+	sh.mu.RUnlock()
+	sh.syncFor(need)
+}
+
+// syncFor makes every write with commit sequence <= need durable before returning.
+// It group-commits: concurrent committers to one shard share msync passes instead of
+// each running (or worse, skipping) one. A caller whose need is already covered by a
+// COMPLETED pass returns immediately; if a pass is in flight it waits -- the pass may
+// cover it (its dirty capture may postdate this caller's apply), and if not the loop
+// elects a waiter to lead the next pass, which then covers every waiter at once. N
+// concurrent commits thus pay ~2 msync passes.
+//
+// This also closes a durability hole in the old code, which swapped the dirty list and
+// msync'd with no coordination: a racing sync() could observe an empty dirty list and
+// return -- acking its commit durable -- while the pass covering its pages was still in
+// flight. Here nobody returns before a pass whose capture postdates their writes has
+// COMPLETED.
+func (sh *shard) syncFor(need uint64) {
 	if sh.onSync != nil {
 		sh.onSync()
 	}
 	if sh.alloc == nil {
 		return // in-memory shard
 	}
-	// Persistent shard: msync the pages written since the last sync so the commit
-	// is durable before this returns. Capture the ranges and advance the durable
-	// mark under the lock (dirty is guarded by mu), then msync lock-free — only the
-	// current flusher runs sync() per shard, so no concurrent sync races here.
+	sh.smu.Lock()
+	for sh.syncedSeq < need {
+		if sh.syncing {
+			sh.scond.Wait() // an in-flight pass may cover us; re-check when it lands
+			continue
+		}
+		sh.syncing = true
+		sh.smu.Unlock()
+		covered := sh.syncPass()
+		sh.smu.Lock()
+		if covered > sh.syncedSeq {
+			sh.syncedSeq = covered
+		}
+		sh.syncing = false
+		sh.scond.Broadcast()
+	}
+	sh.smu.Unlock()
+}
+
+// syncPass runs one durability pass: msync the pages written since the last pass.
+// It returns the commit sequence the pass covers -- captured under the same lock
+// acquisition as the dirty list, so every write applied at or before that sequence
+// is either in the captured ranges or was covered by an earlier pass.
+func (sh *shard) syncPass() uint64 {
 	sh.mu.Lock()
+	covered := sh.commitSeq
 	dirty := sh.dirty
 	sh.dirty = nil
 	sup := sh.dirtySup
@@ -237,4 +278,5 @@ func (sh *shard) sync() {
 	for _, s := range sup {
 		s.seg.unpin()
 	}
+	return covered
 }

--- a/collections/groupcommit_test.go
+++ b/collections/groupcommit_test.go
@@ -1,0 +1,85 @@
+package collections
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+)
+
+// TestGroupCommitCoalescesSyncs drives many concurrent durable transactions into a
+// single-shard persistent collection and asserts (a) every commit's data survives a
+// reopen -- each commit waited for a covering msync pass, closing the old race where a
+// commit could observe an empty dirty list and ack before the covering msync finished --
+// and (b) the msync passes were shared: far fewer passes ran than commits (group commit).
+func TestGroupCommitCoalescesSyncs(t *testing.T) {
+	const n = 64
+	dir := t.TempDir()
+	c, err := Open(Options{Shards: 1, Dir: dir})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	base := c.OpStats().Sync.Count
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start // maximize commit overlap
+			tx := c.Begin()
+			tx.Put([]byte(fmt.Sprintf("job.%d", i)), mustAd(t, fmt.Sprintf(`[ ClusterId = %d; Owner = "grp" ]`, i)))
+			if res := tx.Commit(); res.Conflicted() {
+				t.Errorf("commit %d conflicted: %v", i, res.Conflicts)
+			}
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	passes := c.OpStats().Sync.Count - base
+	t.Logf("%d concurrent durable commits ran %d msync passes", n, passes)
+	if passes >= n {
+		t.Errorf("no coalescing: %d msync passes for %d concurrent commits", passes, n)
+	}
+	if err := c.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Durability: every acked commit must be present after reopen.
+	c2, err := Open(Options{Shards: 1, Dir: dir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c2.Close()
+	for i := 0; i < n; i++ {
+		if _, ok := c2.Get([]byte(fmt.Sprintf("job.%d", i))); !ok {
+			t.Errorf("job.%d missing after reopen (commit acked but not durable)", i)
+		}
+	}
+}
+
+// TestGroupCommitSequentialUnchanged pins that WITHOUT concurrency the coalescing is
+// inert: each sequential durable commit still runs its own msync pass (its sequence is
+// always past the last completed pass), so single-writer durability behavior -- and its
+// metrics -- are unchanged.
+func TestGroupCommitSequentialUnchanged(t *testing.T) {
+	const n = 8
+	c, err := Open(Options{Shards: 1, Dir: t.TempDir()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+
+	base := c.OpStats().Sync.Count
+	for i := 0; i < n; i++ {
+		tx := c.Begin()
+		tx.Put([]byte(fmt.Sprintf("seq.%d", i)), mustAd(t, `[ Owner = "grp" ]`))
+		if res := tx.Commit(); res.Conflicted() {
+			t.Fatalf("commit %d conflicted", i)
+		}
+	}
+	if passes := c.OpStats().Sync.Count - base; passes != n {
+		t.Errorf("sequential commits ran %d msync passes, want %d (one each)", passes, n)
+	}
+}

--- a/collections/persist_test.go
+++ b/collections/persist_test.go
@@ -811,6 +811,10 @@ func TestDeleteTombstoneFlushPath(t *testing.T) {
 	sh.dirtySup = nil // clear any prior state
 	seq := sh.commitSeq + 1
 	ok, _ := sh.del(h, key, seq)
+	// Mirror the real Delete path: advance the commit sequence for the tombstone.
+	// sync() group-commits by sequence (syncFor), so dirty state queued WITHOUT a
+	// sequence bump -- which no production path does -- would look already-covered.
+	sh.commitSeq = seq
 	nQueued := len(sh.dirtySup)
 	sh.mu.Unlock()
 	if !ok {

--- a/collections/shard.go
+++ b/collections/shard.go
@@ -35,6 +35,15 @@ type shard struct {
 	flushing bool
 	onSync   func() // durability sync run once per committed batch; nil = no-op
 
+	// Sync coalescing (group commit for the durability msync; see shard.syncFor).
+	// syncedSeq is the highest commitSeq a COMPLETED msync pass covers; syncing marks a
+	// pass in flight. A syncFor caller already covered rides free; others wait for or
+	// lead a pass whose dirty capture postdates their writes. Guarded by smu/scond.
+	smu       sync.Mutex
+	scond     *sync.Cond
+	syncing   bool
+	syncedSeq uint64
+
 	// Persistent segment allocation. alloc is nil for an in-memory shard (RAM
 	// segments); for a persistent shard it creates an mmap-backed segment file.
 	// writeErr is the first segment-allocation failure (sticky; guarded by mu),
@@ -113,11 +122,13 @@ type supRef struct {
 }
 
 func newShard(segSize int, onSync func()) *shard {
-	return &shard{
+	sh := &shard{
 		dir:     make(map[uint64]loc),
 		segSize: segSize,
 		onSync:  onSync,
 	}
+	sh.scond = sync.NewCond(&sh.smu)
+	return sh
 }
 
 // allocSeg creates a new segment via the persistent factory if configured, else a

--- a/collections/store.go
+++ b/collections/store.go
@@ -549,7 +549,7 @@ func (c *Collection) Delete(key []byte) bool {
 	sh.unlockWrite(acq, held)
 	if ok {
 		c.removeOrdered(key)
-		sh.sync() // durability point for the tombstone (not coalesced)
+		sh.sync() // durability point for the tombstone (group-committed via syncFor)
 		if sh.delLog != nil {
 			sh.delLog.record(key, seq) // retain for resuming watchers
 			sh.hub.publish(sh.idx, seq, key, nil, nil, true)

--- a/collections/txn.go
+++ b/collections/txn.go
@@ -344,10 +344,10 @@ func (tx *Txn) Commit() CommitResult {
 	// the commit -- a small commit touches one shard and syncs inline with no goroutines;
 	// only a large, many-shard commit fans out.
 	if tx.durable {
-		var toSync []int
+		var toSync []shardCommit
 		for _, c := range commits {
 			if c.changed {
-				toSync = append(toSync, c.idx)
+				toSync = append(toSync, c)
 			}
 		}
 		if len(toSync) > 0 {
@@ -356,14 +356,18 @@ func (tx *Txn) Commit() CommitResult {
 			// the true commit durability latency. The per-shard Sync counter still records
 			// each msync, but its total is now fsync WORK, not this latency -- so measure
 			// the wall time here explicitly (commitSync).
+			//
+			// syncFor(seq) group-commits: concurrent transactions hitting the same shard
+			// share msync passes (and none returns before the pass covering ITS writes
+			// completes), so under commit fan-out N transactions pay ~2 passes, not N.
 			syncStart := time.Now()
 			if len(toSync) == 1 {
-				tx.c.shards[toSync[0]].sync()
+				tx.c.shards[toSync[0].idx].syncFor(toSync[0].seq)
 			} else {
 				var wg sync.WaitGroup
 				wg.Add(len(toSync))
-				for _, idx := range toSync {
-					go func(sh *shard) { defer wg.Done(); sh.sync() }(tx.c.shards[idx])
+				for _, c := range toSync {
+					go func(sh *shard, seq uint64) { defer wg.Done(); sh.syncFor(seq) }(tx.c.shards[c.idx], c.seq)
 				}
 				wg.Wait()
 			}


### PR DESCRIPTION
## Why
Production probes (`rpc_call_phase_seconds{op="commit",phase="wait"}`) show ~9% of commits pay a 100–500ms server-side durability sync — the dominant term in the collector's residual 1–2.5s flush tail. Under the collector's adaptive fan-out, a flush's commit units are *concurrent transactions on one table*, each running its own msync.

Worse, reading the path revealed a **durability hole**: `sync()` swapped the shard's dirty list with no coordination ("only the current flusher runs sync() per shard" predates `Txn.Commit`'s parallel shard-sync fan-out). Two racing commits: the loser sees an empty dirty list and **returns — acking durable — while the winner's msync covering the loser's pages is still in flight**. A crash in that window loses an acked commit.

## What
`shard.syncFor(seq)` — classic group commit for the durability msync:
- A caller whose `seq` is covered by a **completed** pass returns immediately (free ride).
- If a pass is in flight, wait — its dirty capture may postdate the caller's apply; re-check when it lands.
- Otherwise one waiter leads the next pass, whose capture (dirty list + covered sequence under one lock acquisition) covers every waiter at once.

Nobody returns before a pass whose capture postdates their writes has **completed** — closing the hole. `Txn.Commit`/`applyBatch`/`applyOne` pass their exact sequence; `sync()` remains for callers that don't know theirs (everything-so-far).

## Results
- `TestGroupCommitCoalescesSyncs`: **64 concurrent durable commits → 2 msync passes**, and every commit survives reopen.
- `TestGroupCommitSequentialUnchanged`: sequential commits still run one pass each — no behavior/metrics change without concurrency.
- Full collections suite green (incl. `-race` on the new tests); db and dbrpc suites green over this change.
- The delete-tombstone test now mirrors the real `Delete` path's sequence bump (it hand-rolled `sh.del` without advancing `commitSeq`, an invariant every production path maintains).

Server-side only — no wire, API, or collector change needed to benefit.
