### PR TITLE
collections: don't panic on a chain link into a nonexistent segment

### DIFF
--- a/collections/dangling_loc_test.go
+++ b/collections/dangling_loc_test.go
@@ -1,0 +1,27 @@
+package collections
+
+import "testing"
+
+// TestFindCurrentDanglingLocNoPanic reproduces the reported crash shape: a directory/chain
+// location that references a segment index past the live set (a stale link left by a reaped
+// segment). The walk must treat it as end-of-chain, not index out of range.
+func TestFindCurrentDanglingLocNoPanic(t *testing.T) {
+	sh := &shard{} // no live segments: any seg index is out of range
+	if _, ok := sh.findCurrent(loc{seg: 44, off: 0x2ce}, []byte("16257.1830")); ok {
+		t.Fatal("a dangling head loc must yield not-found, not a match")
+	}
+}
+
+// TestSpliceDeadFromChainDanglingNoPanic guards the compaction chain-splice against the same
+// dangling location.
+func TestSpliceDeadFromChainDanglingNoPanic(t *testing.T) {
+	sh := &shard{dir: map[uint64]loc{7: {seg: 44, off: 16}}}
+	// deadSet marks a live-set index; the head at seg 44 is simply nonexistent.
+	sh.spliceDeadFromChain(7, map[uint32]struct{}{0: {}})
+	// And with the dangling segment itself marked dead (the leading-loop path).
+	sh.dir[7] = loc{seg: 44, off: 16}
+	sh.spliceDeadFromChain(7, map[uint32]struct{}{44: {}})
+	if _, ok := sh.dir[7]; ok {
+		t.Errorf("dir entry pointing only into a dead/absent segment should be dropped")
+	}
+}

--- a/collections/shard.go
+++ b/collections/shard.go
@@ -160,13 +160,28 @@ func (sh *shard) dirGet(h uint64) loc {
 	return noLoc
 }
 
+// segAt returns the segment for a location's index, or nil if the index is out of range or
+// that slot has been reaped. A recNext chain link should only ever reference a live segment;
+// a link into a nonexistent one is corruption (e.g. a stale link left behind by a reaped
+// segment). Returning nil lets a chain walk terminate defensively rather than panic on an
+// out-of-range index. Caller holds at least the read lock.
+func (sh *shard) segAt(id uint32) *segment {
+	if int(id) >= len(sh.segs) {
+		return nil
+	}
+	return sh.segs[id]
+}
+
 // findCurrent walks the bucket chain from head and returns the location of the
 // current (non-superseded) record whose key matches, if any. Collisions and
 // superseded versions are skipped by comparing the inline key and the atomic
 // supersededBySeq field. Caller holds at least the read lock.
 func (sh *shard) findCurrent(head loc, key []byte) (loc, bool) {
 	for l := head; l.valid(); {
-		seg := sh.segs[l.seg]
+		seg := sh.segAt(l.seg)
+		if seg == nil {
+			break // dangling chain link into a nonexistent segment; treat as end-of-chain
+		}
 		if recSuperseded(seg.data, l.off) == seqMax && bytes.Equal(recKey(seg.data, l.off), key) {
 			return l, true
 		}
@@ -393,9 +408,17 @@ func (sh *shard) lookupSealedAt(key []byte, h uint64, s0 uint64) (loc, bool) {
 // the reap the directory must not reference a removed segment. Caller holds the write lock.
 func (sh *shard) spliceDeadFromChain(h uint64, deadSet map[uint32]struct{}) {
 	isDead := func(l loc) bool { _, d := deadSet[l.seg]; return l.valid() && d }
+	// segNext reads the next link from l, terminating the walk (returns noLoc) if l dangles
+	// into a nonexistent segment -- the same corruption findCurrent guards against.
+	segNext := func(l loc) loc {
+		if s := sh.segAt(l.seg); s != nil {
+			return recNext(s.data, l.off)
+		}
+		return noLoc
+	}
 	head := sh.dir[h]
 	for isDead(head) {
-		head = recNext(sh.segs[head.seg].data, head.off)
+		head = segNext(head)
 	}
 	if head != sh.dir[h] {
 		if head.valid() {
@@ -405,11 +428,14 @@ func (sh *shard) spliceDeadFromChain(h uint64, deadSet map[uint32]struct{}) {
 		}
 	}
 	for l := head; l.valid(); {
-		seg := sh.segs[l.seg]
+		seg := sh.segAt(l.seg)
+		if seg == nil {
+			break
+		}
 		nxt := recNext(seg.data, l.off)
 		orig := nxt
 		for isDead(nxt) {
-			nxt = recNext(sh.segs[nxt.seg].data, nxt.off)
+			nxt = segNext(nxt)
 		}
 		if nxt != orig {
 			setRecNext(seg.data, l.off, nxt)


### PR DESCRIPTION
### The crash

A schedd-sync commit stream panicked the writer:

```
panic: runtime error: index out of range [44] with length 1
  collections.(*shard).findCurrent  shard.go:169
  collections.(*shard).put          shard.go:190
  collections.(*shard).applyTxn / (*Txn).Commit
```

A bucket-chain / directory `loc` referenced segment index 44, but the shard had one live segment — a **dangling link into a nonexistent segment** (a stale link left behind by a reaped segment under heavy update churn). Walking it (`findCurrent`, and `spliceDeadFromChain` during compaction) indexed `sh.segs` out of range.

### Fix

Bounds-check the segment (`shard.segAt`) in both chain walkers and treat a dangling link as end-of-chain rather than indexing out of range. A link into a segment that doesn't exist has no record to consider.

- In `findCurrent` this **self-heals**: the key reads as not-present, so the next `put` overwrites the stale directory head with a valid location.
- `rebuildDir` already rewrites every chain among current records on reload, so a restart clears the state entirely (matching the report that the daemon recovered after a single panic, no crash-loop).

Tests reproduce the crash shape (a `loc{seg:44}` against a shard with no such segment) for both walkers and assert no panic.

> This is defensive robustness — the panic is fixed and the state self-repairs. The **source** of the stale link under this workload (likely a segment-id/location inconsistency across compaction + reopen) warrants a separate root-cause investigation; I'm continuing to dig.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
