### PR TITLE
archive: Truncate (empty in place) + fix Collection.Truncate sidecar-index leak

### DIFF
--- a/collections/archive.go
+++ b/collections/archive.go
@@ -188,6 +188,15 @@ func (a *Archive) Rotate(now float64) (int, error) { return a.c.Rotate(now) }
 // whole-segment steps.
 func (a *Archive) Count() int { return a.c.Len() }
 
+// Truncate drops every record, resetting the archive to empty in place: all segments are
+// unmapped and their data + sidecar-index files unlinked (via the backing Collection's
+// Truncate). Segment counters keep advancing, so a fresh Append starts a new segment. This
+// is the destructive reset a from-scratch history re-sync uses -- empty the store, then
+// re-ingest from the source. Retention/index/zone-map configuration is preserved. Safe
+// against concurrent queries (a scan holding a pin reads its old data until it finishes);
+// callers must serialize Truncate against the single Append writer.
+func (a *Archive) Truncate() { a.c.Truncate() }
+
 // Close flushes and unmaps the archive. It must not be used afterward.
 func (a *Archive) Close() error { return a.c.Close() }
 

--- a/collections/archive_truncate_test.go
+++ b/collections/archive_truncate_test.go
@@ -1,0 +1,104 @@
+package collections
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// countFilesWithSuffix walks dir and counts files whose name ends in suffix -- used to
+// assert that Truncate actually unlinks segment data (.dat) and sidecar (.idx) files, not
+// just resets in-memory state.
+func countFilesWithSuffix(t *testing.T, dir, suffix string) int {
+	t.Helper()
+	n := 0
+	err := filepath.Walk(dir, func(_ string, fi os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !fi.IsDir() && strings.HasSuffix(fi.Name(), suffix) {
+			n++
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return n
+}
+
+// TestArchiveTruncate verifies Truncate empties the archive in place: records gone, on-disk
+// segment + sidecar files unlinked, the store still usable (append + query) afterward, and
+// the emptiness durable across a reopen. The archive is indexed (categorical + value) and
+// uses a tiny segment size so several sealed segments with sidecar indexes exist -- the case
+// that exercises the reapAndHook sidecar cleanup, not just the active segment.
+func TestArchiveTruncate(t *testing.T) {
+	dir := t.TempDir()
+	opts := ArchiveOptions{
+		SegmentSize:      8 << 10, // many small sealed segments (each with an .idx sidecar)
+		CategoricalAttrs: []string{"Owner"},
+		ValueAttrs:       []string{"Memory"},
+		ZoneAttrs:        []string{"CompletionDate"},
+	}
+	a, _ := buildArchive(t, dir, 300, opts)
+
+	if a.Count() != 300 {
+		t.Fatalf("pre-truncate Count = %d, want 300", a.Count())
+	}
+	if archiveLiveSegs(a) < 2 {
+		t.Fatalf("expected several sealed segments, got %d", archiveLiveSegs(a))
+	}
+	if dats := countFilesWithSuffix(t, dir, ".dat"); dats < 2 {
+		t.Fatalf("expected >=2 .dat files before truncate, got %d", dats)
+	}
+	if idxs := countFilesWithSuffix(t, dir, ".idx"); idxs < 1 {
+		t.Fatalf("expected >=1 sidecar .idx file before truncate, got %d", idxs)
+	}
+
+	a.Truncate()
+
+	if a.Count() != 0 {
+		t.Fatalf("post-truncate Count = %d, want 0", a.Count())
+	}
+	if got := archiveQueryIDs(t, a, "true"); len(got) != 0 {
+		t.Fatalf("post-truncate query returned %d ads, want 0", len(got))
+	}
+	// The data + sidecar files must be unlinked, not merely forgotten -- otherwise recovery
+	// would resurrect the truncated records and the disk would leak.
+	if dats := countFilesWithSuffix(t, dir, ".dat"); dats != 0 {
+		t.Errorf("post-truncate .dat files = %d, want 0 (segments not unlinked)", dats)
+	}
+	if idxs := countFilesWithSuffix(t, dir, ".idx"); idxs != 0 {
+		t.Errorf("post-truncate .idx sidecar files = %d, want 0 (sidecars not unlinked)", idxs)
+	}
+
+	// Still usable: appends after a truncate are retained and queryable.
+	appendJob := func(id int, owner string) {
+		ad := mustAd(t, `[ ID=`+itoa(id)+`; Owner="`+owner+`"; Memory=1024; CompletionDate=1800000000 ]`)
+		if err := a.Append(ad); err != nil {
+			t.Fatal(err)
+		}
+	}
+	appendJob(1000, "frank")
+	appendJob(1001, "frank")
+	if a.Count() != 2 {
+		t.Fatalf("post-truncate re-append Count = %d, want 2", a.Count())
+	}
+	if got := archiveQueryIDs(t, a, `Owner == "frank"`); len(got) != 2 {
+		t.Fatalf(`query Owner=="frank" returned %d, want 2`, len(got))
+	}
+	if err := a.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Durability: reopen sees exactly the two post-truncate records, never the 300 dropped.
+	b, err := OpenArchive(func() ArchiveOptions { o := opts; o.Dir = dir; return o }())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer b.Close()
+	if b.Count() != 2 {
+		t.Errorf("reopened Count = %d, want 2 (truncate not durable)", b.Count())
+	}
+}

--- a/collections/truncate.go
+++ b/collections/truncate.go
@@ -38,9 +38,12 @@ func (c *Collection) Truncate() {
 		sh.writeErr = nil
 		sh.mu.Unlock()
 		// Reap (munmap + unlink) outside the lock; retire() already deferred any still-
-		// pinned segment to its last unpin.
+		// pinned segment to its last unpin. reapAndHook (not bare reap) so a sealed
+		// segment's mmap sidecar index is unmapped with its data (the onReap hook) --
+		// otherwise the sidecar mapping leaks. Every other drop path (compact/retention/
+		// retrain) already routes through reapAndHook; Truncate must too.
 		for _, seg := range toReap {
-			_ = seg.reap()
+			_ = seg.reapAndHook()
 		}
 	}
 	for _, oi := range c.ordered {

--- a/db/archive.go
+++ b/db/archive.go
@@ -197,6 +197,12 @@ func (t *ArchiveTable) Count() int { return t.a.Count() }
 // time (unix seconds, for age-based retention). Returns how many segments were dropped.
 func (t *ArchiveTable) Rotate(now float64) (int, error) { return t.a.Rotate(now) }
 
+// Truncate drops every record, resetting the archive to empty in place (see
+// collections.Archive.Truncate). It is the destructive reset behind a from-scratch history
+// re-sync: empty the table, then re-ingest from the source. The persisted config (indexes,
+// zone maps, retention) is retained, so the archive keeps its shape.
+func (t *ArchiveTable) Truncate() { t.a.Truncate() }
+
 // Close flushes and closes the archive.
 func (t *ArchiveTable) Close() error { return t.a.Close() }
 

--- a/dbrpc/archive_truncate_test.go
+++ b/dbrpc/archive_truncate_test.go
@@ -1,0 +1,68 @@
+package dbrpc
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/db"
+)
+
+// TestArchiveTruncateOverRPC verifies TruncateTable works on an append-only archive (routed
+// to archiveAdmin, not the mutable-table admin), is DAEMON-gated, and leaves the archive
+// usable for fresh appends afterward -- the runtime "empty history, then re-sync" path.
+func TestArchiveTruncateOverRPC(t *testing.T) {
+	ctx := context.Background()
+
+	seed := func(c *Client) {
+		if err := c.CreateArchiveTable(ctx, "history", db.ArchiveConfig{ValueAttrs: []string{"ClusterId"}}); err != nil {
+			t.Fatalf("CreateArchiveTable: %v", err)
+		}
+		for i := 0; i < 50; i++ {
+			if err := c.ArchiveAppend(ctx, "history", fmt.Sprintf("ClusterId = %d\nJobStatus = 4", i)); err != nil {
+				t.Fatalf("ArchiveAppend: %v", err)
+			}
+		}
+	}
+	countAll := func(c *Client) int {
+		got, err := c.ArchiveQuery(ctx, "history", "true", 0)
+		if err != nil {
+			t.Fatalf("ArchiveQuery: %v", err)
+		}
+		return len(got)
+	}
+
+	// Unprivileged: refused, and the archive is untouched.
+	c, cleanup := catServerPair(t, ServeOptions{})
+	seed(c)
+	if _, err := c.TruncateTable(ctx, "history"); err == nil {
+		t.Fatal("archive truncate should be refused without DAEMON privilege")
+	}
+	if n := countAll(c); n != 50 {
+		t.Fatalf("unauthorized truncate changed the archive: %d records, want 50", n)
+	}
+	cleanup()
+
+	// Privileged: empties the archive, which then accepts new appends.
+	c, cleanup = catServerPair(t, ServeOptions{Privileged: true})
+	defer cleanup()
+	seed(c)
+	if n := countAll(c); n != 50 {
+		t.Fatalf("setup: %d records, want 50", n)
+	}
+	if _, err := c.TruncateTable(ctx, "history"); err != nil {
+		t.Fatalf("privileged archive truncate: %v", err)
+	}
+	if n := countAll(c); n != 0 {
+		t.Fatalf("after truncate: %d records, want 0", n)
+	}
+	// Re-ingest a couple records to prove the emptied archive is still live.
+	for i := 0; i < 2; i++ {
+		if err := c.ArchiveAppend(ctx, "history", fmt.Sprintf("ClusterId = %d\nJobStatus = 4", 900+i)); err != nil {
+			t.Fatalf("post-truncate ArchiveAppend: %v", err)
+		}
+	}
+	if n := countAll(c); n != 2 {
+		t.Fatalf("after re-append: %d records, want 2", n)
+	}
+}

--- a/dbrpc/diag.go
+++ b/dbrpc/diag.go
@@ -220,10 +220,16 @@ func (s *Server) admin(t *db.DB, action string, args []string, privileged bool) 
 // only to future writes and would not prune the current data.
 // archiveAdmin runs a management action on an append-only archive (history) table: the
 // layout-tuning subset of table admin -- retrain the ZSTD dictionary, add/drop/rebuild
-// per-segment indexes, and rewrite. Encryption/time-travel/truncate/hot-set actions do not
-// apply to an archive. DAEMON-gated by the caller, like the mutable-table admin.
+// per-segment indexes, rewrite, set retention, rotate -- plus truncate (empty the archive).
+// Encryption/time-travel/hot-set actions do not apply to an archive. DAEMON-gated by the
+// caller, like the mutable-table admin.
 func archiveAdmin(a *db.ArchiveTable, action string, args []string) (string, error) {
 	switch action {
+	case "truncate":
+		// Destructive reset: drop every record (a from-scratch re-sync empties the archive,
+		// then re-ingests from the source). Retention/index config is preserved.
+		a.Truncate()
+		return "archive truncated", nil
 	case "index.add.categorical":
 		if len(args) == 0 {
 			return "", fmt.Errorf("index.add.categorical needs at least one attribute")


### PR DESCRIPTION
## What

Adds `Archive.Truncate` / `ArchiveTable.Truncate` and wires a `truncate` action into the archive admin path (`archiveAdmin`, DAEMON-gated). `Client.TruncateTable(ctx, "history")` now works on an append-only history table — it routes through the existing `opAdmin` archive branch, so **no new wire op** is needed.

This is the primitive behind a from-scratch, no-restart history **re-sync**: empty the archive, then re-ingest from the source. Retention / index / zone-map configuration is preserved (the archive keeps its shape).

## Latent leak fixed along the way

`Collection.Truncate` dropped segments with bare `seg.reap()`, which unmaps + unlinks a segment's data file (and `.idx` container) but **never runs the `onReap` hook** — so a sealed segment's mmap **sidecar index** stayed mapped. Every other drop path (compaction, retention, retrain) already uses `reapAndHook`; Truncate was the outlier. This leaked on both mutable-table restore (key + attr sidecars) and archive truncate. Switched to `reapAndHook`.

## Tests

- **collections** (`-race`): truncate empties an indexed archive with several sealed segments, unlinks all `.dat` + `.idx` files, stays usable for fresh appends, and the emptiness survives a reopen.
- **dbrpc**: `TruncateTable` on an archive is DAEMON-gated, empties it, and the emptied archive still accepts appends.

Full collections / db / dbrpc suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)