### PR TITLE
collections: newest-first (reverse) scan option

### DIFF
--- a/collections/reverse_scan_test.go
+++ b/collections/reverse_scan_test.go
@@ -1,0 +1,101 @@
+package collections
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/classad"
+	"github.com/PelicanPlatform/classad/collections/vm"
+)
+
+// TestReverseScan verifies ReverseScan yields records newest-first across both
+// segment boundaries and within a segment, that an early stop returns the K most
+// recently appended, that a filtered Query preserves the order, and that it
+// survives a persistent reopen.
+func TestReverseScan(t *testing.T) {
+	dir := t.TempDir()
+	// Small segments so the 200 records span several, exercising cross-segment order.
+	c, err := Open(Options{AppendOnly: true, ReverseScan: true, Dir: dir, SegmentSize: 1 << 12})
+	if err != nil {
+		t.Fatal(err)
+	}
+	const n = 200
+	for i := 0; i < n; i++ {
+		ad, _ := classad.Parse(fmt.Sprintf(`[ N = %d; Even = %v ]`, i, i%2 == 0))
+		if err := c.Put([]byte("k"), ad); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Full reverse scan: N should count down n-1 .. 0.
+	want := n - 1
+	seen := 0
+	for ad := range c.Scan() {
+		v, _ := ad.EvaluateAttrInt("N")
+		if v != int64(want) {
+			t.Fatalf("reverse scan order: got N=%d, want %d", v, want)
+		}
+		want--
+		seen++
+	}
+	if seen != n {
+		t.Fatalf("reverse scan saw %d records, want %d", seen, n)
+	}
+
+	// Early stop (pushed-down LIMIT 5) => the 5 newest: 199,198,197,196,195.
+	var top []int64
+	for ad := range c.Scan() {
+		v, _ := ad.EvaluateAttrInt("N")
+		top = append(top, v)
+		if len(top) == 5 {
+			break
+		}
+	}
+	wantTop := []int64{199, 198, 197, 196, 195}
+	if fmt.Sprint(top) != fmt.Sprint(wantTop) {
+		t.Fatalf("LIMIT 5 newest = %v, want %v", top, wantTop)
+	}
+
+	// Filtered Query also newest-first: even N descending 198,196,...
+	q, err := vm.Parse(`Even == true`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	prev := int64(n)
+	cnt := 0
+	for ad := range c.Query(q) {
+		v, _ := ad.EvaluateAttrInt("N")
+		if v%2 != 0 {
+			t.Fatalf("query returned odd N=%d", v)
+		}
+		if v >= prev {
+			t.Fatalf("query not descending: %d after %d", v, prev)
+		}
+		prev = v
+		cnt++
+	}
+	if cnt != n/2 {
+		t.Fatalf("even query returned %d, want %d", cnt, n/2)
+	}
+	c.Close()
+
+	// Reopen: reverse order and count survive.
+	c2, err := Open(Options{AppendOnly: true, ReverseScan: true, Dir: dir, SegmentSize: 1 << 12})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c2.Close()
+	want = n - 1
+	seen = 0
+	for ad := range c2.Scan() {
+		v, _ := ad.EvaluateAttrInt("N")
+		if v != int64(want) {
+			t.Fatalf("after reopen reverse order: got N=%d, want %d", v, want)
+		}
+		want--
+		seen++
+	}
+	if seen != n {
+		t.Fatalf("after reopen reverse scan saw %d, want %d", seen, n)
+	}
+}

--- a/collections/shard.go
+++ b/collections/shard.go
@@ -617,3 +617,40 @@ func forEachVisibleKeyed(s0 uint64, wins []segWindow, fn func(key, ad []byte, co
 		}
 	}
 }
+
+// forEachVisibleKeyedReverse is forEachVisibleKeyed in newest-first order: it
+// walks the windows from the last (newest) segment backward and, within each
+// segment, visits records back-to-front. Because records are variable-length and
+// self-describe only their forward length, each window's record offsets are
+// collected in a single forward pass, then replayed in reverse -- so the whole
+// walk is still O(records), just with a per-segment offset slice. A caller that
+// stops early after K records therefore receives the K most recently appended.
+func forEachVisibleKeyedReverse(s0 uint64, wins []segWindow, fn func(key, ad []byte, codec Codec) bool) {
+	var offs []uint32 // reused across windows
+	for wi := len(wins) - 1; wi >= 0; wi-- {
+		w := wins[wi]
+		offs = offs[:0]
+		for off := 0; off < w.used; {
+			o := uint32(off)
+			total := recTotalLen(w.data, o)
+			if total == 0 {
+				break
+			}
+			offs = append(offs, o)
+			off += int(total)
+		}
+		for i := len(offs) - 1; i >= 0; i-- {
+			o := offs[i]
+			if recIsMarker(w.data, o) {
+				continue // time-checkpoint marker, not a data record
+			}
+			seq := recSeq(w.data, o)
+			sup := recSuperseded(w.data, o)
+			if seq <= s0 && sup > s0 {
+				if !fn(recKey(w.data, o), recAd(w.data, o), w.codec) {
+					return
+				}
+			}
+		}
+	}
+}

--- a/collections/store.go
+++ b/collections/store.go
@@ -32,6 +32,15 @@ type Options struct {
 	// reclaimed only by whole-segment retention, not compaction. Scan/Query see every
 	// appended record; Get/Delete-by-key are not meaningful (there is no key index).
 	AppendOnly bool
+	// ReverseScan makes Scan/Query yield records newest-first (most recently
+	// appended first) instead of in stored order. It walks segments from the last
+	// (newest) backward and, within a segment, records back-to-front -- the natural
+	// "last K" order a history archive presents (condor_history shows the most
+	// recent jobs first). A consumer that stops early (yield/emit returns false)
+	// after K records therefore gets the K newest, a pushed-down LIMIT. Reverse
+	// scans always run serial (never fan out). Default false ⇒ stored order.
+	// Most meaningful with AppendOnly, where stored order is commit order.
+	ReverseScan bool
 	// SegmentSize is the arena segment size in bytes. Default 8 MiB.
 	SegmentSize int
 	// Hasher routes keys to shards / directory buckets. Default 64-bit FNV-1a.
@@ -219,6 +228,10 @@ type Collection struct {
 	queryPar         int
 	qsem             chan struct{}
 	parallelMinBytes int
+
+	// reverseScan yields records newest-first (see Options.ReverseScan). Forces
+	// serial scans (no fan-out), since fan-out has no cross-segment order.
+	reverseScan bool
 
 	// Watch (see watch.go / docs/WATCH.md). hub is nil unless WatchHistory > 0.
 	hub           *watchHub
@@ -471,6 +484,7 @@ func New(opts Options) *Collection {
 		}
 	}
 	c.parallelMinBytes = defaultParallelMinBytes
+	c.reverseScan = opts.ReverseScan
 	c.queryPar = resolveQueryParallelism(opts.QueryParallelism)
 	if c.queryPar >= 2 {
 		// Machine-wide worker budget: bounds total scan goroutines across all
@@ -758,7 +772,7 @@ func (c *Collection) Query(q *vm.Query) iter.Seq[*classad.ClassAd] {
 		usable := c.planIndex(probes)
 		// A large full-scan query (no index) can fan out across segments; the helper
 		// falls back to a serial scan of the same snapshot when it is not worthwhile.
-		if c.queryPar > 1 && len(usable) == 0 {
+		if c.queryPar > 1 && len(usable) == 0 && !c.reverseScan {
 			c.runParallelQuery(q, yield)
 			return
 		}
@@ -806,7 +820,7 @@ func (c *Collection) scanShardAt(sh *shard, s0 uint64, qp queryPlan, emit func(w
 func (c *Collection) scanWindows(s0 uint64, wins []segWindow, qp queryPlan, emit func(w []byte) bool) bool {
 	cont := true
 	var dbuf []byte // decompression buffer reused across ads (single-threaded scan)
-	forEachVisibleKeyed(s0, wins, func(key, ad []byte, codec Codec) bool {
+	visit := func(key, ad []byte, codec Codec) bool {
 		if isSystemKeyBytes(key) {
 			return true // internal system record: hidden from client scans/queries
 		}
@@ -823,7 +837,12 @@ func (c *Collection) scanWindows(s0 uint64, wins []segWindow, qp queryPlan, emit
 			return false
 		}
 		return true
-	})
+	}
+	if c.reverseScan {
+		forEachVisibleKeyedReverse(s0, wins, visit)
+	} else {
+		forEachVisibleKeyed(s0, wins, visit)
+	}
 	return cont
 }
 


### PR DESCRIPTION
Increment 3 of the archive unification.

`Options.ReverseScan` makes `Scan`/`Query` yield records **newest-first**: walk segments from the newest backward and, within a segment, records back-to-front. Records are variable-length (forward-length only), so each window's offsets are collected in one forward pass then replayed in reverse — still O(records), with a per-segment offset slice.

A consumer that stops early after K records gets the **K most recently appended** — a pushed-down `LIMIT`, the order `condor_history` wants. Reverse scans run serial (fan-out has no cross-segment order).

Test: 200 same-key appends across several small segments — full scan counts down N-1..0; `LIMIT 5` returns the 5 newest; a filtered `Query` stays descending; order + count survive a persistent reopen. Full collections suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)