### PR TITLE
dbrpc: server-side projection (QueryRawProject) now serves archive tables

### DIFF
--- a/collections/archive.go
+++ b/collections/archive.go
@@ -216,6 +216,15 @@ func (a *Archive) QueryLimit(q *vm.Query, limit int) iter.Seq[*classad.ClassAd] 
 // QueryProject scans the ads matching q and yields each one projected to just attrs'
 // values (aligned with attrs), read wire-native where possible -- so an aggregate does not
 // pay the full-ad decode QueryLimit costs. The yielded slice is reused; copy to retain.
+// QueryRawProjected yields each ad matching q as a raw projected subset (only the projection
+// attributes, rendered from the stored representation), newest first — the archive-side of the
+// server projection relay. It shares the backing Collection's projection walk, so the same
+// newest-first ordering and pushed-down LIMIT (via early stop by the caller) apply. chaseRefs
+// and redact are as in Collection.QueryRawProjected.
+func (a *Archive) QueryRawProjected(q *vm.Query, projection []string, chaseRefs, redact bool) iter.Seq[RawAd] {
+	return a.c.QueryRawProjected(q, projection, chaseRefs, redact)
+}
+
 func (a *Archive) QueryProject(q *vm.Query, attrs []string) iter.Seq[[]classad.Value] {
 	return a.c.QueryProject(q, attrs)
 }

--- a/db/archive.go
+++ b/db/archive.go
@@ -151,6 +151,19 @@ func (t *ArchiveTable) QueryProject(constraint string, attrs []string) (iter.Seq
 	return t.a.QueryProject(q, attrs), nil
 }
 
+// QueryRawProjected yields each matching ad as a raw projected subset (only the projection
+// attributes, rendered from the stored representation), newest first — the archive-side of the
+// server-side projection op. redact strips private attributes. It mirrors db.DB.QueryRawProjected
+// so the same wire op serves archives and mutable tables uniformly. chaseRefs is false, matching
+// HTCondor's projection protocol (exactly the requested attributes).
+func (t *ArchiveTable) QueryRawProjected(constraint string, projection []string, redact bool) (iter.Seq[collections.RawAd], error) {
+	q, err := vm.Parse(constraint)
+	if err != nil {
+		return nil, fmt.Errorf("archive: parsing constraint: %w", err)
+	}
+	return t.a.QueryRawProjected(q, projection, false, redact), nil
+}
+
 // Aggregate runs a server-side GROUP BY over the archive's matches: it applies the
 // constraint (using the archive's zone-map pruning, so segments no matching record can
 // fall in are never scanned), groups by the raw group columns, and reduces each group

--- a/dbrpc/archive_project_test.go
+++ b/dbrpc/archive_project_test.go
@@ -1,0 +1,73 @@
+package dbrpc
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/classad"
+	"github.com/PelicanPlatform/classad/db"
+)
+
+// TestArchiveRawProjectOverRPC verifies the server-side projection op (QueryRawProject) works
+// on an append-only archive (history) table -- the same op that serves mutable tables -- so a
+// narrow SELECT over history ships only the requested attributes. It checks newest-first
+// order, the pushed-down LIMIT, a constraint, and that unselected attributes are absent.
+func TestArchiveRawProjectOverRPC(t *testing.T) {
+	c, cleanup := catServerPair(t, ServeOptions{})
+	defer cleanup()
+	ctx := context.Background()
+
+	if err := c.CreateArchiveTable(ctx, "history", db.ArchiveConfig{ValueAttrs: []string{"ClusterId"}}); err != nil {
+		t.Fatalf("CreateArchiveTable: %v", err)
+	}
+	// Wide-ish records: only Owner + ClusterId are projected; JobStatus/Cmd must not appear.
+	for i := 0; i < 100; i++ {
+		ad := fmt.Sprintf("ClusterId = %d\nOwner = \"u%d\"\nJobStatus = 4\nCmd = \"/bin/run%d\"", i, i%10, i)
+		if err := c.ArchiveAppend(ctx, "history", ad); err != nil {
+			t.Fatalf("ArchiveAppend: %v", err)
+		}
+	}
+
+	// Newest-first + LIMIT 3: the last three appended (ClusterId 99, 98, 97).
+	rows, err := c.QueryRawProject(ctx, "history", "true", []string{"Owner", "ClusterId"}, 3)
+	if err != nil {
+		t.Fatalf("QueryRawProject: %v", err)
+	}
+	if len(rows) != 3 {
+		t.Fatalf("projected archive query returned %d rows, want 3", len(rows))
+	}
+	wantCluster := []int64{99, 98, 97}
+	for i, r := range rows {
+		ad, perr := classad.ParseOld(r)
+		if perr != nil {
+			t.Fatalf("parse projected ad %q: %v", r, perr)
+		}
+		cid, ok := ad.EvaluateAttrInt("ClusterId")
+		if !ok {
+			t.Fatalf("row %d missing ClusterId: %q", i, r)
+		}
+		if cid != wantCluster[i] {
+			t.Errorf("row %d ClusterId = %d, want %d (newest-first order wrong)", i, cid, wantCluster[i])
+		}
+		if _, ok := ad.Lookup("Owner"); !ok {
+			t.Errorf("row %d missing the projected Owner: %q", i, r)
+		}
+		// Unselected attributes must not cross the wire.
+		if _, ok := ad.Lookup("JobStatus"); ok {
+			t.Errorf("row %d carries unselected JobStatus: %q", i, r)
+		}
+		if _, ok := ad.Lookup("Cmd"); ok {
+			t.Errorf("row %d carries unselected Cmd: %q", i, r)
+		}
+	}
+
+	// A constraint is applied server-side: exactly one record has ClusterId == 42.
+	one, err := c.QueryRawProject(ctx, "history", "ClusterId == 42", []string{"Owner"}, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(one) != 1 {
+		t.Fatalf("ClusterId==42 projected query matched %d, want 1", len(one))
+	}
+}

--- a/dbrpc/queryraw.go
+++ b/dbrpc/queryraw.go
@@ -162,14 +162,24 @@ func (s *Server) streamQueryRawProject(ctx context.Context, reqID uint64, r *rea
 		write(respBad(reqID))
 		return
 	}
-	d, ok := s.tableOr(reqID, table, write)
-	if !ok {
-		return
-	}
 	// The projection (and, unprivileged, redaction) is applied inside the
 	// collection's decode walk: non-projected attributes are never rendered, and a
-	// hot-header-covered projection is served from the hot header alone.
-	seq, err := d.QueryRawProjected(constraint, attrs, !includePrivate)
+	// hot-header-covered projection is served from the hot header alone. Resolve the
+	// source uniformly across a mutable table, a materialized view's backing, and an
+	// append-only archive (history) table -- so the one projection op serves them all
+	// (an archive streams newest-first, like its plain query).
+	var seq iter.Seq[collections.RawAd]
+	var err error
+	if d, ok := s.cat.Table(table); ok {
+		seq, err = d.QueryRawProjected(constraint, attrs, !includePrivate)
+	} else if d, ok := s.cat.ViewBacking(table); ok {
+		seq, err = d.QueryRawProjected(constraint, attrs, !includePrivate)
+	} else if a, ok := s.cat.ArchiveTable(table); ok {
+		seq, err = a.QueryRawProjected(constraint, attrs, !includePrivate)
+	} else {
+		write(respErr(reqID, "no such table: "+table))
+		return
+	}
 	if err != nil {
 		write(respErr(reqID, err.Error()))
 		return


### PR DESCRIPTION
The projection op (`opQueryRawProj`) resolved only mutable tables and view backings via `tableOr`, so a narrow SELECT over a **history archive** could not push its column set to the server and had to fetch whole ads. History ads are exactly the wide records projection helps most.

This routes the op across all three read sources — mutable table, materialized-view backing, and append-only archive — so the one op serves them uniformly and the existing `Client.QueryRawProject` works on an archive name **with no client change**.

## Details

- Adds `Archive.QueryRawProjected` (collections) and `ArchiveTable.QueryRawProjected` (db), mirroring `db.DB.QueryRawProjected`.
- The archive shares the backing Collection's projection walk, so it streams **newest-first** (condor_history order) with the same pushed-down LIMIT.
- `chaseRefs` stays `false`, matching HTCondor's projection protocol (exactly the requested attributes).
- Inline (persistent) collections already render raw projections, so the archive's inline append-log projects correctly.

## Test

`QueryRawProject` over an archive returns only the requested attributes (unselected ones absent), newest-first, honoring the LIMIT and a server-side constraint. Full collections/db/dbrpc suites green.

## Downstream

Unlocks history-table projection in the htcondordb REPL: once tagged, dropping the archive exclusion in `projectionAttrs` (htcondordb#79) lets `SELECT cols FROM history` ship only those columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)