### PR TITLE
dbrpc: WatchTable now serves archive (history) tables

### DIFF
--- a/db/archive.go
+++ b/db/archive.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"iter"
@@ -209,6 +210,35 @@ func (t *ArchiveTable) Count() int { return t.a.Count() }
 // Rotate drops sealed segments that fall outside the retention policy, given the current
 // time (unix seconds, for age-based retention). Returns how many segments were dropped.
 func (t *ArchiveTable) Rotate(now float64) (int, error) { return t.a.Rotate(now) }
+
+// Watch streams the archive's change events (append-only: upserts and the catch-up/live
+// markers, no deletes), converting collections.WatchEvent to the db WatchEvent used by the
+// mutable-table watch so the two are wire-identical. An empty cursor replays the retained
+// history, then goes live. See collections.Archive.Watch.
+func (t *ArchiveTable) Watch(ctx context.Context, cursor []byte) (iter.Seq[WatchEvent], error) {
+	seq, err := t.a.Watch(ctx, cursor)
+	if err != nil {
+		return nil, err
+	}
+	return func(yield func(WatchEvent) bool) {
+		for ev := range seq {
+			we := WatchEvent{Key: string(ev.Key), Ad: ev.Ad, Cursor: ev.Cursor}
+			switch ev.Kind {
+			case collections.WatchDelete:
+				we.Kind = WatchDelete
+			case collections.WatchReset:
+				we.Kind = WatchReset
+			case collections.WatchSynced:
+				we.Kind = WatchSynced
+			case collections.WatchResync:
+				we.Kind = WatchResync
+			}
+			if !yield(we) {
+				return
+			}
+		}
+	}, nil
+}
 
 // Truncate drops every record, resetting the archive to empty in place (see
 // collections.Archive.Truncate). It is the destructive reset behind a from-scratch history

--- a/dbrpc/archive_watch_test.go
+++ b/dbrpc/archive_watch_test.go
@@ -1,0 +1,81 @@
+package dbrpc
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/PelicanPlatform/classad/db"
+)
+
+// TestArchiveWatchOverRPC verifies WatchTable works on an append-only archive (history) table:
+// a fresh watch replays the retained records as upserts, signals WatchSynced, then delivers a
+// live append. This is the change stream the OpenSearch/Kafka history exporters consume.
+func TestArchiveWatchOverRPC(t *testing.T) {
+	c, cleanup := catServerPair(t, ServeOptions{})
+	defer cleanup()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := c.CreateArchiveTable(ctx, "history", db.ArchiveConfig{ValueAttrs: []string{"ClusterId"}}); err != nil {
+		t.Fatalf("CreateArchiveTable: %v", err)
+	}
+	for i := 0; i < 5; i++ {
+		if err := c.ArchiveAppend(ctx, "history", fmt.Sprintf("ClusterId = %d\nJobStatus = 4", i)); err != nil {
+			t.Fatalf("ArchiveAppend: %v", err)
+		}
+	}
+
+	events, stop, err := c.WatchTable(ctx, "history", nil)
+	if err != nil {
+		t.Fatalf("WatchTable(history): %v", err)
+	}
+	defer stop()
+
+	// Replay: 5 upserts then WatchSynced.
+	upserts := 0
+	deadline := time.After(3 * time.Second)
+	for synced := false; !synced; {
+		select {
+		case ev, ok := <-events:
+			if !ok {
+				t.Fatal("stream closed before WatchSynced")
+			}
+			switch db.WatchKind(ev.Kind) {
+			case db.WatchUpsert:
+				upserts++
+				if !strings.Contains(ev.AdText, "ClusterId") {
+					t.Errorf("upsert missing ClusterId: %q", ev.AdText)
+				}
+			case db.WatchSynced:
+				synced = true
+			}
+		case <-deadline:
+			t.Fatalf("timed out during replay after %d upserts", upserts)
+		}
+	}
+	if upserts != 5 {
+		t.Fatalf("replayed %d upserts, want 5", upserts)
+	}
+
+	// Live: a new append is delivered as an upsert.
+	if err := c.ArchiveAppend(ctx, "history", "ClusterId = 99\nJobStatus = 4"); err != nil {
+		t.Fatal(err)
+	}
+	deadline = time.After(3 * time.Second)
+	for {
+		select {
+		case ev, ok := <-events:
+			if !ok {
+				t.Fatal("stream closed waiting for the live append")
+			}
+			if db.WatchKind(ev.Kind) == db.WatchUpsert && strings.Contains(ev.AdText, "99") {
+				return // success
+			}
+		case <-deadline:
+			t.Fatal("timed out waiting for the live append")
+		}
+	}
+}

--- a/dbrpc/server.go
+++ b/dbrpc/server.go
@@ -466,10 +466,6 @@ func adString(ad *classad.ClassAd, includePrivate bool) string {
 func (sc *serverConn) streamWatch(reqID uint64, r *reader) {
 	table := r.str()
 	cursor := append([]byte(nil), r.bytesRef()...)
-	d, ok := sc.s.tableOr(reqID, table, sc.write)
-	if !ok {
-		return
-	}
 	ctx, cancel := context.WithCancel(sc.ctx)
 	sc.wmu.Lock()
 	sc.watches[reqID] = cancel
@@ -481,7 +477,20 @@ func (sc *serverConn) streamWatch(reqID uint64, r *reader) {
 		cancel()
 	}()
 
-	seq, err := d.Watch(ctx, cursor)
+	// Resolve the watch source uniformly across a mutable table, a materialized-view backing,
+	// and an append-only archive (history) table, so one watch op serves them all.
+	var seq iter.Seq[db.WatchEvent]
+	var err error
+	if d, ok := sc.s.cat.Table(table); ok {
+		seq, err = d.Watch(ctx, cursor)
+	} else if d, ok := sc.s.cat.ViewBacking(table); ok {
+		seq, err = d.Watch(ctx, cursor)
+	} else if a, ok := sc.s.cat.ArchiveTable(table); ok {
+		seq, err = a.Watch(ctx, cursor)
+	} else {
+		sc.write(respErr(reqID, "no such table: "+table))
+		return
+	}
 	if err != nil {
 		sc.write(respErr(reqID, err.Error()))
 		return


### PR DESCRIPTION
The watch op (`opWatch`) resolved only mutable tables and view backings via `tableOr`, so a change-data consumer could not watch an append-only **history archive** over the wire. This routes the op across all three sources — mutable table, view backing, and archive — the same way the projection op was extended (classad#97).

## Details
- Adds `db.ArchiveTable.Watch`, converting `collections.WatchEvent` to the db `WatchEvent` so the archive stream is **wire-identical** to a mutable table's (append-only: upserts + catch-up/live markers, no deletes).
- An empty cursor replays the retained history, then goes live.

## Why
This unblocks the OpenSearch and Kafka exporters watching the **history archive directly** — condor_adstash-style completed-job export.

## Test
WatchTable over an archive replays the retained records as upserts, signals `WatchSynced`, and delivers a live append (run under `-race`). Full db/dbrpc suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)