### PR TITLE
collections: prune superseded dictionaries after retrain and at open

### DIFF
--- a/collections/compact.go
+++ b/collections/compact.go
@@ -225,7 +225,29 @@ func (c *Collection) RetrainDict(sampleMax int) (int, error) {
 	c.lastDictBytes.Store(int64(len(dict)))
 	c.lastRetrainUnix.Store(time.Now().UnixNano())
 	c.reindexAfterCompaction() // rebuild indexes over the recompacted segments
+	// The recompaction re-encoded (or left in place) every live segment; dictionaries no
+	// segment references anymore are dead weight -- drop them so the registry does not
+	// grow by one inflated codec per retrain for the life of the process.
+	c.pruneDicts()
 	return len(dict), nil
+}
+
+// pruneDicts drops registered dictionaries that no live segment references (keeping the
+// current write codec), unlinking their on-disk .zst files. Called after a retrain's
+// recompaction (which retires old-codec segments en masse) and at Open (loadDicts loads
+// the full on-disk history; recovery then references only the ids live segments carry).
+func (c *Collection) pruneDicts() {
+	live := map[Codec]bool{c.currentCodec(): true}
+	for _, sh := range c.shards {
+		sh.mu.RLock()
+		for _, seg := range sh.segs {
+			if seg != nil {
+				live[seg.codec] = true
+			}
+		}
+		sh.mu.RUnlock()
+	}
+	c.dicts.prune(func(cd Codec) bool { return live[cd] })
 }
 
 // reindexAfterCompaction rebuilds the segment indexes after compaction replaced the

--- a/collections/compact.go
+++ b/collections/compact.go
@@ -40,6 +40,8 @@ const (
 // safe to call concurrently with reads and writes. Returns the number of shards where
 // space was reclaimed (by either mechanism).
 func (c *Collection) Compact() int {
+	c.maintMu.Lock()
+	defer c.maintMu.Unlock()
 	start := time.Now()
 	defer func() { c.opm.compact.observe(time.Since(start)) }()
 	target := c.currentCodec()
@@ -168,6 +170,8 @@ func (c *Collection) reclaimDeadShard(sh *shard) int {
 // value. Run it during low write activity (or, in an HA deployment, on the sole
 // writer).
 func (c *Collection) Rewrite() int {
+	c.maintMu.Lock()
+	defer c.maintMu.Unlock()
 	n := 0
 	for _, k := range c.Keys() {
 		kb := []byte(k)
@@ -199,6 +203,8 @@ func (c *Collection) Rewrite() int {
 var retrainStallHook func()
 
 func (c *Collection) RetrainDict(sampleMax int) (int, error) {
+	c.maintMu.Lock()
+	defer c.maintMu.Unlock()
 	start := time.Now()
 	defer func() { c.opm.retrain.observe(time.Since(start)) }()
 	dict, err := TrainDict(c.CollectSamples(sampleMax))

--- a/collections/dictprune_test.go
+++ b/collections/dictprune_test.go
@@ -1,0 +1,92 @@
+package collections
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// countDictFiles returns the number of <dir>/dicts/*.zst files.
+func countDictFiles(t *testing.T, dir string) int {
+	t.Helper()
+	entries, err := os.ReadDir(filepath.Join(dir, "dicts"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	n := 0
+	for _, e := range entries {
+		if filepath.Ext(e.Name()) == ".zst" {
+			n++
+		}
+	}
+	return n
+}
+
+// TestRetrainPrunesOldDicts pins the registry/disk lifecycle of trained dictionaries:
+// after a retrain recompacts every segment to the new codec, the superseded
+// dictionaries are dropped from the registry and their .zst files unlinked. Without
+// this the registry grew by one zstd encoder/decoder pair per retrain per table for
+// the life of the daemon -- the live-heap leak observed in production (~25 accumulated
+// dictionaries per table) -- and a reopen reloaded the entire history.
+func TestRetrainPrunesOldDicts(t *testing.T) {
+	t.Parallel()
+	if !mmapSupported {
+		t.Skip("persistence is unix-only")
+	}
+	sample := loadCorpus(t)
+	dir := t.TempDir()
+	c, err := Open(Options{Shards: 2, Dir: dir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	const n = 2000
+	for i := 0; i < n; i++ {
+		if err := c.Put([]byte(fmt.Sprintf("k%d", i)), sample[i%len(sample)]); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	for round := 0; round < 3; round++ {
+		if _, err := c.RetrainDict(1500); err != nil {
+			t.Skipf("RetrainDict unavailable on this corpus: %v", err)
+		}
+	}
+
+	// Only the current dictionary should survive: the registry holds base + current,
+	// and the dicts dir holds one .zst.
+	c.dicts.mu.Lock()
+	regSize := len(c.dicts.byID)
+	c.dicts.mu.Unlock()
+	if regSize != 2 {
+		t.Errorf("registry holds %d codecs after 3 retrains, want 2 (base + current)", regSize)
+	}
+	if files := countDictFiles(t, dir); files != 1 {
+		t.Errorf("dicts dir holds %d .zst files after 3 retrains, want 1", files)
+	}
+	if c.Len() != n {
+		t.Fatalf("Len=%d want %d after retrains", c.Len(), n)
+	}
+	if err := c.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Reopen: data intact under the surviving dictionary, registry stays pruned.
+	c2, err := Open(Options{Shards: 2, Dir: dir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c2.Close()
+	if c2.Len() != n {
+		t.Fatalf("reopen Len=%d want %d", c2.Len(), n)
+	}
+	if _, ok := c2.Get([]byte("k42")); !ok {
+		t.Error("k42 missing after reopen")
+	}
+	c2.dicts.mu.Lock()
+	regSize2 := len(c2.dicts.byID)
+	c2.dicts.mu.Unlock()
+	if regSize2 != 2 {
+		t.Errorf("reopened registry holds %d codecs, want 2", regSize2)
+	}
+}

--- a/collections/persist.go
+++ b/collections/persist.go
@@ -86,6 +86,35 @@ func (r *dictReg) register(codec Codec, dict []byte) (uint32, error) {
 	return id, nil
 }
 
+// prune removes every registered dictionary except id 0 (the base codec) and those
+// keep returns true for, unlinking each removed id's on-disk .zst. Without pruning the
+// registry grows by one codec per retrain FOREVER -- each an un-Closed zstd
+// encoder/decoder pair whose state pools inflated while it was the hot codec -- the
+// dominant live-heap leak in a long-running daemon. The removed codecs are only
+// dereferenced, never Closed: an in-flight scan may still be decompressing through one
+// (its pinned segment holds the codec reference), so the GC reclaims each codec when
+// its last user finishes.
+func (r *dictReg) prune(keep func(Codec) bool) []uint32 {
+	r.mu.Lock()
+	var removed []uint32
+	for id, c := range r.byID {
+		if id == 0 || keep(c) {
+			continue
+		}
+		delete(r.byID, id)
+		delete(r.idOf, c)
+		removed = append(removed, id)
+	}
+	dir := r.dir
+	r.mu.Unlock()
+	for _, id := range removed {
+		if dir != "" {
+			_ = os.Remove(filepath.Join(dir, fmt.Sprintf("%d.zst", id)))
+		}
+	}
+	return removed
+}
+
 // writeDictFile writes a dictionary's bytes to path and fsyncs it (so a codec that
 // segments already reference cannot be lost across a crash).
 func writeDictFile(path string, dict []byte) error {
@@ -224,6 +253,10 @@ func Open(opts Options) (*Collection, error) {
 			return newMmapSegment(id, size, codec, path)
 		}
 	}
+	// Recovery is complete: every live segment's codec is known, so dictionaries only
+	// history references (loadDicts loads the full on-disk set) can be dropped now
+	// instead of holding an inflatable codec each for the life of the process.
+	c.pruneDicts()
 	// Indexes are derived state, not persisted: build them over the recovered
 	// segments so a reopened collection's queries are immediately selective.
 	if c.spec.Load().any() {

--- a/collections/persist_test.go
+++ b/collections/persist_test.go
@@ -661,8 +661,9 @@ func TestPersistentRetrainDictReopen(t *testing.T) {
 }
 
 // TestPersistentMultiRetrainReopen exercises several dictionary generations and a
-// crash (no Close) after the last retrain: every generation's dictionary is on disk
-// and recovery reconstructs whichever the surviving segments reference.
+// crash (no Close) after the last retrain: each retrain's recompaction retires the
+// previous generation's segments, so its dictionary is PRUNED (registry and disk);
+// only the surviving (referenced) dictionary remains, and recovery reconstructs it.
 func TestPersistentMultiRetrainReopen(t *testing.T) {
 	t.Parallel()
 	if !mmapSupported {
@@ -684,10 +685,14 @@ func TestPersistentMultiRetrainReopen(t *testing.T) {
 			t.Fatalf("RetrainDict gen %d: %v", gen, err)
 		}
 	}
-	// Three dictionaries on disk.
-	for id := 1; id <= 3; id++ {
-		if _, err := os.Stat(filepath.Join(dir, "dicts", fmt.Sprintf("%d.zst", id))); err != nil {
-			t.Fatalf("dict %d not persisted: %v", id, err)
+	// Only the latest dictionary survives: each retrain recompacted every segment to
+	// its new codec, so the superseded generations were pruned from disk.
+	if _, err := os.Stat(filepath.Join(dir, "dicts", "3.zst")); err != nil {
+		t.Fatalf("current dict not persisted: %v", err)
+	}
+	for id := 1; id <= 2; id++ {
+		if _, err := os.Stat(filepath.Join(dir, "dicts", fmt.Sprintf("%d.zst", id))); err == nil {
+			t.Fatalf("superseded dict %d still on disk, want pruned", id)
 		}
 	}
 	// Crash: reopen WITHOUT Close.

--- a/collections/store.go
+++ b/collections/store.go
@@ -195,6 +195,14 @@ type Collection struct {
 	// Non-nil after New; persists dictionary bytes only when the collection has a Dir.
 	dicts *dictReg
 
+	// maintMu serializes whole-collection maintenance passes -- Compact and RetrainDict
+	// -- which htcondordb drives from SEPARATE tickers. Unserialized they race twice
+	// over: two concurrent compactShard calls on one shard duplicate its working set,
+	// and Compact's captured currentCodec can be pruned mid-pass by a concurrent
+	// retrain (orphaning the new segments' dictionary, which recovery then cannot
+	// load). Commits and queries never take it.
+	maintMu sync.Mutex
+
 	demand *demandTracker // per-attribute query demand, for SuggestIndexes
 
 	// Query fan-out (see parallel_scan.go). queryPar is the per-query worker cap


### PR DESCRIPTION
Fixes a live-heap leak in long-running daemons: the dict registry grew by one inflated zstd codec per retrain per table forever, and `loadDicts` reloaded the full on-disk history at every open (~25 accumulated dicts/table observed in production). `RetrainDict` and `Open` now prune every dictionary no live segment references, unlinking the `.zst`. Covers all collection types (the prune is in `Collection` itself); pruned codecs are dereferenced, never `Close()`d — in-flight scans keep theirs alive and the GC does the rest. Regression test: 3 retrains → registry holds base+current only, one `.zst` on disk, data intact across reopen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)