### PR TITLE
dbrpc/db: server-side aggregate over archive (history) tables

### DIFF
--- a/db/aggregate.go
+++ b/db/aggregate.go
@@ -1,0 +1,270 @@
+package db
+
+import (
+	"iter"
+	"math"
+	"strconv"
+	"strings"
+
+	"github.com/PelicanPlatform/classad/classad"
+)
+
+// This file holds the shared server-side GROUP BY / reduce engine. Both the mutable-table
+// aggregate (dbrpc's opAggregate) and the archive aggregate (ArchiveTable.Aggregate) drive
+// it, so their grouping and reduction are byte-for-byte identical -- an archive COUNT/SUM/
+// AVG/MIN/MAX over a history table behaves exactly like the same aggregate over a live one.
+// The RPC layer aliases the public types here (AggFunc/AggSpec/AggRow/GroupCol) so its wire
+// API is unchanged.
+
+// AggFunc is a SQL aggregate function.
+type AggFunc uint8
+
+const (
+	AggCount AggFunc = iota // COUNT(*) or COUNT(col)
+	AggSum
+	AggAvg
+	AggMin
+	AggMax
+)
+
+// AggSpec is one aggregate in a query: a function over an argument attribute.
+// Arg "*" (only meaningful for COUNT) counts every row in the group; otherwise
+// Arg is an attribute name evaluated per ad.
+type AggSpec struct {
+	Func AggFunc
+	Arg  string
+}
+
+// AggRow is one group's result: the group-by column values followed by the
+// aggregate values, all rendered as strings (aligned with the request's group
+// columns and aggregate specs).
+type AggRow struct {
+	Group  []string
+	Values []string
+}
+
+// GroupCol is one GROUP BY column for a (possibly bucketed) aggregate: the
+// attribute Attr, optionally floored into fixed-width buckets. BucketWidth == 0
+// groups by the raw attribute value; BucketWidth > 0 (seconds) groups by the
+// epoch-aligned bucket floor(number(Attr)/BucketWidth)*BucketWidth, and a row whose
+// Attr is not a finite number drops out of the result. This is the shared shape a
+// bucketed aggregate and a bucketed materialized view can both group by.
+type GroupCol struct {
+	Attr        string
+	BucketWidth int64
+}
+
+// AggProjection builds the deduplicated list of attributes the aggregation reads
+// (group columns then non-"*" aggregate arguments) and the index of each group
+// column / aggregate argument within that list. An aggregate whose argument is
+// "*" (COUNT(*)) gets index -1. A caller projects a scan to attrs and feeds the
+// resulting value rows, groupCol, and aggCol to AggregateValues.
+func AggProjection(groupCols []GroupCol, aggs []AggSpec) (attrs []string, groupCol, aggCol []int) {
+	idx := map[string]int{}
+	intern := func(name string) int {
+		if i, ok := idx[name]; ok {
+			return i
+		}
+		i := len(attrs)
+		idx[name] = i
+		attrs = append(attrs, name)
+		return i
+	}
+	groupCol = make([]int, len(groupCols))
+	for i, g := range groupCols {
+		groupCol[i] = intern(g.Attr)
+	}
+	aggCol = make([]int, len(aggs))
+	for i, a := range aggs {
+		if a.Arg == "*" {
+			aggCol[i] = -1
+			continue
+		}
+		aggCol[i] = intern(a.Arg)
+	}
+	return attrs, groupCol, aggCol
+}
+
+// AggregateValues is the shared GROUP BY core: it buckets a sequence of projected
+// value rows (each aligned to the attribute list AggProjection returned) by the
+// (possibly time-bucketed) group tuple and reduces each group with the COUNT/SUM/
+// AVG/MIN/MAX accumulators, returning one AggRow per group in first-seen order.
+// groupCol[i]/aggCol[i] index into each value row (aggCol[i] < 0 means COUNT(*)).
+// With no group columns it returns a single row aggregating the whole sequence,
+// still yielding one row over an empty sequence (SQL semantics: COUNT is 0, others
+// undefined). If stop is non-nil it is polled per row and, when it returns true,
+// the scan halts early with the groups accumulated so far -- used to abandon a
+// scan whose client has gone away.
+func AggregateValues(seq iter.Seq[[]classad.Value], groupCols []GroupCol, aggs []AggSpec, groupCol, aggCol []int, stop func() bool) []AggRow {
+	nGroup := len(groupCols)
+
+	// Hash-map aggregation: bucket by the joined group-value tuple, preserving
+	// first-seen order for stable output. scratch builds each row's key without
+	// allocating a slice per row; a group keeps its own copy only when created.
+	groups := map[string]*groupState{}
+	var order []string
+	scratch := make([]string, nGroup)
+	for vals := range seq {
+		if stop != nil && stop() {
+			break // client gone: stop the scan
+		}
+		drop := false
+		for i, g := range groupCols {
+			if g.BucketWidth > 0 {
+				kt, ok := bucketKeyText(vals[groupCol[i]], g.BucketWidth)
+				if !ok {
+					drop = true // non-numeric bucket attribute: row leaves the series
+					break
+				}
+				scratch[i] = kt
+			} else {
+				scratch[i] = ValueText(vals[groupCol[i]])
+			}
+		}
+		if drop {
+			continue
+		}
+		key := strings.Join(scratch, "\x00")
+		gs := groups[key]
+		if gs == nil {
+			gs = &groupState{gvals: append([]string(nil), scratch...), accs: make([]aggAcc, len(aggs))}
+			groups[key] = gs
+			order = append(order, key)
+		}
+		for i, a := range aggs {
+			var v classad.Value
+			if aggCol[i] >= 0 {
+				v = vals[aggCol[i]]
+			}
+			gs.accs[i].update(a, v)
+		}
+	}
+
+	// A group-less aggregate over an empty match still yields one row.
+	if nGroup == 0 && len(order) == 0 {
+		gs := &groupState{accs: make([]aggAcc, len(aggs))}
+		row := AggRow{Values: make([]string, len(aggs))}
+		for i, a := range aggs {
+			row.Values[i] = gs.accs[i].result(a)
+		}
+		return []AggRow{row}
+	}
+
+	out := make([]AggRow, 0, len(order))
+	for _, key := range order {
+		gs := groups[key]
+		row := AggRow{Group: gs.gvals, Values: make([]string, len(aggs))}
+		for i, a := range aggs {
+			row.Values[i] = gs.accs[i].result(a)
+		}
+		out = append(out, row)
+	}
+	return out
+}
+
+// groupState holds one group's key values and per-aggregate accumulators.
+type groupState struct {
+	gvals []string
+	accs  []aggAcc
+}
+
+// aggAcc accumulates one group's data for one aggregate. COUNT needs only
+// counters; SUM/AVG/MIN/MAX collect the evaluated argument values and hand them
+// to the ClassAd library's aggregate functions at the end, so type coercion
+// (int64-exact sums, int+real promotion, boolean and undefined handling, error
+// propagation, numeric-only min/max) matches HTCondor's sum()/avg()/min()/max()
+// exactly rather than a re-implementation.
+type aggAcc struct {
+	rows int             // all rows in the group (COUNT(*))
+	defN int             // rows where the argument is defined (COUNT(col))
+	vals []classad.Value // argument values for SUM/AVG/MIN/MAX
+}
+
+// update folds one row's already-resolved argument value v into the accumulator.
+// For COUNT(*) (spec.Arg == "*") v is ignored.
+func (a *aggAcc) update(spec AggSpec, v classad.Value) {
+	a.rows++
+	if spec.Arg == "*" {
+		return
+	}
+	if !v.IsUndefined() && !v.IsError() {
+		a.defN++
+	}
+	if spec.Func != AggCount {
+		a.vals = append(a.vals, v) // the library aggregates skip undefined / coerce
+	}
+}
+
+func (a *aggAcc) result(spec AggSpec) string {
+	switch spec.Func {
+	case AggCount:
+		// COUNT(*) counts every row; COUNT(col) counts rows where col is defined.
+		if spec.Arg == "*" {
+			return strconv.Itoa(a.rows)
+		}
+		return strconv.Itoa(a.defN)
+	case AggSum:
+		return ValueText(classad.Sum(a.vals))
+	case AggAvg:
+		return ValueText(classad.Avg(a.vals))
+	case AggMin:
+		return ValueText(classad.Min(a.vals))
+	case AggMax:
+		return ValueText(classad.Max(a.vals))
+	}
+	return "undefined"
+}
+
+// --- small value helpers (server-side, string-rendering) ---
+
+// bucketKeyText floors a numeric value into an epoch-aligned bucket of the given
+// width (seconds) and returns its integer-seconds text. ok is false when v is not a
+// finite number (undefined/error/non-numeric string), so the row drops out of the
+// series -- matching the client-side time_bucket semantics.
+func bucketKeyText(v classad.Value, width int64) (string, bool) {
+	f, ok := numberOf(v)
+	if !ok {
+		return "", false
+	}
+	b := int64(math.Floor(f/float64(width))) * width
+	return strconv.FormatInt(b, 10), true
+}
+
+// numberOf returns the numeric value of v (integer or real) and whether it is one.
+func numberOf(v classad.Value) (float64, bool) {
+	switch {
+	case v.IsInteger():
+		i, _ := v.IntValue()
+		return float64(i), true
+	case v.IsReal():
+		r, _ := v.RealValue()
+		return r, true
+	}
+	return 0, false
+}
+
+func trimFloat(f float64) string { return strconv.FormatFloat(f, 'g', -1, 64) }
+
+// ValueText renders a value as a group-key/display string.
+func ValueText(v classad.Value) string {
+	switch {
+	case v.IsUndefined():
+		return "undefined"
+	case v.IsError():
+		return "error"
+	case v.IsBool():
+		b, _ := v.BoolValue()
+		return strconv.FormatBool(b)
+	case v.IsString():
+		s, _ := v.StringValue()
+		return s
+	case v.IsInteger():
+		i, _ := v.IntValue()
+		return strconv.FormatInt(i, 10)
+	case v.IsReal():
+		r, _ := v.RealValue()
+		return trimFloat(r)
+	default:
+		return v.String()
+	}
+}

--- a/db/archive.go
+++ b/db/archive.go
@@ -119,6 +119,41 @@ func (t *ArchiveTable) QueryLimit(constraint string, limit int) (iter.Seq[*class
 	return t.a.QueryLimit(q, limit), nil
 }
 
+// Aggregate runs a server-side GROUP BY over the archive's matches: it applies the
+// constraint (using the archive's zone-map pruning, so segments no matching record can
+// fall in are never scanned), groups by the raw group columns, and reduces each group
+// with COUNT/SUM/AVG/MIN/MAX. It shares the exact grouping/reduce engine (AggregateValues)
+// the mutable-table aggregate uses, so an archive aggregate behaves identically to the same
+// aggregate over a live table -- only the (small) grouped result is produced, not every
+// matched ad. With no group columns it returns a single row over the whole match.
+func (t *ArchiveTable) Aggregate(constraint string, groupBy []string, aggs []AggSpec) ([]AggRow, error) {
+	groupCols := make([]GroupCol, len(groupBy))
+	for i, g := range groupBy {
+		groupCols[i] = GroupCol{Attr: g}
+	}
+	attrs, groupCol, aggCol := AggProjection(groupCols, aggs)
+
+	// limit <= 0: scan the whole (zone-pruned) match; the aggregate reduces it server-side.
+	seq, err := t.QueryLimit(constraint, 0)
+	if err != nil {
+		return nil, err
+	}
+	// Project each matched ad to just the attributes the aggregation reads. The scratch
+	// slice is reused across rows (AggregateValues copies a group's key only when created).
+	proj := func(yield func([]classad.Value) bool) {
+		scratch := make([]classad.Value, len(attrs))
+		for ad := range seq {
+			for i, n := range attrs {
+				scratch[i] = ad.EvaluateAttr(n)
+			}
+			if !yield(scratch) {
+				return
+			}
+		}
+	}
+	return AggregateValues(proj, groupCols, aggs, groupCol, aggCol, nil), nil
+}
+
 // Count is the number of records currently retained (reduced by rotation).
 func (t *ArchiveTable) Count() int { return t.a.Count() }
 

--- a/db/archive_test.go
+++ b/db/archive_test.go
@@ -117,6 +117,78 @@ func TestArchiveTableNameCollision(t *testing.T) {
 	}
 }
 
+// TestArchiveTableAggregate covers the server-side GROUP BY over an archive: COUNT(*) over
+// the whole table, a COUNT with a WHERE constraint (zone-map prunable), and GROUP BY Owner
+// with COUNT/SUM/MAX. The grouped results are asserted against a straight scan of the same
+// rows, so the aggregate must agree with client-side counting.
+func TestArchiveTableAggregate(t *testing.T) {
+	cat, err := OpenCatalog(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cat.Close()
+	hist, err := cat.CreateArchiveTable("history", ArchiveConfig{
+		ValueAttrs: []string{"ClusterId"},
+		ZoneAttrs:  []string{"ClusterId"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// 3 owners with distinct row counts and Cpus values.
+	owners := []string{"alice", "alice", "alice", "bob", "bob", "carol"}
+	cpus := []int{4, 8, 2, 16, 4, 1}
+	for i, o := range owners {
+		if err := hist.AppendOld(fmt.Sprintf("ClusterId = %d\nOwner = %q\nCpus = %d", i, o, cpus[i])); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// COUNT(*) over the whole table.
+	rows, err := hist.Aggregate("true", nil, []AggSpec{{Func: AggCount, Arg: "*"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 || rows[0].Values[0] != "6" {
+		t.Fatalf("COUNT(*) = %+v, want single row value 6", rows)
+	}
+
+	// COUNT with a WHERE constraint (a range the zone map can prune on).
+	rows, err = hist.Aggregate("ClusterId >= 3", nil, []AggSpec{{Func: AggCount, Arg: "*"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 || rows[0].Values[0] != "3" {
+		t.Fatalf("COUNT(*) WHERE ClusterId>=3 = %+v, want 3", rows)
+	}
+
+	// GROUP BY Owner: COUNT(*), SUM(Cpus), MAX(Cpus).
+	rows, err = hist.Aggregate("true", []string{"Owner"}, []AggSpec{
+		{Func: AggCount, Arg: "*"},
+		{Func: AggSum, Arg: "Cpus"},
+		{Func: AggMax, Arg: "Cpus"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := map[string][3]string{}
+	for _, r := range rows {
+		got[r.Group[0]] = [3]string{r.Values[0], r.Values[1], r.Values[2]}
+	}
+	want := map[string][3]string{
+		"alice": {"3", "14", "8"},
+		"bob":   {"2", "20", "16"},
+		"carol": {"1", "1", "1"},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("GROUP BY Owner produced %d groups, want %d: %+v", len(got), len(want), got)
+	}
+	for owner, w := range want {
+		if got[owner] != w {
+			t.Errorf("group %q = %v, want %v", owner, got[owner], w)
+		}
+	}
+}
+
 // TestArchiveRotation verifies retention-based rotation drops old segments.
 func TestArchiveRotation(t *testing.T) {
 	cat, err := OpenCatalog(t.TempDir())

--- a/dbrpc/aggregate.go
+++ b/dbrpc/aggregate.go
@@ -4,39 +4,28 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math"
-	"strconv"
-	"strings"
 
 	"github.com/PelicanPlatform/classad/classad"
+	"github.com/PelicanPlatform/classad/db"
 )
 
-// AggFunc is a SQL aggregate function.
-type AggFunc uint8
+// The aggregate spec/result types and the GROUP BY / reduce engine live in the db module
+// (db/aggregate.go) so the mutable-table aggregate here and the archive aggregate share one
+// implementation. These aliases keep dbrpc's public API and wire encoding unchanged.
+type (
+	AggFunc  = db.AggFunc  // COUNT/SUM/AVG/MIN/MAX selector
+	AggSpec  = db.AggSpec  // one aggregate: a function over an argument attribute
+	AggRow   = db.AggRow   // one group's result: group values then aggregate values
+	GroupCol = db.GroupCol // one GROUP BY column, optionally time-bucketed
+)
 
 const (
-	AggCount AggFunc = iota // COUNT(*) or COUNT(col)
-	AggSum
-	AggAvg
-	AggMin
-	AggMax
+	AggCount = db.AggCount // COUNT(*) or COUNT(col)
+	AggSum   = db.AggSum
+	AggAvg   = db.AggAvg
+	AggMin   = db.AggMin
+	AggMax   = db.AggMax
 )
-
-// AggSpec is one aggregate in a query: a function over an argument attribute.
-// Arg "*" (only meaningful for COUNT) counts every row in the group; otherwise
-// Arg is an attribute name evaluated per ad.
-type AggSpec struct {
-	Func AggFunc
-	Arg  string
-}
-
-// AggRow is one group's result: the group-by column values followed by the
-// aggregate values, all rendered as strings (aligned with the request's group
-// columns and aggregate specs).
-type AggRow struct {
-	Group  []string
-	Values []string
-}
 
 // Aggregate runs a server-side GROUP BY: the server buckets the constraint match
 // by the group-by column tuple in a hash map and returns one AggRow per group.
@@ -94,17 +83,6 @@ func (c *Client) AggregateTable(ctx context.Context, table, constraint string, g
 			}
 		}
 	}
-}
-
-// GroupCol is one GROUP BY column for a (possibly bucketed) aggregate: the
-// attribute Attr, optionally floored into fixed-width buckets. BucketWidth == 0
-// groups by the raw attribute value; BucketWidth > 0 (seconds) groups by the
-// epoch-aligned bucket floor(number(Attr)/BucketWidth)*BucketWidth, and a row whose
-// Attr is not a finite number drops out of the result. This is the shared shape a
-// bucketed aggregate (here) and a bucketed materialized view can both group by.
-type GroupCol struct {
-	Attr        string
-	BucketWidth int64
 }
 
 // ErrBucketedUnsupported is returned by AggregateBucketed against a server too old
@@ -238,9 +216,9 @@ func readAggSpecs(r *reader, reqID uint64, write func([]byte)) ([]AggSpec, bool)
 }
 
 // aggregate is the shared GROUP BY core for both aggregate opcodes: it refuses
-// private attributes for an unprivileged connection, scans the projected columns,
-// buckets by the (possibly time-bucketed) group tuple, and streams one frame per
-// group.
+// private attributes for an unprivileged connection, projects only the attributes
+// the aggregation reads (so the scan stays wire-native), reduces via the db module's
+// shared aggregate engine, and streams one frame per group.
 func (s *Server) aggregate(ctx context.Context, reqID uint64, table, constraint string, groupCols []GroupCol, aggs []AggSpec, includePrivate bool, write func([]byte)) {
 	if !includePrivate {
 		for _, g := range groupCols {
@@ -259,10 +237,8 @@ func (s *Server) aggregate(ctx context.Context, reqID uint64, table, constraint 
 
 	// Project only the attributes the aggregation reads (group columns + the
 	// non-"*" aggregate arguments), so the scan reads them wire-native instead of
-	// fully decoding every matching ad. attrs is deduplicated; groupCol[i]/aggCol[i]
-	// index into the projected value slice.
-	nGroup := len(groupCols)
-	attrs, groupCol, aggCol := projectionFor(groupCols, aggs)
+	// fully decoding every matching ad.
+	attrs, groupCol, aggCol := db.AggProjection(groupCols, aggs)
 	d, ok := s.tableOr(reqID, table, write)
 	if !ok {
 		return
@@ -272,209 +248,19 @@ func (s *Server) aggregate(ctx context.Context, reqID uint64, table, constraint 
 		write(respErr(reqID, err.Error()))
 		return
 	}
-
-	// Hash-map aggregation: bucket by the joined group-value tuple, preserving
-	// first-seen order for stable output. scratch builds each row's key without
-	// allocating a slice per ad; a group keeps its own copy only when created.
-	groups := map[string]*groupState{}
-	var order []string
-	scratch := make([]string, nGroup)
-	for vals := range seq {
-		if cancelled(ctx) {
-			return // client gone: stop the scan
-		}
-		drop := false
-		for i, g := range groupCols {
-			if g.BucketWidth > 0 {
-				kt, ok := bucketKeyText(vals[groupCol[i]], g.BucketWidth)
-				if !ok {
-					drop = true // non-numeric bucket attribute: row leaves the series
-					break
-				}
-				scratch[i] = kt
-			} else {
-				scratch[i] = valueText(vals[groupCol[i]])
-			}
-		}
-		if drop {
-			continue
-		}
-		key := strings.Join(scratch, "\x00")
-		gs := groups[key]
-		if gs == nil {
-			gs = &groupState{gvals: append([]string(nil), scratch...), accs: make([]aggAcc, len(aggs))}
-			groups[key] = gs
-			order = append(order, key)
-		}
-		for i, a := range aggs {
-			var v classad.Value
-			if aggCol[i] >= 0 {
-				v = vals[aggCol[i]]
-			}
-			gs.accs[i].update(a, v)
-		}
+	rows := db.AggregateValues(seq, groupCols, aggs, groupCol, aggCol, func() bool { return cancelled(ctx) })
+	if cancelled(ctx) {
+		return // client gone mid-scan: nothing left to stream
 	}
-
-	// A group-less aggregate over an empty match still yields one row (SQL
-	// semantics: COUNT is 0, others undefined).
-	if nGroup == 0 && len(order) == 0 {
-		gs := &groupState{accs: make([]aggAcc, len(aggs))}
+	for _, row := range rows {
 		frame := respHead(reqID, stStream)
-		for i, a := range aggs {
-			frame = putStr(frame, gs.accs[i].result(a))
-		}
-		write(frame)
-		write(respHead(reqID, stStreamEnd))
-		return
-	}
-
-	for _, key := range order {
-		gs := groups[key]
-		frame := respHead(reqID, stStream)
-		for _, gv := range gs.gvals {
+		for _, gv := range row.Group {
 			frame = putStr(frame, gv)
 		}
-		for i, a := range aggs {
-			frame = putStr(frame, gs.accs[i].result(a))
+		for _, v := range row.Values {
+			frame = putStr(frame, v)
 		}
 		write(frame)
 	}
 	write(respHead(reqID, stStreamEnd))
-}
-
-// groupState holds one group's key values and per-aggregate accumulators.
-type groupState struct {
-	gvals []string
-	accs  []aggAcc
-}
-
-// aggAcc accumulates one group's data for one aggregate. COUNT needs only
-// counters; SUM/AVG/MIN/MAX collect the evaluated argument values and hand them
-// to the ClassAd library's aggregate functions at the end, so type coercion
-// (int64-exact sums, int+real promotion, boolean and undefined handling, error
-// propagation, numeric-only min/max) matches HTCondor's sum()/avg()/min()/max()
-// exactly rather than a re-implementation.
-type aggAcc struct {
-	rows int             // all rows in the group (COUNT(*))
-	defN int             // rows where the argument is defined (COUNT(col))
-	vals []classad.Value // argument values for SUM/AVG/MIN/MAX
-}
-
-// update folds one row's already-resolved argument value v into the accumulator.
-// For COUNT(*) (spec.Arg == "*") v is ignored.
-func (a *aggAcc) update(spec AggSpec, v classad.Value) {
-	a.rows++
-	if spec.Arg == "*" {
-		return
-	}
-	if !v.IsUndefined() && !v.IsError() {
-		a.defN++
-	}
-	if spec.Func != AggCount {
-		a.vals = append(a.vals, v) // the library aggregates skip undefined / coerce
-	}
-}
-
-// projectionFor builds the deduplicated list of attributes the aggregation reads
-// (group columns then non-"*" aggregate arguments) and the index of each group
-// column / aggregate argument within that list. An aggregate whose argument is
-// "*" (COUNT(*)) gets index -1.
-func projectionFor(groupCols []GroupCol, aggs []AggSpec) (attrs []string, groupCol, aggCol []int) {
-	idx := map[string]int{}
-	intern := func(name string) int {
-		if i, ok := idx[name]; ok {
-			return i
-		}
-		i := len(attrs)
-		idx[name] = i
-		attrs = append(attrs, name)
-		return i
-	}
-	groupCol = make([]int, len(groupCols))
-	for i, g := range groupCols {
-		groupCol[i] = intern(g.Attr)
-	}
-	aggCol = make([]int, len(aggs))
-	for i, a := range aggs {
-		if a.Arg == "*" {
-			aggCol[i] = -1
-			continue
-		}
-		aggCol[i] = intern(a.Arg)
-	}
-	return attrs, groupCol, aggCol
-}
-
-func (a *aggAcc) result(spec AggSpec) string {
-	switch spec.Func {
-	case AggCount:
-		// COUNT(*) counts every row; COUNT(col) counts rows where col is defined.
-		if spec.Arg == "*" {
-			return strconv.Itoa(a.rows)
-		}
-		return strconv.Itoa(a.defN)
-	case AggSum:
-		return valueText(classad.Sum(a.vals))
-	case AggAvg:
-		return valueText(classad.Avg(a.vals))
-	case AggMin:
-		return valueText(classad.Min(a.vals))
-	case AggMax:
-		return valueText(classad.Max(a.vals))
-	}
-	return "undefined"
-}
-
-// --- small value helpers (server-side, string-rendering) ---
-
-// bucketKeyText floors a numeric value into an epoch-aligned bucket of the given
-// width (seconds) and returns its integer-seconds text. ok is false when v is not a
-// finite number (undefined/error/non-numeric string), so the row drops out of the
-// series -- matching the client-side time_bucket semantics.
-func bucketKeyText(v classad.Value, width int64) (string, bool) {
-	f, ok := numberOf(v)
-	if !ok {
-		return "", false
-	}
-	b := int64(math.Floor(f/float64(width))) * width
-	return strconv.FormatInt(b, 10), true
-}
-
-// numberOf returns the numeric value of v (integer or real) and whether it is one.
-func numberOf(v classad.Value) (float64, bool) {
-	switch {
-	case v.IsInteger():
-		i, _ := v.IntValue()
-		return float64(i), true
-	case v.IsReal():
-		r, _ := v.RealValue()
-		return r, true
-	}
-	return 0, false
-}
-
-func trimFloat(f float64) string { return strconv.FormatFloat(f, 'g', -1, 64) }
-
-// valueText renders a value as a group-key/display string.
-func valueText(v classad.Value) string {
-	switch {
-	case v.IsUndefined():
-		return "undefined"
-	case v.IsError():
-		return "error"
-	case v.IsBool():
-		b, _ := v.BoolValue()
-		return strconv.FormatBool(b)
-	case v.IsString():
-		s, _ := v.StringValue()
-		return s
-	case v.IsInteger():
-		i, _ := v.IntValue()
-		return strconv.FormatInt(i, 10)
-	case v.IsReal():
-		r, _ := v.RealValue()
-		return trimFloat(r)
-	default:
-		return v.String()
-	}
 }

--- a/dbrpc/archive.go
+++ b/dbrpc/archive.go
@@ -3,7 +3,10 @@ package dbrpc
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 
+	"github.com/PelicanPlatform/classad/classad"
 	"github.com/PelicanPlatform/classad/db"
 )
 
@@ -35,6 +38,71 @@ func (sc *serverConn) streamArchiveQuery(reqID uint64, r *reader) {
 			return // client gone
 		}
 		sc.write(putStr(respHead(reqID, stStream), adString(ad, sc.opts.IncludePrivate)))
+	}
+	sc.write(respHead(reqID, stStreamEnd))
+}
+
+// streamArchiveAggregate runs a server-side GROUP BY over a history table and streams one
+// frame per group, mirroring streamAggregate but against an archive. It reads the raw group
+// columns and aggregate specs, resolves the archive, and reduces via db's shared aggregate
+// engine so the result is identical to the same aggregate over a mutable table. Private
+// attributes are refused for an unprivileged reader, as with the mutable aggregate.
+func (sc *serverConn) streamArchiveAggregate(reqID uint64, r *reader) {
+	name := r.str()
+	constraint := r.str()
+	nGroup := int(r.i32())
+	if nGroup < 0 || nGroup > 1024 {
+		sc.write(respBad(reqID))
+		return
+	}
+	groupCols := make([]GroupCol, nGroup)
+	for i := range groupCols {
+		groupCols[i] = GroupCol{Attr: r.str()}
+	}
+	aggs, ok := readAggSpecs(r, reqID, sc.write)
+	if !ok {
+		return
+	}
+	if !sc.opts.IncludePrivate {
+		for _, g := range groupCols {
+			if classad.IsPrivateAttribute(g.Attr) {
+				sc.write(respErr(reqID, "cannot group by private attribute "+g.Attr))
+				return
+			}
+		}
+		for _, a := range aggs {
+			if a.Arg != "*" && classad.IsPrivateAttribute(a.Arg) {
+				sc.write(respErr(reqID, "cannot aggregate private attribute "+a.Arg))
+				return
+			}
+		}
+	}
+	a, ok := sc.s.cat.ArchiveTable(name)
+	if !ok {
+		sc.write(respErr(reqID, "no such archive: "+name))
+		return
+	}
+	groupBy := make([]string, len(groupCols))
+	for i, g := range groupCols {
+		groupBy[i] = g.Attr
+	}
+	rows, err := a.Aggregate(constraint, groupBy, aggs)
+	if err != nil {
+		sc.write(respErr(reqID, err.Error()))
+		return
+	}
+	for _, row := range rows {
+		if cancelled(sc.ctx) {
+			return // client gone
+		}
+		frame := respHead(reqID, stStream)
+		for _, gv := range row.Group {
+			frame = putStr(frame, gv)
+		}
+		for _, v := range row.Values {
+			frame = putStr(frame, v)
+		}
+		sc.write(frame)
 	}
 	sc.write(respHead(reqID, stStreamEnd))
 }
@@ -80,6 +148,72 @@ func (c *Client) ArchiveQuery(ctx context.Context, name, constraint string, limi
 	return c.streamCtx(ctx, func(id uint64) []byte {
 		return putStr(putI32(putStr(req(id, opArchiveQuery), name), int32(limit)), constraint)
 	})
+}
+
+// ErrArchiveAggregateUnsupported is returned by ArchiveAggregate against a server too old
+// to implement the opcode (it rejects the request as a bad op), so a caller can fall back to
+// client-side aggregation (ArchiveQuery + reduce locally).
+var ErrArchiveAggregateUnsupported = errors.New("dbrpc: server does not support archive aggregation")
+
+// ArchiveAggregate runs a server-side GROUP BY over the named history table: the server
+// applies the constraint (with zone-map pruning), groups by groupBy, and reduces each group
+// with the COUNT/SUM/AVG/MIN/MAX aggs, returning one AggRow per group. With no group columns
+// it returns a single row over the whole match. Only the (small) grouped result crosses the
+// wire, not every matched ad -- the point of pushing a COUNT over ~200k history rows to the
+// server. Against a server that does not implement the opcode it returns an error wrapping
+// ErrArchiveAggregateUnsupported so the caller can fall back to client-side aggregation.
+func (c *Client) ArchiveAggregate(ctx context.Context, name, constraint string, groupBy []string, aggs []AggSpec) ([]AggRow, error) {
+	build := func(id uint64) []byte {
+		b := putStr(putStr(req(id, opArchiveAggregate), name), constraint)
+		b = putI32(b, int32(len(groupBy)))
+		for _, g := range groupBy {
+			b = putStr(b, g)
+		}
+		b = putI32(b, int32(len(aggs)))
+		for _, a := range aggs {
+			b = putStr(putU8(b, byte(a.Func)), a.Arg)
+		}
+		return b
+	}
+	_, frames, err := c.callStream(build)
+	if err != nil {
+		return nil, err
+	}
+	var out []AggRow
+	for {
+		select {
+		case <-ctx.Done():
+			drain(frames)
+			return out, ctx.Err()
+		case frame, ok := <-frames:
+			if !ok {
+				return out, nil
+			}
+			_, status, body, ok := respHeader(frame)
+			if !ok {
+				return out, errShort
+			}
+			switch status {
+			case stStream:
+				row := AggRow{Group: make([]string, len(groupBy)), Values: make([]string, len(aggs))}
+				for i := range row.Group {
+					row.Group[i] = body.str()
+				}
+				for i := range row.Values {
+					row.Values[i] = body.str()
+				}
+				out = append(out, row)
+			case stErr:
+				return out, statusErr(status, body)
+			case stBadReq:
+				// A server too old to know opArchiveAggregate rejects it as a bad
+				// request; signal the caller to fall back to client-side aggregation.
+				return nil, ErrArchiveAggregateUnsupported
+			default:
+				return out, fmt.Errorf("dbrpc: unexpected archive aggregate status %d", status)
+			}
+		}
+	}
 }
 
 // ArchiveRotate enforces the named archive's retention policy now (using the server's

--- a/dbrpc/archive_test.go
+++ b/dbrpc/archive_test.go
@@ -69,3 +69,71 @@ func TestArchiveOverRPC(t *testing.T) {
 		t.Error("archive append should be refused on a read-only connection")
 	}
 }
+
+// TestArchiveAggregateOverRPC covers the server-side archive GROUP BY through the client
+// API: COUNT(*), COUNT with a WHERE constraint, and GROUP BY Owner. Each grouped result is
+// checked against a client-side count over the same rows fetched via ArchiveQuery, proving
+// the server aggregate agrees with counting locally.
+func TestArchiveAggregateOverRPC(t *testing.T) {
+	c, cleanup := catServerPair(t, ServeOptions{})
+	defer cleanup()
+
+	if err := c.CreateArchiveTable(context.Background(), "history", db.ArchiveConfig{
+		ValueAttrs: []string{"ClusterId"},
+		ZoneAttrs:  []string{"ClusterId"},
+	}); err != nil {
+		t.Fatalf("CreateArchiveTable: %v", err)
+	}
+	owners := []string{"alice", "bob", "alice", "carol", "bob", "alice"}
+	cpus := []int{4, 16, 8, 1, 4, 2}
+	for i, o := range owners {
+		if err := c.ArchiveAppend(context.Background(), "history",
+			fmt.Sprintf("ClusterId = %d\nOwner = %q\nCpus = %d", i, o, cpus[i])); err != nil {
+			t.Fatalf("ArchiveAppend: %v", err)
+		}
+	}
+
+	// COUNT(*) over the whole table, checked against ArchiveQuery's row count.
+	all, err := c.ArchiveQuery(context.Background(), "history", "true", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rows, err := c.ArchiveAggregate(context.Background(), "history", "true", nil, []AggSpec{{Func: AggCount, Arg: "*"}})
+	if err != nil {
+		t.Fatalf("ArchiveAggregate COUNT(*): %v", err)
+	}
+	if len(rows) != 1 || rows[0].Values[0] != fmt.Sprint(len(all)) {
+		t.Fatalf("COUNT(*) = %+v, want %d", rows, len(all))
+	}
+
+	// COUNT with a WHERE constraint, checked against the constrained ArchiveQuery.
+	matched, err := c.ArchiveQuery(context.Background(), "history", "ClusterId >= 3", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rows, err = c.ArchiveAggregate(context.Background(), "history", "ClusterId >= 3", nil, []AggSpec{{Func: AggCount, Arg: "*"}})
+	if err != nil {
+		t.Fatalf("ArchiveAggregate constrained COUNT: %v", err)
+	}
+	if len(rows) != 1 || rows[0].Values[0] != fmt.Sprint(len(matched)) {
+		t.Fatalf("COUNT(*) WHERE ClusterId>=3 = %+v, want %d", rows, len(matched))
+	}
+
+	// GROUP BY Owner COUNT(*): assert against a client-side count over every row.
+	wantCounts := map[string]int{}
+	for _, o := range owners {
+		wantCounts[o]++
+	}
+	rows, err = c.ArchiveAggregate(context.Background(), "history", "true", []string{"Owner"}, []AggSpec{{Func: AggCount, Arg: "*"}})
+	if err != nil {
+		t.Fatalf("ArchiveAggregate GROUP BY Owner: %v", err)
+	}
+	if len(rows) != len(wantCounts) {
+		t.Fatalf("GROUP BY Owner produced %d groups, want %d: %+v", len(rows), len(wantCounts), rows)
+	}
+	for _, r := range rows {
+		if got := r.Values[0]; got != fmt.Sprint(wantCounts[r.Group[0]]) {
+			t.Errorf("group %q count = %s, want %d", r.Group[0], got, wantCounts[r.Group[0]])
+		}
+	}
+}

--- a/dbrpc/match.go
+++ b/dbrpc/match.go
@@ -215,7 +215,7 @@ func orTrue(constraint string) string {
 
 // attrKey renders an ad's key attribute value as a string.
 func attrKey(ad *classad.ClassAd, keyAttr string) string {
-	return valueText(ad.EvaluateAttr(keyAttr))
+	return db.ValueText(ad.EvaluateAttr(keyAttr))
 }
 
 func rankText(m db.RankedMatch) string {

--- a/dbrpc/proto.go
+++ b/dbrpc/proto.go
@@ -135,6 +135,12 @@ const (
 	// redact requests source-side private-attribute stripping even on a
 	// privileged connection; an unprivileged connection is always redacted.
 	opQueryRawWire op = 52
+
+	// opArchiveAggregate is a server-side GROUP BY over a history table: like opAggregate
+	// but against an archive, so a COUNT/SUM/AVG/MIN/MAX over ~200k history rows reduces on
+	// the server (using the archive's zone-map pruning) and only the grouped rows cross the
+	// wire, instead of the client fetching and counting every matched ad.
+	opArchiveAggregate op = 53 // [name][constraint][nGroup]{[attr]}[nAgg]{[func u8][arg]} -> stream of [group...][agg...]
 )
 
 // String names an opcode for diagnostics (e.g. the read-only rejection message).
@@ -222,6 +228,8 @@ func (o op) String() string {
 		return "QueryRaw"
 	case opCommitIdem:
 		return "CommitIdempotent"
+	case opArchiveAggregate:
+		return "ArchiveAggregate"
 	}
 	return "op(unknown)"
 }

--- a/dbrpc/server.go
+++ b/dbrpc/server.go
@@ -429,6 +429,8 @@ func (sc *serverConn) dispatch(frame []byte) {
 		sc.streamSnapshot(reqID, body)
 	case opArchiveQuery:
 		sc.streamArchiveQuery(reqID, body)
+	case opArchiveAggregate:
+		sc.streamArchiveAggregate(reqID, body)
 	case opWatchStop:
 		sc.stopWatch(body.u64())
 		sc.write(resp(reqID, stOK))


### PR DESCRIPTION
### Problem

`COUNT(*)` / `GROUP BY` over a history **archive** was only doable by streaming every matching row to the client and reducing there — a `COUNT` over ~200k rows took **~1 minute**. Mutable tables have a server-side aggregate (`opAggregate`); archives had none.

### Change

- **db**: `ArchiveTable.Aggregate(constraint, groupBy, aggs) ([]AggRow, error)`. Applies the constraint via the archive's existing `QueryLimit` path (so it inherits **zone-map segment pruning** — a range constraint on a zone-mapped attr skips whole segments), then reduces with the shared engine.
- **Engine relocation**: the mutable-table aggregate engine lived in `dbrpc`, but `db` can't import `dbrpc`. Moved it down into `db/aggregate.go` (`AggFunc`/`AggSpec`/`AggRow`/`GroupCol` + the COUNT/SUM/AVG/MIN/MAX reduction + `AggregateValues`). `dbrpc` keeps its public names as **type aliases**, so the wire format and client API are unchanged and the mutable path is behavior-preserving (existing `TestAggregate*` all pass).
- **dbrpc**: `opArchiveAggregate` (op 53) + `streamArchiveAggregate` server handler (private-attr gating, mid-stream cancel) + `Client.ArchiveAggregate`. An old server rejects the unknown op (`stBadReq`) → `ErrArchiveAggregateUnsupported`, so a client can fall back to client-side aggregation.

Tests: `db.TestArchiveTableAggregate` (COUNT, constrained COUNT, GROUP BY with COUNT/SUM/MAX) and `dbrpc.TestArchiveAggregateOverRPC` (same over RPC, checked against a client-side count). Both modules `go vet` clean.

This is the server side of htcondordb's slow `SELECT COUNT(*) FROM history`; the htcondordb REPL will route archive aggregates to `ArchiveAggregate` after this is tagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
