### PR TITLE
db,dbrpc: keys-by-constraint (address rows without a Key attribute)

### DIFF
--- a/db/keyswhere_test.go
+++ b/db/keyswhere_test.go
@@ -1,0 +1,72 @@
+package db
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/classad"
+)
+
+// TestKeysWhere returns the storage keys of matching rows, including rows with no key attribute,
+// and stops early when the caller breaks.
+func TestKeysWhere(t *testing.T) {
+	d, err := Open("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+
+	put := func(key, text string) {
+		ad, err := classad.ParseOld(text)
+		if err != nil {
+			t.Fatal(err)
+		}
+		tx := d.Begin()
+		tx.NewClassAd(key, ad)
+		if err := tx.Commit(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	put("0O.-1", `MyType = "Owner"`)
+	put("0O.-2", `MyType = "Owner"`)
+	put("1.0", `MyType = "Job"`)
+
+	collect := func(constraint string) []string {
+		seq, err := d.KeysWhere(constraint)
+		if err != nil {
+			t.Fatalf("KeysWhere(%q): %v", constraint, err)
+		}
+		var out []string
+		for k := range seq {
+			out = append(out, k)
+		}
+		sort.Strings(out)
+		return out
+	}
+
+	if got := collect(`MyType == "Owner"`); len(got) != 2 || got[0] != "0O.-1" || got[1] != "0O.-2" {
+		t.Errorf("KeysWhere(Owner) = %v, want [0O.-1 0O.-2]", got)
+	}
+	if got := collect(`true`); len(got) != 3 {
+		t.Errorf("KeysWhere(true) matched %d, want 3", len(got))
+	}
+	if got := collect(`MyType == "Nope"`); len(got) != 0 {
+		t.Errorf("KeysWhere(no-match) = %v, want empty", got)
+	}
+
+	// A bad constraint errors eagerly (before any scan).
+	if _, err := d.KeysWhere(`MyType ==`); err == nil {
+		t.Error("KeysWhere with a malformed constraint should error")
+	}
+
+	// Early break stops the scan.
+	seq, _ := d.KeysWhere(`true`)
+	n := 0
+	for range seq {
+		n++
+		break
+	}
+	if n != 1 {
+		t.Errorf("early break visited %d keys, want 1", n)
+	}
+}

--- a/db/pushdown.go
+++ b/db/pushdown.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"fmt"
+	"iter"
 
 	"github.com/PelicanPlatform/classad/classad"
 	"github.com/PelicanPlatform/classad/collections/vm"
@@ -107,6 +108,26 @@ func (db *DB) DeleteWhere(constraint string) (int, error) {
 		total += deleted
 	}
 	return total, fmt.Errorf("classad-db: DeleteWhere did not converge in %d rounds for %q (removed %d)", maxDeleteRounds, constraint, total)
+}
+
+// KeysWhere returns an iterator over the storage keys of every row whose ad matches constraint.
+// Unlike a query, it yields the DB keys themselves, so a caller can address matched rows for
+// UPDATE/DELETE without depending on any self-reported key attribute in the ad. The constraint is
+// parsed eagerly (a parse error returns before any scan); the scan is lazy and stops early if the
+// caller's yield returns false. It matches against decoded ads (a full scan, like DeleteWhere).
+func (db *DB) KeysWhere(constraint string) (iter.Seq[string], error) {
+	q, err := vm.Parse(constraint)
+	if err != nil {
+		return nil, fmt.Errorf("classad-db: bad constraint %q: %w", constraint, err)
+	}
+	return func(yield func(string) bool) {
+		db.c.ForEachAd(func(key string, ad *classad.ClassAd) bool {
+			if q.Matches(ad) {
+				return yield(key)
+			}
+			return true
+		})
+	}, nil
 }
 
 // matchingKeys collects up to limit keys whose ads currently match q.

--- a/dbrpc/go.mod
+++ b/dbrpc/go.mod
@@ -4,12 +4,12 @@ go 1.25.0
 
 require (
 	github.com/PelicanPlatform/classad v0.7.0
+	github.com/PelicanPlatform/classad/collections v0.7.0
 	github.com/PelicanPlatform/classad/db v0.7.1
 	github.com/bbockelm/cedar v0.5.3
 )
 
 require (
-	github.com/PelicanPlatform/classad/collections v0.7.0 // indirect
 	github.com/RoaringBitmap/roaring/v2 v2.19.0 // indirect
 	github.com/bits-and-blooms/bitset v1.24.4 // indirect
 	github.com/klauspost/compress v1.19.0 // indirect

--- a/dbrpc/proto.go
+++ b/dbrpc/proto.go
@@ -141,6 +141,11 @@ const (
 	// the server (using the archive's zone-map pruning) and only the grouped rows cross the
 	// wire, instead of the client fetching and counting every matched ad.
 	opArchiveAggregate op = 53 // [name][constraint][nGroup]{[attr]}[nAgg]{[func u8][arg]} -> stream of [group...][agg...]
+
+	// opQueryKeys streams the storage KEYS of the rows matching a constraint (not their ads), so a
+	// caller can address matched rows for UPDATE/DELETE by their real db key regardless of whether
+	// the ad carries a self-reported key attribute. Read-only.
+	opQueryKeys op = 54 // [table][constraint] -> stream of [key]
 )
 
 // String names an opcode for diagnostics (e.g. the read-only rejection message).
@@ -230,6 +235,8 @@ func (o op) String() string {
 		return "CommitIdempotent"
 	case opArchiveAggregate:
 		return "ArchiveAggregate"
+	case opQueryKeys:
+		return "QueryKeys"
 	}
 	return "op(unknown)"
 }

--- a/dbrpc/querykeys_test.go
+++ b/dbrpc/querykeys_test.go
@@ -1,0 +1,86 @@
+package dbrpc
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/classad"
+	"github.com/PelicanPlatform/classad/db"
+)
+
+// TestRPCQueryKeys: the keys-by-constraint op returns the real storage keys of matching rows --
+// even rows that carry no "Key" attribute (the whole point: UPDATE/DELETE can address them).
+func TestRPCQueryKeys(t *testing.T) {
+	c, cleanup := testPair(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	tx, err := c.Begin(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// None of these carry a "Key" attribute; the storage key is supplied separately.
+	_ = tx.NewClassAd(ctx, "0O.-1", `MyType = "Owner"`+"\n"+`State = "Idle"`)
+	_ = tx.NewClassAd(ctx, "0O.-2", `MyType = "Owner"`+"\n"+`State = "Idle"`)
+	_ = tx.NewClassAd(ctx, "1.0", `MyType = "Job"`+"\n"+`State = "Claimed"`)
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := c.QueryKeysTable(ctx, DefaultTable, `MyType == "Owner"`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sort.Strings(got)
+	want := []string{"0O.-1", "0O.-2"}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("QueryKeysTable = %v, want %v (real storage keys of the Key-less Owner rows)", got, want)
+	}
+
+	// A constraint matching nothing yields no keys (not an error).
+	none, err := c.QueryKeysTable(ctx, DefaultTable, `MyType == "Nonesuch"`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(none) != 0 {
+		t.Fatalf("no-match query returned %v, want empty", none)
+	}
+
+	// A bad constraint is a clean error, not a panic/hang.
+	if _, err := c.QueryKeysTable(ctx, DefaultTable, `State ==`); err == nil {
+		t.Fatal("a malformed constraint should error")
+	}
+}
+
+// TestRPCQueryKeysReadOnly confirms keys-by-constraint is a read (allowed on a read-only conn).
+func TestRPCQueryKeysReadOnly(t *testing.T) {
+	d, err := db.Open("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Seed a Key-less row via the store directly.
+	ad, err := classad.ParseOld(`MyType = "Owner"`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tx := d.Begin()
+	tx.NewClassAd("k1", ad)
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+
+	s := NewServer(d)
+	cconn, sconn := netPipe()
+	go func() { _ = s.ServeConnOpts(sconn, ServeOptions{ReadOnly: true}) }()
+	c := NewClient(cconn)
+	defer func() { c.Close(); s.Close(); d.Close() }()
+
+	keys, err := c.QueryKeysTable(context.Background(), DefaultTable, `MyType == "Owner"`)
+	if err != nil {
+		t.Fatalf("QueryKeys on a read-only connection should be allowed: %v", err)
+	}
+	if len(keys) != 1 || keys[0] != "k1" {
+		t.Fatalf("QueryKeys = %v, want [k1]", keys)
+	}
+}

--- a/dbrpc/queryraw.go
+++ b/dbrpc/queryraw.go
@@ -53,6 +53,34 @@ func (c *Client) QueryRawTableStream(ctx context.Context, table, constraint stri
 	}, yield)
 }
 
+// QueryKeys streams the storage keys of the rows matching constraint on the default table.
+func (c *Client) QueryKeys(ctx context.Context, constraint string, yield func(key string) bool) error {
+	return c.QueryKeysTableStream(ctx, DefaultTable, constraint, yield)
+}
+
+// QueryKeysTableStream streams the storage KEYS of the rows matching constraint on the named
+// table (not their ads), so a caller can address matched rows for UPDATE/DELETE by their real db
+// key regardless of whether the ad carries a self-reported key attribute. Read-only.
+func (c *Client) QueryKeysTableStream(ctx context.Context, table, constraint string, yield func(key string) bool) error {
+	return c.streamEach(ctx, func(id uint64) []byte {
+		return putStr(putStr(req(id, opQueryKeys), table), constraint)
+	}, yield)
+}
+
+// QueryKeysTable collects all matching storage keys into a slice (streamed under the hood, so the
+// server never buffers the whole set). Suitable for the bounded match sets of an UPDATE/DELETE.
+func (c *Client) QueryKeysTable(ctx context.Context, table, constraint string) ([]string, error) {
+	var keys []string
+	err := c.QueryKeysTableStream(ctx, table, constraint, func(key string) bool {
+		keys = append(keys, key)
+		return true
+	})
+	if err != nil {
+		return nil, err
+	}
+	return keys, nil
+}
+
 // QueryRawProjectStream is QueryRawProject (server-side projection) with the streaming
 // delivery of QueryRawTableStream.
 func (c *Client) QueryRawProjectStream(ctx context.Context, table, constraint string, attrs []string, limit int, yield func(row string) bool) error {

--- a/dbrpc/server.go
+++ b/dbrpc/server.go
@@ -431,6 +431,8 @@ func (sc *serverConn) dispatch(frame []byte) {
 		sc.streamArchiveQuery(reqID, body)
 	case opArchiveAggregate:
 		sc.streamArchiveAggregate(reqID, body)
+	case opQueryKeys:
+		sc.s.streamQueryKeys(sc.ctx, reqID, body, sc.write)
 	case opWatchStop:
 		sc.stopWatch(body.u64())
 		sc.write(resp(reqID, stOK))
@@ -529,6 +531,35 @@ type viewSealer interface {
 // streamQuery streams the committed ads matching a constraint. Each result is its own
 // frame under reqID, so its frames interleave with other calls' -- no head-of-line
 // blocking -- and end with a terminator.
+// streamQueryKeys streams the storage keys of the rows matching a constraint (not their ads), so a
+// caller can address matched rows for UPDATE/DELETE by their real db key regardless of any
+// self-reported key attribute. Read-only; no private-attribute exposure (keys are returned, not ad
+// bodies). The constraint is still evaluated server-side, so it may reference any attribute.
+func (s *Server) streamQueryKeys(ctx context.Context, reqID uint64, r *reader, write func([]byte)) {
+	table := r.str()
+	constraint := r.str()
+	if r.err != nil {
+		write(respBad(reqID))
+		return
+	}
+	d, ok := s.tableOr(reqID, table, write)
+	if !ok {
+		return
+	}
+	seq, err := d.KeysWhere(constraint)
+	if err != nil {
+		write(respErr(reqID, err.Error()))
+		return
+	}
+	for key := range seq {
+		if cancelled(ctx) {
+			return // client gone: stop the scan
+		}
+		write(putStr(respHead(reqID, stStream), key))
+	}
+	write(respHead(reqID, stStreamEnd))
+}
+
 func (s *Server) streamQuery(ctx context.Context, reqID uint64, r *reader, includePrivate bool, write func([]byte), qlog func(QueryLog)) {
 	start := time.Now()
 	table := r.str()


### PR DESCRIPTION
Adds a read op that streams the **storage keys** of the rows matching a constraint (not their ads), so a caller can address matched rows for UPDATE/DELETE by their real db key regardless of whether the ad carries a self-reported key attribute.

**Motivation:** htcondordb consistent-mode (raft) DELETE/UPDATE recover each matched row's key from a `Key` **attribute** on the ad; Key-less rows (crufty `Owner` records, rows written before key-stamping) couldn't be addressed. The server already turns a constraint into storage keys internally (`db.matchingKeys` → `Collection.ForEachAd`, used by `DeleteWhere`); this exposes it as a first-class op.

## Changes
- **db**: `DB.KeysWhere(constraint) (iter.Seq[string], error)` — constraint parsed eagerly (parse error before any scan); the scan is lazy (`ForEachAd` + `q.Matches`, same as `DeleteWhere`) and stops early when the caller's `yield` returns false.
- **dbrpc**: `opQueryKeys` (54), streamed `[table][constraint] -> stream of [key]`. A **read** (allowed on read-only connections; returns keys only, never ad bodies). Client: `QueryKeysTableStream` (streaming), `QueryKeysTable` (slice collector, streamed under the hood), `QueryKeys` (default table).
- go.mod: `go mod tidy` promoted `collections` from `// indirect` to direct (`queryraw.go` already imported it — a pre-existing mislabel).

## Tests
- **db** `TestKeysWhere`: keys for Key-less rows; no-match yields empty; bad constraint errors; early break stops the scan.
- **dbrpc** `TestRPCQueryKeys`: round-trip returns real storage keys for rows **without** a `Key` attribute; `TestRPCQueryKeysReadOnly`: allowed on a read-only connection.
- Full `db` + `dbrpc` suites + `go vet` green.

## Follow-up (separate, after tag + bump)
htcondordb `repl.matchedKeys` calls `QueryKeysTable` instead of reading a `Key` attribute — fixes consistent-mode UPDATE/DELETE on Key-less rows and deletes the `"a matched row has no Key attribute"` error path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
