### PR TITLE
collections: append-only reload keeps every record live

### DIFF
--- a/collections/appendonly_reload_test.go
+++ b/collections/appendonly_reload_test.go
@@ -1,0 +1,64 @@
+package collections
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/classad"
+)
+
+// TestAppendOnlyReload verifies a persistent append-only collection survives close+reopen with
+// every record (including intentional duplicate keys) still live -- the reload must not apply
+// the mutable store's single-current-version dedup.
+func TestAppendOnlyReload(t *testing.T) {
+	dir := t.TempDir()
+	c, err := Open(Options{AppendOnly: true, Dir: dir, SegmentSize: 1 << 14})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// 50 appends, all under the SAME key (a log with heavy key collision): every one must persist.
+	for i := 0; i < 50; i++ {
+		ad, perr := classad.Parse(fmt.Sprintf(`[ N = %d; Owner = "u%d" ]`, i, i%3))
+		if perr != nil {
+			t.Fatal(perr)
+		}
+		if err := c.Put([]byte("dup"), ad); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := c.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	c2, err := Open(Options{AppendOnly: true, Dir: dir, SegmentSize: 1 << 14})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c2.Close()
+	n := 0
+	seen := map[int64]bool{}
+	for ad := range c2.Scan() {
+		n++
+		if v, ok := ad.EvaluateAttrInt("N"); ok {
+			seen[v] = true
+		}
+	}
+	if n != 50 {
+		t.Fatalf("after reload scan = %d records, want 50 (no dedup on an append log)", n)
+	}
+	if len(seen) != 50 {
+		t.Errorf("distinct N values after reload = %d, want 50 (each append preserved)", len(seen))
+	}
+	// The reopened log keeps appending correctly.
+	ad, _ := classad.Parse(`[ N = 999 ]`)
+	if err := c2.Put([]byte("dup"), ad); err != nil {
+		t.Fatal(err)
+	}
+	n = 0
+	for range c2.Scan() {
+		n++
+	}
+	if n != 51 {
+		t.Errorf("after post-reload append scan = %d, want 51", n)
+	}
+}

--- a/collections/persist.go
+++ b/collections/persist.go
@@ -385,6 +385,10 @@ func (c *Collection) loadShard(sh *shard, shardDir string) (uint64, error) {
 // current version, live iff it is not superseded (a key whose latest record was
 // tombstoned by a delete is absent). Chains are rebuilt fresh.
 func (c *Collection) rebuildDir(sh *shard) {
+	if sh.appendOnly {
+		c.rebuildAppendLog(sh)
+		return
+	}
 	type best struct {
 		loc        loc
 		seq        uint64
@@ -490,6 +494,44 @@ func (c *Collection) rebuildDir(sh *shard) {
 		sh.dir[h] = b.loc
 		count++
 	}
+	sh.count = count
+	if len(sh.segs) > 0 {
+		sh.act = sh.segs[len(sh.segs)-1]
+	}
+}
+
+// rebuildAppendLog restores an append-only shard on reopen. An append log has no per-key
+// supersession or directory, so the single-current-version dedup that rebuildDir performs for a
+// mutable shard must be skipped: every on-disk record stays live (duplicate keys are intentional
+// here). It only recovers the commit sequence, the per-segment min sequence, the live count, and
+// the active (last) segment for continued appends.
+func (c *Collection) rebuildAppendLog(sh *shard) {
+	var maxSeq uint64
+	count := 0
+	for _, seg := range sh.segs {
+		if seg == nil {
+			continue
+		}
+		for off := 0; off < seg.used; {
+			o := uint32(off)
+			total := recTotalLen(seg.data, o)
+			if total == 0 {
+				break
+			}
+			seq := recSeq(seg.data, o)
+			if seq > maxSeq {
+				maxSeq = seq
+			}
+			if seg.minSeq == 0 || seq < seg.minSeq {
+				seg.minSeq = seq
+			}
+			if !recIsMarker(seg.data, o) {
+				count++ // append-only records are never superseded, so all are live
+			}
+			off += int(total)
+		}
+	}
+	sh.commitSeq = maxSeq
 	sh.count = count
 	if len(sh.segs) > 0 {
 		sh.act = sh.segs[len(sh.segs)-1]


### PR DESCRIPTION
Increment 2 of the archive unification.

On reopen, `rebuildDir` enforces the mutable store's single-current-version invariant — superseding on-disk duplicate keys. That is wrong for an append log, where duplicate keys are intentional and every record is permanently live. `rebuildDir` now branches to `rebuildAppendLog` for an append-only shard: recompute the commit sequence, per-segment min sequence, live count, and active segment; build no directory and dedup nothing.

Test: 50 appends under the *same* key, close, reopen with `AppendOnly` — all 50 survive and it keeps appending. Full collections suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)