### PR TITLE
collections/db/dbrpc: archive stat symmetry + runtime retention control

### DIFF
--- a/collections/archive.go
+++ b/collections/archive.go
@@ -235,6 +235,31 @@ func (a *Archive) DropIndex(names ...string) bool { return a.c.DropIndex(names..
 // sealed since the last build).
 func (a *Archive) Reindex() { a.c.Reindex() }
 
+// SetRetention updates the retention bounds at runtime; the next Rotate enforces them.
+func (a *Archive) SetRetention(r Retention) { a.c.SetRetention(r) }
+
+// Retention returns the archive's current retention bounds.
+func (a *Archive) Retention() Retention { return a.c.Retention() }
+
+// Stats reports storage accounting: record count, segment count, and arena/used/dead bytes
+// (dead is ~0 for an append log, which never supersedes). The same struct the mutable store
+// reports, so an archive's storage is visible on the same terms.
+func (a *Archive) Stats() Stats { return a.c.Stats() }
+
+// OpStats reports cumulative operational timing counters (write wait/hold, sync, retrain,
+// reindex, ...) for the archive's writes and maintenance.
+func (a *Archive) OpStats() OpStats { return a.c.OpStats() }
+
+// CodecStats reports the archive's compression: codec, dictionary size, last retrain time,
+// and the sampled compression ratio (up to sampleMax records).
+func (a *Archive) CodecStats(sampleMax int) CodecStats { return a.c.CodecStats(sampleMax) }
+
+// IndexSizes reports the per-attribute index byte footprint (heap postings) versus data.
+func (a *Archive) IndexSizes() IndexSizes { return a.c.IndexSizes() }
+
+// IndexedAttrs returns the categorical and value attributes the archive indexes.
+func (a *Archive) IndexedAttrs() (categorical, value []string) { return a.c.IndexedAttrs() }
+
 // --- zone-map helpers (shared with the Collection's per-segment zone maps) ---
 
 // literalFloat extracts a numeric value from a wire literal node (int/real/bool), for

--- a/collections/retention.go
+++ b/collections/retention.go
@@ -21,13 +21,17 @@ package collections
 // newest value of the age attribute is older than now-MaxAge); MaxAge requires the age
 // attribute to be a configured ZoneAttr so its per-segment max is available.
 func (c *Collection) Rotate(now float64) (int, error) {
-	if !c.appendOnly() || (c.ret == Retention{}) {
+	if !c.appendOnly() {
 		return 0, nil
 	}
-	// Serialize against other whole-collection maintenance (retrain/rewrite), matching
-	// Compact. Commits and queries never take maintMu.
+	// Serialize against other whole-collection maintenance (retrain/rewrite) and against
+	// SetRetention, matching Compact. Commits and queries never take maintMu. c.ret is read
+	// only under maintMu, so the retention check moves inside the lock.
 	c.maintMu.Lock()
 	defer c.maintMu.Unlock()
+	if c.ret == (Retention{}) {
+		return 0, nil // no bounds configured: keep everything
+	}
 
 	sh := c.shards[0] // AppendOnly forces a single shard
 	// Resolve the age attribute once (needs the shared intern table on the Collection).
@@ -69,6 +73,22 @@ func (c *Collection) Rotate(now float64) (int, error) {
 		}
 	}
 	return dropped, err
+}
+
+// SetRetention updates the retention bounds at runtime (an append-only collection). The
+// next Rotate enforces them. Serialized against Rotate/maintenance via maintMu, so c.ret is
+// only ever read or written under that lock.
+func (c *Collection) SetRetention(r Retention) {
+	c.maintMu.Lock()
+	c.ret = r
+	c.maintMu.Unlock()
+}
+
+// Retention returns the current retention bounds.
+func (c *Collection) Retention() Retention {
+	c.maintMu.Lock()
+	defer c.maintMu.Unlock()
+	return c.ret
 }
 
 // oldestLiveSeg returns the index of the oldest non-nil segment, or -1 if the shard

--- a/db/archive.go
+++ b/db/archive.go
@@ -20,6 +20,7 @@ import (
 type ArchiveTable struct {
 	a   *collections.Archive
 	dir string
+	cfg ArchiveConfig // the persisted config (archiveconfig.json); its Retention is mutable at runtime
 }
 
 // ArchiveConfig configures an archive table. Dir is set by the catalog.
@@ -81,13 +82,33 @@ func openArchiveTable(dir string, cfg ArchiveConfig) (*ArchiveTable, error) {
 	if err != nil {
 		return nil, err
 	}
+	t := &ArchiveTable{a: a, dir: dir, cfg: cfg}
 	if create {
 		// Persist the config so a later reopen rebuilds the same indexes/retention.
-		if data, merr := json.MarshalIndent(cfg, "", "  "); merr == nil {
-			_ = os.WriteFile(filepath.Join(dir, archiveConfigFile), data, 0o644)
+		if err := t.saveConfig(); err != nil {
+			return nil, err
 		}
 	}
-	return &ArchiveTable{a: a, dir: dir}, nil
+	return t, nil
+}
+
+// saveConfig persists the archive's config (indexes, zone maps, retention) to
+// archiveconfig.json atomically (tmp + rename), so a runtime change survives a restart and
+// a reader never sees a torn file. A no-op for an in-memory archive (dir == "").
+func (t *ArchiveTable) saveConfig() error {
+	if t.dir == "" {
+		return nil
+	}
+	data, err := json.MarshalIndent(t.cfg, "", "  ")
+	if err != nil {
+		return err
+	}
+	path := filepath.Join(t.dir, archiveConfigFile)
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
 }
 
 // Append adds one ad to the archive (append-only; there is no update or per-key delete).
@@ -181,3 +202,35 @@ func (t *ArchiveTable) DropIndex(names ...string) bool { return t.a.DropIndex(na
 
 // Reindex rebuilds the per-segment indexes over all segments.
 func (t *ArchiveTable) Reindex() { t.a.Reindex() }
+
+// --- diagnostics (mirrors the mutable-table stat surface for symmetry) ---
+
+// Stats reports storage accounting (records, segments, arena/used/dead bytes).
+func (t *ArchiveTable) Stats() Stats { return t.a.Stats() }
+
+// OpStats reports cumulative operational timings. An archive has no DB-level snapshot lock,
+// so SnapshotLock is zero.
+func (t *ArchiveTable) OpStats() OpStats { return OpStats{OpStats: t.a.OpStats()} }
+
+// CodecStats reports the archive's compression (codec, dict size, last retrain, sampled ratio).
+func (t *ArchiveTable) CodecStats(sampleMax int) CodecStats { return t.a.CodecStats(sampleMax) }
+
+// IndexSizes reports the per-attribute index byte footprint.
+func (t *ArchiveTable) IndexSizes() IndexSizes { return t.a.IndexSizes() }
+
+// SidecarSizes reports the sealed-segment sidecar index bytes (mmap-backed, evictable).
+func (t *ArchiveTable) SidecarSizes() SidecarSizes { return t.a.SidecarSizes() }
+
+// IndexedAttrs returns the archive's categorical and value index attributes.
+func (t *ArchiveTable) IndexedAttrs() (categorical, value []string) { return t.a.IndexedAttrs() }
+
+// Retention returns the archive's current retention bounds.
+func (t *ArchiveTable) Retention() collections.Retention { return t.a.Retention() }
+
+// SetRetention updates the retention bounds and persists them (archiveconfig.json), so they
+// take effect on the next Rotate and survive a restart.
+func (t *ArchiveTable) SetRetention(r collections.Retention) error {
+	t.a.SetRetention(r)
+	t.cfg.Retention = r
+	return t.saveConfig()
+}

--- a/db/db.go
+++ b/db/db.go
@@ -293,6 +293,8 @@ type (
 	DropSuggestion  = collections.DropSuggestion
 	IndexSizes      = collections.IndexSizes
 	IndexSize       = collections.IndexSize
+	SidecarSizes    = collections.SidecarSizes
+	Retention       = collections.Retention
 	CodecStats      = collections.CodecStats
 	QueryExplain    = collections.QueryExplain
 	MatchExplain    = collections.MatchExplain

--- a/dbrpc/archive_stats_test.go
+++ b/dbrpc/archive_stats_test.go
@@ -1,0 +1,110 @@
+package dbrpc
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/db"
+)
+
+// TestArchiveDiagnosticsOverRPC verifies `.stats`-level diagnostics work for an archive
+// (history) table through opDiag -- rich storage/codec/op stats plus retention -- the same
+// path a mutable table uses, so archive stats are symmetric instead of just a row count.
+func TestArchiveDiagnosticsOverRPC(t *testing.T) {
+	ctx := context.Background()
+	c, cleanup := catServerPair(t, ServeOptions{Privileged: true})
+	defer cleanup()
+	if err := c.CreateArchiveTable(ctx, "history", db.ArchiveConfig{
+		SegmentSize: 1 << 12, // small -> several segments
+		ValueAttrs:  []string{"ClusterId"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 400; i++ {
+		ad := fmt.Sprintf("ClusterId = %d\nOwner = \"u%d\"\nJobStatus = 4", i, i%10)
+		if err := c.ArchiveAppend(ctx, "history", ad); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	d, err := c.DiagnosticsTable(ctx, "history")
+	if err != nil {
+		t.Fatalf("DiagnosticsTable(history): %v", err)
+	}
+	if !d.Archive {
+		t.Error("diagnostics.Archive = false, want true for a history table")
+	}
+	if d.Stats.Ads != 400 {
+		t.Errorf("Stats.Ads = %d, want 400", d.Stats.Ads)
+	}
+	if d.Stats.Segments < 2 {
+		t.Errorf("Stats.Segments = %d, want several (rich storage stats missing)", d.Stats.Segments)
+	}
+	if d.Stats.ArenaBytes == 0 || d.Stats.UsedBytes == 0 {
+		t.Errorf("byte accounting empty: arena=%d used=%d", d.Stats.ArenaBytes, d.Stats.UsedBytes)
+	}
+	if d.OpStats.ShardWriteHold.Count == 0 {
+		t.Error("OpStats not populated for archive writes")
+	}
+	if d.Retention == nil {
+		t.Error("Retention missing from archive diagnostics")
+	}
+}
+
+// TestArchiveRetentionAdminOverRPC verifies setting retention and manual rotation through the
+// admin RPC path, and that the retention persists into the diagnostics.
+func TestArchiveRetentionAdminOverRPC(t *testing.T) {
+	ctx := context.Background()
+	c, cleanup := catServerPair(t, ServeOptions{Privileged: true})
+	defer cleanup()
+	if err := c.CreateArchiveTable(ctx, "history", db.ArchiveConfig{SegmentSize: 1 << 12}); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 400; i++ {
+		if err := c.ArchiveAppend(ctx, "history", fmt.Sprintf("ClusterId = %d", i)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Set retention: keep at most 2 segments.
+	if _, err := c.AdminTable(ctx, "history", "retention.set", "2", "0"); err != nil {
+		t.Fatalf("retention.set: %v", err)
+	}
+	d, err := c.DiagnosticsTable(ctx, "history")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d.Retention == nil || d.Retention.MaxSegments != 2 {
+		t.Fatalf("after retention.set, Retention = %+v, want MaxSegments=2", d.Retention)
+	}
+	segsBefore := d.Stats.Segments
+
+	// Manual rotate should now drop segments beyond the bound.
+	msg, err := c.AdminTable(ctx, "history", "rotate")
+	if err != nil {
+		t.Fatalf("rotate: %v", err)
+	}
+	if msg == "" {
+		t.Error("rotate returned an empty message")
+	}
+	d2, err := c.DiagnosticsTable(ctx, "history")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d2.Stats.Segments >= segsBefore {
+		t.Errorf("rotate did not drop segments: before %d, after %d", segsBefore, d2.Stats.Segments)
+	}
+	if d2.Stats.Segments > 2 {
+		t.Errorf("after rotate to MaxSegments=2, %d segments remain", d2.Stats.Segments)
+	}
+
+	// A byte-size suffix parses.
+	if _, err := c.AdminTable(ctx, "history", "retention.set", "0", "1MiB"); err != nil {
+		t.Fatalf("retention.set with MiB suffix: %v", err)
+	}
+	d3, _ := c.DiagnosticsTable(ctx, "history")
+	if d3.Retention == nil || d3.Retention.MaxBytes != 1<<20 {
+		t.Fatalf("MaxBytes = %v, want 1MiB (1048576)", d3.Retention)
+	}
+}

--- a/dbrpc/diag.go
+++ b/dbrpc/diag.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/PelicanPlatform/classad/db"
@@ -29,6 +30,13 @@ type Diagnostics struct {
 	// are not listed here).
 	EncryptionEnabled bool     `json:"encryptionEnabled"`
 	EncryptedAttrs    []string `json:"encryptedAttrs,omitempty"`
+
+	// Archive marks an append-only history table (vs. a mutable one), and Retention carries
+	// its rotation bounds. Both are omitted for a mutable table. SidecarSizes reports the
+	// archive's sealed-segment sidecar index bytes.
+	Archive      bool            `json:"archive,omitempty"`
+	Retention    *db.Retention   `json:"retention,omitempty"`
+	SidecarSizes db.SidecarSizes `json:"sidecarSizes"`
 }
 
 // diagSampleMax bounds the ad sample the server takes for index suggestions.
@@ -49,6 +57,27 @@ func (s *Server) diagJSON(t *db.DB) ([]byte, error) {
 		DropSuggestions:    t.SuggestDrops(diagSampleMax),
 		EncryptionEnabled:  t.EncryptionEnabled(),
 		EncryptedAttrs:     t.EncryptedAttrNames(),
+	}
+	return json.Marshal(d)
+}
+
+// archiveDiagJSON assembles the diagnostics for an append-only archive (history) table, from
+// the same stat surface as a mutable table plus the retention bounds -- so `.stats history`
+// reads like `.stats <table>` (storage bytes, segments, codec, op timings) instead of just a
+// row count.
+func (s *Server) archiveDiagJSON(a *db.ArchiveTable) ([]byte, error) {
+	cat, val := a.IndexedAttrs()
+	ret := a.Retention()
+	d := Diagnostics{
+		Stats:              a.Stats(),
+		OpStats:            a.OpStats(),
+		CategoricalIndexes: cat,
+		ValueIndexes:       val,
+		IndexSizes:         a.IndexSizes(),
+		Codec:              a.CodecStats(diagSampleMax),
+		Archive:            true,
+		Retention:          &ret,
+		SidecarSizes:       a.SidecarSizes(),
 	}
 	return json.Marshal(d)
 }
@@ -231,9 +260,99 @@ func archiveAdmin(a *db.ArchiveTable, action string, args []string) (string, err
 			return "", fmt.Errorf("retrain: %w", err)
 		}
 		return fmt.Sprintf("retrained ZSTD dictionary (%d bytes) and recompressed the archive", dictBytes), nil
+	case "retention.set":
+		r, err := parseRetentionArgs(args)
+		if err != nil {
+			return "", err
+		}
+		if err := a.SetRetention(r); err != nil {
+			return "", fmt.Errorf("retention.set: %w", err)
+		}
+		return "retention: " + retentionSummary(r), nil
+	case "rotate":
+		n, err := a.Rotate(float64(time.Now().Unix()))
+		if err != nil {
+			return "", fmt.Errorf("rotate: %w", err)
+		}
+		return fmt.Sprintf("rotated: dropped %d segment(s)", n), nil
 	default:
 		return "", fmt.Errorf("unknown archive admin action %q", action)
 	}
+}
+
+// parseRetentionArgs parses `<maxSegments> <maxBytes> [maxAgeAttr maxAgeSeconds]` into a
+// Retention. maxSegments is a count (0 = no bound); maxBytes accepts a byte count or a size
+// suffix (KiB/MiB/GiB/TiB, or KB/MB/GB/TB; 0 = no bound); maxAgeAttr/maxAgeSeconds set the
+// age bound (both must be given). All-zero clears retention (keep everything).
+func parseRetentionArgs(args []string) (db.Retention, error) {
+	var r db.Retention
+	if len(args) < 2 {
+		return r, fmt.Errorf("retention.set needs <maxSegments> <maxBytes> [maxAgeAttr maxAgeSeconds]")
+	}
+	seg, err := strconv.Atoi(args[0])
+	if err != nil || seg < 0 {
+		return r, fmt.Errorf("maxSegments must be a non-negative integer, got %q", args[0])
+	}
+	r.MaxSegments = seg
+	b, err := parseByteSize(args[1])
+	if err != nil {
+		return r, fmt.Errorf("maxBytes: %w", err)
+	}
+	r.MaxBytes = b
+	if len(args) >= 4 {
+		r.MaxAgeAttr = args[2]
+		age, err := strconv.ParseFloat(args[3], 64)
+		if err != nil || age < 0 {
+			return r, fmt.Errorf("maxAgeSeconds must be a non-negative number, got %q", args[3])
+		}
+		r.MaxAge = age
+	} else if len(args) == 3 {
+		return r, fmt.Errorf("maxAgeAttr given without maxAgeSeconds")
+	}
+	return r, nil
+}
+
+// parseByteSize parses a byte count with an optional binary (KiB/MiB/GiB/TiB) or decimal
+// (KB/MB/GB/TB) suffix; a bare number is bytes.
+func parseByteSize(s string) (int64, error) {
+	s = strings.TrimSpace(s)
+	mult := int64(1)
+	for _, u := range []struct {
+		suf string
+		m   int64
+	}{
+		{"KiB", 1 << 10}, {"MiB", 1 << 20}, {"GiB", 1 << 30}, {"TiB", 1 << 40},
+		{"KB", 1000}, {"MB", 1000 * 1000}, {"GB", 1000 * 1000 * 1000}, {"TB", 1000 * 1000 * 1000 * 1000},
+	} {
+		if len(s) > len(u.suf) && strings.EqualFold(s[len(s)-len(u.suf):], u.suf) {
+			mult = u.m
+			s = strings.TrimSpace(s[:len(s)-len(u.suf)])
+			break
+		}
+	}
+	n, err := strconv.ParseFloat(s, 64)
+	if err != nil || n < 0 {
+		return 0, fmt.Errorf("invalid size %q", s)
+	}
+	return int64(n * float64(mult)), nil
+}
+
+// retentionSummary renders a Retention for an admin acknowledgement.
+func retentionSummary(r db.Retention) string {
+	if (r == db.Retention{}) {
+		return "unbounded (keep everything)"
+	}
+	parts := make([]string, 0, 3)
+	if r.MaxSegments > 0 {
+		parts = append(parts, fmt.Sprintf("maxSegments=%d", r.MaxSegments))
+	}
+	if r.MaxBytes > 0 {
+		parts = append(parts, fmt.Sprintf("maxBytes=%d", r.MaxBytes))
+	}
+	if r.MaxAgeAttr != "" && r.MaxAge > 0 {
+		parts = append(parts, fmt.Sprintf("maxAge=%gs on %s", r.MaxAge, r.MaxAgeAttr))
+	}
+	return join(parts)
 }
 
 func addIndex(t *db.DB, what string, categorical, value []string) string {

--- a/dbrpc/server.go
+++ b/dbrpc/server.go
@@ -1095,6 +1095,15 @@ func (s *Server) handle(sc *serverConn, reqID uint64, o op, r *reader, includePr
 		}
 		d, ok := s.cat.Table(table)
 		if !ok {
+			// Not a mutable table: it may be an append-only archive (history) table, whose
+			// diagnostics mirror the mutable stat surface plus retention.
+			if a, aok := s.cat.ArchiveTable(table); aok {
+				data, err := s.archiveDiagJSON(a)
+				if err != nil {
+					return respErr(reqID, err.Error())
+				}
+				return putStr(resp(reqID, stOK), string(data))
+			}
 			return respErr(reqID, "no such table: "+table)
 		}
 		data, err := s.diagJSON(d)


### PR DESCRIPTION
Two admin gaps the archive unification left behind: an archive's `.stats` showed only a row count, and there was no way to change retention or drop segments at runtime. Now that the archive **is** a Collection underneath, both are just plumbing.

**Stat symmetry**: `collections.Archive` delegates `Stats`/`OpStats`/`CodecStats`/`IndexSizes`/`IndexedAttrs` to its Collection (`SidecarSizes` already existed); `db.ArchiveTable` exposes the same; and the `opDiag` server handler, when a name is not a mutable table, builds a `Diagnostics` for the archive instead of erroring. `Diagnostics` gains `Archive`/`Retention`/`SidecarSizes` fields (omitted for mutable tables). So an archive reports storage bytes (arena/used/live/dead), segment count, codec/compression, and op timings on the same terms as a table — the operator finally sees disk usage.

**Retention control**: `Collection.SetRetention`/`Retention` (guarded by `maintMu`); `db.ArchiveTable` persists the change to `archiveconfig.json` atomically (tmp+rename) so it survives restart and the reopen-wins path applies it. New DAEMON-gated archive admin actions:
- `retention.set <maxSegments> <maxBytes> [maxAgeAttr maxAgeSeconds]` — `maxBytes` accepts `KiB/MiB/GiB/TiB` or `KB/MB/GB/TB`; all-zero clears.
- `rotate` — drop out-of-bounds segments now.

Routed through the existing `opAdmin → archiveAdmin` (no new client method).

Tests: archive diagnostics over RPC (Archive flag, non-zero storage/op stats, retention present); `retention.set` + `rotate` over RPC (bound applied, segments dropped, size suffix parsed). Full collections/db/dbrpc suites green.

The htcondordb REPL side (render the rich `.stats history`, add `.retention`/`.rotate`) follows once this tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)