### PR TITLE
collections: per-segment zone maps + age-based retention

### DIFF
--- a/collections/persist.go
+++ b/collections/persist.go
@@ -202,6 +202,12 @@ func Open(opts Options) (*Collection, error) {
 	c := New(opts)
 	c.dir = opts.Dir
 	c.inline = true
+	// Records are inline-encoded (names, not interned ids); zone-map value extraction
+	// must look up by name. New defaulted the shards to id-based lookup for the in-memory
+	// case; flip them here now that inline encoding is confirmed.
+	for _, sh := range c.shards {
+		sh.zoneInline = true
+	}
 	// Indexes on a persistent collection are in-memory only (rebuilt on recovery, see
 	// below). Replace the interned spec New built with an inline one that extracts
 	// values by name (records carry no intern ids).
@@ -368,6 +374,11 @@ func (c *Collection) loadShard(sh *shard, shardDir string) (uint64, error) {
 	spec := c.spec.Load()
 	for _, seg := range sh.segs {
 		if seg != nil && seg != sh.act {
+			// Recompute the sealed segment's zone map (not persisted separately; cheap to
+			// rebuild from the segment's own records). No-op unless append-only + ZoneAttrs.
+			if sh.appendOnly && len(sh.zoneAttrs) > 0 && seg.zones == nil {
+				seg.zones = computeSegZones(seg.data, seg.used, sh.zoneAttrs, sh.zoneInline, seg.codec)
+			}
 			if c.loadSealedIndex(seg, spec) {
 				// Phase 3: the segment's keys are now reachable through the sealed
 				// probe, so evict them from the resident directory -- the RAM win. Safe

--- a/collections/retention.go
+++ b/collections/retention.go
@@ -17,9 +17,9 @@ package collections
 // once no in-flight scan still pins it (a scan that started earlier keeps reading a
 // consistent snapshot until it finishes; the reclaim is deferred to its last unpin).
 //
-// NOTE: MaxAgeAttr/MaxAge (drop by a segment's max value of a time attribute) needs the
-// per-segment zone map, which the append-only Collection does not yet maintain; until
-// then Rotate honors MaxSegments and MaxBytes only. Both suffice to bound disk use.
+// Retention honors MaxSegments, MaxBytes, and MaxAgeAttr/MaxAge (drop a segment whose
+// newest value of the age attribute is older than now-MaxAge); MaxAge requires the age
+// attribute to be a configured ZoneAttr so its per-segment max is available.
 func (c *Collection) Rotate(now float64) (int, error) {
 	if !c.appendOnly() || (c.ret == Retention{}) {
 		return 0, nil
@@ -30,6 +30,12 @@ func (c *Collection) Rotate(now float64) (int, error) {
 	defer c.maintMu.Unlock()
 
 	sh := c.shards[0] // AppendOnly forces a single shard
+	// Resolve the age attribute once (needs the shared intern table on the Collection).
+	var ageID uint32
+	var ageOK bool
+	if c.ret.MaxAgeAttr != "" && c.ret.MaxAge > 0 {
+		ageID, ageOK = c.intern.LookupID(c.ret.MaxAgeAttr)
+	}
 	var toReap []*segment
 	dropped := 0
 
@@ -39,7 +45,7 @@ func (c *Collection) Rotate(now float64) (int, error) {
 		if idx < 0 || sh.segs[idx] == sh.act {
 			break // nothing left, or only the active (still-appended) segment remains
 		}
-		if !sh.overRetention(c.ret, idx) {
+		if !sh.overRetention(c.ret, idx, now, ageID, ageOK) {
 			break
 		}
 		seg := sh.segs[idx]
@@ -79,8 +85,9 @@ func oldestLiveSeg(sh *shard) int {
 
 // overRetention reports whether the segment at idx (the oldest live one) should be
 // dropped under r. Evaluated one segment at a time so count/byte bounds converge as
-// segments are reclaimed. Caller holds sh.mu.
-func (sh *shard) overRetention(r Retention, idx int) bool {
+// segments are reclaimed. ageID/ageOK carry the interned age attribute (resolved by the
+// caller) for MaxAge. Caller holds sh.mu.
+func (sh *shard) overRetention(r Retention, idx int, now float64, ageID uint32, ageOK bool) bool {
 	if r.MaxSegments > 0 {
 		live := 0
 		for _, seg := range sh.segs {
@@ -103,7 +110,16 @@ func (sh *shard) overRetention(r Retention, idx int) bool {
 			return true
 		}
 	}
-	// MaxAgeAttr/MaxAge: needs per-segment zone maps (a follow-up); ignored for now.
+	// MaxAgeAttr/MaxAge: drop the oldest segment when its newest value of the age
+	// attribute (its zone max, e.g. the latest CompletionDate in the segment) is older
+	// than now-MaxAge. Reuses the per-segment zone map; ageID is the interned id
+	// resolved by the caller (0/false when the age attr is not zone-mapped). The active
+	// segment has nil zones and is never dropped here.
+	if r.MaxAge > 0 && ageOK {
+		if z, ok := sh.segs[idx].zones[ageID]; ok && z.Max < now-r.MaxAge {
+			return true
+		}
+	}
 	return false
 }
 

--- a/collections/segment.go
+++ b/collections/segment.go
@@ -97,6 +97,14 @@ type segment struct {
 	minSeq uint64
 	maxSup uint64
 
+	// zones is this sealed segment's per-attribute numeric [min,max] zone map (see
+	// zonemap.go / Options.ZoneAttrs), keyed by interned attr id. Nil for the active
+	// (still-appended) segment and for any collection without ZoneAttrs -- a nil map
+	// is never prunable, so those segments are always scanned. Guarded by the shard
+	// lock; set once when the segment is sealed, then immutable (a query reads it from
+	// the frozen window snapshot).
+	zones map[uint32]zoneRange
+
 	codec Codec // the codec that compressed this segment's records (immutable)
 
 	// idx is this segment's value/categorical index, or nil if not yet built. It is

--- a/collections/shard.go
+++ b/collections/shard.go
@@ -22,6 +22,15 @@ type shard struct {
 	// skipped. Set once at construction; never mutated.
 	appendOnly bool
 
+	// zoneAttrs are the attributes kept as per-segment numeric [min,max] zone maps
+	// (see Options.ZoneAttrs). Only meaningful with appendOnly. A sealed segment's
+	// zones let a range/equality query skip it wholesale (see zonemap.go). zoneInline
+	// selects name- vs id-based attribute lookup, matching the record encoding (set
+	// true for a persistent/inline collection in Open). Set at construction; the
+	// inline flag is finalized in Open. Never mutated after.
+	zoneAttrs  []zoneAttr
+	zoneInline bool
+
 	commitSeq uint64 // bumped once per committed batch; scan snapshots capture it
 	count     int    // number of live keys
 
@@ -286,6 +295,10 @@ func (sh *shard) del(h uint64, key []byte, seq uint64) (removed, parentEmptied b
 func (sh *shard) writeRecord(seq uint64, next loc, key, ad []byte, codec Codec) (loc, bool) {
 	rl := recordLen(len(key), len(ad))
 	if sh.act == nil || sh.act.codec != codec || sh.act.used+rl > len(sh.act.data) {
+		// The segment we're leaving is now sealed (an append log never rewrites it):
+		// compute its zone map so later range queries can prune it. No-op unless
+		// append-only with ZoneAttrs configured.
+		sh.sealZones(sh.act)
 		size := sh.segSize
 		if rl > size {
 			size = rl
@@ -509,7 +522,8 @@ type segWindow struct {
 	data  []byte
 	used  int
 	codec Codec
-	seg   *segment // for reindex-on-demand and the per-segment index (idx)
+	seg   *segment             // for reindex-on-demand and the per-segment index (idx)
+	zones map[uint32]zoneRange // sealed segment's zone map (nil ⇒ never prunable)
 }
 
 // snapshot captures the shard's scan state under the read lock: the commit
@@ -549,7 +563,7 @@ func (sh *shard) buildWindowsLocked(s0 uint64) []segWindow {
 			continue
 		}
 		seg.pin() // no-op for RAM segments
-		wins = append(wins, segWindow{data: seg.data, used: seg.used, codec: seg.codec, seg: seg})
+		wins = append(wins, segWindow{data: seg.data, used: seg.used, codec: seg.codec, seg: seg, zones: seg.zones})
 	}
 	return wins
 }

--- a/collections/store.go
+++ b/collections/store.go
@@ -46,6 +46,12 @@ type Options struct {
 	// history archive's aging-out). The zero value keeps everything (Rotate is
 	// then inert). Only meaningful with AppendOnly. See Rotate.
 	Retention Retention
+	// ZoneAttrs names numeric attributes to keep a per-segment [min,max] zone map on,
+	// so a range/equality query on one (e.g. CompletionDate > T) skips whole sealed
+	// segments whose span cannot match, and age-based Retention (MaxAgeAttr) can drop
+	// a segment by its newest timestamp. Value-indexed attributes (ValueAttrs) are
+	// zoned automatically. Only meaningful with AppendOnly. Optional. See zonemap.go.
+	ZoneAttrs []string
 	// SegmentSize is the arena segment size in bytes. Default 8 MiB.
 	SegmentSize int
 	// Hasher routes keys to shards / directory buckets. Default 64-bit FNV-1a.
@@ -242,6 +248,11 @@ type Collection struct {
 	// and Rotate). Zero value ⇒ keep everything.
 	ret Retention
 
+	// hasZones caches whether any per-segment zone maps are configured (see
+	// Options.ZoneAttrs / zonemap.go), so the query hot path skips probe extraction
+	// when zone pruning is off. Append-only only.
+	hasZones bool
+
 	// Watch (see watch.go / docs/WATCH.md). hub is nil unless WatchHistory > 0.
 	hub           *watchHub
 	watchBuf      int
@@ -433,6 +444,34 @@ func New(opts Options) *Collection {
 		c.matchRoots = append(c.matchRoots, strings.ToLower(r))
 	}
 	c.spec.Store(newIndexSpec(c.intern, opts.CategoricalAttrs, opts.ValueAttrs))
+	// Zone maps (append-only only): cover the explicit ZoneAttrs plus every value-indexed
+	// attribute (a range query on an indexed attr should prune whole segments too), matching
+	// the archive. Each attribute carries both its folded name and its interned id so the
+	// per-segment scan can read the value whether records are inline- or id-encoded; the
+	// zone map is keyed by id, which zonePrune/age-retention resolve names to via c.intern.
+	// zoneInline is finalized in Open (a persistent collection stores inline names).
+	if opts.AppendOnly && (len(opts.ZoneAttrs) > 0 || len(opts.ValueAttrs) > 0) {
+		var zattrs []zoneAttr
+		seen := map[uint32]struct{}{}
+		addZone := func(name string) {
+			id := c.intern.Intern(name)
+			if _, ok := seen[id]; !ok {
+				seen[id] = struct{}{}
+				// LookupByName folds case internally, so the raw name is fine for inline lookup.
+				zattrs = append(zattrs, zoneAttr{name: name, id: id})
+			}
+		}
+		for _, n := range opts.ZoneAttrs {
+			addZone(n)
+		}
+		for _, n := range opts.ValueAttrs { // value-indexed attrs are zoned automatically
+			addZone(n)
+		}
+		c.hasZones = len(zattrs) > 0
+		for _, sh := range shards {
+			sh.zoneAttrs = zattrs
+		}
+	}
 	// In-memory sealing: when this collection is in-memory (no Dir), mmap is supported, and
 	// indexes are configured, seal each sealed RAM segment's index into an anonymous mmap
 	// sidecar (off the Go heap: no GC scan of the sealed majority's bitmaps, RSS reclaimable
@@ -720,6 +759,10 @@ type queryPlan struct {
 	wireOK   bool // native + partial-safe: try wire-native evaluation
 	ws       *wireScope
 	resolver func(name string, scope ast.AttributeScope) classad.Value
+	// zoneProbes are the query's top-level AND probes, used to skip whole sealed
+	// segments whose zone map cannot contain a match (append-only zone pruning). Set
+	// only when the collection has zone attributes; nil otherwise (no pruning cost).
+	zoneProbes []vm.Probe
 }
 
 // Query returns an iterator over the ads matching q, with the same
@@ -742,6 +785,9 @@ func (c *Collection) Query(q *vm.Query) iter.Seq[*classad.ClassAd] {
 			wireOK:   q.Native() && plan.PartialSafe,
 			ws:       ws,
 			resolver: ws.resolve, // bound once to avoid a per-ad closure allocation
+		}
+		if c.hasZones {
+			qp.zoneProbes = q.Probes() // enable sealed-segment zone pruning
 		}
 		// Chained collection: a serial two-pass scan per shard resolves each ad's
 		// inherited (parent) attributes. Indexes and query fan-out are bypassed here
@@ -848,10 +894,25 @@ func (c *Collection) scanWindows(s0 uint64, wins []segWindow, qp queryPlan, emit
 		}
 		return true
 	}
+	// Zone pruning: drop sealed segments whose [min,max] zone map cannot contain a
+	// record satisfying a required conjunct (e.g. CompletionDate > T skips every
+	// older segment). A nil-zones window (the active segment, or any collection
+	// without ZoneAttrs) is never prunable. The caller still releases every original
+	// window; this only narrows what is walked.
+	walk := wins
+	if len(qp.zoneProbes) > 0 {
+		walk = make([]segWindow, 0, len(wins))
+		for _, w := range wins {
+			if w.zones != nil && zonePrune(w.zones, qp.zoneProbes, c.intern) {
+				continue
+			}
+			walk = append(walk, w)
+		}
+	}
 	if c.reverseScan {
-		forEachVisibleKeyedReverse(s0, wins, visit)
+		forEachVisibleKeyedReverse(s0, walk, visit)
 	} else {
-		forEachVisibleKeyed(s0, wins, visit)
+		forEachVisibleKeyed(s0, walk, visit)
 	}
 	return cont
 }

--- a/collections/zonemap.go
+++ b/collections/zonemap.go
@@ -1,0 +1,93 @@
+package collections
+
+import "github.com/PelicanPlatform/classad/collections/wire"
+
+// Zone maps for an append-only collection: a sealed segment records the numeric
+// [min,max] span of each configured ZoneAttr across its records, so a query with a
+// range/equality constraint on such an attribute can skip whole segments whose span
+// cannot contain a match (the archive's per-segment pruning, expressed as a Collection
+// rule). The zoneRange type and the zonePrune/zoneMayMatch predicates are shared with
+// the archive (archive.go / archive_query.go).
+//
+// Only sealed segments carry zones; the active (still-appended) segment has nil zones
+// and is always scanned, so an in-flight record is never pruned away. Zones are
+// computed once when a segment stops being active (seal) and, on reopen, for every
+// non-active segment (loadShard).
+
+// zoneAttr is one zone-mapped attribute: its (folded) name for inline-encoded records
+// and its interned id for id-encoded records. The computed zone map is keyed by id
+// regardless of encoding, since zone pruning (zonePrune) and age retention resolve a
+// query/config attribute name to the same interned id via the shared intern table.
+type zoneAttr struct {
+	name string
+	id   uint32
+}
+
+// computeSegZones scans a sealed segment's records and returns the per-attribute
+// numeric min/max for the given zone attributes (absent/non-numeric values ignored).
+// inline selects name-based vs id-based attribute lookup, matching how the collection
+// encodes records (persistent collections store inline names; in-memory ones store
+// interned ids). Returns nil when no zone attributes are configured. Caller holds the
+// shard write lock (seal) or runs single-threaded during Open (reopen).
+func computeSegZones(data []byte, upto int, attrs []zoneAttr, inline bool, codec Codec) map[uint32]zoneRange {
+	if len(attrs) == 0 {
+		return nil
+	}
+	zones := make(map[uint32]zoneRange, len(attrs))
+	var buf []byte
+	for off := 0; off < upto; {
+		o := uint32(off)
+		total := recTotalLen(data, o)
+		if total == 0 {
+			break
+		}
+		if recIsMarker(data, o) {
+			off += int(total)
+			continue
+		}
+		if w, err := codec.Decompress(buf[:0], recAd(data, o)); err == nil {
+			buf = w
+			ad := wire.Ad(w)
+			for _, za := range attrs {
+				var node []byte
+				var ok bool
+				if inline {
+					node, ok = ad.LookupByName(za.name)
+				} else {
+					node, ok = ad.Lookup(za.id)
+				}
+				if !ok {
+					continue
+				}
+				f, ok := literalFloat(node)
+				if !ok {
+					continue
+				}
+				z, seen := zones[za.id]
+				if !seen {
+					zones[za.id] = zoneRange{Min: f, Max: f}
+				} else {
+					if f < z.Min {
+						z.Min = f
+					}
+					if f > z.Max {
+						z.Max = f
+					}
+					zones[za.id] = z
+				}
+			}
+		}
+		off += int(total)
+	}
+	return zones
+}
+
+// sealZones computes and installs zones for a segment that has just stopped being the
+// active append target. No-op unless the shard is append-only with zone attributes
+// configured. Caller holds the shard write lock.
+func (sh *shard) sealZones(seg *segment) {
+	if seg == nil || !sh.appendOnly || len(sh.zoneAttrs) == 0 || seg.zones != nil {
+		return
+	}
+	seg.zones = computeSegZones(seg.data, seg.used, sh.zoneAttrs, sh.zoneInline, seg.codec)
+}

--- a/collections/zonemap_test.go
+++ b/collections/zonemap_test.go
@@ -1,0 +1,184 @@
+package collections
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/classad"
+	"github.com/PelicanPlatform/classad/collections/vm"
+)
+
+func sealedWithZones(sh *shard) int {
+	n := 0
+	for _, s := range sh.segs {
+		if s != nil && s != sh.act && len(s.zones) > 0 {
+			n++
+		}
+	}
+	return n
+}
+
+// TestZoneMapPrune verifies that a range query on a zone-mapped attribute returns the
+// correct records while skipping whole sealed segments, that results are identical to a
+// full scan, that zones survive a reopen, and that the active segment is never pruned.
+func TestZoneMapPrune(t *testing.T) {
+	dir := t.TempDir()
+	c, err := Open(Options{
+		AppendOnly:  true,
+		Dir:         dir,
+		SegmentSize: 1 << 12, // many small segments
+		ZoneAttrs:   []string{"Ts"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Ts increases monotonically with i, so each sealed segment covers a disjoint,
+	// increasing [min,max] window -- ideal for pruning.
+	const n = 400
+	for i := 0; i < n; i++ {
+		ad, _ := classad.Parse(fmt.Sprintf(`[ N = %d; Ts = %d ]`, i, i))
+		if err := c.Put([]byte("k"), ad); err != nil {
+			t.Fatal(err)
+		}
+	}
+	sh := c.shards[0]
+	if sealedWithZones(sh) == 0 {
+		t.Fatal("expected sealed segments to carry zone maps")
+	}
+
+	// A range query on the zone-mapped attribute must return exactly the matching
+	// records. Ts == N == i, so the expected N set is a simple arithmetic range; the
+	// pruned Query result (sorted) must equal it exactly -- pruning may not drop a match.
+	check := func(qs string, wantLo, wantHi int) {
+		t.Helper()
+		q, err := vm.Parse(qs)
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := map[int64]bool{}
+		for v := wantLo; v <= wantHi; v++ {
+			want[int64(v)] = true
+		}
+		got := map[int64]bool{}
+		for ad := range c.Query(q) {
+			v, _ := ad.EvaluateAttrInt("N")
+			ts, _ := ad.EvaluateAttrInt("Ts")
+			if !want[v] {
+				t.Fatalf("query %q returned N=%d (Ts=%d) outside expected [%d,%d]", qs, v, ts, wantLo, wantHi)
+			}
+			got[v] = true
+		}
+		if len(got) != len(want) {
+			t.Fatalf("query %q returned %d records, want %d (a match was pruned away)", qs, len(got), len(want))
+		}
+	}
+	check(`Ts >= 350`, 350, n-1)
+	check(`Ts < 40`, 0, 39)
+	check(`Ts >= 100 && Ts <= 120`, 100, 120)
+	check(`Ts == 275`, 275, 275)
+
+	// A query outside the whole Ts range prunes everything -> empty, no crash.
+	q, _ := vm.Parse(`Ts >= 100000`)
+	for range c.Query(q) {
+		t.Fatal("query above max Ts should return no records")
+	}
+	c.Close()
+
+	// Reopen recomputes zones; the same query still prunes and returns the same set.
+	c2, err := Open(Options{AppendOnly: true, Dir: dir, SegmentSize: 1 << 12, ZoneAttrs: []string{"Ts"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c2.Close()
+	if sealedWithZones(c2.shards[0]) == 0 {
+		t.Fatal("expected zone maps to be recomputed on reopen")
+	}
+	q2, _ := vm.Parse(`Ts >= 380`)
+	cnt := 0
+	for ad := range c2.Query(q2) {
+		v, _ := ad.EvaluateAttrInt("Ts")
+		if v < 380 {
+			t.Fatalf("pruned query returned Ts=%d < 380", v)
+		}
+		cnt++
+	}
+	if cnt != n-380 {
+		t.Errorf("after reopen Ts>=380 returned %d, want %d", cnt, n-380)
+	}
+}
+
+// TestZoneMapInMemory exercises the id-based (non-inline) zone path: an in-memory
+// append-only collection encodes with interned ids, so value extraction must look up by
+// id. Zones must still populate and a range query must return the correct set.
+func TestZoneMapInMemory(t *testing.T) {
+	c := New(Options{AppendOnly: true, SegmentSize: 1 << 12, ZoneAttrs: []string{"Ts"}})
+	const n = 400
+	for i := 0; i < n; i++ {
+		ad, _ := classad.Parse(fmt.Sprintf(`[ N = %d; Ts = %d ]`, i, i))
+		if err := c.Put([]byte("k"), ad); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if sealedWithZones(c.shards[0]) == 0 {
+		t.Fatal("in-memory (id-encoded) collection: expected non-empty zone maps")
+	}
+	q, _ := vm.Parse(`Ts >= 360`)
+	cnt := 0
+	for ad := range c.Query(q) {
+		v, _ := ad.EvaluateAttrInt("Ts")
+		if v < 360 {
+			t.Fatalf("id-path pruned query returned Ts=%d < 360", v)
+		}
+		cnt++
+	}
+	if cnt != n-360 {
+		t.Errorf("id-path Ts>=360 returned %d, want %d", cnt, n-360)
+	}
+}
+
+// TestZoneMapMaxAgeRetention verifies MaxAgeAttr/MaxAge drops segments whose newest
+// timestamp is older than now-MaxAge, using the zone map.
+func TestZoneMapMaxAgeRetention(t *testing.T) {
+	dir := t.TempDir()
+	c, err := Open(Options{
+		AppendOnly:  true,
+		Dir:         dir,
+		SegmentSize: 1 << 12,
+		ZoneAttrs:   []string{"CompletionDate"},
+		Retention:   Retention{MaxAgeAttr: "CompletionDate", MaxAge: 100},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// CompletionDate 0..399. With now=400 and MaxAge=100, any sealed segment whose max
+	// CompletionDate < 300 must be dropped; segments spanning >=300 survive.
+	const n = 400
+	for i := 0; i < n; i++ {
+		ad, _ := classad.Parse(fmt.Sprintf(`[ N = %d; CompletionDate = %d ]`, i, i))
+		if err := c.Put([]byte("k"), ad); err != nil {
+			t.Fatal(err)
+		}
+	}
+	dropped, err := c.Rotate(400)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dropped == 0 {
+		t.Fatal("MaxAge retention dropped nothing; expected old segments to age out")
+	}
+	// Every surviving record must have CompletionDate within a segment whose max >= 300.
+	minSurv := int64(1 << 30)
+	for ad := range c.Scan() {
+		v, _ := ad.EvaluateAttrInt("CompletionDate")
+		if v < minSurv {
+			minSurv = v
+		}
+	}
+	// The oldest surviving record sits in the first not-dropped segment; its segment's
+	// max is >= 300, so nothing with CompletionDate up to (300 - one-segment-span) should
+	// remain. We assert the clearly-aged records (< 200) are gone.
+	if minSurv < 200 {
+		t.Errorf("oldest surviving CompletionDate = %d; segments below the age cut should be dropped", minSurv)
+	}
+	c.Close()
+}


### PR DESCRIPTION
Increment 5 — the final Phase-1 capability of the archive unification.

`Options.ZoneAttrs` keeps a per-segment numeric `[min,max]` zone map for each named attribute (plus every value-indexed attr) on an append-only collection. A range/equality query on a zone-mapped attribute then **skips whole sealed segments** whose span cannot contain a match — e.g. `CompletionDate > T` reads only the recent segments. `zoneRange`/`zonePrune`/`zoneMayMatch` are shared with the archive.

- Zones are computed once when a segment **seals** and recomputed on **reopen** for every non-active segment (not persisted separately — cheap to rebuild). The active segment has nil zones and is never pruned.
- **Encoding-aware extraction**: persistent collections store inline names (lookup by name), in-memory ones interned ids (lookup by id); the map is keyed by interned id, which `zonePrune`/age-retention resolve names to via the shared intern table. Both paths tested.
- `Retention.MaxAgeAttr/MaxAge` now works: `Rotate` drops the oldest segment when its zone max for the age attribute is older than `now-MaxAge`.

Tests: range/equality pruning returns exactly the full-scan set (inline + id-encoded paths); empty-range prunes everything cleanly; zones survive reopen; MaxAge retention ages out old segments. Full collections suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)