### PR TITLE
collections/db/dbrpc: append-only retrain/rewrite/reindex for archives

### DIFF
--- a/collections/appendonly_test.go
+++ b/collections/appendonly_test.go
@@ -46,20 +46,22 @@ func TestAppendOnlyMode(t *testing.T) {
 		t.Fatalf("scan returned %d records, want 3 (all appends, no dedup)", got)
 	}
 
-	// Maintenance that would rewrite/renumber the log is inert.
+	// Compaction and per-key delete are inert on an append log (no supersession to
+	// reclaim, no key directory to delete from).
 	if n := c.Compact(); n != 0 {
 		t.Errorf("Compact on append-only did work (%d); want no-op", n)
-	}
-	if n := c.Rewrite(); n != 0 {
-		t.Errorf("Rewrite on append-only did work (%d); want no-op", n)
-	}
-	if _, err := c.RetrainDict(1000); err == nil {
-		t.Error("RetrainDict on append-only should error (recompression path is not append-safe)")
 	}
 	if c.Delete([]byte("1.0")) {
 		t.Error("Delete on append-only should be a no-op")
 	}
+	// Rewrite DOES work on an append log -- it reseals each segment in place preserving
+	// order (see retrain_appendonly.go), rather than the compaction live-copy, and must
+	// leave the record count unchanged. (RetrainDict, which also reseals, is exercised in
+	// TestAppendOnlyRetrain, where the corpus is large enough to train a dictionary.)
+	if n := c.Rewrite(); n != 3 {
+		t.Errorf("Rewrite on append-only rewrote %d, want 3 (all records resealed)", n)
+	}
 	if got := count(); got != 3 {
-		t.Errorf("after inert maintenance scan = %d, want 3 (log unchanged)", got)
+		t.Errorf("after maintenance scan = %d, want 3 (log unchanged)", got)
 	}
 }

--- a/collections/archive.go
+++ b/collections/archive.go
@@ -206,6 +206,35 @@ func (a *Archive) Watch(ctx context.Context, cursor []byte) (iter.Seq[WatchEvent
 // evictable page cache), broken out by structure. An operator diagnostic.
 func (a *Archive) SidecarSizes() SidecarSizes { return a.c.SidecarSizes() }
 
+// RetrainDict trains a fresh ZSTD dictionary from up to sampleMax records and recompresses
+// every segment in place under it (an append-only reseal that preserves order), returning
+// the new dictionary's size in bytes. This is how an archive's compression adapts to the
+// data it has accumulated.
+func (a *Archive) RetrainDict(sampleMax int) (int, error) { return a.c.RetrainDict(sampleMax) }
+
+// Rewrite recompresses and re-encodes every segment in place under the current codec and
+// hot set (e.g. after a hot-set change), preserving order, and returns the number of
+// records rewritten.
+func (a *Archive) Rewrite() int { return a.c.Rewrite() }
+
+// AddIndex adds per-segment indexes on the named categorical and/or value attributes and
+// rebuilds them over the existing segments, so subsequent queries on those attributes are
+// accelerated. Returns false if the index set was unchanged.
+func (a *Archive) AddIndex(categorical, value []string) bool {
+	if !a.c.AddIndex(categorical, value) {
+		return false
+	}
+	a.c.Reindex()
+	return true
+}
+
+// DropIndex removes the named per-segment indexes. Returns false if none matched.
+func (a *Archive) DropIndex(names ...string) bool { return a.c.DropIndex(names...) }
+
+// Reindex rebuilds the per-segment indexes over all segments (e.g. to pick up segments
+// sealed since the last build).
+func (a *Archive) Reindex() { a.c.Reindex() }
+
 // --- zone-map helpers (shared with the Collection's per-segment zone maps) ---
 
 // literalFloat extracts a numeric value from a wire literal node (int/real/bool), for

--- a/collections/compact.go
+++ b/collections/compact.go
@@ -1,7 +1,6 @@
 package collections
 
 import (
-	"errors"
 	"time"
 )
 
@@ -177,7 +176,13 @@ func (c *Collection) reclaimDeadShard(sh *shard) int {
 // writer).
 func (c *Collection) Rewrite() int {
 	if c.appendOnly() {
-		return 0 // rewriting an append log would duplicate every record (no supersession)
+		// Append-only rewrite recompresses/re-encodes each segment in place (current
+		// codec + current hot set), preserving order -- no supersession, no duplication.
+		c.maintMu.Lock()
+		n := c.Len()
+		c.resealAppendOnly(c.currentCodec())
+		c.maintMu.Unlock()
+		return n
 	}
 	c.maintMu.Lock()
 	defer c.maintMu.Unlock()
@@ -211,17 +216,7 @@ func (c *Collection) Rewrite() int {
 // transactions; production leaves it nil.
 var retrainStallHook func()
 
-// errAppendOnlyRetrain is returned by RetrainDict on an append-only collection, where the
-// compaction-based recompression path does not apply.
-var errAppendOnlyRetrain = errors.New("collections: RetrainDict is not supported on an append-only collection")
-
 func (c *Collection) RetrainDict(sampleMax int) (int, error) {
-	if c.appendOnly() {
-		// Retrain recompresses via compactShard, which renumbers segments and rebuilds the
-		// directory -- illegal for an append log. Append-only recompression (per-segment
-		// reseal preserving order) is a separate path (not yet implemented).
-		return 0, errAppendOnlyRetrain
-	}
 	c.maintMu.Lock()
 	defer c.maintMu.Unlock()
 	start := time.Now()
@@ -244,16 +239,19 @@ func (c *Collection) RetrainDict(sampleMax int) (int, error) {
 	if retrainStallHook != nil {
 		retrainStallHook() // test seam: observe concurrent access during a long retrain
 	}
-	for _, sh := range c.shards {
-		c.compactShard(sh, codec) // recompress to the new codec
+	if c.appendOnly() {
+		// Append log: recompress each segment in place (reseal preserving order) instead
+		// of the compaction live-copy, which would supersede/renumber -- illegal here.
+		c.resealAppendOnly(codec)
+	} else {
+		for _, sh := range c.shards {
+			c.compactShard(sh, codec) // recompress to the new codec
+		}
+		c.reindexAfterCompaction() // rebuild indexes over the recompacted segments
+		c.pruneDicts()
 	}
 	c.lastDictBytes.Store(int64(len(dict)))
 	c.lastRetrainUnix.Store(time.Now().UnixNano())
-	c.reindexAfterCompaction() // rebuild indexes over the recompacted segments
-	// The recompaction re-encoded (or left in place) every live segment; dictionaries no
-	// segment references anymore are dead weight -- drop them so the registry does not
-	// grow by one inflated codec per retrain for the life of the process.
-	c.pruneDicts()
 	return len(dict), nil
 }
 

--- a/collections/retrain_appendonly.go
+++ b/collections/retrain_appendonly.go
@@ -1,0 +1,156 @@
+package collections
+
+// Append-only recompression. The mutable store recompresses (RetrainDict) and repacks
+// (Rewrite) via compaction -- a live-copy that supersedes old versions, renumbers
+// segments, and rebuilds the key directory. None of that is legal for an append log,
+// where every record is permanently live and order is meaningful. Instead each sealed
+// segment is *resealed in place*: its records are decoded, re-encoded with the current
+// hot set, recompressed under a target codec, and written to a fresh same-id segment
+// file, preserving append order (seq, key, and time markers). The new segment is swapped
+// for the old under the shard lock; the old file is unlinked once in-flight scans drop
+// their pins (the standard retire/reap path). Indexes are rebuilt afterward by Reindex.
+
+// resealAppendOnly rebuilds every segment of an append-only collection under targetCodec
+// and the current hot set, preserving append order, then rebuilds indexes. It is the
+// shared engine for append-only RetrainDict (targetCodec = the new-dictionary codec) and
+// Rewrite (targetCodec = the current codec, to apply a hot-set change or repack). The
+// caller holds maintMu.
+func (c *Collection) resealAppendOnly(targetCodec Codec) {
+	for _, sh := range c.shards {
+		// Retire the active segment from the write path so it becomes immutable and is
+		// resealed too; the next write allocates a fresh active segment under the current
+		// codec. Snapshot the segments to reseal under the same lock.
+		sh.mu.Lock()
+		var srcs []*segment
+		for _, s := range sh.segs {
+			if s != nil {
+				srcs = append(srcs, s)
+			}
+		}
+		sh.act = nil
+		sh.mu.Unlock()
+
+		var toReap []*segment
+		for _, src := range srcs {
+			newseg := c.resealOneSegment(sh, src, targetCodec)
+			if newseg == nil {
+				continue // reseal failed: leave the original in place (best-effort)
+			}
+			sh.mu.Lock()
+			// Swap only if the source still occupies its slot (append-only segments are
+			// not otherwise mutated, but stay defensive against a concurrent reseal).
+			if int(src.id) < len(sh.segs) && sh.segs[src.id] == src {
+				sh.segs[src.id] = newseg
+				if src.retire() {
+					toReap = append(toReap, src)
+				}
+			} else {
+				// Slot moved under us: drop the freshly built segment's file rather than
+				// leak it.
+				newseg.retire()
+				newseg.reapAndHook()
+			}
+			sh.mu.Unlock()
+		}
+		for _, seg := range toReap {
+			seg.reapAndHook() // munmap + unlink the old segment file, off-lock
+		}
+	}
+	// Rebuild the per-segment indexes (and seal sidecars) over the fresh segments, and
+	// drop any dictionary no live segment references anymore.
+	c.reindexAfterCompaction()
+	c.pruneDicts()
+}
+
+// resealEntry is one record staged for reseal: a data record (its re-encoded, recompressed
+// stored bytes and key) or a time-checkpoint marker (marker=true, millis set).
+type resealEntry struct {
+	seq    uint64
+	key    []byte
+	stored []byte
+	marker bool
+	millis uint64
+}
+
+// resealOneSegment builds a new segment holding src's records re-encoded with the current
+// hot set and recompressed under targetCodec, preserving order. It returns the new segment
+// (with the same logical id as src) or nil on any error. The source is immutable (sealed
+// or retired from the write path), so it is read without the shard lock.
+func (c *Collection) resealOneSegment(sh *shard, src *segment, targetCodec Codec) *segment {
+	if src == nil || src.used == 0 {
+		return nil
+	}
+	// Pass 1: decode + re-encode + recompress every record, computing the exact size the
+	// new segment needs so it fits in a single segment (append order is 1:1).
+	var entries []resealEntry
+	total := 0
+	for off := 0; off < src.used; {
+		o := uint32(off)
+		rl := recTotalLen(src.data, o)
+		if rl == 0 {
+			break
+		}
+		if recIsMarker(src.data, o) {
+			seq := recSeq(src.data, o)
+			millis := recMarkerMillis(src.data, o)
+			entries = append(entries, resealEntry{seq: seq, marker: true, millis: millis})
+			total += recordLen(0, 8)
+			off += int(rl)
+			continue
+		}
+		seq := recSeq(src.data, o)
+		key := append([]byte(nil), recKey(src.data, o)...)
+		wireBytes, err := src.codec.Decompress(nil, recAd(src.data, o))
+		if err != nil {
+			return nil
+		}
+		ad, err := c.decodeWire(wireBytes)
+		if err != nil {
+			return nil
+		}
+		stored := targetCodec.Compress(nil, c.encodeAd(ad))
+		entries = append(entries, resealEntry{seq: seq, key: key, stored: stored})
+		total += recordLen(len(key), len(stored))
+		off += int(rl)
+	}
+	if total == 0 {
+		return nil
+	}
+
+	// Allocate a new same-id segment sized to the recompressed data (rounded up by the
+	// allocator). sh.alloc names the file by the codec's dictionary id; a nil alloc
+	// (in-memory collection) yields a RAM segment.
+	size := recAlign(total)
+	var newseg *segment
+	if sh.alloc == nil {
+		newseg = newSegment(src.id, size, targetCodec)
+		newseg.pinReap = sh.sealRAM
+	} else {
+		s, err := sh.alloc(src.id, size, targetCodec)
+		if err != nil {
+			return nil
+		}
+		newseg = s
+	}
+
+	// Pass 2: append the staged records in order.
+	for _, e := range entries {
+		if e.marker {
+			if _, ok := newseg.appendMarker(e.seq, e.millis); !ok {
+				return nil
+			}
+			continue
+		}
+		if _, ok := newseg.append(e.seq, noLoc, e.key, e.stored); !ok {
+			return nil
+		}
+	}
+	// Persistent segments: flush the written extent so recovery sees a complete segment.
+	if newseg.persistent {
+		newseg.synced = newseg.used
+		if err := newseg.flush(); err != nil {
+			return nil
+		}
+	}
+	return newseg
+}

--- a/collections/retrain_appendonly_test.go
+++ b/collections/retrain_appendonly_test.go
@@ -1,0 +1,161 @@
+package collections
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/classad"
+)
+
+// scanAllN returns every record's N value from a full scan, in scan order.
+func scanAllN(t *testing.T, c *Collection) []int64 {
+	t.Helper()
+	var out []int64
+	for ad := range c.Scan() {
+		v, _ := ad.EvaluateAttrInt("N")
+		out = append(out, v)
+	}
+	return out
+}
+
+// TestAppendOnlyRetrain verifies RetrainDict works on an append-only collection: it trains
+// a dictionary, recompresses every segment in place preserving all records and order, keeps
+// queries correct, and survives a reopen. The retrained data should be no larger than before.
+func TestAppendOnlyRetrain(t *testing.T) {
+	dir := t.TempDir()
+	open := func() *Collection {
+		c, err := Open(Options{AppendOnly: true, Dir: dir, SegmentSize: 1 << 13, ValueAttrs: []string{"N"}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return c
+	}
+	c := open()
+	const n = 500
+	// Repetitive, dictionary-friendly ads.
+	for i := 0; i < n; i++ {
+		ad, _ := classad.Parse(fmt.Sprintf(
+			`[ N=%d; Owner="user_%d"; JobStatus="Completed"; Cmd="/usr/bin/some_long_repeated_command_path"; Args="--flag=value --other=thing" ]`,
+			i, i%20))
+		if err := c.Put([]byte("k"), ad); err != nil {
+			t.Fatal(err)
+		}
+	}
+	before := scanAllN(t, c)
+	if len(before) != n {
+		t.Fatalf("before retrain: %d records, want %d", len(before), n)
+	}
+
+	sz, err := c.RetrainDict(1000)
+	if err != nil {
+		t.Fatalf("RetrainDict on append-only collection: %v", err)
+	}
+	if sz == 0 {
+		t.Fatal("RetrainDict returned zero dictionary size")
+	}
+
+	// Every record survives, in the same scan order, with intact attributes.
+	after := scanAllN(t, c)
+	if fmt.Sprint(after) != fmt.Sprint(before) {
+		t.Fatalf("retrain changed the record set/order:\nbefore=%v\nafter=%v", before, after)
+	}
+	if got := c.Len(); got != n {
+		t.Errorf("Len after retrain = %d, want %d", got, n)
+	}
+	// Attributes are intact (spot-check an indexed query).
+	cnt := 0
+	for ad := range c.Query(mustQ(t, `N >= 250`)) {
+		if v, _ := ad.EvaluateAttrInt("N"); v < 250 {
+			t.Fatalf("query returned N=%d < 250", v)
+		}
+		own, _ := ad.EvaluateAttrString("Owner")
+		if !strings.HasPrefix(own, "user_") {
+			t.Fatalf("Owner attribute corrupted after retrain: %q", own)
+		}
+		cnt++
+	}
+	if cnt != 250 {
+		t.Errorf("N>=250 after retrain returned %d, want 250", cnt)
+	}
+	c.Close()
+
+	// Reopen: the recompressed segments recover with the new dictionary, data intact.
+	c2 := open()
+	defer c2.Close()
+	reopened := scanAllN(t, c2)
+	if fmt.Sprint(reopened) != fmt.Sprint(before) {
+		t.Fatalf("after reopen record set/order differs from pre-retrain")
+	}
+}
+
+// TestAppendOnlyRewrite verifies Rewrite recompresses/re-encodes an append-only collection
+// in place, preserving every record and keeping queries correct.
+func TestAppendOnlyRewrite(t *testing.T) {
+	dir := t.TempDir()
+	c, err := Open(Options{AppendOnly: true, Dir: dir, SegmentSize: 1 << 12})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+	const n = 300
+	for i := 0; i < n; i++ {
+		ad, _ := classad.Parse(fmt.Sprintf(`[ N=%d; Owner="u%d" ]`, i, i%5))
+		c.Put([]byte("k"), ad)
+	}
+	before := scanAllN(t, c)
+	got := c.Rewrite()
+	if got != n {
+		t.Errorf("Rewrite reported %d, want %d", got, n)
+	}
+	after := scanAllN(t, c)
+	if fmt.Sprint(after) != fmt.Sprint(before) {
+		t.Fatalf("rewrite changed the record set/order")
+	}
+	if c.Len() != n {
+		t.Errorf("Len after rewrite = %d, want %d", c.Len(), n)
+	}
+	// A query still returns correct results after rewrite.
+	cnt := 0
+	for range c.Query(mustQ(t, `Owner == "u2"`)) {
+		cnt++
+	}
+	if cnt != n/5 {
+		t.Errorf(`Owner=="u2" after rewrite returned %d, want %d`, cnt, n/5)
+	}
+}
+
+// TestAppendOnlyAddIndex verifies AddIndex/DropIndex/Reindex work on an append-only
+// collection: adding an index makes a query on that attribute return correct results.
+func TestAppendOnlyAddIndex(t *testing.T) {
+	c := New(Options{AppendOnly: true, SegmentSize: 1 << 12})
+	const n = 400
+	for i := 0; i < n; i++ {
+		ad, _ := classad.Parse(fmt.Sprintf(`[ N=%d; G=%d ]`, i, i%4))
+		c.Put([]byte("k"), ad)
+	}
+	if !c.AddIndex(nil, []string{"G"}) {
+		t.Fatal("AddIndex returned false on append-only collection")
+	}
+	c.Reindex()
+	// Query the newly-indexed attribute: correct results.
+	var got []int64
+	for ad := range c.Query(mustQ(t, `G == 3`)) {
+		v, _ := ad.EvaluateAttrInt("N")
+		got = append(got, v)
+	}
+	if len(got) != n/4 {
+		t.Fatalf("G==3 returned %d, want %d", len(got), n/4)
+	}
+	if !c.DropIndex("G") {
+		t.Error("DropIndex returned false")
+	}
+	// Still correct after dropping the index (full scan).
+	cnt := 0
+	for range c.Query(mustQ(t, `G == 3`)) {
+		cnt++
+	}
+	if cnt != n/4 {
+		t.Errorf("after DropIndex G==3 returned %d, want %d", cnt, n/4)
+	}
+}

--- a/db/archive.go
+++ b/db/archive.go
@@ -161,3 +161,23 @@ func (t *ArchiveTable) Rotate(now float64) (int, error) { return t.a.Rotate(now)
 
 // Close flushes and closes the archive.
 func (t *ArchiveTable) Close() error { return t.a.Close() }
+
+// RetrainDict trains a fresh ZSTD dictionary from up to sampleMax records and recompresses
+// every segment in place under it, returning the new dictionary's size in bytes.
+func (t *ArchiveTable) RetrainDict(sampleMax int) (int, error) { return t.a.RetrainDict(sampleMax) }
+
+// Rewrite recompresses and re-encodes every segment in place under the current codec and
+// hot set, returning the number of records rewritten.
+func (t *ArchiveTable) Rewrite() int { return t.a.Rewrite() }
+
+// AddIndex adds per-segment indexes on the named categorical and/or value attributes and
+// rebuilds them over existing segments. Returns false if the index set was unchanged.
+func (t *ArchiveTable) AddIndex(categorical, value []string) bool {
+	return t.a.AddIndex(categorical, value)
+}
+
+// DropIndex removes the named per-segment indexes. Returns false if none matched.
+func (t *ArchiveTable) DropIndex(names ...string) bool { return t.a.DropIndex(names...) }
+
+// Reindex rebuilds the per-segment indexes over all segments.
+func (t *ArchiveTable) Reindex() { t.a.Reindex() }

--- a/dbrpc/archive_test.go
+++ b/dbrpc/archive_test.go
@@ -70,6 +70,75 @@ func TestArchiveOverRPC(t *testing.T) {
 	}
 }
 
+// TestArchiveAdminOverRPC covers archive maintenance through the admin RPC path: retrain
+// the dictionary, add a value index, and reindex a history table, verifying data stays
+// correct and that the actions are DAEMON-gated.
+func TestArchiveAdminOverRPC(t *testing.T) {
+	ctx := context.Background()
+	c, cleanup := catServerPair(t, ServeOptions{Privileged: true})
+	defer cleanup()
+	if err := c.CreateArchiveTable(ctx, "history", db.ArchiveConfig{ValueAttrs: []string{"ClusterId"}}); err != nil {
+		t.Fatal(err)
+	}
+	// Dictionary-friendly, repetitive records so retrain can train.
+	for i := 0; i < 400; i++ {
+		ad := fmt.Sprintf("ClusterId = %d\nOwner = \"user_%d\"\nCmd = \"/usr/bin/long_repeated_command_path\"\nJobStatus = 4", i, i%20)
+		if err := c.ArchiveAppend(ctx, "history", ad); err != nil {
+			t.Fatal(err)
+		}
+	}
+	countMatches := func(constraint string) int {
+		rows, err := c.ArchiveQuery(ctx, "history", constraint, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return len(rows)
+	}
+	before := countMatches("ClusterId >= 200")
+
+	// Retrain the dictionary (recompresses the archive in place).
+	msg, err := c.AdminTable(ctx, "history", "codec.retrain", "1000")
+	if err != nil {
+		t.Fatalf("archive codec.retrain: %v", err)
+	}
+	if msg == "" {
+		t.Error("retrain returned an empty message")
+	}
+	if after := countMatches("ClusterId >= 200"); after != before {
+		t.Errorf("retrain changed result count: before %d, after %d", before, after)
+	}
+
+	// Add a value index on Owner-adjacent attribute, then reindex.
+	if _, err := c.AdminTable(ctx, "history", "index.add.value", "ClusterId"); err != nil {
+		t.Fatalf("archive index.add.value: %v", err)
+	}
+	if _, err := c.AdminTable(ctx, "history", "index.reindex"); err != nil {
+		t.Fatalf("archive index.reindex: %v", err)
+	}
+	if after := countMatches("ClusterId >= 200"); after != before {
+		t.Errorf("reindex changed result count: before %d, after %d", before, after)
+	}
+	// A specific record is still findable.
+	if n := countMatches("ClusterId == 321"); n != 1 {
+		t.Errorf("ClusterId==321 matched %d after maintenance, want 1", n)
+	}
+
+	// Unknown archive admin action errors.
+	if _, err := c.AdminTable(ctx, "history", "encrypt.set", "X"); err == nil {
+		t.Error("encrypt.set should be rejected for an archive table")
+	}
+
+	// Admin is DAEMON-gated: a non-privileged connection is refused.
+	rc, rcleanup := catServerPair(t, ServeOptions{})
+	defer rcleanup()
+	if err := rc.CreateArchiveTable(ctx, "history", db.ArchiveConfig{}); err != nil {
+		// created on its own catalog; ignore
+	}
+	if _, err := rc.AdminTable(ctx, "history", "codec.retrain"); err == nil {
+		t.Error("archive admin should require DAEMON authorization")
+	}
+}
+
 // TestArchiveAggregateOverRPC covers the server-side archive GROUP BY through the client
 // API: COUNT(*), COUNT with a WHERE constraint, and GROUP BY Owner. Each grouped result is
 // checked against a client-side count over the same rows fetched via ArchiveQuery, proving

--- a/dbrpc/diag.go
+++ b/dbrpc/diag.go
@@ -189,6 +189,53 @@ func (s *Server) admin(t *db.DB, action string, args []string, privileged bool) 
 // is built over the existing ads (AddIndex updates only the spec; existing
 // segments' indexes are rebuilt by Reindex). Without this the index would apply
 // only to future writes and would not prune the current data.
+// archiveAdmin runs a management action on an append-only archive (history) table: the
+// layout-tuning subset of table admin -- retrain the ZSTD dictionary, add/drop/rebuild
+// per-segment indexes, and rewrite. Encryption/time-travel/truncate/hot-set actions do not
+// apply to an archive. DAEMON-gated by the caller, like the mutable-table admin.
+func archiveAdmin(a *db.ArchiveTable, action string, args []string) (string, error) {
+	switch action {
+	case "index.add.categorical":
+		if len(args) == 0 {
+			return "", fmt.Errorf("index.add.categorical needs at least one attribute")
+		}
+		return changedMsg("categorical index on "+join(args), a.AddIndex(args, nil)), nil
+	case "index.add.value":
+		if len(args) == 0 {
+			return "", fmt.Errorf("index.add.value needs at least one attribute")
+		}
+		return changedMsg("value index on "+join(args), a.AddIndex(nil, args)), nil
+	case "index.drop":
+		if len(args) == 0 {
+			return "", fmt.Errorf("index.drop needs at least one attribute")
+		}
+		changed := a.DropIndex(args...)
+		if changed {
+			a.Reindex()
+		}
+		return changedMsg("dropped index on "+join(args), changed), nil
+	case "index.reindex":
+		a.Reindex()
+		return "reindexed", nil
+	case "rewrite":
+		return fmt.Sprintf("rewrote %d record(s) with the current hot set", a.Rewrite()), nil
+	case "codec.retrain":
+		sampleMax := diagSampleMax
+		if len(args) == 1 {
+			if v, err := strconv.Atoi(args[0]); err == nil && v > 0 {
+				sampleMax = v
+			}
+		}
+		dictBytes, err := a.RetrainDict(sampleMax)
+		if err != nil {
+			return "", fmt.Errorf("retrain: %w", err)
+		}
+		return fmt.Sprintf("retrained ZSTD dictionary (%d bytes) and recompressed the archive", dictBytes), nil
+	default:
+		return "", fmt.Errorf("unknown archive admin action %q", action)
+	}
+}
+
 func addIndex(t *db.DB, what string, categorical, value []string) string {
 	changed := t.AddIndex(categorical, value)
 	if !changed {

--- a/dbrpc/server.go
+++ b/dbrpc/server.go
@@ -1189,6 +1189,18 @@ func (s *Server) handle(sc *serverConn, reqID uint64, o op, r *reader, includePr
 		}
 		d, ok := s.cat.Table(table)
 		if !ok {
+			// Not a mutable table: it may be an append-only archive (history) table, which
+			// supports the layout-tuning subset of admin actions (retrain/reindex/rewrite).
+			if a, aok := s.cat.ArchiveTable(table); aok {
+				if !privileged {
+					return respErr(reqID, fmt.Sprintf("admin action %q requires DAEMON authorization", action))
+				}
+				msg, err := archiveAdmin(a, action, args)
+				if err != nil {
+					return respErr(reqID, err.Error())
+				}
+				return putStr(resp(reqID, stOK), msg)
+			}
 			return respErr(reqID, "no such table: "+table)
 		}
 		msg, err := s.admin(d, action, args, privileged)


### PR DESCRIPTION
The store side of the original "retrain history / create-and-change indices on history" request (Phase 4 of the archive unification). The REPL meta-commands follow in htcondordb.

`RetrainDict` and `Rewrite` now **work** on an append-only collection instead of being inert. They cannot use the mutable store's compaction (a live-copy that supersedes, renumbers segments, and rebuilds the key directory — all illegal for an append log). Instead each segment is **resealed in place**: records decoded, re-encoded with the current hot set, recompressed under a target codec, written to a fresh same-id segment file preserving append order (seq, key, time markers); the new segment swapped under the shard lock, the old file unlinked once in-flight scans drop their pins. RetrainDict trains+registers a new dictionary then reseals under it; Rewrite reseals under the current codec.

`AddIndex`/`DropIndex`/`Reindex` already worked on append-only; all four are now exposed through the **Archive facade** and **db.ArchiveTable**, and reachable over **dbrpc** as archive-scoped admin actions (`codec.retrain`, `index.add.value`/`categorical`, `index.drop`, `index.reindex`, `rewrite`). The `opAdmin` handler routes a name that resolves to an archive to `archiveAdmin`, DAEMON-gated like mutable-table admin. The client needs no new method — `AdminTable(name, action)` already carries the archive name.

Tests: append-only retrain (data + order intact, survives reopen), rewrite, add/drop index, and archive admin end-to-end over RPC (retrain/reindex/index.add, DAEMON-gated, unknown-action rejected). Full collections/db/dbrpc suites green, race-clean.

Stacks conceptually on #88 (merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)