### PR TITLE
db: fast archive aggregates -- O(1) COUNT(*) and a wire-native projected scan

### DIFF
--- a/collections/archive.go
+++ b/collections/archive.go
@@ -194,6 +194,13 @@ func (a *Archive) QueryLimit(q *vm.Query, limit int) iter.Seq[*classad.ClassAd] 
 	}
 }
 
+// QueryProject scans the ads matching q and yields each one projected to just attrs'
+// values (aligned with attrs), read wire-native where possible -- so an aggregate does not
+// pay the full-ad decode QueryLimit costs. The yielded slice is reused; copy to retain.
+func (a *Archive) QueryProject(q *vm.Query, attrs []string) iter.Seq[[]classad.Value] {
+	return a.c.QueryProject(q, attrs)
+}
+
 // Watch streams the archive as change data: a full replay of retained records (oldest
 // first) then live appends, resumable from an opaque cursor. A cursor older than what
 // rotation still retains yields a WatchReset and resumes from the current floor. See

--- a/db/archive.go
+++ b/db/archive.go
@@ -6,6 +6,8 @@ import (
 	"iter"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 
 	"github.com/PelicanPlatform/classad/classad"
 	"github.com/PelicanPlatform/classad/collections"
@@ -138,6 +140,17 @@ func (t *ArchiveTable) QueryLimit(constraint string, limit int) (iter.Seq[*class
 	return t.a.QueryLimit(q, limit), nil
 }
 
+// QueryProject scans the matching ads and yields each projected to just attrs' values, read
+// wire-native where possible -- so an aggregate reads only the attributes it needs instead
+// of fully decoding every record. Errors only on a malformed constraint.
+func (t *ArchiveTable) QueryProject(constraint string, attrs []string) (iter.Seq[[]classad.Value], error) {
+	q, err := vm.Parse(constraint)
+	if err != nil {
+		return nil, fmt.Errorf("archive: parsing constraint: %w", err)
+	}
+	return t.a.QueryProject(q, attrs), nil
+}
+
 // Aggregate runs a server-side GROUP BY over the archive's matches: it applies the
 // constraint (using the archive's zone-map pruning, so segments no matching record can
 // fall in are never scanned), groups by the raw group columns, and reduces each group
@@ -146,31 +159,35 @@ func (t *ArchiveTable) QueryLimit(constraint string, limit int) (iter.Seq[*class
 // aggregate over a live table -- only the (small) grouped result is produced, not every
 // matched ad. With no group columns it returns a single row over the whole match.
 func (t *ArchiveTable) Aggregate(constraint string, groupBy []string, aggs []AggSpec) ([]AggRow, error) {
+	// Fast path: an unconstrained COUNT(*) with no grouping is the retained record count,
+	// which the archive tracks in O(1). This is the common `SELECT COUNT(*) FROM history`;
+	// scanning tens of thousands of records to count them would be needlessly slow.
+	if len(groupBy) == 0 && len(aggs) == 1 && aggs[0].Func == AggCount && aggs[0].Arg == "*" &&
+		isMatchAll(constraint) {
+		return []AggRow{{Values: []string{strconv.Itoa(t.a.Count())}}}, nil
+	}
+
 	groupCols := make([]GroupCol, len(groupBy))
 	for i, g := range groupBy {
 		groupCols[i] = GroupCol{Attr: g}
 	}
 	attrs, groupCol, aggCol := AggProjection(groupCols, aggs)
 
-	// limit <= 0: scan the whole (zone-pruned) match; the aggregate reduces it server-side.
-	seq, err := t.QueryLimit(constraint, 0)
+	// Scan wire-native, reading only the attributes the aggregation projects (empty for a
+	// pure COUNT), so it does not fully decode every matched record -- mirroring the mutable
+	// table's aggregate. Zone maps still prune segments no matching record can fall in.
+	seq, err := t.QueryProject(constraint, attrs)
 	if err != nil {
 		return nil, err
 	}
-	// Project each matched ad to just the attributes the aggregation reads. The scratch
-	// slice is reused across rows (AggregateValues copies a group's key only when created).
-	proj := func(yield func([]classad.Value) bool) {
-		scratch := make([]classad.Value, len(attrs))
-		for ad := range seq {
-			for i, n := range attrs {
-				scratch[i] = ad.EvaluateAttr(n)
-			}
-			if !yield(scratch) {
-				return
-			}
-		}
-	}
-	return AggregateValues(proj, groupCols, aggs, groupCol, aggCol, nil), nil
+	return AggregateValues(seq, groupCols, aggs, groupCol, aggCol, nil), nil
+}
+
+// isMatchAll reports whether a constraint imposes no filter (an empty string or a literal
+// "true"), so an aggregate over it covers every retained record.
+func isMatchAll(constraint string) bool {
+	c := strings.TrimSpace(constraint)
+	return c == "" || strings.EqualFold(c, "true")
 }
 
 // Count is the number of records currently retained (reduced by rotation).

--- a/db/archive_count_test.go
+++ b/db/archive_count_test.go
@@ -1,0 +1,71 @@
+package db
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+)
+
+// TestArchiveCountFastPath verifies an unconstrained COUNT(*) equals the archive's O(1)
+// record count (the fast path), and that constrained COUNT and SUM -- which take the
+// wire-native projected scan -- stay correct over a larger, multi-segment archive.
+func TestArchiveCountFastPath(t *testing.T) {
+	cat, err := OpenCatalog(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cat.Close()
+	hist, err := cat.CreateArchiveTable("history", ArchiveConfig{
+		SegmentSize: 1 << 12, // small -> several sealed segments
+		ValueAttrs:  []string{"ClusterId"},
+		ZoneAttrs:   []string{"ClusterId"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	const n = 500
+	sumOver := 0
+	for i := 0; i < n; i++ {
+		if err := hist.AppendOld(fmt.Sprintf("ClusterId = %d\nMemory = %d", i, i*2)); err != nil {
+			t.Fatal(err)
+		}
+		if i >= 300 {
+			sumOver += i * 2
+		}
+	}
+
+	// Unconstrained COUNT(*) -> the O(1) record count.
+	rows, err := hist.Aggregate("", nil, []AggSpec{{Func: AggCount, Arg: "*"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 || rows[0].Values[0] != strconv.Itoa(n) {
+		t.Fatalf("COUNT(*) = %+v, want %d", rows, n)
+	}
+	if rows[0].Values[0] != strconv.Itoa(hist.Count()) {
+		t.Errorf("COUNT(*) %s != Count() %d", rows[0].Values[0], hist.Count())
+	}
+	// "true" is also match-all (same fast path).
+	rows, _ = hist.Aggregate("true", nil, []AggSpec{{Func: AggCount, Arg: "*"}})
+	if rows[0].Values[0] != strconv.Itoa(n) {
+		t.Errorf(`COUNT(*) WHERE true = %s, want %d`, rows[0].Values[0], n)
+	}
+
+	// Constrained COUNT(*) goes through the projected scan (not the fast path).
+	rows, err = hist.Aggregate("ClusterId >= 300", nil, []AggSpec{{Func: AggCount, Arg: "*"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rows[0].Values[0] != strconv.Itoa(n-300) {
+		t.Errorf("COUNT(*) WHERE ClusterId>=300 = %s, want %d", rows[0].Values[0], n-300)
+	}
+
+	// SUM over a projected attribute (regression: the projected scan reads Memory correctly).
+	rows, err = hist.Aggregate("ClusterId >= 300", nil, []AggSpec{{Func: AggSum, Arg: "Memory"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rows[0].Values[0] != strconv.Itoa(sumOver) {
+		t.Errorf("SUM(Memory) WHERE ClusterId>=300 = %s, want %d", rows[0].Values[0], sumOver)
+	}
+}


### PR DESCRIPTION
`SELECT COUNT(*) FROM history` was **fully decoding every retained record**. The archive aggregate ran `QueryLimit(constraint, 0)`, which yields a decoded `*classad.ClassAd` per record, then reduced — tens of thousands of ZSTD-decompress+decode ops just to count (the ~2.4s the operator saw for 57k rows). The mutable-table aggregate avoids this by scanning wire-native and projecting only the attributes it reads; the archive simply was not using that path.

**Fixes:**
- **Unconstrained `COUNT(*)`** (no `WHERE`, or `WHERE true`) with no `GROUP BY` returns the archive's **O(1)** retained-record count directly — the common `SELECT COUNT(*) FROM history`.
- **Every other aggregate** now scans via `QueryProject` (wire-native, reads only the projected attributes — empty for a pure COUNT) instead of `QueryLimit`, so it no longer decodes full ads. Zone-map pruning still applies.

`collections.Archive` and `db.ArchiveTable` gain `QueryProject` (delegating to the backing Collection's, which the mutable path already uses); `Aggregate` is rewritten to use it plus the COUNT fast path.

Tests: unconstrained `COUNT(*)` equals `Count()` over a multi-segment archive; constrained `COUNT` and `SUM(attr)` stay correct through the projected scan; existing aggregate/group-by tests pass. Full collections/db/dbrpc suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)