### PR TITLE
collections: bounded-range index probes, batched posting unions, in-place sidecar re-index

### DIFF
--- a/collections/archive.go
+++ b/collections/archive.go
@@ -261,14 +261,14 @@ func (a *Archive) RetrainDict(sampleMax int) (int, error) { return a.c.RetrainDi
 // records rewritten.
 func (a *Archive) Rewrite() int { return a.c.Rewrite() }
 
-// AddIndex adds per-segment indexes on the named categorical and/or value attributes.
+// AddIndex adds per-segment indexes on the named categorical and/or value attributes and
+// rebuilds every segment's index under the new set, so existing records are covered too.
 // Returns false if the index set was unchanged.
 //
-// Reach: it takes effect immediately for segments not yet sealed to an immutable sidecar,
-// and for every segment sealed from now on. Segments ALREADY sealed keep the index they
-// were sealed with -- Reindex cannot rewrite an immutable sidecar -- so an existing archive
-// only picks the new index up everywhere after a Rewrite, which re-encodes the whole store.
-// StaleIndexSegments reports how many segments are still on the old configuration.
+// Cost: the rebuild decompresses every record in the archive once. It does NOT rewrite any
+// segment data -- a sealed segment's bytes are already correct and are left untouched; only
+// the derived index sidecar beside them is rebuilt (see Collection.reindexSealed). That is
+// the difference from Rewrite, which re-encodes and rewrites the whole store.
 func (a *Archive) AddIndex(categorical, value []string) bool {
 	if !a.c.AddIndex(categorical, value) {
 		return false
@@ -280,8 +280,9 @@ func (a *Archive) AddIndex(categorical, value []string) bool {
 // DropIndex removes the named per-segment indexes. Returns false if none matched.
 func (a *Archive) DropIndex(names ...string) bool { return a.c.DropIndex(names...) }
 
-// Reindex rebuilds the per-segment indexes over all segments (e.g. to pick up segments
-// sealed since the last build).
+// Reindex rebuilds the per-segment indexes over all segments: those sealed since the last
+// build, and those whose sidecar was built under a superseded index configuration. Segment
+// data is never touched.
 func (a *Archive) Reindex() { a.c.Reindex() }
 
 // SetRetention updates the retention bounds at runtime; the next Rotate enforces them.
@@ -314,7 +315,9 @@ func (a *Archive) IndexedAttrs() (categorical, value []string) { return a.c.Inde
 func (a *Archive) ZoneAttrs() []string { return a.c.ZoneAttrs() }
 
 // StaleIndexSegments reports how many of the archive's sealed segments still carry an index
-// built under an older configuration, and how many are sealed in total. See AddIndex.
+// built under an older configuration, and how many are sealed in total. Normally zero:
+// AddIndex/DropIndex rebuild as they go. A non-zero count means a rebuild was interrupted or
+// failed (it is best-effort per segment); a Reindex retries those segments.
 func (a *Archive) StaleIndexSegments() (stale, sealed int) { return a.c.StaleIndexSegments() }
 
 // --- zone-map helpers (shared with the Collection's per-segment zone maps) ---

--- a/collections/archive.go
+++ b/collections/archive.go
@@ -261,9 +261,14 @@ func (a *Archive) RetrainDict(sampleMax int) (int, error) { return a.c.RetrainDi
 // records rewritten.
 func (a *Archive) Rewrite() int { return a.c.Rewrite() }
 
-// AddIndex adds per-segment indexes on the named categorical and/or value attributes and
-// rebuilds them over the existing segments, so subsequent queries on those attributes are
-// accelerated. Returns false if the index set was unchanged.
+// AddIndex adds per-segment indexes on the named categorical and/or value attributes.
+// Returns false if the index set was unchanged.
+//
+// Reach: it takes effect immediately for segments not yet sealed to an immutable sidecar,
+// and for every segment sealed from now on. Segments ALREADY sealed keep the index they
+// were sealed with -- Reindex cannot rewrite an immutable sidecar -- so an existing archive
+// only picks the new index up everywhere after a Rewrite, which re-encodes the whole store.
+// StaleIndexSegments reports how many segments are still on the old configuration.
 func (a *Archive) AddIndex(categorical, value []string) bool {
 	if !a.c.AddIndex(categorical, value) {
 		return false
@@ -303,6 +308,14 @@ func (a *Archive) IndexSizes() IndexSizes { return a.c.IndexSizes() }
 
 // IndexedAttrs returns the categorical and value attributes the archive indexes.
 func (a *Archive) IndexedAttrs() (categorical, value []string) { return a.c.IndexedAttrs() }
+
+// ZoneAttrs returns the attributes carrying per-segment [min,max] zone maps -- the ones a
+// range query prunes whole segments on, not just postings.
+func (a *Archive) ZoneAttrs() []string { return a.c.ZoneAttrs() }
+
+// StaleIndexSegments reports how many of the archive's sealed segments still carry an index
+// built under an older configuration, and how many are sealed in total. See AddIndex.
+func (a *Archive) StaleIndexSegments() (stale, sealed int) { return a.c.StaleIndexSegments() }
 
 // --- zone-map helpers (shared with the Collection's per-segment zone maps) ---
 

--- a/collections/archive_indexinfo_test.go
+++ b/collections/archive_indexinfo_test.go
@@ -1,7 +1,15 @@
 package collections
 
 import (
+	"crypto/sha256"
+	"fmt"
+	"io/fs"
+	"maps"
+	"os"
+	"path/filepath"
 	"slices"
+	"strings"
+	"sync"
 	"testing"
 )
 
@@ -35,18 +43,23 @@ func TestArchiveIndexIntrospection(t *testing.T) {
 	}
 }
 
-// TestArchiveAddIndexZonesAndReach pins the two things an operator needs to know when
-// indexing an existing archive: a value index added at runtime becomes zone-mapped like one
-// configured at creation, and it does NOT reach already-sealed segments until a rewrite.
-func TestArchiveAddIndexZonesAndReach(t *testing.T) {
+// TestArchiveAddIndexReindexesInPlace is the point of a re-index as distinct from a
+// rewrite: adding an index to an existing archive must reach every already-sealed segment
+// by rebuilding only their index sidecars, leaving all segment DATA byte-for-byte untouched.
+// It also checks that a value index added at runtime becomes zone-mapped, as one configured
+// at creation would be.
+func TestArchiveAddIndexReindexesInPlace(t *testing.T) {
 	t.Parallel()
-	a, src := buildArchive(t, t.TempDir(), 400, ArchiveOptions{
-		CategoricalAttrs: []string{"Owner"},
-	})
+	dir := t.TempDir()
+	a, src := buildArchive(t, dir, 400, ArchiveOptions{CategoricalAttrs: []string{"Owner"}})
 	defer a.Close()
 	if got := a.ZoneAttrs(); len(got) != 0 {
 		t.Fatalf("zone attrs = %v, want none (no value or zone attrs configured)", got)
 	}
+	if _, sealed := a.StaleIndexSegments(); sealed == 0 {
+		t.Fatal("expected several sealed segments")
+	}
+	before := hashArchiveData(t, dir)
 
 	if !a.AddIndex(nil, []string{"CompletionDate"}) {
 		t.Fatal("AddIndex reported no change")
@@ -54,20 +67,17 @@ func TestArchiveAddIndexZonesAndReach(t *testing.T) {
 	if got := a.ZoneAttrs(); !slices.Contains(got, "CompletionDate") {
 		t.Errorf("zone attrs = %v, want CompletionDate: a runtime value index should be zoned too", got)
 	}
-
-	// The segments sealed before the add keep their old index set.
-	stale, sealed := a.StaleIndexSegments()
-	if sealed == 0 {
-		t.Fatal("expected several sealed segments")
+	// Every sealed segment now carries an index built under the current configuration.
+	if stale, sealed := a.StaleIndexSegments(); stale != 0 {
+		t.Errorf("stale/sealed = %d/%d, want 0 stale: the sidecars are rebuilt in place", stale, sealed)
 	}
-	if stale != sealed {
-		t.Errorf("stale/sealed = %d/%d, want every already-sealed segment stale", stale, sealed)
+	// ... and not one byte of segment data was rewritten to get there.
+	after := hashArchiveData(t, dir)
+	if len(before) == 0 {
+		t.Fatal("no segment data files found")
 	}
-
-	// A rewrite re-encodes every segment, so all sidecars are rebuilt on the current set.
-	a.Rewrite()
-	if stale, sealed = a.StaleIndexSegments(); stale != 0 {
-		t.Errorf("after rewrite stale/sealed = %d/%d, want 0 stale", stale, sealed)
+	if !maps.Equal(before, after) {
+		t.Errorf("segment data changed: a re-index must not rewrite data\n before=%v\n after=%v", before, after)
 	}
 
 	// Correctness is unchanged throughout: the new index is a pruning aid, not a filter.
@@ -75,6 +85,7 @@ func TestArchiveAddIndexZonesAndReach(t *testing.T) {
 		`CompletionDate > 1700000100`,
 		`CompletionDate > 1700000100 && CompletionDate < 1700000200`,
 		`Owner == "carol" && CompletionDate >= 1700000300`,
+		`CompletionDate > 1700000900`, // above every value: fully pruned
 	} {
 		got := archiveQueryIDs(t, a, qs)
 		want := bruteIDs(src, mustQuery(t, qs))
@@ -82,4 +93,116 @@ func TestArchiveAddIndexZonesAndReach(t *testing.T) {
 			t.Errorf("%s: got %d ads, want %d", qs, len(got), len(want))
 		}
 	}
+}
+
+// TestArchiveReindexSurvivesReopen checks that an in-place re-indexed sidecar is the one
+// found on reopen -- i.e. the rebuild really replaced the on-disk sidecar, rather than only
+// the in-process mapping.
+func TestArchiveReindexSurvivesReopen(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	opts := ArchiveOptions{CategoricalAttrs: []string{"Owner"}}
+	a, src := buildArchive(t, dir, 400, opts)
+	if !a.AddIndex(nil, []string{"CompletionDate"}) {
+		t.Fatal("AddIndex reported no change")
+	}
+	if err := a.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	opts.Dir = dir
+	opts.ValueAttrs = []string{"CompletionDate"} // the config a restart would replay
+	b, err := OpenArchive(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer b.Close()
+	if stale, sealed := b.StaleIndexSegments(); stale != 0 {
+		t.Errorf("after reopen stale/sealed = %d/%d, want the rebuilt sidecars to load", stale, sealed)
+	}
+	for _, qs := range []string{`CompletionDate > 1700000100`, `CompletionDate > 1700000100 && CompletionDate < 1700000200`} {
+		got := archiveQueryIDs(t, b, qs)
+		want := bruteIDs(src, mustQuery(t, qs))
+		if !equalInts(got, want) {
+			t.Errorf("after reopen %s: got %d ads, want %d", qs, len(got), len(want))
+		}
+	}
+}
+
+// hashArchiveData fingerprints every file under dir that is NOT an index sidecar, so a test
+// can assert that a re-index left the segment data alone.
+func hashArchiveData(t *testing.T, dir string) map[string]string {
+	t.Helper()
+	out := map[string]string{}
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() || strings.HasSuffix(path, ".idx") {
+			return err
+		}
+		b, rerr := os.ReadFile(path)
+		if rerr != nil {
+			return rerr
+		}
+		rel, _ := filepath.Rel(dir, path)
+		out[rel] = fmt.Sprintf("%x", sha256.Sum256(b))
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", dir, err)
+	}
+	return out
+}
+
+// TestArchiveReindexUnderConcurrentScans is the safety anchor for swapping a sealed
+// segment's sidecar while it is being read. A scan's candidate bitmaps are zero-copy views
+// into the mapping, so releasing a displaced mapping one pin too early is a use-after-munmap
+// (a crash, not a wrong answer). Readers hammer the archive while an indexer forces repeated
+// sidecar swaps; every query must keep returning the brute-force answer.
+func TestArchiveReindexUnderConcurrentScans(t *testing.T) {
+	t.Parallel()
+	a, src := buildArchive(t, t.TempDir(), 1200, ArchiveOptions{
+		CategoricalAttrs: []string{"Owner"},
+		ValueAttrs:       []string{"Memory"},
+	})
+	defer a.Close()
+
+	queries := []string{
+		`Memory > 2048`,
+		`Memory > 2048 && Memory < 6144`,
+		`Owner == "carol"`,
+		`CompletionDate > 1700000600`,
+		`Owner == "bob" && Memory >= 4096`,
+	}
+	want := make([][]int, len(queries))
+	for i, qs := range queries {
+		want[i] = bruteIDs(src, mustQuery(t, qs))
+	}
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+	for r := 0; r < 6; r++ {
+		wg.Add(1)
+		go func(r int) {
+			defer wg.Done()
+			for n := 0; ; n++ {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				i := (r + n) % len(queries)
+				if got := archiveQueryIDs(t, a, queries[i]); !equalInts(got, want[i]) {
+					t.Errorf("%s: got %d ads, want %d", queries[i], len(got), len(want[i]))
+					return
+				}
+			}
+		}(r)
+	}
+	// Each add/drop bumps the spec generation, so every sealed sidecar is rebuilt and its
+	// predecessor queued for release -- exactly the window under test.
+	for i := 0; i < 6; i++ {
+		a.AddIndex(nil, []string{"CompletionDate"})
+		a.DropIndex("CompletionDate")
+	}
+	close(stop)
+	wg.Wait()
 }

--- a/collections/archive_indexinfo_test.go
+++ b/collections/archive_indexinfo_test.go
@@ -1,0 +1,85 @@
+package collections
+
+import (
+	"slices"
+	"testing"
+)
+
+// TestArchiveIndexIntrospection covers what `.indexes <archive>` reports: the configured
+// index attributes and the zone-mapped ones. Zone maps cover the explicit ZoneAttrs plus
+// every value-indexed attribute, which is what makes a range query prune whole segments.
+func TestArchiveIndexIntrospection(t *testing.T) {
+	t.Parallel()
+	a, _ := buildArchive(t, t.TempDir(), 400, ArchiveOptions{
+		CategoricalAttrs: []string{"Owner", "JobStatus"},
+		ValueAttrs:       []string{"Memory"},
+		ZoneAttrs:        []string{"CompletionDate"},
+	})
+	defer a.Close()
+
+	cat, val := a.IndexedAttrs()
+	if !slices.Contains(cat, "Owner") || !slices.Contains(cat, "JobStatus") {
+		t.Errorf("categorical indexes = %v, want Owner and JobStatus", cat)
+	}
+	if !slices.Contains(val, "Memory") {
+		t.Errorf("value indexes = %v, want Memory", val)
+	}
+	zones := a.ZoneAttrs()
+	for _, want := range []string{"CompletionDate", "Memory"} {
+		if !slices.Contains(zones, want) {
+			t.Errorf("zone attrs = %v, want %s (explicit zone attrs plus value-indexed ones)", zones, want)
+		}
+	}
+	if slices.Contains(zones, "Owner") {
+		t.Errorf("zone attrs = %v: a categorical index is not zone-mapped", zones)
+	}
+}
+
+// TestArchiveAddIndexZonesAndReach pins the two things an operator needs to know when
+// indexing an existing archive: a value index added at runtime becomes zone-mapped like one
+// configured at creation, and it does NOT reach already-sealed segments until a rewrite.
+func TestArchiveAddIndexZonesAndReach(t *testing.T) {
+	t.Parallel()
+	a, src := buildArchive(t, t.TempDir(), 400, ArchiveOptions{
+		CategoricalAttrs: []string{"Owner"},
+	})
+	defer a.Close()
+	if got := a.ZoneAttrs(); len(got) != 0 {
+		t.Fatalf("zone attrs = %v, want none (no value or zone attrs configured)", got)
+	}
+
+	if !a.AddIndex(nil, []string{"CompletionDate"}) {
+		t.Fatal("AddIndex reported no change")
+	}
+	if got := a.ZoneAttrs(); !slices.Contains(got, "CompletionDate") {
+		t.Errorf("zone attrs = %v, want CompletionDate: a runtime value index should be zoned too", got)
+	}
+
+	// The segments sealed before the add keep their old index set.
+	stale, sealed := a.StaleIndexSegments()
+	if sealed == 0 {
+		t.Fatal("expected several sealed segments")
+	}
+	if stale != sealed {
+		t.Errorf("stale/sealed = %d/%d, want every already-sealed segment stale", stale, sealed)
+	}
+
+	// A rewrite re-encodes every segment, so all sidecars are rebuilt on the current set.
+	a.Rewrite()
+	if stale, sealed = a.StaleIndexSegments(); stale != 0 {
+		t.Errorf("after rewrite stale/sealed = %d/%d, want 0 stale", stale, sealed)
+	}
+
+	// Correctness is unchanged throughout: the new index is a pruning aid, not a filter.
+	for _, qs := range []string{
+		`CompletionDate > 1700000100`,
+		`CompletionDate > 1700000100 && CompletionDate < 1700000200`,
+		`Owner == "carol" && CompletionDate >= 1700000300`,
+	} {
+		got := archiveQueryIDs(t, a, qs)
+		want := bruteIDs(src, mustQuery(t, qs))
+		if !equalInts(got, want) {
+			t.Errorf("%s: got %d ads, want %d", qs, len(got), len(want))
+		}
+	}
+}

--- a/collections/archive_mmapindex.go
+++ b/collections/archive_mmapindex.go
@@ -152,17 +152,20 @@ func (si *mmapSegIndex) probeOffsets(up usableProbe) *roaring.Bitmap {
 		postedOff := le32(si.data, attrOff+4)
 		switch up.op {
 		case "==", "in":
-			bm := roaring.New()
 			// Bloom fast path: if every probe value is definitely absent, skip the
 			// per-value binary search over the (paged) sorted key blob entirely; only
 			// the exceptional records can still match and are re-verified upstream.
-			if !si.catBloomAllAbsent(attrOff, up.svals) {
-				for _, s := range up.svals {
-					if off, ok := si.catFindEq(attrOff, s); ok {
-						bm.Or(si.bitmapAt(off))
-					}
-				}
+			n := len(up.svals)
+			if si.catBloomAllAbsent(attrOff, up.svals) {
+				n = 0
 			}
+			bm := unionPostings(n, func(i int) *roaring.Bitmap {
+				off, ok := si.catFindEq(attrOff, up.svals[i])
+				if !ok {
+					return nil
+				}
+				return si.bitmapAt(off)
+			})
 			bm.Or(si.bitmapAt(excOff))
 			return bm
 		case "!=":
@@ -202,12 +205,13 @@ func (si *mmapSegIndex) probeOffsets(up usableProbe) *roaring.Bitmap {
 	postedOff := le32(si.data, attrOff+4)
 	switch up.op {
 	case "==", "in":
-		bm := roaring.New()
-		for _, f := range up.fvals {
-			if off, ok := si.valFind(attrOff, f); ok {
-				bm.Or(si.bitmapAt(off))
+		bm := unionPostings(len(up.fvals), func(i int) *roaring.Bitmap {
+			off, ok := si.valFind(attrOff, up.fvals[i])
+			if !ok {
+				return nil
 			}
-		}
+			return si.bitmapAt(off)
+		})
 		bm.Or(si.bitmapAt(excOff))
 		return bm
 	case "!=":
@@ -225,7 +229,7 @@ func (si *mmapSegIndex) probeOffsets(up usableProbe) *roaring.Bitmap {
 		bm.AndNot(si.bitmapAt(postedOff))
 		return bm
 	case "<", "<=", ">", ">=":
-		bm := si.valRange(attrOff, up.op, up.fvals[0])
+		bm := si.valRange(attrOff, up)
 		bm.Or(si.bitmapAt(excOff))
 		return bm
 	}
@@ -445,31 +449,22 @@ func (si *mmapSegIndex) valFind(attrOff uint32, f float64) (bmOff uint32, ok boo
 	return 0, false
 }
 
-// valRange ORs the bitmaps of every key satisfying (op, t). Keys are sorted, so a
-// boundary search bounds the scan to the matching run — only those keys' pages and
-// bitmaps are touched.
-func (si *mmapSegIndex) valRange(attrOff uint32, op string, t float64) *roaring.Bitmap {
+// valRange unions the bitmaps of every key satisfying up's range bound(s). Keys are
+// sorted, so a boundary search bounds the scan to the matching run — only those keys'
+// pages and bitmaps are touched — and a two-sided probe bounds it at both ends, paging
+// in just the band rather than everything above (or below) one threshold.
+func (si *mmapSegIndex) valRange(attrOff uint32, up usableProbe) *roaring.Bitmap {
 	d := si.data
 	n := int(le32(d, attrOff+8))
 	keyBase := attrOff + 12
 	bmOffBase := keyBase + uint32(n)*8
-	bm := roaring.New()
 	// [from, to) is the index range of matching keys.
-	var from, to int
-	switch op {
-	case ">":
-		from, to = si.upperBound(keyBase, n, t), n
-	case ">=":
-		from, to = si.lowerBound(keyBase, n, t), n
-	case "<":
-		from, to = 0, si.lowerBound(keyBase, n, t)
-	case "<=":
-		from, to = 0, si.upperBound(keyBase, n, t)
-	}
-	for i := from; i < to; i++ {
-		bm.Or(si.bitmapAt(le32(d, bmOffBase+uint32(i)*4)))
-	}
-	return bm
+	from, to := rangeSpan(up, n,
+		func(t float64) int { return si.lowerBound(keyBase, n, t) },
+		func(t float64) int { return si.upperBound(keyBase, n, t) })
+	return unionPostings(to-from, func(i int) *roaring.Bitmap {
+		return si.bitmapAt(le32(d, bmOffBase+uint32(from+i)*4))
+	})
 }
 
 // lowerBound returns the first index i with key[i] >= t (or n).

--- a/collections/index_dynamic.go
+++ b/collections/index_dynamic.go
@@ -126,11 +126,10 @@ func (c *Collection) DropIndex(names ...string) bool {
 // StaleIndexSegments counts sealed segments whose index sidecar was built under an older
 // index configuration than the current one, and the total number of sealed segments.
 //
-// A sealed segment's sidecar is immutable: Reindex deliberately skips it, so AddIndex /
-// DropIndex only reach segments sealed afterwards. Rewrite rebuilds every segment and
-// therefore every sidecar, which is how an existing archive picks up a new index -- at the
-// cost of re-encoding the whole store. Reporting the count lets `.indexes` say plainly that
-// an added index is not live everywhere yet instead of leaving the operator to wonder.
+// A sealed segment's sidecar is immutable, but it is also derived: Reindex rebuilds a stale
+// one in place (a new mapping beside the live one, swapped atomically) without touching the
+// segment data, so this is normally zero. A non-zero count means some segment's rebuild did
+// not complete -- resealing is best-effort per segment -- and a Reindex will retry it.
 func (c *Collection) StaleIndexSegments() (stale, sealed int) {
 	gen := c.spec.Load().gen
 	for _, sh := range c.shards {

--- a/collections/index_dynamic.go
+++ b/collections/index_dynamic.go
@@ -78,6 +78,12 @@ func (c *Collection) addIndex(categorical, value []string, auto bool) bool {
 		}
 		next.gen = cur.gen + 1
 		if c.spec.CompareAndSwap(cur, next) {
+			// An append-only collection zones every value-indexed attribute (New wires
+			// ZoneAttrs and ValueAttrs together), so a value index added at runtime must
+			// extend the zone set too -- otherwise a range query on it would prune
+			// postings but never whole segments, unlike an identical index configured at
+			// creation. No-op for a mutable collection.
+			c.addZoneAttrs(value)
 			return true
 		}
 	}
@@ -115,6 +121,37 @@ func (c *Collection) DropIndex(names ...string) bool {
 			return true
 		}
 	}
+}
+
+// StaleIndexSegments counts sealed segments whose index sidecar was built under an older
+// index configuration than the current one, and the total number of sealed segments.
+//
+// A sealed segment's sidecar is immutable: Reindex deliberately skips it, so AddIndex /
+// DropIndex only reach segments sealed afterwards. Rewrite rebuilds every segment and
+// therefore every sidecar, which is how an existing archive picks up a new index -- at the
+// cost of re-encoding the whole store. Reporting the count lets `.indexes` say plainly that
+// an added index is not live everywhere yet instead of leaving the operator to wonder.
+func (c *Collection) StaleIndexSegments() (stale, sealed int) {
+	gen := c.spec.Load().gen
+	for _, sh := range c.shards {
+		sh.mu.RLock()
+		segs := append([]*segment(nil), sh.segs...)
+		sh.mu.RUnlock()
+		for _, seg := range segs {
+			if seg == nil {
+				continue
+			}
+			mm := seg.msidx.Load()
+			if mm == nil {
+				continue // not sealed to a sidecar: Reindex still rebuilds it in place
+			}
+			sealed++
+			if mm.specGen != gen {
+				stale++
+			}
+		}
+	}
+	return stale, sealed
 }
 
 // IndexedAttrs returns the currently-indexed attribute names, split by kind, in the

--- a/collections/index_query.go
+++ b/collections/index_query.go
@@ -118,6 +118,181 @@ type usableProbe struct {
 	op     string
 	svals  []string
 	fvals  []float64
+
+	// hiOp/hiVal bound a numeric range probe from above, so a conjunction like
+	// `Memory > 1024 && Memory < 4096` plans as ONE two-sided band rather than two
+	// half-open probes that each union half the key space before intersecting. Set
+	// only when op is ">" or ">=" (coalesceRanges normalizes to lower-bound-first);
+	// empty hiOp means the probe is one-sided.
+	//
+	// The fields are an optimization, never a correctness requirement: a code path
+	// that reads only op/fvals still produces a correct candidate superset -- just a
+	// wider one -- because dropping the upper bound only widens the range.
+	hiOp  string
+	hiVal float64
+}
+
+// twoSided reports whether up carries both bounds of a numeric band.
+func (up usableProbe) twoSided() bool { return up.hiOp != "" }
+
+// isRangeOp reports whether op is an indexable numeric range comparison.
+func isRangeOp(op string) bool {
+	switch op {
+	case "<", "<=", ">", ">=":
+		return true
+	}
+	return false
+}
+
+// coalesceRanges merges the range probes of a conjunction that constrain the same value
+// attribute from both sides into a single two-sided band probe. `Memory > 1024 && Memory
+// < 4096` otherwise plans as two probes, each of which unions the postings of half the
+// attribute's key space (potentially every record in the segment) only for the
+// intersection to throw most of it away; a band scans just the keys inside it.
+//
+// Repeated bounds on one side tighten (`Memory > 1024 && Memory > 2048` keeps > 2048).
+// Probes on other attributes, categorical probes, and non-range operators pass through
+// untouched and keep their input order, so the plan stays deterministic.
+func coalesceRanges(out []usableProbe) []usableProbe {
+	// Fast path: nothing to merge unless two range probes share an attribute.
+	if !hasMergeableRanges(out) {
+		return out
+	}
+	// lo/hi hold the tightest bound seen per attribute, at the slot of its first range
+	// probe; later range probes on that attribute are folded in and dropped.
+	slot := make(map[uint32]int, len(out))
+	merged := out[:0]
+	for _, up := range out {
+		if up.cat || !isRangeOp(up.op) {
+			merged = append(merged, up)
+			continue
+		}
+		i, seen := slot[up.attrID]
+		if !seen {
+			slot[up.attrID] = len(merged)
+			merged = append(merged, up)
+			continue
+		}
+		merged[i] = mergeRange(merged[i], up)
+	}
+	return merged
+}
+
+// hasMergeableRanges reports whether two range probes in the conjunction target the same
+// value attribute (the only case coalesceRanges changes anything).
+func hasMergeableRanges(out []usableProbe) bool {
+	for i, a := range out {
+		if a.cat || !isRangeOp(a.op) {
+			continue
+		}
+		for _, b := range out[i+1:] {
+			if !b.cat && isRangeOp(b.op) && b.attrID == a.attrID {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// mergeRange folds range probe b into a (same attribute), keeping the tightest bound on
+// each side and normalizing to lower-bound-first. A probe that ends up with only an upper
+// bound stays one-sided in "<"/"<=" form.
+func mergeRange(a, b usableProbe) usableProbe {
+	loOp, loVal, hasLo := rangeLow(a)
+	hiOp, hiVal, hasHi := rangeHigh(a)
+	if op, v, ok := rangeLow(b); ok {
+		// Tighter lower bound wins; at equal values the exclusive ">" wins.
+		if !hasLo || v > loVal || (v == loVal && op == ">") {
+			loOp, loVal, hasLo = op, v, true
+		}
+	}
+	if op, v, ok := rangeHigh(b); ok {
+		if !hasHi || v < hiVal || (v == hiVal && op == "<") {
+			hiOp, hiVal, hasHi = op, v, true
+		}
+	}
+	switch {
+	case hasLo && hasHi:
+		return usableProbe{attrID: a.attrID, op: loOp, fvals: []float64{loVal}, hiOp: hiOp, hiVal: hiVal}
+	case hasLo:
+		return usableProbe{attrID: a.attrID, op: loOp, fvals: []float64{loVal}}
+	default:
+		return usableProbe{attrID: a.attrID, op: hiOp, fvals: []float64{hiVal}}
+	}
+}
+
+// rangeLow / rangeHigh decompose a (possibly two-sided) range probe into its bounds.
+func rangeLow(up usableProbe) (op string, val float64, ok bool) {
+	if up.op == ">" || up.op == ">=" {
+		return up.op, up.fvals[0], true
+	}
+	return "", 0, false
+}
+
+func rangeHigh(up usableProbe) (op string, val float64, ok bool) {
+	if up.hiOp != "" {
+		return up.hiOp, up.hiVal, true
+	}
+	if up.op == "<" || up.op == "<=" {
+		return up.op, up.fvals[0], true
+	}
+	return "", 0, false
+}
+
+// rangeBands maps a value attribute to the two-sided probe the planner coalesced its range
+// conjuncts into. nil when the conjunction has no band.
+func rangeBands(usable []usableProbe) map[uint32]usableProbe {
+	var bands map[uint32]usableProbe
+	for _, up := range usable {
+		if up.twoSided() {
+			if bands == nil {
+				bands = make(map[uint32]usableProbe, 1)
+			}
+			bands[up.attrID] = up
+		}
+	}
+	return bands
+}
+
+// applyBand redirects an explain's selectivity estimate for one half of a coalesced range
+// to the whole band (and marks it), since the band is what the planner actually probes.
+// Non-range and un-coalesced probes pass through unchanged.
+func applyBand(bands map[uint32]usableProbe, up usableProbe, pe *ProbeExplain) usableProbe {
+	if bands == nil || up.cat || !isRangeOp(up.op) {
+		return up
+	}
+	if b, ok := bands[up.attrID]; ok {
+		pe.Banded = true
+		return b
+	}
+	return up
+}
+
+// rangeSpan returns the [from,to) index window of a sorted ascending key run that a range
+// probe admits. Both bounds are applied, so a two-sided probe touches only the keys inside
+// its band.
+func rangeSpan(up usableProbe, n int, lowerBound, upperBound func(t float64) int) (from, to int) {
+	from, to = 0, n
+	switch up.op {
+	case ">":
+		from = upperBound(up.fvals[0])
+	case ">=":
+		from = lowerBound(up.fvals[0])
+	case "<":
+		to = lowerBound(up.fvals[0])
+	case "<=":
+		to = upperBound(up.fvals[0])
+	}
+	switch up.hiOp {
+	case "<":
+		to = lowerBound(up.hiVal)
+	case "<=":
+		to = upperBound(up.hiVal)
+	}
+	if to < from {
+		to = from // an empty band (lo above hi): no keys match
+	}
+	return from, to
 }
 
 // planIndex matches the query's probes against the configured indexes. Empty means
@@ -139,6 +314,11 @@ type ProbeExplain struct {
 	HasSelectivity bool    `json:"hasSelectivity"`
 	Selectivity    float64 `json:"selectivity,omitempty"`
 	EstCandidates  int64   `json:"estCandidates,omitempty"`
+
+	// Banded marks a range conjunct the planner merged with the opposite bound on the
+	// same attribute (`Memory > 1024 && Memory < 4096`) into a single two-sided index
+	// probe. Selectivity/EstCandidates then describe the band, not this half of it.
+	Banded bool `json:"banded,omitempty"`
 }
 
 // QueryExplain is a description of how the store would execute a query, for the
@@ -176,11 +356,13 @@ func (c *Collection) ExplainQuery(q *vm.Query) QueryExplain {
 		Shards:      len(c.shards),
 		TotalAds:    total,
 	}
+	bands := rangeBands(usable)
 	for _, p := range probes {
 		pe := ProbeExplain{Attr: p.Attr, Op: p.Op}
 		var up usableProbe
 		var isUsable bool
 		pe.Indexed, pe.Kind, up, isUsable = c.probeIndexKind(p)
+		up = applyBand(bands, up, &pe)
 		if isUsable {
 			if cand, covered := c.estimateCandidates(up); covered {
 				pe.HasSelectivity = true
@@ -302,7 +484,7 @@ func (c *Collection) planIndex(probes []vm.Probe) []usableProbe {
 			}
 		}
 	}
-	return out
+	return coalesceRanges(out)
 }
 
 func catUsable(id uint32, p vm.Probe) (usableProbe, bool) {
@@ -564,12 +746,7 @@ func (si *segIndex) probeOffsets(up usableProbe) *roaring.Bitmap {
 		cp := si.cat[up.attrID]
 		switch up.op {
 		case "==", "in":
-			bm := roaring.New()
-			for _, s := range up.svals {
-				if p := cp.post[s]; p != nil {
-					bm.Or(p)
-				}
-			}
+			bm := unionPostings(len(up.svals), func(i int) *roaring.Bitmap { return cp.post[up.svals[i]] })
 			bm.Or(cp.exc)
 			return bm
 		case "!=":
@@ -603,12 +780,7 @@ func (si *segIndex) probeOffsets(up usableProbe) *roaring.Bitmap {
 	vp := si.val[up.attrID]
 	switch up.op {
 	case "==", "in":
-		bm := roaring.New()
-		for _, f := range up.fvals {
-			if p := vp.post[f]; p != nil {
-				bm.Or(p)
-			}
-		}
+		bm := unionPostings(len(up.fvals), func(i int) *roaring.Bitmap { return vp.post[up.fvals[i]] })
 		bm.Or(vp.exc)
 		return bm
 	case "!=":
@@ -626,27 +798,15 @@ func (si *segIndex) probeOffsets(up usableProbe) *roaring.Bitmap {
 		bm.AndNot(vp.posted)
 		return bm
 	case "<", "<=", ">", ">=":
-		bm := roaring.New()
-		// Boundary-search the sorted keys to the matching run [from,to), then OR only
-		// those keys' bitmaps -- O(log n + matches) instead of scanning every key.
+		// Boundary-search the sorted keys to the matching run [from,to), then union only
+		// those keys' bitmaps -- O(log n + matches) instead of scanning every key. A
+		// two-sided probe bounds the run on both ends, so a narrow band touches few keys
+		// however wide either half-open side would have been.
 		keys := vp.sortedKeys
-		t := up.fvals[0]
-		var from, to int
-		switch up.op {
-		case ">":
-			from, to = upperBoundF(keys, t), len(keys)
-		case ">=":
-			from, to = lowerBoundF(keys, t), len(keys)
-		case "<":
-			from, to = 0, lowerBoundF(keys, t)
-		case "<=":
-			from, to = 0, upperBoundF(keys, t)
-		}
-		for i := from; i < to; i++ {
-			if p := vp.post[keys[i]]; p != nil {
-				bm.Or(p)
-			}
-		}
+		from, to := rangeSpan(up, len(keys),
+			func(t float64) int { return lowerBoundF(keys, t) },
+			func(t float64) int { return upperBoundF(keys, t) })
+		bm := unionPostings(to-from, func(i int) *roaring.Bitmap { return vp.post[keys[from+i]] })
 		bm.Or(vp.exc)
 		return bm
 	}

--- a/collections/index_query.go
+++ b/collections/index_query.go
@@ -42,22 +42,30 @@ func (c *Collection) Reindex() {
 		act := sh.act
 		sealRAM := sh.sealRAM
 		type target struct {
-			seg  *segment
-			used int
-			seal bool // convert to the mmap sidecar after (re)building
+			seg    *segment
+			used   int
+			seal   bool // convert to the mmap sidecar after (re)building
+			reseal bool // already sidecar-sealed under an older spec: rebuild the sidecar in place
 		}
 		var tgts []target
 		for _, seg := range sh.segs {
 			if seg == nil {
 				continue
 			}
-			if seg.msidx.Load() != nil {
-				continue // already sealed to a mmap sidecar; its index config is frozen
+			if mm := seg.msidx.Load(); mm != nil {
+				// Already sealed to an immutable mmap sidecar. Its DATA is final, but the
+				// index derived from it is not: rebuild the sidecar in place when the index
+				// configuration has moved on, so .addindex/.dropindex reach existing
+				// segments without the whole-store re-encode a rewrite would cost.
+				if spec.any() && seg.used > 0 && mm.specGen != spec.gen {
+					tgts = append(tgts, target{seg: seg, used: seg.used, reseal: true})
+				}
+				continue
 			}
 			cur := seg.idx.Load()
 			if !spec.any() {
 				if cur != nil {
-					tgts = append(tgts, target{seg, seg.used, false}) // clear a now-orphaned index
+					tgts = append(tgts, target{seg: seg, used: seg.used}) // clear a now-orphaned index
 				}
 				continue
 			}
@@ -69,13 +77,17 @@ func (c *Collection) Reindex() {
 			// an older spec generation; otherwise a current-but-unsealed sealable segment
 			// still needs converting.
 			if cur == nil || int(cur.upto) < seg.used || cur.specGen != spec.gen {
-				tgts = append(tgts, target{seg, seg.used, sealable})
+				tgts = append(tgts, target{seg: seg, used: seg.used, seal: sealable})
 			} else if sealable {
-				tgts = append(tgts, target{seg, seg.used, true})
+				tgts = append(tgts, target{seg: seg, used: seg.used, seal: true})
 			}
 		}
 		sh.mu.RUnlock()
 		for _, t := range tgts {
+			if t.reseal {
+				c.reindexSealed(sh, t.seg, spec)
+				continue
+			}
 			if !spec.any() {
 				t.seg.idx.Store(nil)
 				continue

--- a/collections/index_range_bench_test.go
+++ b/collections/index_range_bench_test.go
@@ -1,0 +1,162 @@
+package collections
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/RoaringBitmap/roaring/v2"
+)
+
+// benchRangeCollection builds a single-shard collection with a high-cardinality value
+// index -- the shape a history range query hits, where the matching key run holds one
+// posting per distinct timestamp rather than a handful of buckets.
+func benchRangeCollection(tb testing.TB, n, ndv int) *Collection {
+	tb.Helper()
+	c := New(Options{Shards: 1, ValueAttrs: []string{"CompletionDate"}})
+	for i := 0; i < n; i++ {
+		ad := mustAd(tb, fmt.Sprintf(`[ ID=%d; CompletionDate=%d ]`, i, i%ndv))
+		if err := c.Put([]byte(fmt.Sprintf("k%d", i)), ad); err != nil {
+			tb.Fatal(err)
+		}
+	}
+	c.Reindex()
+	return c
+}
+
+func benchSegIndex(tb testing.TB, c *Collection) *segIndex {
+	tb.Helper()
+	for _, sh := range c.shards {
+		for _, seg := range sh.segs {
+			if seg == nil {
+				continue
+			}
+			if si := seg.idx.Load(); si != nil {
+				return si
+			}
+		}
+	}
+	tb.Fatal("no built segment index")
+	return nil
+}
+
+// benchProbes returns the coalesced (band) plan and the un-coalesced one, so a benchmark
+// can measure exactly what merging the two bounds buys.
+func benchProbes(tb testing.TB, c *Collection, lo, hi float64) (band, split []usableProbe) {
+	tb.Helper()
+	id, ok := c.intern.LookupID("CompletionDate")
+	if !ok {
+		tb.Fatal("CompletionDate not interned")
+	}
+	split = []usableProbe{
+		{attrID: id, op: ">", fvals: []float64{lo}},
+		{attrID: id, op: "<", fvals: []float64{hi}},
+	}
+	return coalesceRanges(append([]usableProbe(nil), split...)), split
+}
+
+// BenchmarkRangeBandCandidates compares candidate-bitmap construction for a two-sided
+// range as one band probe vs. the two half-open probes it replaces. The band scans only
+// the keys inside it; the split plan unions everything above lo, unions everything below
+// hi, and intersects.
+func BenchmarkRangeBandCandidates(b *testing.B) {
+	const n, ndv = 200000, 20000
+	c := benchRangeCollection(b, n, ndv)
+	si := benchSegIndex(b, c)
+
+	// Bands from a wide slice of the key space down to a narrow one.
+	for _, w := range []int{ndv / 2, ndv / 10, ndv / 100} {
+		lo := float64(ndv/2 - w/2)
+		hi := float64(ndv/2 + w/2)
+		band, split := benchProbes(b, c, lo, hi)
+		b.Run(fmt.Sprintf("keys=%d/band", w), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				sinkBM = si.candidateOffsets(band)
+			}
+		})
+		b.Run(fmt.Sprintf("keys=%d/split", w), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				sinkBM = si.candidateOffsets(split)
+			}
+		})
+	}
+}
+
+// BenchmarkRangeBandCandidatesMmap is BenchmarkRangeBandCandidates on the sealed-segment
+// tier, where every posting the scan touches is also a page fault into the sidecar.
+func BenchmarkRangeBandCandidatesMmap(b *testing.B) {
+	const n, ndv = 200000, 20000
+	c := benchRangeCollection(b, n, ndv)
+	si := benchSegIndex(b, c)
+	path := filepath.Join(b.TempDir(), "seg.idx")
+	if err := writeSidecarIndex(path, si); err != nil {
+		b.Fatal(err)
+	}
+	data, closer, err := mapFile(path)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer func() { _ = closer() }()
+	mm, err := parseMmapSidecar(data)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	for _, w := range []int{ndv / 2, ndv / 10, ndv / 100} {
+		lo := float64(ndv/2 - w/2)
+		hi := float64(ndv/2 + w/2)
+		band, split := benchProbes(b, c, lo, hi)
+		b.Run(fmt.Sprintf("keys=%d/band", w), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				sinkBM = mm.candidateOffsets(band)
+			}
+		})
+		b.Run(fmt.Sprintf("keys=%d/split", w), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				sinkBM = mm.candidateOffsets(split)
+			}
+		})
+	}
+}
+
+// BenchmarkUnionPostings compares roaring's batched union against the running in-place Or
+// it replaced, over the posting-count range a value-index scan actually produces. Postings
+// hold RECORD BYTE OFFSETS, so they are spread across the segment's whole address space
+// (here 8 MiB, roaring's container size being 64 Ki) rather than packed densely -- which is
+// what lets the batch parallelize per container.
+func BenchmarkUnionPostings(b *testing.B) {
+	const segBytes, recBytes = 8 << 20, 512
+	for _, n := range []int{2, 8, 64, 128, 256, 512, 1024, 16384} {
+		bms := make([]*roaring.Bitmap, n)
+		for i := range bms {
+			bm := roaring.New()
+			for j := 0; j < 12; j++ { // ~12 records share each key
+				bm.Add(uint32((i + j*n) % (segBytes / recBytes) * recBytes))
+			}
+			bms[i] = bm
+		}
+		at := func(i int) *roaring.Bitmap { return bms[i] }
+		b.Run(fmt.Sprintf("n=%d/batched", n), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				sinkBM = unionPostings(n, at)
+			}
+		})
+		b.Run(fmt.Sprintf("n=%d/running", n), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				acc := roaring.New()
+				for j := 0; j < n; j++ {
+					acc.Or(bms[j])
+				}
+				sinkBM = acc
+			}
+		})
+	}
+}
+
+var sinkBM *roaring.Bitmap

--- a/collections/index_range_test.go
+++ b/collections/index_range_test.go
@@ -1,0 +1,384 @@
+package collections
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/classad"
+
+	"github.com/PelicanPlatform/classad/collections/vm"
+	"github.com/RoaringBitmap/roaring/v2"
+)
+
+// TestCoalesceRanges pins the planner's range-merging rules: opposite bounds on one
+// attribute become one two-sided probe, same-side bounds tighten, and everything else
+// passes through in input order.
+func TestCoalesceRanges(t *testing.T) {
+	t.Parallel()
+	val := func(op string, v float64) usableProbe {
+		return usableProbe{attrID: 1, op: op, fvals: []float64{v}}
+	}
+	cat := func(op string, s string) usableProbe {
+		return usableProbe{attrID: 2, cat: true, op: op, svals: []string{s}}
+	}
+
+	tests := []struct {
+		name string
+		in   []usableProbe
+		want []usableProbe
+	}{{
+		name: "two sided band",
+		in:   []usableProbe{val(">", 1024), val("<", 4096)},
+		want: []usableProbe{{attrID: 1, op: ">", fvals: []float64{1024}, hiOp: "<", hiVal: 4096}},
+	}, {
+		// The upper bound arriving first must still normalize to lower-bound-first.
+		name: "upper bound first",
+		in:   []usableProbe{val("<=", 4096), val(">=", 1024)},
+		want: []usableProbe{{attrID: 1, op: ">=", fvals: []float64{1024}, hiOp: "<=", hiVal: 4096}},
+	}, {
+		name: "tighten same side",
+		in:   []usableProbe{val(">", 1024), val(">", 2048), val("<", 4096)},
+		want: []usableProbe{{attrID: 1, op: ">", fvals: []float64{2048}, hiOp: "<", hiVal: 4096}},
+	}, {
+		// At an equal bound the exclusive comparison is the tighter one.
+		name: "equal bound prefers exclusive",
+		in:   []usableProbe{val(">=", 1024), val(">", 1024), val("<=", 4096), val("<", 4096)},
+		want: []usableProbe{{attrID: 1, op: ">", fvals: []float64{1024}, hiOp: "<", hiVal: 4096}},
+	}, {
+		name: "one sided untouched",
+		in:   []usableProbe{val(">", 1024)},
+		want: []usableProbe{val(">", 1024)},
+	}, {
+		name: "empty band survives as a band",
+		in:   []usableProbe{val(">", 4096), val("<", 1024)},
+		want: []usableProbe{{attrID: 1, op: ">", fvals: []float64{4096}, hiOp: "<", hiVal: 1024}},
+	}, {
+		name: "non-range probes pass through in order",
+		in:   []usableProbe{cat("==", "alice"), val(">", 1024), val("==", 7), val("<", 4096)},
+		want: []usableProbe{
+			cat("==", "alice"),
+			{attrID: 1, op: ">", fvals: []float64{1024}, hiOp: "<", hiVal: 4096},
+			val("==", 7),
+		},
+	}, {
+		name: "different attributes do not merge",
+		in:   []usableProbe{val(">", 1024), {attrID: 9, op: "<", fvals: []float64{4096}}},
+		want: []usableProbe{val(">", 1024), {attrID: 9, op: "<", fvals: []float64{4096}}},
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := coalesceRanges(append([]usableProbe(nil), tc.in...))
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %d probes %+v, want %d %+v", len(got), got, len(tc.want), tc.want)
+			}
+			for i := range got {
+				if !probeEqual(got[i], tc.want[i]) {
+					t.Errorf("probe %d: got %+v, want %+v", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+func probeEqual(a, b usableProbe) bool {
+	if a.attrID != b.attrID || a.cat != b.cat || a.op != b.op || a.hiOp != b.hiOp || a.hiVal != b.hiVal {
+		return false
+	}
+	if len(a.fvals) != len(b.fvals) || len(a.svals) != len(b.svals) {
+		return false
+	}
+	for i := range a.fvals {
+		if a.fvals[i] != b.fvals[i] {
+			return false
+		}
+	}
+	for i := range a.svals {
+		if a.svals[i] != b.svals[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// TestRangeBandQueryResults is the correctness anchor for coalescing: a two-sided range
+// query must return exactly the ads a brute-force scan returns, including the type
+// exceptions the index cannot post (a string-valued Memory) and empty bands.
+func TestRangeBandQueryResults(t *testing.T) {
+	t.Parallel()
+	c := New(Options{Shards: 4, CategoricalAttrs: []string{"Owner"}, ValueAttrs: []string{"Memory", "Cpus"}})
+	src := map[int]*classad.ClassAd{}
+	for i := 0; i < 4000; i++ {
+		text := fmt.Sprintf(`[ ID=%d; Owner="u%d"; Memory=%d; Cpus=%d ]`, i, i%20, (i%64+1)*128, i%16)
+		if i%53 == 0 { // exception: Memory is not a number, so it cannot be posted
+			text = fmt.Sprintf(`[ ID=%d; Owner="u%d"; Memory="lots"; Cpus=%d ]`, i, i%20, i%16)
+		}
+		ad := mustAd(t, text)
+		src[i] = ad
+		if err := c.Put([]byte(fmt.Sprintf("k%d", i)), ad); err != nil {
+			t.Fatal(err)
+		}
+	}
+	c.Reindex()
+
+	queries := []string{
+		`Memory > 1024 && Memory < 4096`,
+		`Memory >= 1024 && Memory <= 4096`,
+		`Memory > 1024 && Memory <= 1024`, // empty band
+		`Memory > 8192 && Memory < 1024`,  // inverted: empty band
+		`Memory >= 128 && Memory <= 8192`, // whole span
+		`Memory > 1024 && Memory > 2048 && Memory < 4096`,
+		`Memory > 1024 && Memory < 4096 && Cpus >= 4 && Cpus < 12`,
+		`Memory > 1024 && Memory < 4096 && Owner == "u3"`,
+		`Memory > 99999 && Memory < 999999`, // above every value
+		`(Memory > 1024 && Memory < 2048) || (Cpus > 2 && Cpus < 6)`,
+	}
+	for _, qs := range queries {
+		indexedVsBrute(t, c, src, qs)
+	}
+}
+
+// TestRangeBandPrunesKeyRun checks the pruning win: a band that falls in a gap between
+// the indexed values admits NO candidates, even though each half-open side on its own
+// admits half the segment. Per-segment [min,max] stats cannot see into the gap, so this
+// is the key-run scan doing the work -- which only a coalesced probe can bound at both ends.
+func TestRangeBandPrunesKeyRun(t *testing.T) {
+	t.Parallel()
+	c := New(Options{Shards: 1, ValueAttrs: []string{"Memory"}})
+	// Memory is 0 or 10000 -- nothing in between -- so the band (100, 9000) is empty
+	// while `> 100` and `< 9000` each match half the segment.
+	for i := 0; i < 2000; i++ {
+		mem := 0
+		if i%2 == 0 {
+			mem = 10000
+		}
+		if err := c.Put([]byte(fmt.Sprintf("k%d", i)), mustAd(t, fmt.Sprintf(`[ ID=%d; Memory=%d ]`, i, mem))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	c.Reindex()
+
+	si := firstSegIndex(t, c)
+	plan := func(qs string) []usableProbe { return planOf(t, c, qs) }
+	for _, qs := range []string{`Memory > 100`, `Memory < 9000`} {
+		if si.candidateOffsets(plan(qs)).IsEmpty() {
+			t.Errorf("%s: expected candidates (half the segment matches)", qs)
+		}
+	}
+	band := plan(`Memory > 100 && Memory < 9000`)
+	if len(band) != 1 || !band[0].twoSided() {
+		t.Fatalf("expected one two-sided probe, got %+v", band)
+	}
+	if cand := si.candidateOffsets(band); !cand.IsEmpty() {
+		t.Errorf("the band (100, 9000) falls in the value gap: want no candidates, got %d", cand.GetCardinality())
+	}
+	// Sanity: the pruning is not the index lying -- the query really returns nothing.
+	bandQ, err := vm.Parse(`Memory > 100 && Memory < 9000`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ids := queryIDs(t, c, bandQ); len(ids) != 0 {
+		t.Errorf("band query returned %d ads, want 0", len(ids))
+	}
+
+	// A band entirely below the segment's span must still skip the whole prefix: the
+	// coalesced probe has to test BOTH bounds against the segment stats, or it would
+	// lose a skip the separate `< 100` probe would have found on its own.
+	below := plan(`Memory > -10 && Memory < -1`)
+	if len(below) != 1 || !below[0].twoSided() {
+		t.Fatalf("expected one two-sided probe, got %+v", below)
+	}
+	if !si.skipsPrefix(below) {
+		t.Error("a band below every value should skip the indexed prefix")
+	}
+}
+
+// TestRangeBandBandsExplain checks that .explain attributes the band's selectivity to each
+// half rather than reporting two barely-selective one-sided probes.
+func TestRangeBandExplain(t *testing.T) {
+	t.Parallel()
+	c := New(Options{Shards: 1, ValueAttrs: []string{"Memory"}})
+	for i := 0; i < 2000; i++ {
+		if err := c.Put([]byte(fmt.Sprintf("k%d", i)),
+			mustAd(t, fmt.Sprintf(`[ ID=%d; Memory=%d ]`, i, i))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	c.Reindex()
+
+	q, err := vm.Parse(`Memory > 900 && Memory < 1100`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ex := c.ExplainQuery(q)
+	if ex.IndexUsable != 1 {
+		t.Errorf("IndexUsable = %d, want 1 (the two bounds coalesce into one probe)", ex.IndexUsable)
+	}
+	if len(ex.Probes) != 2 {
+		t.Fatalf("want both conjuncts explained, got %+v", ex.Probes)
+	}
+	for _, pe := range ex.Probes {
+		if !pe.Banded {
+			t.Errorf("%s %s: want Banded", pe.Attr, pe.Op)
+		}
+		// ~200 of 2000 values fall in the band; each half alone would be ~half the set.
+		if !pe.HasSelectivity || pe.Selectivity > 0.25 {
+			t.Errorf("%s %s: selectivity %.3f should reflect the narrow band", pe.Attr, pe.Op, pe.Selectivity)
+		}
+	}
+}
+
+// TestRangeBandTierParity checks that a band probe gives identical candidates on the
+// in-RAM segIndex and on the mmap sidecar a sealed segment is read through.
+func TestRangeBandTierParity(t *testing.T) {
+	t.Parallel()
+	c := New(Options{Shards: 1, CategoricalAttrs: []string{"Owner"}, ValueAttrs: []string{"Memory"}})
+	for i := 0; i < 6000; i++ {
+		text := fmt.Sprintf(`[ ID=%d; Owner="u%d"; Memory=%d ]`, i, i%37, i%1500)
+		if i%67 == 0 {
+			text = fmt.Sprintf(`[ ID=%d; Owner="u%d"; Memory="x" ]`, i, i%37)
+		}
+		if err := c.Put([]byte(fmt.Sprintf("k%d", i)), mustAd(t, text)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	c.Reindex()
+
+	queries := []string{
+		`Memory > 200 && Memory < 800`,
+		`Memory >= 0 && Memory <= 1499`,
+		`Memory > 1400 && Memory < 200`, // empty band
+		`Memory > 200 && Memory < 800 && Owner == "u5"`,
+		`Memory >= 700 && Memory <= 700`,
+	}
+	segs := 0
+	for _, sh := range c.shards {
+		for _, seg := range sh.segs {
+			if seg == nil {
+				continue
+			}
+			live := seg.idx.Load()
+			if live == nil {
+				continue
+			}
+			path := filepath.Join(t.TempDir(), fmt.Sprintf("seg-%d.idx", seg.id))
+			if err := writeSidecarIndex(path, live); err != nil {
+				t.Fatalf("write sidecar: %v", err)
+			}
+			data, closer, err := mapFile(path)
+			if err != nil {
+				t.Fatalf("map sidecar: %v", err)
+			}
+			mm, err := parseMmapSidecar(data)
+			if err != nil {
+				t.Fatalf("parse sidecar: %v", err)
+			}
+			for _, qs := range queries {
+				q, err := vm.Parse(qs)
+				if err != nil {
+					t.Fatalf("parse %q: %v", qs, err)
+				}
+				u := c.planIndex(q.Probes())
+				if live.skipsPrefix(u) != mm.skipsPrefix(u) {
+					t.Errorf("seg %d %q: skipsPrefix mismatch", seg.id, qs)
+				}
+				if !bmEqual(live.candidateOffsets(u), mm.candidateOffsets(u)) {
+					t.Errorf("seg %d %q: candidateOffsets mismatch", seg.id, qs)
+				}
+			}
+			_ = closer()
+			segs++
+		}
+	}
+	if segs == 0 {
+		t.Fatal("no segments compared")
+	}
+}
+
+// TestUnionPostings checks that the batched union matches a naive running Or across the
+// threshold, for empty, nil-holed, and overlapping inputs.
+func TestUnionPostings(t *testing.T) {
+	t.Parallel()
+	for _, n := range []int{0, 1, 2, 3, 4, 5, 17, 300} {
+		for _, holes := range []bool{false, true} {
+			bms := make([]*roaring.Bitmap, n)
+			for i := range bms {
+				if holes && i%3 == 0 {
+					continue // a key with no posting
+				}
+				bm := roaring.New()
+				for j := 0; j < 40; j++ {
+					bm.Add(uint32(i*7 + j)) // overlapping runs
+				}
+				bms[i] = bm
+			}
+			want := roaring.New()
+			for _, bm := range bms {
+				if bm != nil {
+					want.Or(bm)
+				}
+			}
+			got := unionPostings(n, func(i int) *roaring.Bitmap { return bms[i] })
+			if !bmEqual(got, want) {
+				t.Errorf("n=%d holes=%v: union mismatch (%d vs %d)", n, holes, got.GetCardinality(), want.GetCardinality())
+			}
+			// The result must be independently mutable: writing to it must not disturb
+			// the postings it was built from (they are live index state, or mmap-backed).
+			got.Add(1 << 20)
+			for i, bm := range bms {
+				if bm != nil && bm.Contains(1<<20) {
+					t.Fatalf("n=%d: mutating the union leaked into posting %d", n, i)
+				}
+			}
+		}
+	}
+}
+
+// --- helpers ---
+
+func firstSegIndex(t *testing.T, c *Collection) *segIndex {
+	t.Helper()
+	for _, sh := range c.shards {
+		for _, seg := range sh.segs {
+			if seg == nil {
+				continue
+			}
+			if si := seg.idx.Load(); si != nil {
+				return si
+			}
+		}
+	}
+	t.Fatal("no built segment index")
+	return nil
+}
+
+func planOf(t *testing.T, c *Collection, constraint string) []usableProbe {
+	t.Helper()
+	q, err := vm.Parse(constraint)
+	if err != nil {
+		t.Fatalf("parse %q: %v", constraint, err)
+	}
+	return c.planIndex(q.Probes())
+}
+
+// indexedVsBrute compares the indexed query answer against evaluating the constraint over
+// every source ad.
+func indexedVsBrute(t *testing.T, c *Collection, src map[int]*classad.ClassAd, constraint string) {
+	t.Helper()
+	q, err := vm.Parse(constraint)
+	if err != nil {
+		t.Fatalf("parse %q: %v", constraint, err)
+	}
+	got, want := queryIDs(t, c, q), bruteIDs(src, q)
+	if len(got) != len(want) {
+		t.Errorf("%s: indexed returned %d ads, brute force %d", constraint, len(got), len(want))
+		return
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Errorf("%s: id mismatch at %d (%d vs %d)", constraint, i, got[i], want[i])
+			return
+		}
+	}
+}

--- a/collections/match_index.go
+++ b/collections/match_index.go
@@ -162,11 +162,15 @@ func (c *Collection) ExplainMatch(job *classad.ClassAd, targetConstraint string)
 		prunable = false // estimated to barely prune -> a scan is cheaper
 	}
 	for _, g := range plan {
+		// Report the coalesced band's selectivity for each half of a two-sided range,
+		// matching what the planner probes (see ExplainQuery).
+		bands := rangeBands(c.planIndex(g.Probes))
 		for _, p := range g.Probes {
 			pe := ProbeExplain{Attr: p.Attr, Op: p.Op}
 			var up usableProbe
 			var isUsable bool
 			pe.Indexed, pe.Kind, up, isUsable = c.probeIndexKind(p)
+			up = applyBand(bands, up, &pe)
 			if isUsable {
 				ex.IndexUsable++
 				if cand, covered := c.estimateCandidates(up); covered {

--- a/collections/project.go
+++ b/collections/project.go
@@ -51,7 +51,7 @@ func (c *Collection) QueryProject(q *vm.Query, attrs []string) iter.Seq[[]classa
 			resolver: ws.resolve,
 		}
 		probes := q.Probes()
-		if c.hasZones {
+		if c.hasZones.Load() {
 			qp.zoneProbes = probes // enable sealed-segment zone pruning (mirrors Query)
 		}
 		c.demand.record(probes)

--- a/collections/rawprojected.go
+++ b/collections/rawprojected.go
@@ -56,7 +56,7 @@ func (c *Collection) QueryRawProjected(q *vm.Query, projection []string, chaseRe
 			resolver: ws.resolve,
 		}
 		probes := q.Probes()
-		if c.hasZones {
+		if c.hasZones.Load() {
 			qp.zoneProbes = probes // enable sealed-segment zone pruning (mirrors Query)
 		}
 		c.demand.record(probes)

--- a/collections/readindex.go
+++ b/collections/readindex.go
@@ -44,6 +44,61 @@ type indexPrimitives interface {
 	bloomAbsent(up usableProbe) bool
 }
 
+// bulkOrMin is the posting count at which unionPostings switches from a running in-place
+// Or to roaring's batched union. The batch trades transient memory (it promotes each
+// accumulating container to a dense bitmap container) for linear rather than quadratic
+// merge cost, so it only pays once there are enough postings for the quadratic term to
+// dominate -- measured crossover is around 100 on an 8 MiB segment's offset space.
+const bulkOrMin = 128
+
+// unionOrWorkers is the worker count handed to roaring's batched union. One is deliberate:
+// almost all of the batch's win is algorithmic (see unionPostings), extra workers add well
+// under 2x on top, and a query is often already fanned out across shards and segments --
+// so spending a whole machine's cores inside one probe would oversubscribe it.
+const unionOrWorkers = 1
+
+// unionPostings ORs n posting bitmaps -- at(i) returns the i'th, or nil for "no posting" --
+// into one fresh, mutable bitmap.
+//
+// A range probe over a high-cardinality attribute (say `CompletionDate > t`) unions one
+// posting per distinct key in the matching run, which can be thousands, and each posting is
+// a handful of record offsets scattered across the segment. Folding those with a running
+// acc.Or is quadratic: the accumulator's containers stay ARRAY containers, so every one of
+// the n merges re-runs a two-pointer merge over everything accumulated so far. roaring's
+// batched union instead promotes each accumulating container to a bitmap container and
+// unions lazily into it (cardinality repaired once at the end), which makes each posting
+// cost its own size rather than the accumulator's -- ~15x by itself on a 10k-posting range
+// over an 8 MiB segment's offset space. FastOr does NOT do this promotion, so it is not the
+// right batch here despite the name; ParOr is.
+func unionPostings(n int, at func(i int) *roaring.Bitmap) *roaring.Bitmap {
+	if n < bulkOrMin {
+		return runningOr(n, at)
+	}
+	bms := make([]*roaring.Bitmap, 0, n)
+	for i := 0; i < n; i++ {
+		if p := at(i); p != nil {
+			bms = append(bms, p)
+		}
+	}
+	if len(bms) < bulkOrMin { // mostly holes: not enough left to repay the batch
+		return runningOr(len(bms), func(i int) *roaring.Bitmap { return bms[i] })
+	}
+	// ParOr returns a fresh bitmap that shares containers copy-on-write with its inputs
+	// (exactly as a running Or's appendCopy already would), so the result is safe to
+	// mutate. It also compacts bms in place, which is why bms is not reused after.
+	return roaring.ParOr(unionOrWorkers, bms...)
+}
+
+func runningOr(n int, at func(i int) *roaring.Bitmap) *roaring.Bitmap {
+	bm := roaring.New()
+	for i := 0; i < n; i++ {
+		if p := at(i); p != nil {
+			bm.Or(p)
+		}
+	}
+	return bm
+}
+
 func indexCovers(ix indexPrimitives, usable []usableProbe) bool {
 	for _, up := range usable {
 		if !ix.coversProbe(up) {
@@ -92,14 +147,27 @@ func indexCanSkip(ix indexPrimitives, up usableProbe) bool {
 			}
 		}
 		return true
+	case "<", "<=", ">", ">=":
+		// A two-sided probe skips if EITHER bound puts the segment's whole [min,max]
+		// outside the band, so a band narrower than the segment's span prunes segments
+		// that neither half-open side would have.
+		return rangeBoundSkips(s, up.op, up.fvals[0]) ||
+			(up.twoSided() && rangeBoundSkips(s, up.hiOp, up.hiVal))
+	}
+	return false
+}
+
+// rangeBoundSkips reports whether no value in [s.min, s.max] satisfies one range bound.
+func rangeBoundSkips(s *segStats, op string, t float64) bool {
+	switch op {
 	case "<":
-		return s.min >= up.fvals[0]
+		return s.min >= t
 	case "<=":
-		return s.min > up.fvals[0]
+		return s.min > t
 	case ">":
-		return s.max <= up.fvals[0]
+		return s.max <= t
 	case ">=":
-		return s.max < up.fvals[0]
+		return s.max < t
 	}
 	return false
 }
@@ -151,9 +219,30 @@ func estCandidatesFromStats(s *segStats, up usableProbe) float64 {
 		}
 		return indexable
 	case "<", "<=", ">", ">=":
-		return s.estRange(up.op, up.fvals[0])*indexable + float64(s.exc)
+		frac := s.estRange(up.op, up.fvals[0])
+		if up.twoSided() {
+			frac = s.estBand(up)
+		}
+		return frac*indexable + float64(s.exc)
 	}
 	return indexable
+}
+
+// estBand estimates the fraction of indexable records inside a two-sided range probe's
+// band. Over a uniform [min,max] the two one-sided fractions overlap by
+// lowFrac + highFrac - 1, so a narrow band scores far more selective than either side
+// alone -- which is the point of coalescing them: the planner now applies the band first.
+func (s *segStats) estBand(up usableProbe) float64 {
+	lo := s.estRange(up.op, up.fvals[0])
+	hi := s.estRange(up.hiOp, up.hiVal)
+	if !s.hasRange || s.max <= s.min {
+		// A degenerate span makes each side a 0/1 verdict; the band is their AND.
+		return math.Min(lo, hi)
+	}
+	if f := lo + hi - 1; f > 0 {
+		return f
+	}
+	return 0
 }
 
 // indexSelectivityOrder returns indices into usable ordered by ascending estimated candidate
@@ -199,17 +288,16 @@ func indexCandidateOffsets(ix indexPrimitives, usable []usableProbe) *roaring.Bi
 // indexCandidateOffsetsGroups returns the DNF union over groups of each group's candidate
 // intersection. Callers pass only prunable plans (every group has a usable probe).
 func indexCandidateOffsetsGroups(ix indexPrimitives, groups [][]usableProbe) *roaring.Bitmap {
-	var acc *roaring.Bitmap
-	for _, g := range groups {
-		gb := indexCandidateOffsets(ix, g)
-		if gb == nil {
-			gb = roaring.New()
-		}
-		if acc == nil {
-			acc = gb
-		} else {
-			acc.Or(gb)
+	if len(groups) == 0 {
+		return nil
+	}
+	// Each group's intersection is computed first, then the disjuncts are unioned in one
+	// batch (see unionPostings) rather than folded pairwise.
+	per := make([]*roaring.Bitmap, len(groups))
+	for i, g := range groups {
+		if per[i] = indexCandidateOffsets(ix, g); per[i] == nil {
+			per[i] = roaring.New()
 		}
 	}
-	return acc
+	return unionPostings(len(per), func(i int) *roaring.Bitmap { return per[i] })
 }

--- a/collections/sealed_index.go
+++ b/collections/sealed_index.go
@@ -101,6 +101,125 @@ func (c *Collection) sealSegmentIndex(seg *segment, si *segIndex) {
 	c.publishSidecar(seg, path, nil)
 }
 
+// reindexSealed rebuilds a sealed segment's index sidecar in place, under the current
+// index spec, WITHOUT touching the segment's data. This is what separates a re-index from
+// a rewrite: the arena bytes are immutable and already correct, so only the derived index
+// needs rebuilding -- an added or dropped index reaches an existing archive for the cost of
+// decompressing its records once, not re-encoding and rewriting every segment.
+//
+// A sealed sidecar is itself immutable and may be mapped under a live scan, so it is never
+// edited: a whole new mapping is built beside it, published atomically, and the displaced
+// one is released once the segment's scan pins drain (segment.releaseStale) -- the same
+// safety rule compaction's retire/reap already follows.
+//
+// Returns true if the segment now carries an index built under spec. Best-effort: on any
+// error the existing sidecar is left in place and false is returned, so the segment keeps
+// serving queries under its older (still correct, just less selective) index.
+func (c *Collection) reindexSealed(sh *shard, seg *segment, spec *indexSpec) bool {
+	si := buildSegIndex(seg.data, seg.used, seg.codec, spec)
+	if si == nil {
+		return false
+	}
+	c.rezoneSealed(sh, seg)
+	if seg.persistent {
+		return c.reindexSealedFile(sh, seg, si)
+	}
+	return c.reindexSealedAnon(sh, seg, si)
+}
+
+// rezoneSealed recomputes a sealed segment's zone map against the shard's CURRENT zone
+// attributes, so an attribute zoned after the segment was sealed (a runtime value index --
+// see Collection.addZoneAttrs) gains whole-segment pruning on the same pass that rebuilds
+// its postings. The records are being decompressed for the index anyway, so this costs
+// little beyond the extra lookups.
+//
+// The new map REPLACES the old rather than mutating it: a scan window captured the old map
+// by reference under the read lock and reads it without further synchronization.
+func (c *Collection) rezoneSealed(sh *shard, seg *segment) {
+	sh.mu.RLock()
+	attrs, inline, appendOnly := sh.zoneAttrs, sh.zoneInline, sh.appendOnly
+	sh.mu.RUnlock()
+	if !appendOnly || len(attrs) == 0 {
+		return
+	}
+	zones := computeSegZones(seg.data, seg.used, attrs, inline, seg.codec)
+	sh.mu.Lock()
+	seg.zones = zones
+	sh.mu.Unlock()
+}
+
+// reindexSealedFile rebuilds a persistent segment's combined sidecar (attribute index +
+// key index) and swaps the whole mapping. The key index is rebuilt from the same immutable
+// bytes, so it is byte-identical to the one being replaced -- it is regenerated rather than
+// copied out of the live mapping so the new container is self-contained.
+func (c *Collection) reindexSealedFile(sh *shard, seg *segment, si *segIndex) bool {
+	path := snapshotPath(seg)
+	if path == "" {
+		return false
+	}
+	attrBlob, err := buildSidecarIndex(si)
+	if err != nil {
+		return false
+	}
+	// Rename over the live file: the existing mapping is unaffected (it holds the old
+	// inode), so readers keep working until they are swapped over below.
+	if err := writeFileAtomic(path, buildSegmentSidecar(attrBlob, buildKeyIndex(seg.data, seg.used, c.h))); err != nil {
+		return false
+	}
+	data, closer, err := mapFile(path)
+	if err != nil {
+		return false
+	}
+	attr, key, ok := splitSegmentSidecar(data)
+	if !ok {
+		_ = closer()
+		return false
+	}
+	ki, err := parseKeyIndex(key)
+	if err != nil || int(ki.upto) != seg.used {
+		_ = closer()
+		return false
+	}
+	if !sidecarCRCValid(attr) {
+		_ = closer()
+		return false
+	}
+	mm, err := parseMmapSidecar(attr)
+	if err != nil || mm == nil || int(mm.upto) != seg.used {
+		_ = closer()
+		return false
+	}
+	// Publish under the shard write lock: the readers that touch a sidecar without a scan
+	// pin (SidecarSizes, IndexSizes) hold the read lock while they do, so the lock is what
+	// bounds them. Pinned scan readers are handled by the pin drain instead.
+	sh.mu.Lock()
+	seg.msidx.Store(mm)
+	seg.keyIdx.Store(ki)
+	seg.keyBloom.Store(bloomFromKeyIndex(ki))
+	seg.idx.Store(nil) // the heap copy stays dropped; msidx serves queries
+	seg.swapSidecarHook(func() { _ = closer() }, true)
+	sh.mu.Unlock()
+	seg.releaseStale() // free the displaced mapping now if no scan is reading it
+	return true
+}
+
+// reindexSealedAnon is reindexSealedFile for an in-memory collection's sealed RAM segment,
+// whose sidecar is an anonymous mapping holding only the attribute index (there is no key
+// sidecar to rebuild).
+func (c *Collection) reindexSealedAnon(sh *shard, seg *segment, si *segIndex) bool {
+	mm, closer, err := sealedIndexAnon(si)
+	if err != nil {
+		return false
+	}
+	sh.mu.Lock()
+	seg.msidx.Store(mm)
+	seg.idx.Store(nil)
+	seg.swapSidecarHook(func() { _ = closer() }, false)
+	sh.mu.Unlock()
+	seg.releaseStale()
+	return true
+}
+
 // sealAndEvictShard realizes the pageable-directory RAM win (phase 3) during operation,
 // not only at reopen: for every sealed (non-active) persistent segment it ensures a key
 // sidecar exists, then evicts that segment's keys from the resident directory so they are

--- a/collections/segment.go
+++ b/collections/segment.go
@@ -144,6 +144,12 @@ type segment struct {
 	// reaped, so a query scanning a rotating segment never reads a torn index mapping.
 	onReap func()
 
+	// staleUnmaps hold sidecar mappings displaced by an in-place re-index (the segment
+	// data is untouched; only its index was rebuilt). Each is released once the pin
+	// count drains, since a scan that loaded the old index may still be reading it.
+	// Guarded by reapMu.
+	staleUnmaps []func()
+
 	// keyIdx is a sealed segment's pageable key-index sidecar (key-hash -> record
 	// offset), or nil. Phase 1 of the pageable primary index: built at seal, mmapped
 	// on reopen, torn down with the segment (onReapKey, run alongside onReap). It does
@@ -214,9 +220,15 @@ func (s *segment) unpin() {
 	s.reapMu.Unlock()
 	if doReap {
 		s.reapAndHook()
-	} else if doUnmap {
-		_ = s.unmapAndHook()
+		return
 	}
+	if doUnmap {
+		_ = s.unmapAndHook()
+		return
+	}
+	// Not retiring: a sidecar displaced by an in-place re-index becomes unreachable as
+	// soon as the last scan that could have loaded it drops its pin.
+	s.releaseStale()
 }
 
 // unmapAndHook unmaps the segment's data (munmap + close file, WITHOUT unlinking
@@ -268,12 +280,17 @@ func (s *segment) runReapHook() {
 	s.reapMu.Lock()
 	h, hk := s.onReap, s.onReapKey
 	s.onReap, s.onReapKey = nil, nil
+	stale := s.staleUnmaps // sidecars displaced by an in-place re-index, not yet released
+	s.staleUnmaps = nil
 	s.reapMu.Unlock()
 	if h != nil {
 		h()
 	}
 	if hk != nil {
 		hk()
+	}
+	for _, f := range stale {
+		f()
 	}
 }
 
@@ -284,6 +301,49 @@ func (s *segment) setOnReapKey(f func()) {
 	s.reapMu.Lock()
 	s.onReapKey = f
 	s.reapMu.Unlock()
+}
+
+// swapSidecarHook installs the unmap closer for a freshly published sidecar mapping and
+// queues the one it displaced for release. Used by an in-place sealed-segment re-index
+// (see Collection.reindexSealed*), which builds a NEW mapping beside the live one rather
+// than mutating it -- a sealed sidecar is immutable, and a scan may be reading it.
+//
+// key selects which hook the closer belongs to: the combined attribute+key sidecar of a
+// persistent segment (onReapKey) or the attribute-only anonymous mapping of a RAM one
+// (onReap). The caller must have already published the new mmapSegIndex/mmapKeyIndex, so
+// nothing can newly reach the displaced mapping by the time it is queued.
+func (s *segment) swapSidecarHook(closer func(), key bool) {
+	s.reapMu.Lock()
+	var old func()
+	if key {
+		old, s.onReapKey = s.onReapKey, closer
+	} else {
+		old, s.onReap = s.onReap, closer
+	}
+	if old != nil {
+		s.staleUnmaps = append(s.staleUnmaps, old)
+	}
+	s.reapMu.Unlock()
+}
+
+// releaseStale unmaps every sidecar mapping displaced by an in-place re-index, once no
+// scan pins the segment. A scan holds its pin for its whole life (see shard.snapshot),
+// and candidate bitmaps are zero-copy views into the sidecar, so a displaced mapping is
+// unreachable exactly when the pin count reaches zero -- the same moment a retired
+// segment's data becomes reapable. Called after each swap and at every unpin, so the
+// mapping is freed at the first instant it is provably safe.
+func (s *segment) releaseStale() {
+	s.reapMu.Lock()
+	if s.refs != 0 || len(s.staleUnmaps) == 0 {
+		s.reapMu.Unlock()
+		return
+	}
+	stale := s.staleUnmaps
+	s.staleUnmaps = nil
+	s.reapMu.Unlock()
+	for _, f := range stale {
+		f()
+	}
 }
 
 // reapAndHook reaps the segment (munmap + unlink of its data) and then runs onReap

--- a/collections/store.go
+++ b/collections/store.go
@@ -257,8 +257,10 @@ type Collection struct {
 
 	// hasZones caches whether any per-segment zone maps are configured (see
 	// Options.ZoneAttrs / zonemap.go), so the query hot path skips probe extraction
-	// when zone pruning is off. Append-only only.
-	hasZones bool
+	// when zone pruning is off. Append-only only. Atomic because a runtime AddIndex on
+	// an append-only collection can turn zone maps on (see addZoneAttrs) while queries
+	// are reading it.
+	hasZones atomic.Bool
 
 	// Watch (see watch.go / docs/WATCH.md). hub is nil unless WatchHistory > 0.
 	hub           *watchHub
@@ -474,7 +476,7 @@ func New(opts Options) *Collection {
 		for _, n := range opts.ValueAttrs { // value-indexed attrs are zoned automatically
 			addZone(n)
 		}
-		c.hasZones = len(zattrs) > 0
+		c.hasZones.Store(len(zattrs) > 0)
 		for _, sh := range shards {
 			sh.zoneAttrs = zattrs
 		}
@@ -806,7 +808,7 @@ func (c *Collection) Query(q *vm.Query) iter.Seq[*classad.ClassAd] {
 			ws:       ws,
 			resolver: ws.resolve, // bound once to avoid a per-ad closure allocation
 		}
-		if c.hasZones {
+		if c.hasZones.Load() {
 			qp.zoneProbes = q.Probes() // enable sealed-segment zone pruning
 		}
 		// Chained collection: a serial two-pass scan per shard resolves each ad's

--- a/collections/zonemap.go
+++ b/collections/zonemap.go
@@ -82,6 +82,54 @@ func computeSegZones(data []byte, upto int, attrs []zoneAttr, inline bool, codec
 	return zones
 }
 
+// ZoneAttrs returns the attributes this collection keeps per-segment [min,max] zone maps
+// on, in configuration order (explicit ZoneAttrs first, then the value-indexed attributes
+// that are zoned automatically). Empty for a mutable collection, which has no zone maps.
+// Diagnostic only -- it is how `.indexes` on an archive can show which range queries prune
+// whole segments rather than only postings.
+func (c *Collection) ZoneAttrs() []string {
+	if !c.hasZones.Load() || len(c.shards) == 0 {
+		return nil
+	}
+	sh := c.shards[0] // every shard carries the same zone-attribute list
+	sh.mu.RLock()
+	defer sh.mu.RUnlock()
+	names := make([]string, 0, len(sh.zoneAttrs))
+	for _, za := range sh.zoneAttrs {
+		names = append(names, za.name)
+	}
+	return names
+}
+
+// addZoneAttrs extends the zone-mapped attribute set of an append-only collection with
+// names not already covered, so a value index added at RUNTIME gets whole-segment pruning
+// too (construction wires ZoneAttrs + ValueAttrs together; see New). Segments already
+// sealed keep the zone map they were sealed with -- a nil entry simply never prunes -- so
+// the new attribute starts pruning from the next segment sealed, or across the whole
+// archive after a Rewrite. No-op unless the collection is append-only.
+func (c *Collection) addZoneAttrs(names []string) {
+	if !c.appendOnly() || len(names) == 0 {
+		return
+	}
+	for _, sh := range c.shards {
+		sh.mu.Lock()
+		seen := make(map[uint32]struct{}, len(sh.zoneAttrs))
+		for _, za := range sh.zoneAttrs {
+			seen[za.id] = struct{}{}
+		}
+		for _, n := range names {
+			id := c.intern.Intern(n)
+			if _, ok := seen[id]; ok {
+				continue
+			}
+			seen[id] = struct{}{}
+			sh.zoneAttrs = append(sh.zoneAttrs, zoneAttr{name: n, id: id})
+		}
+		sh.mu.Unlock()
+	}
+	c.hasZones.Store(true)
+}
+
 // sealZones computes and installs zones for a segment that has just stopped being the
 // active append target. No-op unless the shard is append-only with zone attributes
 // configured. Caller holds the shard write lock.

--- a/db/archive.go
+++ b/db/archive.go
@@ -290,6 +290,16 @@ func (t *ArchiveTable) SidecarSizes() SidecarSizes { return t.a.SidecarSizes() }
 // IndexedAttrs returns the archive's categorical and value index attributes.
 func (t *ArchiveTable) IndexedAttrs() (categorical, value []string) { return t.a.IndexedAttrs() }
 
+// ZoneAttrs returns the attributes carrying per-segment [min,max] zone maps, on which a
+// range query prunes whole segments rather than only postings.
+func (t *ArchiveTable) ZoneAttrs() []string { return t.a.ZoneAttrs() }
+
+// StaleIndexSegments reports how many sealed segments still carry an index built under an
+// older configuration, and how many are sealed in total (see collections.Archive.AddIndex:
+// a sealed sidecar is immutable, so a runtime index change reaches old segments only via
+// a Rewrite).
+func (t *ArchiveTable) StaleIndexSegments() (stale, sealed int) { return t.a.StaleIndexSegments() }
+
 // Retention returns the archive's current retention bounds.
 func (t *ArchiveTable) Retention() collections.Retention { return t.a.Retention() }
 

--- a/db/db.go
+++ b/db/db.go
@@ -297,6 +297,7 @@ type (
 	Retention       = collections.Retention
 	CodecStats      = collections.CodecStats
 	QueryExplain    = collections.QueryExplain
+	ProbeExplain    = collections.ProbeExplain
 	MatchExplain    = collections.MatchExplain
 )
 

--- a/dbrpc/diag.go
+++ b/dbrpc/diag.go
@@ -37,6 +37,16 @@ type Diagnostics struct {
 	Archive      bool            `json:"archive,omitempty"`
 	Retention    *db.Retention   `json:"retention,omitempty"`
 	SidecarSizes db.SidecarSizes `json:"sidecarSizes"`
+
+	// ZoneAttrs are the archive attributes carrying per-segment [min,max] zone maps: a
+	// range query on one of these prunes whole segments, not just postings.
+	ZoneAttrs []string `json:"zoneAttrs,omitempty"`
+	// SealedSegments is how many of the archive's segments are sealed to an immutable
+	// index sidecar, and StaleIndexSegments how many of those were sealed under an older
+	// index configuration -- i.e. how much of the archive a runtime .addindex/.dropindex
+	// has NOT reached yet (only a rewrite reaches them).
+	SealedSegments     int `json:"sealedSegments,omitempty"`
+	StaleIndexSegments int `json:"staleIndexSegments,omitempty"`
 }
 
 // diagSampleMax bounds the ad sample the server takes for index suggestions.
@@ -68,6 +78,7 @@ func (s *Server) diagJSON(t *db.DB) ([]byte, error) {
 func (s *Server) archiveDiagJSON(a *db.ArchiveTable) ([]byte, error) {
 	cat, val := a.IndexedAttrs()
 	ret := a.Retention()
+	stale, sealed := a.StaleIndexSegments()
 	d := Diagnostics{
 		Stats:              a.Stats(),
 		OpStats:            a.OpStats(),
@@ -78,6 +89,9 @@ func (s *Server) archiveDiagJSON(a *db.ArchiveTable) ([]byte, error) {
 		Archive:            true,
 		Retention:          &ret,
 		SidecarSizes:       a.SidecarSizes(),
+		ZoneAttrs:          a.ZoneAttrs(),
+		SealedSegments:     sealed,
+		StaleIndexSegments: stale,
 	}
 	return json.Marshal(d)
 }
@@ -234,12 +248,12 @@ func archiveAdmin(a *db.ArchiveTable, action string, args []string) (string, err
 		if len(args) == 0 {
 			return "", fmt.Errorf("index.add.categorical needs at least one attribute")
 		}
-		return changedMsg("categorical index on "+join(args), a.AddIndex(args, nil)), nil
+		return archiveIndexMsg(a, changedMsg("categorical index on "+join(args), a.AddIndex(args, nil))), nil
 	case "index.add.value":
 		if len(args) == 0 {
 			return "", fmt.Errorf("index.add.value needs at least one attribute")
 		}
-		return changedMsg("value index on "+join(args), a.AddIndex(nil, args)), nil
+		return archiveIndexMsg(a, changedMsg("value index on "+join(args), a.AddIndex(nil, args))), nil
 	case "index.drop":
 		if len(args) == 0 {
 			return "", fmt.Errorf("index.drop needs at least one attribute")
@@ -248,7 +262,7 @@ func archiveAdmin(a *db.ArchiveTable, action string, args []string) (string, err
 		if changed {
 			a.Reindex()
 		}
-		return changedMsg("dropped index on "+join(args), changed), nil
+		return archiveIndexMsg(a, changedMsg("dropped index on "+join(args), changed)), nil
 	case "index.reindex":
 		a.Reindex()
 		return "reindexed", nil
@@ -284,6 +298,19 @@ func archiveAdmin(a *db.ArchiveTable, action string, args []string) (string, err
 	default:
 		return "", fmt.Errorf("unknown archive admin action %q", action)
 	}
+}
+
+// archiveIndexMsg appends the sealed-segment reach to an index-change acknowledgement. A
+// sealed segment's index sidecar is immutable, so an index added or dropped now applies to
+// segments sealed from here on; the already-sealed ones keep what they were sealed with
+// until a rewrite re-encodes them. Saying so is the difference between an operator seeing
+// "no change in query time" and understanding why.
+func archiveIndexMsg(a *db.ArchiveTable, msg string) string {
+	stale, _ := a.StaleIndexSegments()
+	if stale == 0 {
+		return msg
+	}
+	return fmt.Sprintf("%s; %d already-sealed segment(s) keep the previous index set -- run a rewrite to apply it to them", msg, stale)
 }
 
 // parseRetentionArgs parses `<maxSegments> <maxBytes> [maxAgeAttr maxAgeSeconds]` into a

--- a/dbrpc/diag.go
+++ b/dbrpc/diag.go
@@ -101,7 +101,8 @@ func (s *Server) archiveDiagJSON(a *db.ArchiveTable) ([]byte, error) {
 //	index.add.categorical <attr>...   add categorical (string eq/membership) indexes
 //	index.add.value <attr>...         add value (numeric + range) indexes
 //	index.drop <attr>...              drop indexes on the given attributes
-//	index.reindex                     rebuild all indexes from live ads
+//	index.reindex                     rebuild all indexes from live ads (archives: rebuild
+//	                                  stale segment sidecars in place, no data rewrite)
 //	hot.add <attr>...                 pin attributes into the hot set
 //	hot.refresh <sampleMax> <topN>    recompute the hot set from sampled frequency
 //	compact                           reclaim dead space in warranted shards
@@ -300,17 +301,16 @@ func archiveAdmin(a *db.ArchiveTable, action string, args []string) (string, err
 	}
 }
 
-// archiveIndexMsg appends the sealed-segment reach to an index-change acknowledgement. A
-// sealed segment's index sidecar is immutable, so an index added or dropped now applies to
-// segments sealed from here on; the already-sealed ones keep what they were sealed with
-// until a rewrite re-encodes them. Saying so is the difference between an operator seeing
-// "no change in query time" and understanding why.
+// archiveIndexMsg appends the sealed-segment reach to an index-change acknowledgement. The
+// change rebuilds every segment's index sidecar in place, so normally there is nothing to
+// add; a non-zero stale count means some segment's rebuild did not complete (it is
+// best-effort per segment) and index.reindex should be retried.
 func archiveIndexMsg(a *db.ArchiveTable, msg string) string {
 	stale, _ := a.StaleIndexSegments()
 	if stale == 0 {
 		return msg
 	}
-	return fmt.Sprintf("%s; %d already-sealed segment(s) keep the previous index set -- run a rewrite to apply it to them", msg, stale)
+	return fmt.Sprintf("%s; %d segment(s) failed to rebuild and keep the previous index set -- retry with index.reindex", msg, stale)
 }
 
 // parseRetentionArgs parses `<maxSegments> <maxBytes> [maxAgeAttr maxAgeSeconds]` into a


### PR DESCRIPTION
Three independent index improvements to `collections`, plus the archive-side plumbing to see and manage them.

## 1. Bounded-range probes

`Memory > 1024 && Memory < 4096` planned as two probes, each unioning roughly half the attribute's key space, then intersecting. `planIndex` now coalesces opposite-bound conjuncts on one value attribute into a single two-sided probe (`coalesceRanges`), so the key-run scan is bounded at both ends.

`usableProbe` carries an optional `hiOp`/`hiVal`. The fields are an optimization, never a correctness requirement: a code path that reads only `op`/`fvals` still produces a correct (merely wider) candidate superset, so partial handling degrades safely.

One subtlety worth reviewing: `indexCanSkip` **must** test both bounds. Un-coalesced, the two conjuncts were separate probes and either could skip the prefix on its own; checking only the lower bound would silently lose the upper bound's skip. That is parity, not a new capability — segment stats are `[min,max]` and cannot see into a gap inside the span. Gap pruning happens in the key-run scan (`rangeSpan`).

Selectivity now scores the band rather than either half, which also improves `planFrac`'s pushdown gate (it previously multiplied the two halves under an independence assumption that does not hold for two bounds on one attribute). `ExplainQuery`/`MatchExplain` attribute the band's estimate to each half and flag it (`ProbeExplain.Banded`), otherwise a lone `>` would report an implausibly low number.

## 2. Batched posting unions

Folding a probe's postings with a running `acc.Or` is quadratic: the accumulator's containers stay *array* containers, so every merge re-runs a two-pointer merge over everything accumulated so far. A CPU profile of a range probe showed 45% of time in `union2by2` under `arrayContainer.iorArray`.

`FastOr` does **not** fix this — its lazy path only promotes *run* containers, not array ones, and it measured as a wash on the real path. `ParOr` does: `lazyIOrOnRange` calls `getFastContainerAtIndex(idx, true)`, promoting the accumulator to a bitmap container so each posting costs its own size rather than the accumulator's.

`unionPostings` (readindex.go) is applied at all six union sites across both index tiers, above a 128-posting threshold — below that the batch's container promotion costs more memory than it saves time. One worker: nearly all of the win is algorithmic (`ParOr(1, …)` gets ~8x of the 13x), and queries are often already fanned out across shards and segments.

## Measurements

Candidate-bitmap build, 200k-record segment, 20k-value index:

| band width | in-RAM | mmap sidecar |
|---|---|---|
| 200 keys | 24.06ms → 27µs | 25.76ms → 60µs |
| 2000 keys | 26.00ms → 160µs | 27.74ms → 455µs |
| 10000 keys | 34.87ms → 918µs | 39.28ms → 2.44ms |

The batched union alone accounts for ~15x of that, measured against the un-coalesced plan.

## 3. In-place sidecar re-index

`Reindex` skipped any segment already sealed to an mmap sidecar ("its index config is frozen"), so `AddIndex`/`DropIndex` reached only segments sealed afterwards; covering an existing archive meant a `Rewrite`, which re-encodes and rewrites every segment. But the frozen thing is the segment *data* — the sidecar is derived, and only it needs rebuilding.

`reindexSealed` never edits the live sidecar. It builds a whole new mapping beside it, publishes it atomically, and queues the displaced one for release:

- the new container is renamed over the old path; POSIX rename leaves the existing mapping on the old inode, so readers keep working;
- the pointer swap takes the shard **write** lock, because the readers that touch a sidecar without a scan pin (`SidecarSizes`, `IndexSizes`) hold the read lock while they do;
- pinned scan readers are covered by the pin drain. A scan pins every segment it reads for its whole life and candidate bitmaps are zero-copy views into the sidecar, so a displaced mapping is unreachable exactly when the pin count reaches zero (`segment.releaseStale`) — the rule compaction's retire/reap already follows.

The same pass recomputes the segment's zone map against the shard's current zone attributes (the records are being decompressed for the postings anyway), so a value index added at runtime gains whole-segment pruning like one configured at creation. The new map replaces the old rather than mutating it, since a scan window holds the old one by reference.

50k-record ZSTD archive, 6 sealed segments, adding one value index:

| | time | durable writes |
|---|---|---|
| in-place re-index | 91ms | 1.8 MiB (sidecars only) |
| rewrite | 156ms | 9.0 MiB (every segment + sidecars) |

Wall clock understates it: re-index only decompresses, rewrite decompresses *and* recompresses, transiently doubles disk usage, and evicts the page cache for the whole store.

Note that `Archive.AddIndex` is consequently now genuinely expensive — synchronous, decompressing the whole archive. It is DAEMON-gated and explicitly invoked, so it was left synchronous; making it a background rebuild is a small follow-up if preferred.

## 4. Archive index introspection

`Collection.ZoneAttrs()` and `StaleIndexSegments()`, plumbed through `Archive` → `db.ArchiveTable` → `dbrpc.Diagnostics` (`ZoneAttrs`, `SealedSegments`, `StaleIndexSegments`), so `.indexes` on a history table can enumerate what it indexes instead of refusing. `ProbeExplain` is re-exported from `db`. Consumed by htcondordb (PR to follow, needs a tag first).

`StaleIndexSegments` is normally zero now that re-indexing reaches sealed segments; a non-zero count means a per-segment rebuild did not complete (it is best-effort) and `index.reindex` retries.

## Testing

- `coalesceRanges` unit table: merge, tighten, equal-bound preference, inverted band, multi-attribute, non-range passthrough.
- Band queries vs brute force across both tiers, including type exceptions, empty bands, and DNF.
- Band-in-a-value-gap admits no candidates while each half-open side admits half the segment; a band below the span still skips the prefix (the parity case above).
- In-place re-index: every non-`.idx` file is SHA-256'd before and after to prove no segment byte moves; the rebuilt sidecar is the one found on reopen; six readers hammer the archive while an indexer forces repeated sidecar swaps (a premature unmap is a SIGSEGV, not a wrong answer).
- `unionPostings` equivalence with a naive running Or across the threshold, including nil holes and independent mutability of the result.
- Benchmarks: `BenchmarkRangeBandCandidates{,Mmap}`, `BenchmarkUnionPostings`.

All four modules green; `collections` green under `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## 5. Unsatisfiable bands eliminated at plan time (added after the initial push)

Coalescing made `Memory < 1024 && Memory > 2048` produce an *inverted* band. It returned nothing (correct), but nothing recognized it as impossible: the key-run scan found no postings, yet the probe still unioned in the exception set, `skipsPrefix` stayed false, and every shard was snapshotted and its un-indexed tail scanned.

An empty band is a property of the **predicate**, not of any segment's data — which makes it a stronger fact than every other skip in the planner. Those must re-verify the exception set because the *index* cannot classify those records; here there is nothing to classify. A conjunct must be TRUE for an ad to match, and no ClassAd value can be both below the low bound and above the high one.

That claim is the one thing worth reviewing carefully, so it is pinned empirically rather than argued from three-valued logic: `TestEmptyBandSemantics` evaluates every empty-band shape against numbers, reals, strings (including numeric-looking ones), booleans, a list spanning both bounds, a nested ad, an undefined-producing expression, `1/0`, `undefined`, `error`, and a missing attribute — plus controls so it can only pass for the right reason.

Given that, `indexCanSkip` returns true ahead of the per-segment stats, `indexCandidateOffsets` returns empty rather than the exception set, and `scanShardCandidates{,Groups}` return *before* taking a snapshot — no pins, no page faults, no decompression. In a DNF plan an impossible disjunct is dropped from the union; the plan dies only if every disjunct is impossible.

Boundary cases: a single-point band is empty unless **both** bounds include the point (`>= 700 && <= 700` is satisfiable, `> 700 && <= 700` is not). A NaN bound reports not-empty, so nothing is eliminated on the strength of a NaN.

`ExplainQuery`/`ExplainMatch` report `Plan: "empty"`. That is the useful part for the case this most often arises from — not a hand-written contradiction, but a job whose `Requirements` contradict themselves once its constants are baked in. Such a job can never match any slot, and `.explain` now says so instead of showing a plan that visits every slot.

200k-record collection, 1 in 97 records exceptional:

| | time | allocs |
|---|---|---|
| before | 604µs | 238 KiB / 10842 |
| after | 2.0µs | 2.9 KiB / 56 |


---

## 6. Same-side merges reported in explain (added after the initial push)

`coalesceRanges` already collapsed redundant same-side bounds — `Memory > 1024 && Memory > 512` plans as the single probe `> 1024`, order-independently, and `>= 1024 && > 1024` prefers the exclusive bound. That behaviour was correct but only covered *incidentally* by the test table, via a case that also carried an upper bound; the same-side cases are now explicit (both orders, upper bounds, equal-value preference, three-bound collapse) with a behavioural test alongside.

The explain path was wrong, though. It keyed off two-sidedness, so `Memory > 1024 && Memory > 512` listed both conjuncts unmarked with their own selectivities — 89% and 95% — when only one probe (89%) is ever run. The 95% line advertised a reach nothing probes.

`rangeMerges`/`applyMerge` now key off the planned range probe for the attribute rather than its shape. A conjunct that *is* that probe passes through unmarked with its own number; one folded into it — the other half of a band, or a subsumed same-side bound — is marked and reports the merged probe's number. `ProbeExplain.Banded` is renamed `Coalesced`, which covers both shapes.

## 7. Equality folded with the range on the same attribute (added after the initial push)

`Memory == 2048 && Memory > 1024` ran two probes: the range one unioned the postings of every key above 1024 — most of the segment — only for the intersection to reduce it to the single key the equality had already named. The same pathology the two-sided coalescing fixed, one conjunct shape over.

`foldEqualities` narrows the equality to the values the range admits and drops the range probe. This is **exact**, not merely a sound superset: a record holds one value for the attribute, so `post[v]` lies wholly inside the range's key union when v satisfies the range and wholly outside it otherwise, and both probes union in the same exception set — so the intersection *is* the narrowed equality. Several equalities on one attribute intersect the same way. `!=` is deliberately left alone: it excludes one value rather than pinning the rest.

When nothing survives the narrowing (`Memory == 2048 && Memory > 4096`) the conjunction cannot hold for any record. That is recorded as `unsat` and eliminated by section 5's machinery, exception set included. As there, the claim is pinned empirically rather than argued: `TestEqualityFoldSemantics` evaluates every fold shape — including `in`-lists and `!Memory` — against numbers, reals, numeric-looking strings, booleans, lists, nested ads, `undefined`, and `error`, with controls for the folds that must still match.

Explain follows the folded plan, so the absorbed range conjunct reports the equality's selectivity (~1.6%) rather than the sweeping reach it never probes (~89%).

200k records, 4096 distinct values, 1 in 89 exceptional:

| | time | allocated |
|---|---|---|
| `== && >` satisfiable | 11.82ms → **1.92ms** | 3.3 MiB → 287 KiB |
| `== && >` contradictory | 5.15ms → **11.4µs** | 2.2 MiB → 3.1 KiB |

With this the per-attribute value folding is complete for the pinning ops: opposite bounds coalesce, same-side bounds subsume, equalities intersect, and an equality absorbs the range. `!=`, presence, and categorical probes are untouched by design.
