### PR TITLE
classad: implement the magic CurrentTime attribute

### DIFF
--- a/classad/classad.go
+++ b/classad/classad.go
@@ -895,6 +895,11 @@ func (c *ClassAd) GetTarget() *ClassAd {
 func (c *ClassAd) EvaluateAttr(name string) (result Value) {
 	expr := c.lookupInternal(name)
 	if expr == nil {
+		// CurrentTime is a magic attribute: when the ad does not define it, it resolves to
+		// the current time (matching how an expression referencing it evaluates).
+		if strings.EqualFold(name, currentTimeAttr) {
+			return currentTimeValue()
+		}
 		return NewUndefinedValue()
 	}
 
@@ -1189,6 +1194,15 @@ func (c *ClassAd) flattenExpr(expr ast.Expr) ast.Expr {
 				// Evaluate the attribute
 				val := c.EvaluateAttr(v.Name)
 				return c.valueToExpr(val)
+			}
+		}
+		// The magic CurrentTime attribute folds to the current time (a constant) when the
+		// ad does not define it, so the query optimizer sees an indexable literal (e.g.
+		// `CompletionDate > CurrentTime - 86400` becomes a range probe). Mirrors the
+		// evaluation-time magic in evaluateAttributeReference.
+		if isCurrentTimeRef(v) {
+			if _, ok := c.Lookup(v.Name); !ok {
+				return c.valueToExpr(currentTimeValue())
 			}
 		}
 		// Keep the reference if undefined or scoped

--- a/classad/currenttime.go
+++ b/classad/currenttime.go
@@ -1,0 +1,45 @@
+package classad
+
+import (
+	"time"
+
+	"github.com/PelicanPlatform/classad/ast"
+)
+
+// CurrentTime is ClassAd's magic attribute for "now": an expression that references it
+// evaluates to the current wall-clock time in Unix seconds (like the time() builtin),
+// unless the ClassAd explicitly defines CurrentTime -- in which case the ad's value wins.
+// This matches HTCondor, where CurrentTime is always available and history/queue
+// expressions such as `CurrentTime - EnteredHistoryTime` rely on it.
+//
+// The magic is provided in two places, which must agree:
+//   - Evaluation: evaluateAttributeReference returns the current time when an unscoped (or
+//     MY-scoped) CurrentTime reference is otherwise undefined.
+//   - Query planning: FoldConstants (flattenExpr) folds CurrentTime to a literal, so a
+//     constraint like `CompletionDate > CurrentTime - 86400` becomes an indexable range
+//     probe and can prune whole segments/zones. The query compiler folds once at compile
+//     time (see collections/vm), so a single "now" is shared by the program and its probes.
+
+// currentTimeAttr is the folded (lower-case) name of the magic attribute.
+const currentTimeAttr = "currenttime"
+
+// isCurrentTimeRef reports whether ref is the magic CurrentTime attribute: an unscoped or
+// MY-scoped reference named "CurrentTime" (case-insensitive). TARGET/PARENT/absolute
+// references are ordinary lookups, never the magic attribute.
+func isCurrentTimeRef(ref *ast.AttributeReference) bool {
+	if ref == nil {
+		return false
+	}
+	switch ref.Scope {
+	case ast.NoScope, ast.MyScope:
+		return ref.NormalizedName() == currentTimeAttr
+	default:
+		return false
+	}
+}
+
+// currentTimeValue returns the current time as an integer Unix-seconds value, matching the
+// time() builtin (NewIntValue(time.Now().Unix())).
+func currentTimeValue() Value {
+	return NewIntValue(time.Now().Unix())
+}

--- a/classad/currenttime_test.go
+++ b/classad/currenttime_test.go
@@ -1,0 +1,83 @@
+package classad
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestCurrentTimeMagic verifies CurrentTime evaluates to ~now when the ad does not define
+// it, works inside an arithmetic expression, and is always "defined".
+func TestCurrentTimeMagic(t *testing.T) {
+	before := time.Now().Unix()
+	ad, err := Parse(`[ EnteredHistoryTime = 1000 ]`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	after := time.Now().Unix() + 1
+
+	now, err := ad.EvaluateAttr("CurrentTime").IntValue()
+	if err != nil {
+		t.Fatalf("CurrentTime did not evaluate to an int: %v", err)
+	}
+	if now < before || now > after {
+		t.Errorf("CurrentTime = %d, want within [%d, %d]", now, before, after)
+	}
+
+	evalExpr := func(s string) Value {
+		e, perr := ParseExpr(s)
+		if perr != nil {
+			t.Fatalf("parse %q: %v", s, perr)
+		}
+		return e.Eval(ad)
+	}
+
+	// Used in an expression: CurrentTime - EnteredHistoryTime.
+	if v, _ := evalExpr("CurrentTime - EnteredHistoryTime").IntValue(); v < before-1000 || v > after-1000 {
+		t.Errorf("CurrentTime - EnteredHistoryTime = %d, want ~%d", v, now-1000)
+	}
+
+	// isUndefined(CurrentTime) is false -- the magic attribute is always defined.
+	if b, _ := evalExpr("isUndefined(CurrentTime)").BoolValue(); b {
+		t.Error("isUndefined(CurrentTime) = true, want false")
+	}
+
+	// Case-insensitive.
+	if _, err := ad.EvaluateAttr("currenttime").IntValue(); err != nil {
+		t.Error("lowercase currenttime did not resolve to the magic value")
+	}
+}
+
+// TestCurrentTimeAdOverride verifies an ad that explicitly defines CurrentTime wins.
+func TestCurrentTimeAdOverride(t *testing.T) {
+	ad, err := Parse(`[ CurrentTime = 42 ]`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v, err := ad.EvaluateAttr("CurrentTime").IntValue(); err != nil || v != 42 {
+		t.Errorf("ad-defined CurrentTime = %d (err %v), want 42", v, err)
+	}
+}
+
+// TestFoldConstantsCurrentTime verifies FoldConstants replaces CurrentTime with a literal so
+// the query optimizer sees a constant threshold (range-probe extraction).
+func TestFoldConstantsCurrentTime(t *testing.T) {
+	before := time.Now().Unix()
+	e, err := ParseExpr(`CompletionDate > CurrentTime - 86400`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	folded := FoldConstants(e.internal())
+	if strings.Contains(strings.ToLower(folded.String()), "currenttime") {
+		t.Errorf("FoldConstants left CurrentTime unfolded: %q", folded.String())
+	}
+	// The RHS folds to a literal now-86400.
+	rhs, _ := ParseExpr(`CurrentTime - 86400`)
+	n, err := New().exprToValue(FoldConstants(rhs.internal())).IntValue()
+	if err != nil {
+		t.Fatalf("CurrentTime - 86400 did not fold to an int literal: %q", FoldConstants(rhs.internal()).String())
+	}
+	if n < before-86400 || n > time.Now().Unix()-86400+1 {
+		t.Errorf("folded CurrentTime-86400 = %d, out of expected range", n)
+	}
+}

--- a/classad/evaluator.go
+++ b/classad/evaluator.go
@@ -470,6 +470,17 @@ func (e *Evaluator) evalNode(expr ast.Expr) Value {
 }
 
 func (e *Evaluator) evaluateAttributeReference(ref *ast.AttributeReference) Value {
+	v := e.resolveAttributeReference(ref)
+	// CurrentTime is a magic attribute: an unscoped/MY reference that the ad does not
+	// otherwise define resolves to the current time (Unix seconds). An ad-defined
+	// CurrentTime wins, since resolveAttributeReference then returns a defined value.
+	if v.IsUndefined() && isCurrentTimeRef(ref) {
+		return currentTimeValue()
+	}
+	return v
+}
+
+func (e *Evaluator) resolveAttributeReference(ref *ast.AttributeReference) Value {
 	if e.resolver != nil {
 		// A custom resolver replaces ClassAd-scope resolution entirely (used for
 		// evaluating a native program against an encoded ad). It receives the

--- a/collections/vm/currenttime_test.go
+++ b/collections/vm/currenttime_test.go
@@ -1,0 +1,70 @@
+package vm
+
+import (
+	"testing"
+	"time"
+
+	"github.com/PelicanPlatform/classad/classad"
+)
+
+// TestCurrentTimeProbe verifies a query referencing CurrentTime folds it to a constant at
+// compile time, so `CompletionDate > CurrentTime - 86400` yields an indexable range probe on
+// CompletionDate (not a non-prunable attr-vs-expr comparison). This is what lets the archive
+// prune whole segments/zones for "jobs in the last day" queries.
+func TestCurrentTimeProbe(t *testing.T) {
+	before := time.Now().Unix()
+	q, err := Parse(`CompletionDate > CurrentTime - 86400`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	after := time.Now().Unix()
+
+	probes := q.Probes()
+	if len(probes) != 1 {
+		t.Fatalf("got %d probes, want 1 (CurrentTime should fold to a constant threshold)", len(probes))
+	}
+	p := probes[0]
+	if p.Attr != "CompletionDate" || p.Op != ">" {
+		t.Fatalf("probe = {%s %s}, want {CompletionDate >}", p.Attr, p.Op)
+	}
+	if len(p.Vals) != 1 {
+		t.Fatalf("probe has %d values, want 1", len(p.Vals))
+	}
+	n, err := p.Vals[0].IntValue()
+	if err != nil {
+		t.Fatalf("probe threshold is not an integer literal: %v", err)
+	}
+	if n < before-86400 || n > after-86400 {
+		t.Errorf("probe threshold = %d, want ~now-86400 (in [%d, %d])", n, before-86400, after-86400)
+	}
+}
+
+// TestCurrentTimeMatch verifies a compiled query with CurrentTime matches ads correctly
+// (recent kept, old rejected).
+func TestCurrentTimeMatch(t *testing.T) {
+	now := time.Now().Unix()
+	q, err := Parse(`CompletionDate > CurrentTime - 86400`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	recent, _ := classad.Parse(`[ CompletionDate = ` + itoa(now-3600) + ` ]`) // 1h ago
+	old, _ := classad.Parse(`[ CompletionDate = ` + itoa(now-2*86400) + ` ]`) // 2d ago
+	if !q.Matches(recent) {
+		t.Error("recent ad (1h ago) should match CompletionDate > CurrentTime - 86400")
+	}
+	if q.Matches(old) {
+		t.Error("old ad (2d ago) should not match CompletionDate > CurrentTime - 86400")
+	}
+}
+
+// TestNonCurrentTimeUnchanged sanity-checks that a query without CurrentTime still compiles
+// and its probes are unaffected (the fold is gated on referencing CurrentTime).
+func TestNonCurrentTimeUnchanged(t *testing.T) {
+	q, err := Parse(`Memory > 2048`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p := q.Probes(); len(p) != 1 || p[0].Attr != "Memory" || p[0].Op != ">" {
+		t.Fatalf("Memory probe unexpectedly changed: %v", p)
+	}
+}

--- a/collections/vm/query.go
+++ b/collections/vm/query.go
@@ -1,6 +1,8 @@
 package vm
 
 import (
+	"strings"
+
 	"github.com/PelicanPlatform/classad/ast"
 	"github.com/PelicanPlatform/classad/classad"
 	"github.com/PelicanPlatform/classad/parser"
@@ -13,7 +15,30 @@ type Query struct {
 }
 
 // Compile compiles an already-parsed expression into a Query.
-func Compile(expr ast.Expr) *Query { return &Query{prog: CompileProgram(expr)} }
+//
+// When the expression references the magic CurrentTime attribute, its constants are folded
+// once here (FoldConstants resolves CurrentTime to the current time) so a single "now" is
+// baked into both the program and its index probes -- the constraint prunes correctly and
+// evaluates consistently, instead of the program re-reading the clock per ad. Expressions
+// that do not reference CurrentTime are compiled unchanged.
+func Compile(expr ast.Expr) *Query {
+	if referencesCurrentTime(expr) {
+		expr = classad.FoldConstants(expr)
+	}
+	return &Query{prog: CompileProgram(expr)}
+}
+
+// referencesCurrentTime reports whether expr reads the magic CurrentTime attribute (an
+// unscoped reference by that name). It reuses the read-collection walk, so it sees the same
+// unscoped references the planner does.
+func referencesCurrentTime(expr ast.Expr) bool {
+	for _, n := range collectReads(expr, map[string]bool{}, nil) {
+		if strings.EqualFold(n, "CurrentTime") {
+			return true
+		}
+	}
+	return false
+}
 
 // Parse parses a ClassAd expression string and compiles it into a Query.
 func Parse(exprStr string) (*Query, error) {


### PR DESCRIPTION
`CurrentTime` is ClassAd's magic "now" attribute: any expression referencing it evaluates to the current wall-clock time in Unix seconds (like `time()`), unless the ad explicitly defines `CurrentTime` (then the ad's value wins). Matches HTCondor — history/queue expressions like `CurrentTime - EnteredHistoryTime` rely on it.

**Evaluation**: `evaluateAttributeReference` (the resolution point shared by the tree-walker *and* the bytecode VM via `ResolveRef`) returns the current time when an unscoped/MY `CurrentTime` reference is otherwise undefined; `EvaluateAttr` does the same for a direct lookup (so `EvaluateAttrInt` sees it too).

**Query optimizer**: `FoldConstants` folds `CurrentTime` to a literal, so `CompletionDate > CurrentTime - 86400` becomes an indexable **range probe** and prunes whole segments/zones (the "jobs in the last day" pattern). To keep the program and its probes consistent — a single `now`, so a `< CurrentTime` constraint cannot prune a boundary record the eval would keep — the query compiler folds **once at compile time, only when the expression references CurrentTime**; other queries compile byte-for-byte as before.

Tests: CurrentTime in an expression and as a bare attribute, ad-defined override, `isUndefined(CurrentTime)` is false, `FoldConstants` collapses it to a literal, a WHERE query yields a `CompletionDate` range probe and matches recent-not-old, and a non-CurrentTime query is unchanged. All four modules green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)