### PR TITLE
collections: newest-first indexed scan; restore archive index acceleration

### DIFF
--- a/collections/archive.go
+++ b/collections/archive.go
@@ -80,29 +80,27 @@ const archiveWatchCap = 1 << 10
 
 // archiveCollectionOptions maps ArchiveOptions onto the append-log Collection configuration.
 //
-// The archive contract is newest-first Query (condor_history order), which the Collection
-// guarantees only on the full-scan (ReverseScan) path -- its indexed scan visits candidates
-// in index order. So the archive does not yet configure per-segment categorical/value
-// indexes: every query full-scans newest-first, pruned by zone maps, and re-verifies the
-// predicate. Correctness and newest-first LIMIT hold; categorical/value index acceleration
-// awaits a newest-first indexed scan (a follow-up). ValueAttrs are numeric, so they are
-// folded into the zone maps to keep range/equality pruning on them.
+// The archive contract is newest-first Query (condor_history order). The Collection honors
+// that on both the full-scan and the conjunctive indexed path (ReverseScan is reverse-aware
+// there); disjunctive (OR) index queries fall back to a reverse full scan. So per-segment
+// categorical/value indexes are configured for acceleration while newest-first is preserved.
 func archiveCollectionOptions(opts ArchiveOptions) Options {
 	segSize := opts.SegmentSize
 	if segSize <= 0 {
 		segSize = defaultArchiveSegmentSize
 	}
-	zones := append(append([]string(nil), opts.ZoneAttrs...), opts.ValueAttrs...)
 	return Options{
-		AppendOnly:   true, // pure append log: no supersession, no compaction, no key dir
-		ReverseScan:  true, // newest-first Query, matching condor_history order
-		Dir:          opts.Dir,
-		SegmentSize:  segSize,
-		Codec:        opts.Codec,
-		HotAttrs:     opts.HotAttrs,
-		ZoneAttrs:    zones,
-		Retention:    opts.Retention,
-		WatchHistory: archiveWatchCap, // enable the append-stream watch
+		AppendOnly:       true, // pure append log: no supersession, no compaction, no key dir
+		ReverseScan:      true, // newest-first Query, matching condor_history order
+		Dir:              opts.Dir,
+		SegmentSize:      segSize,
+		Codec:            opts.Codec,
+		HotAttrs:         opts.HotAttrs,
+		CategoricalAttrs: opts.CategoricalAttrs,
+		ValueAttrs:       opts.ValueAttrs, // numeric ValueAttrs are auto-added to the zone maps
+		ZoneAttrs:        opts.ZoneAttrs,
+		Retention:        opts.Retention,
+		WatchHistory:     archiveWatchCap, // enable the append-stream watch
 	}
 }
 

--- a/collections/index_query.go
+++ b/collections/index_query.go
@@ -678,7 +678,7 @@ func cmpFloat(op string, k, t float64) bool {
 // visited record is MVCC-visibility filtered and full-query re-verified, so the
 // result is identical to a full scan. Returns false if the consumer stopped.
 func (c *Collection) scanShardIndexed(sh *shard, usable []usableProbe, qp queryPlan, emit func(w []byte) bool) bool {
-	return c.scanShardCandidates(sh, usable, func(w []byte) bool {
+	return c.scanShardCandidates(sh, usable, c.reverseScan, func(w []byte) bool {
 		if !matchWire(w, qp) {
 			return true // not a match: keep scanning
 		}
@@ -691,9 +691,14 @@ func (c *Collection) scanShardIndexed(sh *shard, usable []usableProbe, qp queryP
 // stop the whole scan). Windows whose per-segment index does not cover the probes,
 // and the un-indexed tail of those that do, are full-scanned -- so onCand sees a
 // superset of the true candidates and the caller must re-verify. Returns false if
-// onCand asked to stop. This is the shared candidate-enumeration used by both the
-// indexed Query path (scanShardIndexed) and index-pre-filtered Match.
-func (c *Collection) scanShardCandidates(sh *shard, usable []usableProbe, onCand func(w []byte) bool) bool {
+// onCand asked to stop. This is the shared candidate-enumeration used by the indexed
+// Query path (scanShardIndexed).
+//
+// When reverse is set (an append-only, newest-first collection), candidates are visited
+// newest-first: segments from the last backward, and within a segment the un-indexed tail
+// (written last) before the indexed prefix, each in descending offset order. A consumer
+// that stops early then gets the newest matches -- a pushed-down LIMIT through the index.
+func (c *Collection) scanShardCandidates(sh *shard, usable []usableProbe, reverse bool, onCand func(w []byte) bool) bool {
 	s0, wins := sh.snapshot()
 	defer releaseWindows(wins)
 	var dbuf []byte
@@ -732,6 +737,10 @@ func (c *Collection) scanShardCandidates(sh *shard, usable []usableProbe, onCand
 		return true
 	}
 
+	if reverse {
+		return scanShardCandidatesReverse(wins, usable, visit)
+	}
+
 	for _, w := range wins {
 		si := w.seg.readIdx()
 		if si == nil || !si.covers(usable) {
@@ -764,6 +773,62 @@ func (c *Collection) scanShardCandidates(sh *shard, usable []usableProbe, onCand
 		if int(si.coveredUpto()) < w.used {
 			if !scanRange(w, int(si.coveredUpto()), w.used) {
 				return false
+			}
+		}
+	}
+	return true
+}
+
+// scanShardCandidatesReverse is scanShardCandidates' newest-first traversal: segments from
+// the last backward, and within each the tail (newest records, written after the index)
+// before the indexed prefix, both in descending offset order. visit returns true to stop.
+// Records are variable-length (forward-length only), so a range walked in reverse is
+// collected forward into a reused slice, then replayed backward.
+func scanShardCandidatesReverse(wins []segWindow, usable []usableProbe, visit func(w segWindow, o uint32) bool) bool {
+	var offs []uint32 // reused across ranges
+	scanRangeReverse := func(w segWindow, from, to int) bool {
+		offs = offs[:0]
+		for off := from; off < to; {
+			o := uint32(off)
+			total := recTotalLen(w.data, o)
+			if total == 0 {
+				break
+			}
+			offs = append(offs, o)
+			off += int(total)
+		}
+		for i := len(offs) - 1; i >= 0; i-- {
+			if visit(w, offs[i]) {
+				return false
+			}
+		}
+		return true
+	}
+	for wi := len(wins) - 1; wi >= 0; wi-- {
+		w := wins[wi]
+		si := w.seg.readIdx()
+		if si == nil || !si.covers(usable) {
+			if !scanRangeReverse(w, 0, w.used) {
+				return false
+			}
+			continue
+		}
+		// Tail (newest, written after the index) first, descending.
+		if int(si.coveredUpto()) < w.used {
+			if !scanRangeReverse(w, int(si.coveredUpto()), w.used) {
+				return false
+			}
+		}
+		if si.skipsPrefix(usable) {
+			continue // prefix provably has no candidate
+		}
+		// Then the indexed prefix candidates, descending (newest of the prefix first).
+		if cand := si.candidateOffsets(usable); cand != nil {
+			it := cand.ReverseIterator()
+			for it.HasNext() {
+				if visit(w, it.Next()) {
+					return false
+				}
 			}
 		}
 	}

--- a/collections/reverse_indexed_test.go
+++ b/collections/reverse_indexed_test.go
@@ -1,0 +1,172 @@
+package collections
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/classad"
+	"github.com/PelicanPlatform/classad/collections/vm"
+)
+
+// TestReverseIndexedScan verifies that an append-only, newest-first collection with a
+// value index returns indexed queries newest-first (not index order), that an early stop
+// yields the newest matches, that records appended after the index was built (the tail)
+// still come out newest-first ahead of the indexed prefix, and that a disjunctive query
+// stays newest-first via the reverse full-scan fallback -- all while matching a reference
+// full scan.
+func TestReverseIndexedScan(t *testing.T) {
+	dir := t.TempDir()
+	open := func() *Collection {
+		c, err := Open(Options{
+			AppendOnly:  true,
+			ReverseScan: true,
+			Dir:         dir,
+			SegmentSize: 1 << 12, // small -> several sealed segments
+			ValueAttrs:  []string{"G"},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return c
+	}
+	c := open()
+	const n = 400
+	for i := 0; i < n; i++ {
+		ad, _ := classad.Parse(fmt.Sprintf(`[ N=%d; G=%d ]`, i, i%4)) // G in {0,1,2,3}
+		if err := c.Put([]byte("k"), ad); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Reopen so Reindex builds the per-segment sidecar indexes; queries now take the
+	// indexed path.
+	if err := c.Close(); err != nil {
+		t.Fatal(err)
+	}
+	c = open()
+	defer c.Close()
+
+	// Indexed equality query, newest-first: G==1 matches N in {1,5,9,...,397}; descending.
+	q := mustParseQuery(t, `G == 1`)
+	var got []int64
+	for ad := range c.Query(q) {
+		v, _ := ad.EvaluateAttrInt("N")
+		g, _ := ad.EvaluateAttrInt("G")
+		if g != 1 {
+			t.Fatalf("indexed query returned G=%d, want 1", g)
+		}
+		got = append(got, v)
+	}
+	if len(got) != n/4 {
+		t.Fatalf("G==1 returned %d, want %d", len(got), n/4)
+	}
+	for i := 1; i < len(got); i++ {
+		if got[i] >= got[i-1] {
+			t.Fatalf("indexed query not newest-first at %d: %v", i, got[:i+1])
+		}
+	}
+	if got[0] != 397 {
+		t.Errorf("newest G==1 is N=%d, want 397", got[0])
+	}
+
+	// Early stop: the 3 newest G==1 are 397, 393, 389.
+	var top []int64
+	for ad := range c.Query(q) {
+		v, _ := ad.EvaluateAttrInt("N")
+		top = append(top, v)
+		if len(top) == 3 {
+			break
+		}
+	}
+	if fmt.Sprint(top) != fmt.Sprint([]int64{397, 393, 389}) {
+		t.Errorf("LIMIT 3 newest G==1 = %v, want [397 393 389]", top)
+	}
+
+	// Append more after reopen (the un-indexed tail). New G==1 records (401, 405, ...) are
+	// newest and must precede the indexed prefix, still newest-first.
+	for i := n; i < n+40; i++ {
+		ad, _ := classad.Parse(fmt.Sprintf(`[ N=%d; G=%d ]`, i, i%4))
+		if err := c.Put([]byte("k"), ad); err != nil {
+			t.Fatal(err)
+		}
+	}
+	got = got[:0]
+	for ad := range c.Query(q) {
+		v, _ := ad.EvaluateAttrInt("N")
+		got = append(got, v)
+	}
+	if got[0] != 437 { // newest G==1 in [400,440) is 437
+		t.Errorf("after tail append, newest G==1 = %d, want 437", got[0])
+	}
+	for i := 1; i < len(got); i++ {
+		if got[i] >= got[i-1] {
+			t.Fatalf("tail+prefix not newest-first at %d: %v", i, got[:i+1])
+		}
+	}
+
+	// Disjunctive (OR) query stays newest-first via the reverse full-scan fallback.
+	orq := mustParseQuery(t, `G == 0 || G == 3`)
+	var prev int64 = 1 << 30
+	seen := 0
+	for ad := range c.Query(orq) {
+		v, _ := ad.EvaluateAttrInt("N")
+		g, _ := ad.EvaluateAttrInt("G")
+		if g != 0 && g != 3 {
+			t.Fatalf("OR query returned G=%d", g)
+		}
+		if v >= prev {
+			t.Fatalf("OR query not newest-first: %d after %d", v, prev)
+		}
+		prev = v
+		seen++
+	}
+	if seen == 0 {
+		t.Fatal("OR query returned nothing")
+	}
+}
+
+// TestReverseIndexedMatchesFullScan cross-checks the reverse indexed path against a
+// non-indexed reverse collection: the same query must return the same set in the same
+// (newest-first) order.
+func TestReverseIndexedMatchesFullScan(t *testing.T) {
+	build := func(withIndex bool) []int64 {
+		dir := t.TempDir()
+		opts := Options{AppendOnly: true, ReverseScan: true, Dir: dir, SegmentSize: 1 << 12}
+		if withIndex {
+			opts.ValueAttrs = []string{"G"}
+		}
+		c, err := Open(opts)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i := 0; i < 300; i++ {
+			ad, _ := classad.Parse(fmt.Sprintf(`[ N=%d; G=%d ]`, i, i%3))
+			c.Put([]byte("k"), ad)
+		}
+		c.Close()
+		c, _ = Open(opts)
+		defer c.Close()
+		var out []int64
+		for ad := range c.Query(mustQ(t, `G == 2`)) {
+			v, _ := ad.EvaluateAttrInt("N")
+			out = append(out, v)
+		}
+		return out
+	}
+	indexed := build(true)
+	full := build(false)
+	if fmt.Sprint(indexed) != fmt.Sprint(full) {
+		t.Fatalf("indexed result != full-scan result\nindexed=%v\nfull=%v", indexed, full)
+	}
+	if len(indexed) == 0 {
+		t.Fatal("empty result")
+	}
+}
+
+func mustQ(t *testing.T, s string) *vm.Query {
+	t.Helper()
+	q, err := vm.Parse(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return q
+}

--- a/collections/store.go
+++ b/collections/store.go
@@ -804,7 +804,11 @@ func (c *Collection) Query(q *vm.Query) iter.Seq[*classad.ClassAd] {
 		// group and every group is index-usable, prune via the union of the groups'
 		// candidate sets (DNF: OR of AND-of-probes), re-verifying each candidate. A
 		// single group falls through to the conjunctive path below unchanged.
-		if plan := q.ProbePlan(); len(plan) > 1 {
+		// The disjunctive index path visits candidates in index order, which a
+		// newest-first (reverse) collection cannot honor; it falls through to a
+		// reverse full scan instead, keeping ORs newest-first (the conjunctive path
+		// is made reverse-aware in scanShardCandidates).
+		if plan := q.ProbePlan(); len(plan) > 1 && !c.reverseScan {
 			for _, g := range plan {
 				c.demand.record(g.Probes)
 			}


### PR DESCRIPTION
Increment 8 of the archive unification — restores the categorical/value index acceleration the facade deferred (#87), without losing newest-first order.

The conjunctive indexed scan (`scanShardCandidates`, used by `Query`) now honors `ReverseScan`: it walks segments newest-first and, within a segment, the un-indexed **tail** (written after the index) before the indexed **prefix**, both descending — so an indexed query on a newest-first collection returns the newest matches first, and an early stop is a pushed-down `LIMIT` through the index. Roaring's `ReverseIterator` drives the prefix; variable-length tail ranges are collected then replayed backward. The forward path is untouched (Match, which shares the primitive, stays order-agnostic).

The disjunctive (OR) index path visits candidates in index order, which reverse cannot honor, so it falls back to a reverse full scan for reverse collections — correct and newest-first, just unaccelerated for ORs.

With newest-first preserved on the indexed path, the **archive facade re-enables `CategoricalAttrs`/`ValueAttrs` indexes**.

Tests: indexed query newest-first + early stop + tail/prefix ordering + OR fallback + indexed-equals-full-scan cross-check. Full suite green, race-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)