### PR TITLE
changefeed: pin classad deps to v0.21.0 (unblock a valid tag)

### DIFF
--- a/changefeed/go.mod
+++ b/changefeed/go.mod
@@ -3,9 +3,9 @@ module github.com/PelicanPlatform/classad/changefeed
 go 1.25.0
 
 require (
-	github.com/PelicanPlatform/classad v0.20.4
-	github.com/PelicanPlatform/classad/collections v0.20.4
-	github.com/PelicanPlatform/classad/db v0.20.4
+	github.com/PelicanPlatform/classad v0.21.0
+	github.com/PelicanPlatform/classad/collections v0.21.0
+	github.com/PelicanPlatform/classad/db v0.21.0
 )
 
 require (


### PR DESCRIPTION
The merged changefeed go.mod still requires db v0.20.4, which predates db/replicate — it only builds via the local replace, and is broken for external consumers (and for a clean module tag). Bump the requires to v0.21.0.

Prereq for tagging changefeed/v0.21.0.

\U0001F916 Generated with [Claude Code](https://claude.com/claude-code)