### PR TITLE
collections: append-only mode (foundation for archive unification)

### DIFF
--- a/collections/appendonly_test.go
+++ b/collections/appendonly_test.go
@@ -1,0 +1,65 @@
+package collections
+
+import (
+	"testing"
+
+	"github.com/PelicanPlatform/classad/classad"
+)
+
+// TestAppendOnlyMode covers the append-log Collection: every Put appends a record (no per-key
+// supersession), the collection is single-shard, and Compact/Delete/Rewrite/RetrainDict are
+// inert so the log is never rewritten.
+func TestAppendOnlyMode(t *testing.T) {
+	c := New(Options{AppendOnly: true, Shards: 8}) // Shards forced to 1
+	defer c.Close()
+	if got := len(c.shards); got != 1 {
+		t.Fatalf("append-only shards = %d, want 1 (forced)", got)
+	}
+
+	// Two Puts to the SAME key both persist (no supersession) -- append semantics.
+	for i, text := range []string{
+		`[ ClusterId = 1; JobStatus = 4; Owner = "alice" ]`,
+		`[ ClusterId = 1; JobStatus = 3; Owner = "alice" ]`, // same key, different content
+		`[ ClusterId = 2; JobStatus = 4; Owner = "bob" ]`,
+	} {
+		ad, err := classad.Parse(text)
+		if err != nil {
+			t.Fatal(err)
+		}
+		key := []byte("1.0")
+		if i == 2 {
+			key = []byte("2.0")
+		}
+		if err := c.Put(key, ad); err != nil {
+			t.Fatalf("append %d: %v", i, err)
+		}
+	}
+
+	count := func() int {
+		n := 0
+		for range c.Scan() {
+			n++
+		}
+		return n
+	}
+	if got := count(); got != 3 {
+		t.Fatalf("scan returned %d records, want 3 (all appends, no dedup)", got)
+	}
+
+	// Maintenance that would rewrite/renumber the log is inert.
+	if n := c.Compact(); n != 0 {
+		t.Errorf("Compact on append-only did work (%d); want no-op", n)
+	}
+	if n := c.Rewrite(); n != 0 {
+		t.Errorf("Rewrite on append-only did work (%d); want no-op", n)
+	}
+	if _, err := c.RetrainDict(1000); err == nil {
+		t.Error("RetrainDict on append-only should error (recompression path is not append-safe)")
+	}
+	if c.Delete([]byte("1.0")) {
+		t.Error("Delete on append-only should be a no-op")
+	}
+	if got := count(); got != 3 {
+		t.Errorf("after inert maintenance scan = %d, want 3 (log unchanged)", got)
+	}
+}

--- a/collections/compact.go
+++ b/collections/compact.go
@@ -1,6 +1,9 @@
 package collections
 
-import "time"
+import (
+	"errors"
+	"time"
+)
 
 // Compaction reclaims space consumed by superseded/deleted records.
 //
@@ -40,6 +43,9 @@ const (
 // safe to call concurrently with reads and writes. Returns the number of shards where
 // space was reclaimed (by either mechanism).
 func (c *Collection) Compact() int {
+	if c.appendOnly() {
+		return 0 // an append log never supersedes, so there is nothing to compact
+	}
 	c.maintMu.Lock()
 	defer c.maintMu.Unlock()
 	start := time.Now()
@@ -170,6 +176,9 @@ func (c *Collection) reclaimDeadShard(sh *shard) int {
 // value. Run it during low write activity (or, in an HA deployment, on the sole
 // writer).
 func (c *Collection) Rewrite() int {
+	if c.appendOnly() {
+		return 0 // rewriting an append log would duplicate every record (no supersession)
+	}
 	c.maintMu.Lock()
 	defer c.maintMu.Unlock()
 	n := 0
@@ -202,7 +211,17 @@ func (c *Collection) Rewrite() int {
 // transactions; production leaves it nil.
 var retrainStallHook func()
 
+// errAppendOnlyRetrain is returned by RetrainDict on an append-only collection, where the
+// compaction-based recompression path does not apply.
+var errAppendOnlyRetrain = errors.New("collections: RetrainDict is not supported on an append-only collection")
+
 func (c *Collection) RetrainDict(sampleMax int) (int, error) {
+	if c.appendOnly() {
+		// Retrain recompresses via compactShard, which renumbers segments and rebuilds the
+		// directory -- illegal for an append log. Append-only recompression (per-segment
+		// reseal preserving order) is a separate path (not yet implemented).
+		return 0, errAppendOnlyRetrain
+	}
 	c.maintMu.Lock()
 	defer c.maintMu.Unlock()
 	start := time.Now()

--- a/collections/shard.go
+++ b/collections/shard.go
@@ -17,6 +17,11 @@ type shard struct {
 	segs []*segment     // indexed by segment id (id == index)
 	act  *segment       // current append target
 
+	// appendOnly makes this a pure append log (see Options.AppendOnly): put appends
+	// without superseding or indexing by key, del is a no-op, and compaction is
+	// skipped. Set once at construction; never mutated.
+	appendOnly bool
+
 	commitSeq uint64 // bumped once per committed batch; scan snapshots capture it
 	count     int    // number of live keys
 
@@ -180,6 +185,15 @@ func (sh *shard) findCurrent(head loc, key []byte) (loc, bool) {
 // superseded at seq; the new record is prepended as the bucket head. Caller holds
 // the write lock.
 func (sh *shard) put(h uint64, key, ad []byte, seq uint64, codec Codec) {
+	if sh.appendOnly {
+		// Append log: write a new record with no bucket-chain link and never supersede
+		// or index it. Records accumulate in commit order; there is no per-key current
+		// version or directory (Get/Delete-by-key are inert), and Scan/Query see them all.
+		if _, ok := sh.writeRecord(seq, noLoc, key, ad, codec); ok {
+			sh.count++
+		}
+		return
+	}
 	head := sh.dirGet(h)
 	// Write the new record first: if segment allocation fails (persistent store,
 	// disk full), the key is left unchanged rather than superseded-with-no-successor.
@@ -220,6 +234,9 @@ func (sh *shard) put(h uint64, key, ad []byte, seq uint64, codec Codec) {
 // zero (parentEmptied) -- the signal Delete uses to auto-delete an orphaned
 // structural parent. Caller holds the write lock.
 func (sh *shard) del(h uint64, key []byte, seq uint64) (removed, parentEmptied bool) {
+	if sh.appendOnly {
+		return false, false // an append log has no per-key delete
+	}
 	old, ok := sh.findCurrent(sh.dirGet(h), key)
 	if !ok {
 		// Not in the active directory; probe the sealed segments (evicted keys).

--- a/collections/store.go
+++ b/collections/store.go
@@ -23,8 +23,15 @@ type codecHolder struct{ c Codec }
 // Options configures a Collection.
 type Options struct {
 	// Shards is the number of independently-locked shards; rounded up to a power
-	// of two. Default 16.
+	// of two. Default 16. Forced to 1 when AppendOnly (an append log is a single
+	// ordered sequence: it needs one segment chain, not sharded key routing).
 	Shards int
+	// AppendOnly makes the collection a pure append log: every Put appends a new
+	// record (no per-key supersession, no directory, no compaction, no deletes) --
+	// the model a history archive needs. Records accumulate in commit order and are
+	// reclaimed only by whole-segment retention, not compaction. Scan/Query see every
+	// appended record; Get/Delete-by-key are not meaningful (there is no key index).
+	AppendOnly bool
 	// SegmentSize is the arena segment size in bytes. Default 8 MiB.
 	SegmentSize int
 	// Hasher routes keys to shards / directory buckets. Default 64-bit FNV-1a.
@@ -358,6 +365,9 @@ func New(opts Options) *Collection {
 	if n <= 0 {
 		n = 16
 	}
+	if opts.AppendOnly {
+		n = 1 // an append log is a single ordered sequence, not sharded
+	}
 	n = nextPow2(n)
 	segSize := opts.SegmentSize
 	if segSize <= 0 {
@@ -374,6 +384,7 @@ func New(opts Options) *Collection {
 	shards := make([]*shard, n)
 	for i := range shards {
 		shards[i] = newShard(segSize, opts.CommitSync)
+		shards[i].appendOnly = opts.AppendOnly
 	}
 	c := &Collection{
 		shards: shards,
@@ -530,6 +541,10 @@ func (c *Collection) Update(batch []AdUpdate) error {
 // Put inserts or updates a single ad. It is the hot path for the common
 // one-ad-at-a-time daemon pattern, so unlike Update it takes no per-call slice or
 // map allocations: it encodes, compresses, and commits directly to the one shard.
+// appendOnly reports whether this is an append-log collection (Options.AppendOnly). It is a
+// whole-collection property, set once at construction, so the first shard's flag speaks for all.
+func (c *Collection) appendOnly() bool { return len(c.shards) > 0 && c.shards[0].appendOnly }
+
 func (c *Collection) Put(key []byte, ad *classad.ClassAd) error {
 	codec := c.currentCodec()
 	stored := codec.Compress(nil, c.encodeAd(ad.AST()))


### PR DESCRIPTION
**Phase 1, increment 1** of unifying the history archive onto the `Collection` store (so the archive inherits ZSTD dict retraining, add/change indices, and rewrite instead of reimplementing them in a ~90KB fork).

Adds `Options.AppendOnly`: a pure append log rather than a mutable MVCC store.
- **Shards forced to 1** — a log is a single ordered sequence, not sharded key routing (this also sidesteps the cross-shard ordering/cursor problem for newest-first + watch + rotation, which come next).
- Each `Put` **appends** a new record with no bucket-chain link and never supersedes or indexes it by key (no directory; `Get`/`Delete`-by-key are inert). `Scan`/`Query` see every appended record in commit order.
- `del` is a no-op; `Compact`/`Rewrite`/`RetrainDict` are skipped — they rewrite/renumber segments, which is illegal for an append log. (Append-only recompression via a per-segment reseal that preserves order is a later increment — that's how retrain will eventually work here.)

Mutable-store behavior is unchanged; every guard keys off the flag. Test: same-key double append both persist (no dedup), single-shard forced, and the maintenance ops are inert leaving the log intact. Full collections suite green.

Next increments: zone-map indexing, newest-first scan, retention rotation, append-only reload, then reimplement `db.ArchiveTable` on top and delete the fork.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
