### PR TITLE
collections: cap zstd encoder concurrency (bound + stop encoder-memory growth)

### DIFF
--- a/collections/codec.go
+++ b/collections/codec.go
@@ -54,7 +54,19 @@ type zstdCodec struct {
 // NewZSTDCodec returns a ZSTD codec. If dict is non-empty it is used as a shared
 // compression dictionary (see TrainDict). Pass nil for dictionary-less ZSTD.
 func NewZSTDCodec(dict []byte) (Codec, error) {
-	var eopts []zstd.EOption
+	// Encoder concurrency 1 caps the encoder's memory. A zstd.Encoder preallocates one
+	// match-finder state -- including a large history buffer (fastBase.ensureHist) -- PER
+	// concurrency slot, and the default is GOMAXPROCS. This codec is shared and used
+	// almost entirely by single-shot EncodeAll on small ads (a few KB) that compress in
+	// microseconds and are already issued serially per commit/compaction, so the
+	// GOMAXPROCS slots buy nothing but sit resident forever. On a many-core host that is
+	// hundreds of MB of encoder history per trained dictionary; a heap profile of a
+	// production daemon showed ~310 MB (83% of live heap) in exactly this path. With a cap
+	// of 1 EncodeAll stays fully correct and concurrency-safe (concurrent callers serialize
+	// on the one state), at ~GOMAXPROCS-times less resident memory. Decoders are left at
+	// the default: DecodeAll parallelism helps the read/query path and did not show up as
+	// resident in the profile.
+	eopts := []zstd.EOption{zstd.WithEncoderConcurrency(1)}
 	var dopts []zstd.DOption
 	if len(dict) > 0 {
 		eopts = append(eopts, zstd.WithEncoderDict(dict))

--- a/collections/codec.go
+++ b/collections/codec.go
@@ -51,22 +51,29 @@ type zstdCodec struct {
 	spool   sync.Pool      // *streamDec, one per concurrent prefix read
 }
 
+// zstdEncoderConcurrency caps how many encoder states (each a resident multi-MB match
+// window) a shared zstd codec preallocates. The default is GOMAXPROCS, which on a
+// many-core host holds hundreds of MB per trained dictionary; 4 keeps ample parallelism
+// for concurrent same-table commits while bounding memory independent of core count.
+const zstdEncoderConcurrency = 4
+
 // NewZSTDCodec returns a ZSTD codec. If dict is non-empty it is used as a shared
 // compression dictionary (see TrainDict). Pass nil for dictionary-less ZSTD.
 func NewZSTDCodec(dict []byte) (Codec, error) {
-	// Encoder concurrency 1 caps the encoder's memory. A zstd.Encoder preallocates one
-	// match-finder state -- including a large history buffer (fastBase.ensureHist) -- PER
-	// concurrency slot, and the default is GOMAXPROCS. This codec is shared and used
-	// almost entirely by single-shot EncodeAll on small ads (a few KB) that compress in
-	// microseconds and are already issued serially per commit/compaction, so the
-	// GOMAXPROCS slots buy nothing but sit resident forever. On a many-core host that is
-	// hundreds of MB of encoder history per trained dictionary; a heap profile of a
-	// production daemon showed ~310 MB (83% of live heap) in exactly this path. With a cap
-	// of 1 EncodeAll stays fully correct and concurrency-safe (concurrent callers serialize
-	// on the one state), at ~GOMAXPROCS-times less resident memory. Decoders are left at
-	// the default: DecodeAll parallelism helps the read/query path and did not show up as
-	// resident in the profile.
-	eopts := []zstd.EOption{zstd.WithEncoderConcurrency(1)}
+	// Cap encoder concurrency to bound the encoder's resident memory. A zstd.Encoder
+	// preallocates one match-finder state -- including a large history buffer
+	// (fastBase.ensureHist) -- PER concurrency slot, and the default is GOMAXPROCS. This
+	// codec is shared; a commit compresses each ad with it, and concurrent same-table
+	// commits (collector fan-out + many advertisers) do run Compress in parallel, so a
+	// couple of slots earn their keep -- but GOMAXPROCS of them, each a multi-MB window
+	// that stays resident once a slot is ever used, is pure waste on a many-core host. A
+	// production heap profile showed the encoder path holding 310+ MB (>80% of live heap),
+	// still creeping upward as slots warmed. Capping at zstdEncoderConcurrency keeps enough
+	// parallelism for the write path (compresses are microseconds, so a short burst drains
+	// immediately) while hard-bounding memory at N*window per codec regardless of load or
+	// core count. Decoders are left at the default: DecodeAll parallelism helps the
+	// read/query path and did not show up as resident in the profile.
+	eopts := []zstd.EOption{zstd.WithEncoderConcurrency(zstdEncoderConcurrency)}
 	var dopts []zstd.DOption
 	if len(dict) > 0 {
 		eopts = append(eopts, zstd.WithEncoderDict(dict))

--- a/collections/codec_concurrency_test.go
+++ b/collections/codec_concurrency_test.go
@@ -1,0 +1,65 @@
+package collections
+
+import (
+	"bytes"
+	"fmt"
+	"sync"
+	"testing"
+)
+
+// TestZSTDCodecConcurrentEncodeAll verifies the shared codec's EncodeAll stays correct
+// and concurrency-safe under the encoder-concurrency cap of 1 (added to bound the
+// encoder's resident history buffers): many goroutines compress/decompress through the
+// one codec at once, each round-tripping its own distinct payload. With concurrency 1 the
+// calls serialize internally rather than corrupting a shared state, so every payload must
+// survive intact.
+func TestZSTDCodecConcurrentEncodeAll(t *testing.T) {
+	t.Parallel()
+	dict := TrainDictOrSkip(t)
+	c, err := NewZSTDCodec(dict)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const workers, iters = 16, 200
+	var wg sync.WaitGroup
+	var bad int64
+	var mu sync.Mutex
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			for i := 0; i < iters; i++ {
+				src := []byte(fmt.Sprintf("Name = \"slot%d_%d@host.example\"\nState = \"Claimed\"\nMemory = %d\n", w, i, 1024+i))
+				comp := c.Compress(nil, src)
+				out, err := c.Decompress(nil, comp)
+				if err != nil || !bytes.Equal(out, src) {
+					mu.Lock()
+					bad++
+					mu.Unlock()
+					return
+				}
+			}
+		}(w)
+	}
+	wg.Wait()
+	if bad != 0 {
+		t.Fatalf("%d worker(s) saw corruption/mismatch under concurrent EncodeAll", bad)
+	}
+}
+
+// TrainDictOrSkip trains a small dictionary from the test corpus, skipping the test if the
+// pure-Go BuildDict cannot (a known limitation on some corpora) so the concurrency check
+// still runs dictionary-less elsewhere.
+func TrainDictOrSkip(t *testing.T) []byte {
+	t.Helper()
+	sample := loadCorpus(t)
+	texts := make([][]byte, 0, len(sample))
+	for _, ad := range sample {
+		texts = append(texts, []byte(ad.String()))
+	}
+	dict, err := TrainDict(texts)
+	if err != nil {
+		return nil // dictionary-less codec still exercises the concurrency cap
+	}
+	return dict
+}


### PR DESCRIPTION
A production heap profile (htcondordb v0.7.2, live) showed the shared ZSTD encoder holding **310+ MB — over 80% of live heap — and still climbing** (372 MB → 460 MB over the first hour). Root cause: `zstd.Encoder` preallocates a resident multi-MB match-finder window **per concurrency slot**, and `NewZSTDCodec` used the default = GOMAXPROCS. On a many-core CM that is hundreds of MB per trained dictionary, warming up as slots are first used.

The dict-registry prune (#76) already bounded codec *count* (growth is warm-up, not unbounded), but the per-codec GOMAXPROCS multiplier makes the plateau huge. Concurrent same-table commits (collector fan-out over 8 write lanes + many advertisers) genuinely compress in parallel, so **cap at 4, not 1**: enough for the write path (compresses are microseconds; an 8-on-4 burst drains instantly) while **hard-bounding encoder memory at 4×window per codec regardless of core count** — which also stops the slow warm-up climb, not just lowers the ceiling. Decoders stay at default (read parallelism; never resident in the profile).

Expected effect: DB steady state from ~460 MB toward well under 100 MB, same win in the collector's embedded store. A new test round-trips 16×200 concurrent compress/decompress through one codec (concurrency-safety under the cap). Footprint + growth fix; not a correctness change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)