### PR TITLE
dbrpc,collections,db: O(1) COUNT(*) fast path for mutable tables

### DIFF
--- a/collections/count_gate_test.go
+++ b/collections/count_gate_test.go
@@ -1,0 +1,52 @@
+package collections
+
+import (
+	"testing"
+
+	"github.com/PelicanPlatform/classad/collections/vm"
+)
+
+// TestChainedGateForCountFastPath documents why the COUNT(*) fast path is gated on
+// !Chained(): for a chained collection Len() counts the structural (parent-only) cluster ads
+// that a match-all query hides, so using Len() as the row count would overcount. For a flat
+// collection there are no hidden ads, so Len() is exactly the match-all row count.
+func TestChainedGateForCountFastPath(t *testing.T) {
+	// Chained: 3 procs + 2 cluster (structural) ads.
+	c := chainedJobsCollection(t)
+	if !c.Chained() {
+		t.Fatal("chained collection reports Chained() = false")
+	}
+	if c.Len() != 5 {
+		t.Fatalf("Len() = %d, want 5 (3 procs + 2 structural clusters)", c.Len())
+	}
+	matchAll, err := vm.Parse("true")
+	if err != nil {
+		t.Fatal(err)
+	}
+	rows := 0
+	for range c.Query(matchAll) { // structural ads are hidden
+		rows++
+	}
+	if rows != 3 {
+		t.Fatalf("match-all rows = %d, want 3 (clusters hidden)", rows)
+	}
+	if c.Len() == rows {
+		t.Fatal("expected Len() != visible rows for a chained collection (the fast path must not use Len here)")
+	}
+
+	// Flat: no structural ads ⇒ Len() == match-all rows, Chained() false ⇒ fast path valid.
+	f := New(Options{})
+	f.Put([]byte("a"), mustAd(t, `[X=1]`))
+	f.Put([]byte("b"), mustAd(t, `[X=2]`))
+	f.Put([]byte("c"), mustAd(t, `[X=3]`))
+	if f.Chained() {
+		t.Fatal("flat collection reports Chained() = true")
+	}
+	m := 0
+	for range f.Query(matchAll) {
+		m++
+	}
+	if f.Len() != 3 || m != 3 {
+		t.Fatalf("flat: Len() = %d, rows = %d, want 3/3", f.Len(), m)
+	}
+}

--- a/collections/store.go
+++ b/collections/store.go
@@ -714,7 +714,9 @@ func (c *Collection) Flatten(key []byte) (*classad.ClassAd, bool) {
 	return c.Get(key)
 }
 
-// Len returns the number of live keys across all shards.
+// Len returns the number of live keys across all shards. Note this includes structural
+// (parent-only) ads of a chained collection, which Scan/Query hide -- so Len equals the
+// number of rows a match-all query returns only when the collection is not Chained.
 func (c *Collection) Len() int {
 	n := 0
 	for _, sh := range c.shards {
@@ -724,6 +726,11 @@ func (c *Collection) Len() int {
 	}
 	return n
 }
+
+// Chained reports whether the collection has structural (parent-only) ads that Scan/Query
+// hide (HTCondor cluster/proc chaining). When false, Len is exactly the match-all row count,
+// which the COUNT(*) fast path relies on.
+func (c *Collection) Chained() bool { return c.isStructural != nil }
 
 // Keys returns every visible key in the collection at a consistent per-shard
 // snapshot, in no particular order. Structural (parent-only) keys of a chained

--- a/db/archive.go
+++ b/db/archive.go
@@ -177,7 +177,7 @@ func (t *ArchiveTable) Aggregate(constraint string, groupBy []string, aggs []Agg
 	// which the archive tracks in O(1). This is the common `SELECT COUNT(*) FROM history`;
 	// scanning tens of thousands of records to count them would be needlessly slow.
 	if len(groupBy) == 0 && len(aggs) == 1 && aggs[0].Func == AggCount && aggs[0].Arg == "*" &&
-		isMatchAll(constraint) {
+		IsMatchAll(constraint) {
 		return []AggRow{{Values: []string{strconv.Itoa(t.a.Count())}}}, nil
 	}
 
@@ -197,9 +197,10 @@ func (t *ArchiveTable) Aggregate(constraint string, groupBy []string, aggs []Agg
 	return AggregateValues(seq, groupCols, aggs, groupCol, aggCol, nil), nil
 }
 
-// isMatchAll reports whether a constraint imposes no filter (an empty string or a literal
-// "true"), so an aggregate over it covers every retained record.
-func isMatchAll(constraint string) bool {
+// IsMatchAll reports whether a constraint imposes no filter (an empty string or a literal
+// "true"), so an aggregate over it covers every record. Shared with the mutable-table
+// COUNT(*) fast path in dbrpc.
+func IsMatchAll(constraint string) bool {
 	c := strings.TrimSpace(constraint)
 	return c == "" || strings.EqualFold(c, "true")
 }

--- a/db/db.go
+++ b/db/db.go
@@ -271,8 +271,13 @@ func (db *DB) SuggestIndexes(sampleMax int) []collections.IndexSuggestion {
 	return db.c.SuggestIndexes(sampleMax)
 }
 
-// Len returns the number of committed ads.
+// Len returns the number of committed ads (including structural parent-only ads of a chained
+// collection, which Query hides -- see Collection.Len / Chained).
 func (db *DB) Len() int { return db.c.Len() }
+
+// Chained reports whether the table has structural (parent-only) ads that Query hides, so a
+// caller knows when Len equals the match-all row count (the COUNT(*) fast path).
+func (db *DB) Chained() bool { return db.c.Chained() }
 
 // LookupClassAd returns the committed ad for key (the hash table, outside any
 // transaction), or (nil, false).

--- a/dbrpc/aggregate.go
+++ b/dbrpc/aggregate.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 
 	"github.com/PelicanPlatform/classad/classad"
 	"github.com/PelicanPlatform/classad/db"
@@ -243,6 +244,21 @@ func (s *Server) aggregate(ctx context.Context, reqID uint64, table, constraint 
 	if !ok {
 		return
 	}
+
+	// Fast path: an unconstrained COUNT(*) with no grouping is the collection's live row
+	// count, which it tracks in O(shards) via Len() -- no scan of every ad. This is the common
+	// `SELECT COUNT(*) FROM <table>`. Only when the collection has no hidden structural
+	// (parent-only) ads, which a match-all scan excludes but Len() counts (a chained job_queue
+	// has them; a flat table like Startd does not). Mirrors ArchiveTable.Aggregate.
+	if len(groupCols) == 0 && len(aggs) == 1 && aggs[0].Func == AggCount && aggs[0].Arg == "*" &&
+		db.IsMatchAll(constraint) && !d.Chained() {
+		frame := respHead(reqID, stStream)
+		frame = putStr(frame, strconv.Itoa(d.Len()))
+		write(frame)
+		write(respHead(reqID, stStreamEnd))
+		return
+	}
+
 	seq, err := d.QueryProject(constraint, attrs)
 	if err != nil {
 		write(respErr(reqID, err.Error()))

--- a/dbrpc/count_fastpath_test.go
+++ b/dbrpc/count_fastpath_test.go
@@ -1,0 +1,60 @@
+package dbrpc
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"testing"
+)
+
+// TestAggregateCountStarFastPath verifies the unconstrained COUNT(*) fast path (Len(), no
+// scan) returns the right count for empty and "true" constraints, that a constrained COUNT(*)
+// still takes the scan path and stays correct, and that the fast path reflects deletes.
+func TestAggregateCountStarFastPath(t *testing.T) {
+	c, cleanup := testPair(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	tx, _ := c.Begin(ctx)
+	for i := 0; i < 50; i++ {
+		_ = tx.NewClassAd(ctx, strconv.Itoa(i), fmt.Sprintf("Cpus = %d", i))
+	}
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	count := func(constraint string) string {
+		rows, err := c.Aggregate(ctx, constraint, nil, []AggSpec{{Func: AggCount, Arg: "*"}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(rows) != 1 || len(rows[0].Values) != 1 {
+			t.Fatalf("count rows = %+v, want a single one-value row", rows)
+		}
+		return rows[0].Values[0]
+	}
+
+	// Unconstrained COUNT(*): the fast path. Both spellings of match-all.
+	if got := count("true"); got != "50" {
+		t.Errorf(`COUNT(*) WHERE true = %s, want 50`, got)
+	}
+	if got := count(""); got != "50" {
+		t.Errorf(`COUNT(*) (empty constraint) = %s, want 50`, got)
+	}
+	// Constrained COUNT(*): the scan path stays correct.
+	if got := count("Cpus >= 25"); got != "25" {
+		t.Errorf(`COUNT(*) WHERE Cpus >= 25 = %s, want 25`, got)
+	}
+
+	// The fast path tracks deletes (Len decrements on delete).
+	n, err := c.DeleteWhere(ctx, "Cpus < 10")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 10 {
+		t.Fatalf("DeleteWhere removed %d, want 10", n)
+	}
+	if got := count("true"); got != "40" {
+		t.Errorf(`COUNT(*) after deleting 10 = %s, want 40`, got)
+	}
+}


### PR DESCRIPTION
## What

An unconstrained `SELECT COUNT(*)` on a **mutable** table was doing a full scan — `dbrpc.Server.aggregate` → `QueryProject` over every ad, folding each into a counter. Counting ~11k `StartD` ads measured **~190ms**:

```
htcondordb> select count(*) from Startd
COUNT(*)
--------
11453   
(1 row in 192.09ms)
```

Archives already had an O(1) fast path (`ArchiveTable.Aggregate` → `Archive.Count()`); mutable tables never got one, even though `Collection.Len()` is O(shards).

## Fix

Wire the same fast path into the mutable aggregate: a no-group, match-all `COUNT(*)` returns `d.Len()` with **no scan**.

**Gated on `!d.Chained()`.** `Len()` counts the structural (parent-only) cluster ads of a chained `job_queue` collection that a match-all query *hides*, so the fast path is used only for flat tables where `Len()` is exactly the match-all row count (`Startd`, `Schedd`, `Master`, `Negotiator`, …). A chained table (`jobs`) still scans and stays correct.

- **collections**: `Collection.Chained()` (reports it has structural ads); `Len()` doc clarified.
- **db**: `DB.Chained()`; export `IsMatchAll` (was `isMatchAll`) so the mutable and archive count paths share identical match-all semantics.
- **dbrpc**: the fast path in `aggregate()`, mirroring `ArchiveTable.Aggregate`.

## Tests

- **dbrpc** `TestAggregateCountStarFastPath`: `COUNT(*)` over empty and `"true"` constraints (fast path), a constrained `COUNT(*)` still correct (scan path), and the count tracks deletes.
- **collections** `TestChainedGateForCountFastPath`: documents why a chained collection must not use `Len()` — `Len()=5` (3 procs + 2 clusters) but a match-all query returns 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
