### PR TITLE
collections: eager per-segment indexing for archives (index freshness)

### DIFF
--- a/collections/archive.go
+++ b/collections/archive.go
@@ -26,6 +26,11 @@ import (
 type Archive struct {
 	c   *Collection
 	dir string
+	// lastSeal is the shard seal count at the last eager reindex. When Append observes a new
+	// seal it reindexes the just-sealed segment, so a categorical/value query on freshly
+	// appended history is index-accelerated immediately rather than scanning until the next
+	// periodic reindex. Touched only by the single-writer Append.
+	lastSeal uint64
 }
 
 // zoneRange is one attribute's numeric span within a segment (a zone map entry). Shared
@@ -152,7 +157,21 @@ func dirHasEntries(dir string) bool {
 func (a *Archive) Append(ad *classad.ClassAd) error {
 	// An append log has no key; a nil key routes to the single append-only shard and
 	// stores a zero-length key. Duplicate appends are all retained.
-	return a.c.Put(nil, ad)
+	if err := a.c.Put(nil, ad); err != nil {
+		return err
+	}
+	// If this append sealed a segment, build its sidecar index now (off the write lock),
+	// so categorical/value queries on just-appended history are accelerated immediately
+	// instead of scanning until the next periodic reindex. Reindex builds only the missing
+	// sidecar (all older segments are already sealed) and is serialized against the periodic
+	// reindex. Skipped when no per-segment indexes are configured (nothing to build).
+	if a.c.hasSegmentIndexes() {
+		if seal := a.c.appendSealSeq(); seal != a.lastSeal {
+			a.lastSeal = seal
+			a.c.Reindex()
+		}
+	}
+	return nil
 }
 
 // Flush makes prior appends durable and queryable. The Collection keeps appended records

--- a/collections/archive_eager_index_test.go
+++ b/collections/archive_eager_index_test.go
@@ -1,0 +1,151 @@
+package collections
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/classad"
+	"github.com/PelicanPlatform/classad/collections/vm"
+)
+
+// sealedIndexed returns (sealed, indexed): the number of sealed (non-active) segments and how
+// many of them already carry a sidecar index.
+func sealedIndexed(a *Archive) (sealed, indexed int) {
+	sh := a.c.shards[0]
+	sh.mu.RLock()
+	defer sh.mu.RUnlock()
+	for _, s := range sh.segs {
+		if s != nil && s != sh.act {
+			sealed++
+			if s.msidx.Load() != nil {
+				indexed++
+			}
+		}
+	}
+	return
+}
+
+// TestArchiveEagerIndex verifies that appending to an archive builds the sidecar index of
+// each segment as it seals -- so a categorical/value query on just-appended history is
+// index-accelerated immediately, without waiting for a periodic reindex or a reopen.
+func TestArchiveEagerIndex(t *testing.T) {
+	dir := t.TempDir()
+	a, err := CreateArchive(ArchiveOptions{Dir: dir, SegmentSize: 1 << 12, ValueAttrs: []string{"G"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer a.Close()
+	const n = 500
+	for i := 0; i < n; i++ {
+		ad, _ := classad.Parse(fmt.Sprintf(`[ N=%d; G=%d ]`, i, i%4))
+		if err := a.Append(ad); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Every sealed segment already has a sidecar index -- no explicit Reindex, no reopen.
+	sealed, indexed := sealedIndexed(a)
+	if sealed < 2 {
+		t.Fatalf("expected several sealed segments, got %d", sealed)
+	}
+	if indexed != sealed {
+		t.Errorf("eager index: %d/%d sealed segments have a sidecar (want all)", indexed, sealed)
+	}
+
+	// The query is correct over the indexed archive.
+	q, _ := vm.Parse(`G == 2`)
+	cnt := 0
+	for range a.Query(q) {
+		cnt++
+	}
+	if cnt != n/4 {
+		t.Errorf("G==2 returned %d, want %d", cnt, n/4)
+	}
+}
+
+// TestArchiveEagerIndexNoAttrs verifies the eager path is inert (no reindex churn) when the
+// archive configures no per-segment indexes -- appends must still succeed and query correctly.
+func TestArchiveEagerIndexNoAttrs(t *testing.T) {
+	dir := t.TempDir()
+	a, err := CreateArchive(ArchiveOptions{Dir: dir, SegmentSize: 1 << 12}) // no ValueAttrs/CategoricalAttrs
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer a.Close()
+	for i := 0; i < 300; i++ {
+		ad, _ := classad.Parse(fmt.Sprintf(`[ N=%d ]`, i))
+		if err := a.Append(ad); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if a.Count() != 300 {
+		t.Fatalf("Count = %d, want 300", a.Count())
+	}
+	q, _ := vm.Parse(`N >= 150`)
+	cnt := 0
+	for range a.Query(q) {
+		cnt++
+	}
+	if cnt != 150 {
+		t.Errorf("N>=150 returned %d, want 150", cnt)
+	}
+}
+
+// TestArchiveEagerIndexConcurrent exercises the new concurrency: eager reindex (from the
+// appending writer) racing the periodic maintenance reindex and concurrent queries. Run
+// under -race; reindexMu must serialize the two reindexers.
+func TestArchiveEagerIndexConcurrent(t *testing.T) {
+	dir := t.TempDir()
+	a, err := CreateArchive(ArchiveOptions{Dir: dir, SegmentSize: 1 << 12, ValueAttrs: []string{"G"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer a.Close()
+
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+	// Periodic "maintenance" reindexer.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-done:
+				return
+			default:
+			}
+			a.Reindex()
+		}
+	}()
+	// Concurrent queriers.
+	q, _ := vm.Parse(`G == 1`)
+	for r := 0; r < 3; r++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-done:
+					return
+				default:
+				}
+				for range a.Query(q) {
+				}
+			}
+		}()
+	}
+	// Single writer appending (each seal triggers an eager reindex).
+	for i := 0; i < 600; i++ {
+		ad, _ := classad.Parse(fmt.Sprintf(`[ N=%d; G=%d ]`, i, i%4))
+		if err := a.Append(ad); err != nil {
+			t.Fatal(err)
+		}
+	}
+	close(done)
+	wg.Wait()
+
+	if a.Count() != 600 {
+		t.Errorf("Count = %d, want 600", a.Count())
+	}
+}

--- a/collections/index_query.go
+++ b/collections/index_query.go
@@ -25,6 +25,11 @@ import (
 // span of segments therefore evolves toward the current spec at whatever cadence
 // the caller reindexes — no write-path or compaction coupling.
 func (c *Collection) Reindex() {
+	// Serialize concurrent reindexers so two do not build and install the same segment's
+	// sidecar at once (the eager per-seal reindex vs. the periodic one). Idempotent and
+	// cheap when there is nothing new to build.
+	c.reindexMu.Lock()
+	defer c.reindexMu.Unlock()
 	start := time.Now()
 	defer func() { c.opm.reindex.observe(time.Since(start)) }()
 	spec := c.spec.Load()

--- a/collections/shard.go
+++ b/collections/shard.go
@@ -17,6 +17,12 @@ type shard struct {
 	segs []*segment     // indexed by segment id (id == index)
 	act  *segment       // current append target
 
+	// sealSeq counts append-only segment seals (a rollover to a new active segment). An
+	// archive watches it to build the just-sealed segment's sidecar index eagerly, off the
+	// write lock, instead of waiting for the next periodic reindex. Bumped under the write
+	// lock; read lock-free.
+	sealSeq atomic.Uint64
+
 	// appendOnly makes this a pure append log (see Options.AppendOnly): put appends
 	// without superseding or indexing by key, del is a no-op, and compaction is
 	// skipped. Set once at construction; never mutated.
@@ -327,6 +333,9 @@ func (sh *shard) writeRecord(seq uint64, next loc, key, ad []byte, codec Codec) 
 		// compute its zone map so later range queries can prune it. No-op unless
 		// append-only with ZoneAttrs configured.
 		sh.sealZones(sh.act)
+		if sh.appendOnly && sh.act != nil {
+			sh.sealSeq.Add(1) // a segment just sealed: signal eager sidecar indexing
+		}
 		size := sh.segSize
 		if rl > size {
 			size = rl

--- a/collections/store.go
+++ b/collections/store.go
@@ -230,6 +230,13 @@ type Collection struct {
 	// load). Commits and queries never take it.
 	maintMu sync.Mutex
 
+	// reindexMu serializes Reindex so concurrent callers (the archive's eager per-seal
+	// reindex, the periodic maintenance reindex, and compaction's reindexAfterCompaction)
+	// cannot both build and install the same segment's sidecar at once. Distinct from
+	// maintMu, which retrain/rotate/rewrite hold across their whole pass (and which those
+	// ops' internal reindexAfterCompaction must not re-take).
+	reindexMu sync.Mutex
+
 	demand *demandTracker // per-attribute query demand, for SuggestIndexes
 
 	// Query fan-out (see parallel_scan.go). queryPar is the per-query worker cap
@@ -607,6 +614,19 @@ func (c *Collection) Update(batch []AdUpdate) error {
 // appendOnly reports whether this is an append-log collection (Options.AppendOnly). It is a
 // whole-collection property, set once at construction, so the first shard's flag speaks for all.
 func (c *Collection) appendOnly() bool { return len(c.shards) > 0 && c.shards[0].appendOnly }
+
+// appendSealSeq returns the append-only shard's segment-seal counter (0 if not append-only),
+// so a caller can detect when a segment has sealed and index it eagerly. See shard.sealSeq.
+func (c *Collection) appendSealSeq() uint64 {
+	if len(c.shards) == 0 {
+		return 0
+	}
+	return c.shards[0].sealSeq.Load()
+}
+
+// hasSegmentIndexes reports whether any per-segment categorical/value index is configured,
+// so eager reindexing is skipped when there is nothing to build.
+func (c *Collection) hasSegmentIndexes() bool { return c.spec.Load().any() }
 
 func (c *Collection) Put(key []byte, ad *classad.ClassAd) error {
 	codec := c.currentCodec()


### PR DESCRIPTION
The one read path where an archive lagged a mutable table: categorical/value `WHERE` queries on **recently-appended** history. A mutable table's frequent compaction keeps its per-segment indexes rebuilt, but an append log never compacts — its sidecar indexes were built only at open, on the periodic maintenance reindex (#69), or via `.reindex`. So a `WHERE Owner == "alice"` over segments sealed since the last reindex **scanned** instead of using the bloom/MPH index. (Zone-mapped range queries were unaffected — they prune regardless.)

Now the archive indexes a just-sealed segment **immediately**: the append-only write path bumps a per-shard seal counter on each rollover, and the Archive facade, after an `Append` that advances it, runs `Reindex` — off the write lock, building only the newly-sealed segment. Skipped when no per-segment indexes are configured.

`Reindex` now serializes on a dedicated `reindexMu` so the eager per-seal reindex and the periodic maintenance reindex cannot build/install the same sidecar at once (distinct from `maintMu`, which the long retrain/rotate/rewrite passes hold and whose internal `reindexAfterCompaction` must not re-take).

Cost: one sidecar build per ~segment-size of appends, paid by the single writer off-lock, amortized over thousands of records; queries are not blocked and sidecars stay pageable mmap (no RAM regression).

Tests: sealed segments carry a sidecar right after `Append` (no reopen/explicit reindex); inert with no index attrs; eager-vs-periodic reindex + concurrent queries is race-clean. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)