### PR TITLE
collections: retention rotation for append-only collections

### DIFF
--- a/collections/retention.go
+++ b/collections/retention.go
@@ -1,0 +1,128 @@
+package collections
+
+// Retention rotation for an append-only collection: Rotate drops whole oldest
+// segments once the collection exceeds a configured bound. This is the archive's
+// aging-out expressed as a Collection rule -- there is no compaction here, only
+// whole-segment reclamation, so the append log's newest-first order and per-record
+// identity are untouched. The Retention type is shared with the archive (archive.go).
+
+// Rotate drops whole oldest segments until the append-only collection is back within
+// its Retention bounds, returning the number of segments dropped. now is the caller's
+// wall clock (unix seconds) for age-based retention -- the store keeps no clock of its
+// own -- and is ignored unless Retention.MaxAgeAttr/MaxAge are set. Rotate is a no-op
+// (returns 0) on a non-append-only collection or when Retention is the zero value.
+//
+// The segment still being appended to is never dropped, so Rotate can bound a growing
+// archive without racing the writer. A dropped segment's file is unmapped and unlinked
+// once no in-flight scan still pins it (a scan that started earlier keeps reading a
+// consistent snapshot until it finishes; the reclaim is deferred to its last unpin).
+//
+// NOTE: MaxAgeAttr/MaxAge (drop by a segment's max value of a time attribute) needs the
+// per-segment zone map, which the append-only Collection does not yet maintain; until
+// then Rotate honors MaxSegments and MaxBytes only. Both suffice to bound disk use.
+func (c *Collection) Rotate(now float64) (int, error) {
+	if !c.appendOnly() || (c.ret == Retention{}) {
+		return 0, nil
+	}
+	// Serialize against other whole-collection maintenance (retrain/rewrite), matching
+	// Compact. Commits and queries never take maintMu.
+	c.maintMu.Lock()
+	defer c.maintMu.Unlock()
+
+	sh := c.shards[0] // AppendOnly forces a single shard
+	var toReap []*segment
+	dropped := 0
+
+	sh.mu.Lock()
+	for {
+		idx := oldestLiveSeg(sh)
+		if idx < 0 || sh.segs[idx] == sh.act {
+			break // nothing left, or only the active (still-appended) segment remains
+		}
+		if !sh.overRetention(c.ret, idx) {
+			break
+		}
+		seg := sh.segs[idx]
+		if n := segLiveCount(seg); n <= sh.count {
+			sh.count -= n
+		} else {
+			sh.count = 0
+		}
+		if seg.retire() { // unpinned ⇒ reap now; else the last unpin reaps it
+			toReap = append(toReap, seg)
+		}
+		sh.segs[idx] = nil // keep the slot so seg.id still equals its index (segAt invariant)
+		dropped++
+	}
+	sh.mu.Unlock()
+
+	var err error
+	for _, seg := range toReap {
+		if e := seg.reapAndHook(); e != nil && err == nil { // munmap + unlink outside the lock
+			err = e
+		}
+	}
+	return dropped, err
+}
+
+// oldestLiveSeg returns the index of the oldest non-nil segment, or -1 if the shard
+// holds none. Rotation nils reclaimed slots (never slices sh.segs), so the oldest live
+// segment can sit past leading nil slots from earlier rotations. Caller holds sh.mu.
+func oldestLiveSeg(sh *shard) int {
+	for i, seg := range sh.segs {
+		if seg != nil {
+			return i
+		}
+	}
+	return -1
+}
+
+// overRetention reports whether the segment at idx (the oldest live one) should be
+// dropped under r. Evaluated one segment at a time so count/byte bounds converge as
+// segments are reclaimed. Caller holds sh.mu.
+func (sh *shard) overRetention(r Retention, idx int) bool {
+	if r.MaxSegments > 0 {
+		live := 0
+		for _, seg := range sh.segs {
+			if seg != nil {
+				live++
+			}
+		}
+		if live > r.MaxSegments {
+			return true
+		}
+	}
+	if r.MaxBytes > 0 {
+		var total int64
+		for _, seg := range sh.segs {
+			if seg != nil {
+				total += int64(seg.used)
+			}
+		}
+		if total > r.MaxBytes {
+			return true
+		}
+	}
+	// MaxAgeAttr/MaxAge: needs per-segment zone maps (a follow-up); ignored for now.
+	return false
+}
+
+// segLiveCount counts the data records (skipping time-checkpoint markers) in a segment
+// by a single forward walk. Used to keep the append-only shard's record count accurate
+// when a segment is rotated out. Append-only records are never superseded, so every
+// data record is live.
+func segLiveCount(seg *segment) int {
+	n := 0
+	for off := 0; off < seg.used; {
+		o := uint32(off)
+		total := recTotalLen(seg.data, o)
+		if total == 0 {
+			break
+		}
+		if !recIsMarker(seg.data, o) {
+			n++
+		}
+		off += int(total)
+	}
+	return n
+}

--- a/collections/retention_test.go
+++ b/collections/retention_test.go
@@ -1,0 +1,182 @@
+package collections
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/classad"
+)
+
+func liveSegs(sh *shard) int {
+	n := 0
+	for _, s := range sh.segs {
+		if s != nil {
+			n++
+		}
+	}
+	return n
+}
+
+func countDatFiles(t *testing.T, dir string) int {
+	t.Helper()
+	n := 0
+	_ = filepath.Walk(dir, func(p string, info os.FileInfo, err error) error {
+		if err == nil && !info.IsDir() && strings.HasSuffix(p, ".dat") {
+			n++
+		}
+		return nil
+	})
+	return n
+}
+
+// TestRetentionRotate verifies Rotate drops whole oldest segments to obey MaxSegments,
+// keeps the active segment, keeps the newest records, decrements Count, unlinks the
+// dropped files, and leaves a state that reopens consistently.
+func TestRetentionRotate(t *testing.T) {
+	dir := t.TempDir()
+	c, err := Open(Options{
+		AppendOnly:  true,
+		Dir:         dir,
+		SegmentSize: 1 << 12, // tiny ⇒ many segments
+		Retention:   Retention{MaxSegments: 3},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	const n = 300
+	for i := 0; i < n; i++ {
+		ad, _ := classad.Parse(fmt.Sprintf(`[ N = %d ]`, i))
+		if err := c.Put([]byte("k"), ad); err != nil {
+			t.Fatal(err)
+		}
+	}
+	sh := c.shards[0]
+	segsBefore := liveSegs(sh)
+	if segsBefore <= 3 {
+		t.Fatalf("need >3 segments to exercise rotation, got %d (raise n or lower SegmentSize)", segsBefore)
+	}
+	if got := c.Len(); got != n {
+		t.Fatalf("Len before rotate = %d, want %d", got, n)
+	}
+
+	dropped, err := c.Rotate(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dropped != segsBefore-3 {
+		t.Fatalf("dropped %d segments, want %d (from %d down to 3)", dropped, segsBefore-3, segsBefore)
+	}
+	if got := liveSegs(sh); got != 3 {
+		t.Fatalf("live segments after rotate = %d, want 3", got)
+	}
+
+	// Surviving records are the newest ones; the oldest N values are gone, and Count
+	// reflects only what remains.
+	var lo, hi int64 = 1 << 30, -1
+	scanned := 0
+	for ad := range c.Scan() {
+		v, _ := ad.EvaluateAttrInt("N")
+		if v < lo {
+			lo = v
+		}
+		if v > hi {
+			hi = v
+		}
+		scanned++
+	}
+	if hi != n-1 {
+		t.Errorf("newest surviving N = %d, want %d (newest never dropped)", hi, n-1)
+	}
+	if lo == 0 {
+		t.Errorf("oldest record (N=0) survived; rotation should have dropped it")
+	}
+	if got := c.Len(); got != scanned {
+		t.Fatalf("Len after rotate = %d, but Scan saw %d", got, scanned)
+	}
+	if scanned >= n {
+		t.Fatalf("Scan saw %d records, expected fewer than %d after rotation", scanned, n)
+	}
+
+	// The dropped segment files are unlinked: exactly one .dat per surviving segment.
+	if files := countDatFiles(t, dir); files != 3 {
+		t.Errorf(".dat files on disk = %d, want 3 (dropped segments unlinked)", files)
+	}
+
+	// Rotate is idempotent once within bounds.
+	again, err := c.Rotate(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if again != 0 {
+		t.Errorf("second Rotate dropped %d, want 0 (already within bounds)", again)
+	}
+	c.Close()
+
+	// Reopen: the surviving records and count persist; scan matches.
+	c2, err := Open(Options{AppendOnly: true, Dir: dir, SegmentSize: 1 << 12, Retention: Retention{MaxSegments: 3}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c2.Close()
+	reopened := 0
+	for range c2.Scan() {
+		reopened++
+	}
+	if reopened != scanned {
+		t.Fatalf("after reopen Scan saw %d, want %d", reopened, scanned)
+	}
+	if got := c2.Len(); got != scanned {
+		t.Fatalf("after reopen Len = %d, want %d", got, scanned)
+	}
+}
+
+// TestRetentionMaxBytes verifies the MaxBytes bound and that a zero Retention (and a
+// non-append-only collection) make Rotate inert.
+func TestRetentionMaxBytes(t *testing.T) {
+	dir := t.TempDir()
+	c, err := Open(Options{AppendOnly: true, Dir: dir, SegmentSize: 1 << 12, Retention: Retention{MaxBytes: 3 << 12}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 300; i++ {
+		ad, _ := classad.Parse(fmt.Sprintf(`[ N = %d ]`, i))
+		if err := c.Put([]byte("k"), ad); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := c.Rotate(0); err != nil {
+		t.Fatal(err)
+	}
+	var total int64
+	for _, s := range c.shards[0].segs {
+		if s != nil {
+			total += int64(s.used)
+		}
+	}
+	if total > 3<<12 {
+		// One over-bound step is allowed only when a single active segment exceeds the
+		// bound; here segments are ~4KB and the bound is ~12KB, so it must hold.
+		t.Errorf("retained bytes = %d, want <= %d", total, int64(3<<12))
+	}
+	c.Close()
+
+	// Zero Retention ⇒ inert.
+	c3, _ := Open(Options{AppendOnly: true, SegmentSize: 1 << 12})
+	for i := 0; i < 200; i++ {
+		ad, _ := classad.Parse(fmt.Sprintf(`[ N = %d ]`, i))
+		_ = c3.Put([]byte("k"), ad)
+	}
+	if d, _ := c3.Rotate(0); d != 0 {
+		t.Errorf("zero-Retention Rotate dropped %d, want 0", d)
+	}
+	c3.Close()
+
+	// Non-append-only ⇒ inert even with a Retention set.
+	c4 := New(Options{Retention: Retention{MaxSegments: 1}})
+	if d, _ := c4.Rotate(0); d != 0 {
+		t.Errorf("non-append-only Rotate dropped %d, want 0", d)
+	}
+}

--- a/collections/store.go
+++ b/collections/store.go
@@ -41,6 +41,11 @@ type Options struct {
 	// scans always run serial (never fan out). Default false ⇒ stored order.
 	// Most meaningful with AppendOnly, where stored order is commit order.
 	ReverseScan bool
+	// Retention bounds how much an AppendOnly collection keeps: Rotate(now) drops
+	// whole oldest segments until the collection is back within these bounds (a
+	// history archive's aging-out). The zero value keeps everything (Rotate is
+	// then inert). Only meaningful with AppendOnly. See Rotate.
+	Retention Retention
 	// SegmentSize is the arena segment size in bytes. Default 8 MiB.
 	SegmentSize int
 	// Hasher routes keys to shards / directory buckets. Default 64-bit FNV-1a.
@@ -232,6 +237,10 @@ type Collection struct {
 	// reverseScan yields records newest-first (see Options.ReverseScan). Forces
 	// serial scans (no fan-out), since fan-out has no cross-segment order.
 	reverseScan bool
+
+	// ret bounds an append-only collection's retained segments (see Options.Retention
+	// and Rotate). Zero value ⇒ keep everything.
+	ret Retention
 
 	// Watch (see watch.go / docs/WATCH.md). hub is nil unless WatchHistory > 0.
 	hub           *watchHub
@@ -485,6 +494,7 @@ func New(opts Options) *Collection {
 	}
 	c.parallelMinBytes = defaultParallelMinBytes
 	c.reverseScan = opts.ReverseScan
+	c.ret = opts.Retention
 	c.queryPar = resolveQueryParallelism(opts.QueryParallelism)
 	if c.queryPar >= 2 {
 		// Machine-wide worker budget: bounds total scan goroutines across all


### PR DESCRIPTION
Increment 4 of the archive unification.

`Options.Retention` + `Collection.Rotate(now)` bound how much an append log keeps: `Rotate` drops whole oldest segments until back within `MaxSegments` / `MaxBytes`, returning the count dropped. No compaction — only whole-segment reclamation, so the log's order and per-record identity are untouched.

- The segment still being appended to is never dropped (bound a growing archive without racing the writer).
- A reclaimed slot is `nil`-d, not sliced out, preserving the `seg.id == index` invariant `segAt` relies on; the file is unmapped and unlinked once no in-flight scan still pins it.
- The shard record count is decremented by the dropped segment's live records; reopen discovers the surviving files and rebuilds consistently.

`MaxAgeAttr`/`MaxAge` needs the per-segment zone map (a follow-up); `Rotate` honors `MaxSegments` and `MaxBytes` for now — both bound disk.

Tests: MaxSegments rotation (newest kept, oldest dropped, files unlinked, Len/Scan consistent, idempotent, survives reopen); MaxBytes bound; zero-Retention and non-append-only are inert. Full collections suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)