### PR TITLE
collections,db: minimum-retention floor + GC floor for change-feed drain

### DIFF
--- a/collections/archive.go
+++ b/collections/archive.go
@@ -45,12 +45,26 @@ type zoneRange struct {
 type Retention struct {
 	MaxSegments int   // keep at most this many sealed segments
 	MaxBytes    int64 // keep at most this many bytes of sealed segment files
-	// MaxAgeAttr / MaxAge: drop a segment whose max value of the given numeric attr
-	// (e.g. "CompletionDate", unix seconds) is older than Now-MaxAge. Now is supplied
-	// per Rotate call so the store needs no clock of its own. MaxAgeAttr must be a
-	// ZoneAttr so its per-segment max is available.
+	// MaxAgeAttr names the numeric attribute (e.g. "CompletionDate", unix seconds) that
+	// MaxAge is measured against. It must be a ZoneAttr so its per-segment max is available.
+	// Now is supplied per Rotate call so the store needs no clock of its own.
 	MaxAgeAttr string
-	MaxAge     float64
+	// MaxAge is a hard ceiling: drop a segment whose newest MaxAgeAttr value is older than
+	// Now-MaxAge, regardless of anything else (a slow or absent consumer never keeps data
+	// past it). Zero ⇒ no age ceiling.
+	MaxAge float64
+	// MinAgeAttr names the numeric attribute the minimum-retention floor and the GC floor are
+	// measured against (a ZoneAttr). It is independent of MaxAgeAttr -- MinAge works with no
+	// MaxAge configured -- though a change-feed queue typically points both at the same
+	// entry-time attribute.
+	MinAgeAttr string
+	// MinAge is the minimum-retention floor, for using the store as a short-lived queue. The
+	// GC floor (SetGCFloor) may reclaim already-consumed records early, but never any younger
+	// than Now-MinAge -- so a consumer always has at least MinAge to drain a record. MinAge
+	// only bounds the GC floor; it never overrides the hard ceilings, so MaxBytes / MaxSegments
+	// / MaxAge still evict even younger-than-MinAge data under pressure. Zero ⇒ consumed
+	// records may be GC'd as soon as the floor passes them.
+	MinAge float64
 }
 
 // ArchiveOptions configures an Archive.
@@ -290,6 +304,15 @@ func (a *Archive) SetRetention(r Retention) { a.c.SetRetention(r) }
 
 // Retention returns the archive's current retention bounds.
 func (a *Archive) Retention() Retention { return a.c.Retention() }
+
+// SetGCFloor installs a runtime GC watermark (in Retention.MinAgeAttr units) so Rotate may
+// reclaim consumed records early -- above MinAge, below the configured ceilings (see
+// Collection.SetGCFloor). Not persisted; re-assert it each maintenance pass. floor <= 0
+// clears it.
+func (a *Archive) SetGCFloor(floor float64) { a.c.SetGCFloor(floor) }
+
+// GCFloor returns the current runtime GC watermark (0 when unset).
+func (a *Archive) GCFloor() float64 { return a.c.GCFloor() }
 
 // Stats reports storage accounting: record count, segment count, and arena/used/dead bytes
 // (dead is ~0 for an append log, which never supersedes). The same struct the mutable store

--- a/collections/retention.go
+++ b/collections/retention.go
@@ -34,11 +34,17 @@ func (c *Collection) Rotate(now float64) (int, error) {
 	}
 
 	sh := c.shards[0] // AppendOnly forces a single shard
-	// Resolve the age attribute once (needs the shared intern table on the Collection).
-	var ageID uint32
-	var ageOK bool
+	// Resolve the two independent age attributes (via the shared intern table): MaxAgeAttr for
+	// the MaxAge ceiling, MinAgeAttr for the MinAge floor and the GC-floor drain. Each is
+	// resolved only when its bound is active.
+	gcFloor := c.gcFloor
+	var maxAgeID, minAgeID uint32
+	var maxAgeOK, minAgeOK bool
 	if c.ret.MaxAgeAttr != "" && c.ret.MaxAge > 0 {
-		ageID, ageOK = c.intern.LookupID(c.ret.MaxAgeAttr)
+		maxAgeID, maxAgeOK = c.intern.LookupID(c.ret.MaxAgeAttr)
+	}
+	if c.ret.MinAgeAttr != "" && gcFloor > 0 {
+		minAgeID, minAgeOK = c.intern.LookupID(c.ret.MinAgeAttr)
 	}
 	var toReap []*segment
 	dropped := 0
@@ -49,7 +55,7 @@ func (c *Collection) Rotate(now float64) (int, error) {
 		if idx < 0 || sh.segs[idx] == sh.act {
 			break // nothing left, or only the active (still-appended) segment remains
 		}
-		if !sh.overRetention(c.ret, idx, now, ageID, ageOK) {
+		if !sh.overRetention(c.ret, idx, now, maxAgeID, maxAgeOK, minAgeID, minAgeOK, gcFloor) {
 			break
 		}
 		seg := sh.segs[idx]
@@ -84,6 +90,32 @@ func (c *Collection) SetRetention(r Retention) {
 	c.maintMu.Unlock()
 }
 
+// SetGCFloor installs a runtime GC watermark, in Retention.MinAgeAttr units, that lets Rotate
+// reclaim already-consumed records EARLY: a segment whose newest MinAgeAttr value is below
+// floor may be dropped before it reaches MaxAge. It is how a change-feed source drains records
+// every live subscriber has acknowledged (floor is the feed's GC floor, i.e. the min ack over
+// live subscribers). It only ever shortens retention -- it can never keep data past the
+// configured ceilings (a slow or absent subscriber holds a low floor, so its data simply ages
+// out under MaxAge), and it never drops anything younger than Retention.MinAge. Requires
+// MinAgeAttr set (and zone-mapped). Passing floor <= 0 clears it. Not persisted -- callers
+// re-assert it each pass from the current live floor; a stale saved value must never GC data
+// across a restart.
+func (c *Collection) SetGCFloor(floor float64) {
+	c.maintMu.Lock()
+	if floor < 0 {
+		floor = 0
+	}
+	c.gcFloor = floor
+	c.maintMu.Unlock()
+}
+
+// GCFloor returns the current runtime GC watermark (0 when unset).
+func (c *Collection) GCFloor() float64 {
+	c.maintMu.Lock()
+	defer c.maintMu.Unlock()
+	return c.gcFloor
+}
+
 // Retention returns the current retention bounds.
 func (c *Collection) Retention() Retention {
 	c.maintMu.Lock()
@@ -103,11 +135,20 @@ func oldestLiveSeg(sh *shard) int {
 	return -1
 }
 
-// overRetention reports whether the segment at idx (the oldest live one) should be
-// dropped under r. Evaluated one segment at a time so count/byte bounds converge as
-// segments are reclaimed. ageID/ageOK carry the interned age attribute (resolved by the
-// caller) for MaxAge. Caller holds sh.mu.
-func (sh *shard) overRetention(r Retention, idx int, now float64, ageID uint32, ageOK bool) bool {
+// overRetention reports whether the segment at idx (the oldest live one) should be dropped
+// under r. Evaluated one segment at a time so count/byte bounds converge as segments are
+// reclaimed. maxAgeID/maxAgeOK carry the interned MaxAgeAttr (for MaxAge); minAgeID/minAgeOK
+// carry the interned MinAgeAttr (for MinAge and gcFloor, the runtime GC watermark from
+// SetGCFloor). Caller holds sh.mu.
+//
+// Two independent reasons drop a segment: (1) it exceeds a hard ceiling -- MaxSegments,
+// MaxBytes, or MaxAge -- enforced unconditionally, so neither a slow/absent consumer nor the
+// MinAge floor can keep data past the configured policy (in particular MaxBytes always wins
+// over MinAge); or (2) it has been fully consumed (its newest MinAgeAttr value is below
+// gcFloor) AND is older than the MinAge floor, letting a short-lived queue drain consumed
+// records early without ever dropping anything younger than MinAge.
+func (sh *shard) overRetention(r Retention, idx int, now float64, maxAgeID uint32, maxAgeOK bool, minAgeID uint32, minAgeOK bool, gcFloor float64) bool {
+	// Hard ceilings first: size/count/age caps that bound resource use unconditionally.
 	if r.MaxSegments > 0 {
 		live := 0
 		for _, seg := range sh.segs {
@@ -130,13 +171,18 @@ func (sh *shard) overRetention(r Retention, idx int, now float64, ageID uint32, 
 			return true
 		}
 	}
-	// MaxAgeAttr/MaxAge: drop the oldest segment when its newest value of the age
-	// attribute (its zone max, e.g. the latest CompletionDate in the segment) is older
-	// than now-MaxAge. Reuses the per-segment zone map; ageID is the interned id
-	// resolved by the caller (0/false when the age attr is not zone-mapped). The active
-	// segment has nil zones and is never dropped here.
-	if r.MaxAge > 0 && ageOK {
-		if z, ok := sh.segs[idx].zones[ageID]; ok && z.Max < now-r.MaxAge {
+	// MaxAge ceiling: newest MaxAgeAttr value older than now-MaxAge ⇒ drop, unconditionally.
+	// (A segment with no zone for the attribute carries no such value and is left to the
+	// size ceilings above; the active segment has nil zones and is never dropped here.)
+	if r.MaxAge > 0 && maxAgeOK {
+		if z, ok := sh.segs[idx].zones[maxAgeID]; ok && z.Max < now-r.MaxAge {
+			return true
+		}
+	}
+	// Early GC of consumed data: newest MinAgeAttr value below the feed's GC floor, but never
+	// younger than the MinAge minimum-retention floor.
+	if gcFloor > 0 && minAgeOK {
+		if z, ok := sh.segs[idx].zones[minAgeID]; ok && z.Max < gcFloor && (r.MinAge <= 0 || z.Max < now-r.MinAge) {
 			return true
 		}
 	}

--- a/collections/retention_floor_test.go
+++ b/collections/retention_floor_test.go
@@ -1,0 +1,170 @@
+package collections
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/classad"
+)
+
+// buildAgedArchive opens an append-only collection with a CompletionDate zone and n records
+// carrying a strictly increasing CompletionDate (base..base+n-1), so older segments have
+// strictly older zone maxima. Returns the collection, its shard, and the interned age id.
+func buildAgedArchive(t *testing.T, ret Retention, n, base int) (*Collection, *shard, uint32) {
+	t.Helper()
+	c, err := Open(Options{
+		AppendOnly:  true,
+		Dir:         t.TempDir(),
+		SegmentSize: 1 << 12, // tiny ⇒ many segments
+		ZoneAttrs:   []string{"CompletionDate"},
+		Retention:   ret,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < n; i++ {
+		ad, _ := classad.Parse(fmt.Sprintf(`[ N = %d; CompletionDate = %d ]`, i, base+i))
+		if err := c.Put([]byte("k"), ad); err != nil {
+			t.Fatal(err)
+		}
+	}
+	sh := c.shards[0]
+	if liveSegs(sh) <= 4 {
+		t.Fatalf("need several segments to exercise retention, got %d", liveSegs(sh))
+	}
+	cdID, ok := c.intern.LookupID("CompletionDate")
+	if !ok {
+		t.Fatal("CompletionDate not interned")
+	}
+	return c, sh, cdID
+}
+
+// assertOldestAtLeast checks every live sealed segment's newest CompletionDate is >= want
+// (i.e. rotation stopped at the right floor and never dropped younger data).
+func assertOldestAtLeast(t *testing.T, sh *shard, cdID uint32, want float64) {
+	t.Helper()
+	for i, seg := range sh.segs {
+		if seg == nil || seg == sh.act {
+			continue
+		}
+		if z, ok := seg.zones[cdID]; ok && z.Max < want {
+			t.Errorf("segment %d survived with CompletionDate max %.0f < %.0f", i, z.Max, want)
+		}
+	}
+}
+
+// TestCeilingIgnoresGCFloor verifies the correction: a hard ceiling (here MaxSegments, and
+// MaxAge) is enforced regardless of the GC floor, so a slow or absent consumer -- which holds
+// a low or unset floor -- can never keep data past the configured retention policy.
+func TestCeilingIgnoresGCFloor(t *testing.T) {
+	// MaxSegments ceiling: no floor set at all (nothing acknowledged) still rotates to 3.
+	c, sh, _ := buildAgedArchive(t, Retention{MaxSegments: 3}, 300, 1000)
+	defer c.Close()
+	c.SetGCFloor(0)
+	if _, err := c.Rotate(0); err != nil {
+		t.Fatal(err)
+	}
+	if got := liveSegs(sh); got != 3 {
+		t.Fatalf("MaxSegments with no ack floor left %d segments, want 3 (ceiling must win)", got)
+	}
+
+	// MaxAge ceiling: un-acknowledged data (floor unset) older than MaxAge is still dropped.
+	c2, sh2, cd2 := buildAgedArchive(t, Retention{MaxAgeAttr: "CompletionDate", MaxAge: 100}, 300, 1000)
+	defer c2.Close()
+	const now = 1000 + 300 - 1 // newest CompletionDate
+	c2.SetGCFloor(0)           // nothing consumed
+	before := liveSegs(sh2)
+	if _, err := c2.Rotate(now); err != nil {
+		t.Fatal(err)
+	}
+	if liveSegs(sh2) >= before {
+		t.Fatalf("MaxAge dropped nothing (%d→%d); un-acked old data must still age out", before, liveSegs(sh2))
+	}
+	assertOldestAtLeast(t, sh2, cd2, now-100) // everything older than now-MaxAge is gone
+}
+
+// TestGCFloorEarlyDrainRespectsMinAge verifies the GC floor drains consumed records EARLY
+// (below any MaxAge), but the MinAge minimum-retention floor keeps consumed-but-young records
+// so the store behaves as a short-lived queue with a guaranteed drain window.
+func TestGCFloorEarlyDrainRespectsMinAge(t *testing.T) {
+	const n, base = 300, 1000
+	const now = base + n - 1 // 1299
+
+	// Loose MaxAge (won't fire) + a MinAge floor of 100 ⇒ nothing younger than now-100=1199
+	// may be reclaimed, even once consumed.
+	c, sh, cdID := buildAgedArchive(t, Retention{MaxAgeAttr: "CompletionDate", MaxAge: 100000, MinAgeAttr: "CompletionDate", MinAge: 100}, n, base)
+	defer c.Close()
+
+	// Subscribers have acknowledged everything below 1250. Early GC would like to drop up to
+	// 1250, but MinAge caps it at 1199: records in [1199,1250) are consumed yet too young.
+	c.SetGCFloor(1250)
+	if _, err := c.Rotate(now); err != nil {
+		t.Fatal(err)
+	}
+	liveAfter := liveSegs(sh)
+	assertOldestAtLeast(t, sh, cdID, 1199) // MinAge floor held, not the 1250 GC floor
+	// And it really did drain the fully-consumed, old-enough segments.
+	for i, seg := range sh.segs {
+		if seg == nil || seg == sh.act {
+			continue
+		}
+		if z, ok := seg.zones[cdID]; ok && z.Max < 1199 {
+			t.Fatalf("segment %d below the MinAge floor survived (max %.0f)", i, z.Max)
+		}
+	}
+
+	// Keep the same GC floor (1250) but advance the clock to 1360 so now-MinAge=1260: the
+	// previously-protected consumed records in [1199,1250) are now older than MinAge and
+	// finally drain, down to the GC floor.
+	c.SetGCFloor(1250)
+	if _, err := c.Rotate(1360); err != nil {
+		t.Fatal(err)
+	}
+	assertOldestAtLeast(t, sh, cdID, 1250)
+	if liveSegs(sh) >= liveAfter {
+		t.Fatalf("advancing the clock past MinAge should have drained more (%d→%d)", liveAfter, liveSegs(sh))
+	}
+}
+
+// TestGCFloorUnsetNoEarlyDrain verifies that with no GC floor set, Rotate does no early
+// draining -- only the configured ceilings apply. MinAge is configured with NO MaxAge, to
+// confirm MinAge works independently of MaxAge.
+func TestGCFloorUnsetNoEarlyDrain(t *testing.T) {
+	// Only a MinAge (its own MinAgeAttr, no MaxAgeAttr/MaxAge, no floor): nothing should drop.
+	c, sh, _ := buildAgedArchive(t, Retention{MinAgeAttr: "CompletionDate", MinAge: 100}, 300, 1000)
+	defer c.Close()
+	before := liveSegs(sh)
+	if d, err := c.Rotate(1000 + 299); err != nil || d != 0 {
+		t.Fatalf("Rotate with only MinAge dropped %d (err %v), want 0 (no floor, no ceiling)", d, err)
+	}
+	if liveSegs(sh) != before {
+		t.Fatalf("segments changed %d→%d with nothing to enforce", before, liveSegs(sh))
+	}
+}
+
+// TestMaxBytesWinsOverMinAge verifies a hard ceiling evicts even data younger than MinAge:
+// MinAge (with a GC floor that has "consumed" everything) protects records from the early
+// drain, but MaxBytes still rotates the store down under byte pressure.
+func TestMaxBytesWinsOverMinAge(t *testing.T) {
+	// MinAge is enormous (protects every record from the drain); a GC floor above everything
+	// marks it all consumed. Only MaxBytes should force eviction.
+	c, sh, _ := buildAgedArchive(t, Retention{MaxBytes: 3 << 12, MinAgeAttr: "CompletionDate", MinAge: 1e9}, 300, 1000)
+	defer c.Close()
+	c.SetGCFloor(1e18) // everything below is "consumed" -- but MinAge protects it from the drain
+	before := liveSegs(sh)
+	if _, err := c.Rotate(1000 + 299); err != nil {
+		t.Fatal(err)
+	}
+	if liveSegs(sh) >= before {
+		t.Fatalf("MaxBytes dropped nothing (%d→%d); it must win over MinAge under pressure", before, liveSegs(sh))
+	}
+	var total int64
+	for _, seg := range sh.segs {
+		if seg != nil {
+			total += int64(seg.used)
+		}
+	}
+	if total > 3<<12 {
+		t.Fatalf("after Rotate total bytes %d still over MaxBytes %d", total, 3<<12)
+	}
+}

--- a/collections/store.go
+++ b/collections/store.go
@@ -255,6 +255,16 @@ type Collection struct {
 	// and Rotate). Zero value ⇒ keep everything.
 	ret Retention
 
+	// gcFloor is a runtime-only GC watermark in Retention.MinAgeAttr units: Rotate may
+	// reclaim a fully-consumed segment (its newest age value < gcFloor) EARLY -- before it
+	// hits MaxAge -- so a change-feed source drains records every live subscriber has already
+	// acknowledged (see changefeed's GC floor). It only ever shortens retention: it never
+	// keeps data past the configured ceilings, and never drops anything younger than
+	// Retention.MinAge. Read/written only under maintMu, alongside ret. Deliberately NOT
+	// persisted: it is recomputed from live subscribers each pass, and a stale saved value
+	// must never silently GC data across a restart. Zero ⇒ no early GC.
+	gcFloor float64
+
 	// hasZones caches whether any per-segment zone maps are configured (see
 	// Options.ZoneAttrs / zonemap.go), so the query hot path skips probe extraction
 	// when zone pruning is off. Append-only only. Atomic because a runtime AddIndex on

--- a/db/archive.go
+++ b/db/archive.go
@@ -310,3 +310,15 @@ func (t *ArchiveTable) SetRetention(r collections.Retention) error {
 	t.cfg.Retention = r
 	return t.saveConfig()
 }
+
+// SetGCFloor installs a runtime GC watermark (in the archive's MinAgeAttr units) so the next
+// Rotate may reclaim already-consumed records early: a change-feed source passes the feed's
+// GC floor (min ack over live subscribers) here to drain records every subscriber has read.
+// It only shortens retention -- it never keeps data past the configured Retention ceilings,
+// and never drops anything younger than Retention.MinAge. Unlike SetRetention this is NOT
+// persisted -- the caller re-asserts it from the current live floor each pass, so a stale
+// value can never GC data across a restart. Passing floor <= 0 clears it.
+func (t *ArchiveTable) SetGCFloor(floor float64) { t.a.SetGCFloor(floor) }
+
+// GCFloor returns the current runtime GC watermark (0 when unset).
+func (t *ArchiveTable) GCFloor() float64 { return t.a.GCFloor() }

--- a/db/retention_floor_test.go
+++ b/db/retention_floor_test.go
@@ -1,0 +1,81 @@
+package db
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/collections"
+)
+
+// TestArchiveGCFloor verifies ArchiveTable.SetGCFloor drives early GC through the db layer,
+// respects the persisted MinAge floor, and -- unlike SetRetention -- is NOT persisted, so a
+// reopen starts with no floor (no accidental GC across a restart).
+func TestArchiveGCFloor(t *testing.T) {
+	dir := t.TempDir()
+	cfg := ArchiveConfig{
+		SegmentSize: 1 << 12, // small ⇒ several segments
+		ZoneAttrs:   []string{"CompletionDate"},
+		// Loose ceiling that will not fire, plus a MinAge minimum-retention floor (its own attr).
+		Retention: collections.Retention{MaxAgeAttr: "CompletionDate", MaxAge: 100000, MinAgeAttr: "CompletionDate", MinAge: 100},
+	}
+
+	cat, err := OpenCatalog(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hist, err := cat.CreateArchiveTable("history", cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const n, base = 400, 1000
+	const now = base + n - 1 // 1399
+	for i := 0; i < n; i++ {
+		if err := hist.AppendOld(fmt.Sprintf("N = %d\nCompletionDate = %d", i, base+i)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	full := hist.Count()
+
+	// A GC floor above everything, but MinAge protects the newest 100 (CompletionDate > now-100
+	// = 1299): early GC drains the consumed older records but leaves the young ones.
+	hist.SetGCFloor(1e9)
+	if got := hist.GCFloor(); got != 1e9 {
+		t.Fatalf("GCFloor = %v, want 1e9", got)
+	}
+	if _, err := hist.Rotate(now); err != nil {
+		t.Fatal(err)
+	}
+	drained := hist.Count()
+	if drained >= full {
+		t.Fatalf("GC floor drained nothing (%d→%d)", full, drained)
+	}
+	if drained == 0 {
+		t.Fatalf("GC floor drained everything; MinAge must have kept the newest records")
+	}
+
+	if err := cat.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Reopen: the GC floor is not persisted, so it starts cleared and a Rotate does no early
+	// draining (only the loose ceiling applies, which does not fire).
+	cat2, err := OpenCatalog(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cat2.Close()
+	hist2, err := cat2.CreateArchiveTable("history", cfg) // idempotent: reopens with persisted config
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := hist2.GCFloor(); got != 0 {
+		t.Fatalf("GCFloor after reopen = %v, want 0 -- the floor must not persist", got)
+	}
+	countReopen := hist2.Count()
+	if _, err := hist2.Rotate(now); err != nil {
+		t.Fatal(err)
+	}
+	if hist2.Count() != countReopen {
+		t.Fatalf("Rotate after reopen changed count %d→%d; a stale floor must not GC across a restart", countReopen, hist2.Count())
+	}
+}


### PR DESCRIPTION
## What

Models the append-only archive as a **short-lived queue**: consumed records drain early, but a configurable **minimum retention** guarantees a drain window, and the existing `Retention` bounds stay hard ceilings.

Two independent controls, on top of the hard-ceiling bounds (`MaxSegments` / `MaxBytes` / `MaxAge`):

- **`Retention.MinAge`** (persisted), measured against its own **`Retention.MinAgeAttr`** so it works **independently of MaxAge**: a minimum-retention floor. A consumed record is never reclaimed while younger than `Now-MinAge`, so a consumer always has at least `MinAge` to drain it.
- **`SetGCFloor(floor)` / `GCFloor()`** on Collection → Archive → `db.ArchiveTable` (runtime, **not** persisted): a GC watermark in `MinAgeAttr` units. `Rotate` may reclaim a fully-consumed segment (its newest `MinAgeAttr` value below `floor`) **early** — before `MaxAge` — which is how a change-feed source drains records every live subscriber has acknowledged (`floor` = the feed's GC floor = min ack over live subscribers).

## The correction

The GC floor **only ever shortens retention**. It can never keep data past the configured policy: a slow or absent subscriber holds a low floor, so its data just ages out under `MaxAge` / `MaxBytes` / `MaxSegments` like anything else. A slow client **does not extend retention beyond the ceiling** — it only forgoes the early drain.

> This replaces the first cut of this PR, which vetoed dropping un-acked data and so let a slow client hold data indefinitely, past the policy. That was backwards.

The early drain never drops anything younger than `MinAge` — but `MinAge` **only** bounds the drain, it never overrides a ceiling. In particular **`MaxBytes` always wins over `MinAge`**: byte pressure evicts even younger-than-`MinAge` data.

## Enforcement

`overRetention` applies the ceilings first, unconditionally, then the early-GC drain (below `gcFloor`, older than `MinAge`). The GC floor is not persisted — callers re-assert it from the current live floor each maintenance pass, so a stale saved value can never GC data across a restart.

## Tests

- **`TestCeilingIgnoresGCFloor`**: `MaxSegments` and `MaxAge` drop un-acknowledged data regardless of the floor (the correction).
- **`TestMaxBytesWinsOverMinAge`**: byte pressure evicts data the `MinAge` floor would otherwise protect.
- **`TestGCFloorEarlyDrainRespectsMinAge`**: the floor drains consumed records early, but `MinAge` keeps the young ones; advancing the clock past `MinAge` then drains them.
- **`TestGCFloorUnsetNoEarlyDrain`**: `MinAge` configured with **no** `MaxAge` (independence); no floor ⇒ no early draining.
- **db**: round-trips through `ArchiveTable` and is cleared on reopen (not persisted).

Follow-up (separate repo): wire htcondordb's change-feed floor loop to call `SetGCFloor(Floor()/1000)` per served archive each pass, and expose `MinAge` in the archive config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
