### PR TITLE
collections: equi-depth histogram for skew-aware value-index range selectivity

### DIFF
--- a/collections/archive_index.go
+++ b/collections/archive_index.go
@@ -53,7 +53,7 @@ import (
 // simply rejected and reindexed.
 const (
 	sidecarMagic   = 0x41524358 // "ARCX"
-	sidecarVersion = 8          // v8 appended a CRC-32C footer over the whole sidecar
+	sidecarVersion = 9          // v9 appended a per-value-attr equi-depth histogram to each stats block
 
 	// mphNDVThreshold gates the categorical minimal-perfect-hash: only an attribute with
 	// at least this many distinct values in a segment gets one. Below it, the sorted key
@@ -384,6 +384,18 @@ func appendSegStats(b []byte, s *segStats) []byte {
 	} else {
 		b = appendBytes(b, nil)
 	}
+	// Equi-depth histogram (v9): bucket count, low edge, then (upper-bound, cumulative-count)
+	// per bucket. Zero buckets for a categorical attribute or an empty value index.
+	if s.hist != nil {
+		b = appendU32(b, uint32(len(s.hist.bound)))
+		b = appendU64(b, math.Float64bits(s.hist.lo))
+		for i := range s.hist.bound {
+			b = appendU64(b, math.Float64bits(s.hist.bound[i]))
+			b = appendU64(b, s.hist.cum[i])
+		}
+	} else {
+		b = appendU32(b, 0)
+	}
 	return b
 }
 
@@ -408,6 +420,14 @@ func readSegStats(d []byte, off uint32) *segStats {
 	}
 	if reg := c.bytes(); len(reg) > 0 {
 		s.hll = &hyperLogLog{reg: append([]uint8(nil), reg...)}
+	}
+	if n := c.u32(); n > 0 && n < 1<<20 {
+		h := &valHistogram{lo: math.Float64frombits(c.u64()), bound: make([]float64, n), cum: make([]uint64, n)}
+		for i := uint32(0); i < n; i++ {
+			h.bound[i] = math.Float64frombits(c.u64())
+			h.cum[i] = c.u64()
+		}
+		s.hist = h
 	}
 	return s
 }

--- a/collections/histogram_test.go
+++ b/collections/histogram_test.go
@@ -1,0 +1,186 @@
+package collections
+
+import (
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/classad"
+)
+
+// skewedMemoryAds inserts a skewed Memory distribution mirroring a real StartD pool: most
+// nodes are small, a handful are huge (768 GiB) which stretch max far past the bulk. Returns
+// the true fraction with Memory > 4096. lowN nodes have Memory in [512,4096]; highN have
+// Memory in (4096, 32768] plus `huge` outliers at 786432.
+func putSkewedMemory(c *Collection, lowN, highN, huge int) float64 {
+	id := 0
+	put := func(mem int) {
+		c.Put([]byte(fmt.Sprintf("k%d", id)), mustAdMem(mem))
+		id++
+	}
+	for i := 0; i < lowN; i++ {
+		put(512 + i%3585) // 512..4096, all <= 4096
+	}
+	for i := 0; i < highN; i++ {
+		put(4097 + i%28671) // 4097..32768, all > 4096
+	}
+	for i := 0; i < huge; i++ {
+		put(786432) // 768 GiB outliers: stretch max, break the uniform assumption
+	}
+	total := lowN + highN + huge
+	return float64(highN+huge) / float64(total)
+}
+
+func mustAdMem(mem int) *classad.ClassAd {
+	ad, err := classad.Parse(fmt.Sprintf(`[ Memory = %d ]`, mem))
+	if err != nil {
+		panic(err)
+	}
+	return ad
+}
+
+// selForOp returns the ExplainQuery selectivity estimate for a single-probe query, requiring
+// the probe to be index-usable with a selectivity.
+func selForOp(t *testing.T, c *Collection, query string) float64 {
+	t.Helper()
+	ex := c.ExplainQuery(mustQuery(t, query))
+	if len(ex.Probes) != 1 || !ex.Probes[0].HasSelectivity {
+		t.Fatalf("%q: expected one probe with selectivity, got %+v", query, ex.Probes)
+	}
+	return ex.Probes[0].Selectivity
+}
+
+// TestHistogramSkewedRangeEstimate is the regression for the wrong-stats bug: with a skewed
+// Memory distribution, the old uniform-[min,max] model estimates `Memory > 4096` at ~99.5%,
+// while the true fraction is ~42%. The equi-depth histogram must estimate close to the truth.
+func TestHistogramSkewedRangeEstimate(t *testing.T) {
+	// The selectivity estimator reads sealed-segment indexes, so persist + Reindex to seal.
+	c, err := Open(Options{Dir: t.TempDir(), ValueAttrs: []string{"Memory"}, SegmentSize: 1 << 12})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+	trueHigh := putSkewedMemory(c, 7957, 5872, 10) // ~0.425 of records have Memory > 4096
+	c.Reindex()
+
+	// What the OLD uniform model would say, for the record: 1 - (4096-min)/(max-min).
+	naiveHigh := 1 - (4096.0-512)/(786432.0-512)
+	if naiveHigh < 0.95 {
+		t.Fatalf("test data not skewed enough: naive estimate %.3f", naiveHigh)
+	}
+
+	gotHigh := selForOp(t, c, "Memory > 4096")
+	gotLow := selForOp(t, c, "Memory <= 4096")
+
+	if math.Abs(gotHigh-trueHigh) > 0.06 {
+		t.Errorf("Memory > 4096 selectivity = %.3f, want ~%.3f (true); naive model would say %.3f", gotHigh, trueHigh, naiveHigh)
+	}
+	if math.Abs(gotLow-(1-trueHigh)) > 0.06 {
+		t.Errorf("Memory <= 4096 selectivity = %.3f, want ~%.3f", gotLow, 1-trueHigh)
+	}
+	// The whole point: the histogram is nowhere near the broken uniform estimate.
+	if gotHigh > 0.7 {
+		t.Errorf("Memory > 4096 selectivity %.3f is still near the broken uniform estimate %.3f", gotHigh, naiveHigh)
+	}
+}
+
+// TestHistogramSurvivesReopen verifies the histogram is serialized into the sealed-segment
+// sidecar (v9) and reconstructed on reopen, so the skew-aware estimate persists.
+func TestHistogramSurvivesReopen(t *testing.T) {
+	dir := t.TempDir()
+	c, err := Open(Options{Dir: dir, ValueAttrs: []string{"Memory"}, SegmentSize: 1 << 12})
+	if err != nil {
+		t.Fatal(err)
+	}
+	trueHigh := putSkewedMemory(c, 4000, 3000, 8)
+	c.Reindex() // seal + write v9 sidecars
+	if err := c.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	d, err := Open(Options{Dir: dir, ValueAttrs: []string{"Memory"}, SegmentSize: 1 << 12})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+	got := selForOp(t, d, "Memory > 4096")
+	if math.Abs(got-trueHigh) > 0.08 {
+		t.Errorf("after reopen, Memory > 4096 selectivity = %.3f, want ~%.3f (histogram lost across the sidecar?)", got, trueHigh)
+	}
+}
+
+// TestValHistogramSerializationRoundTrip round-trips a segStats histogram through the sidecar
+// stats block encoder/decoder and checks the CDF is preserved at several thresholds.
+func TestValHistogramSerializationRoundTrip(t *testing.T) {
+	keys := make([]float64, 0, 500)
+	counts := make([]uint64, 0, 500)
+	var total uint64
+	for v := 0; v < 500; v++ {
+		keys = append(keys, float64(v))
+		c := uint64(1 + v%7) // varied counts
+		counts = append(counts, c)
+		total += c
+	}
+	s := &segStats{hasRange: true, covered: total, hist: buildValHistogram(keys, counts, total)}
+	if s.hist == nil {
+		t.Fatal("nil histogram")
+	}
+	b := appendSegStats(nil, s)
+	got := readSegStats(b, 0)
+	if got.hist == nil {
+		t.Fatal("histogram not decoded")
+	}
+	for _, tv := range []float64{-10, 0, 50, 123, 250, 499, 1000} {
+		a := s.hist.cdf(tv)
+		bb := got.hist.cdf(tv)
+		if math.Abs(a-bb) > 1e-9 {
+			t.Errorf("cdf(%.0f): before %.6f, after %.6f", tv, a, bb)
+		}
+	}
+}
+
+// TestValHistogramCDFProperties verifies the CDF is well-formed: exact at every bucket top
+// (cum/total), 0 below the low edge, 1 at/above the max, and monotonic non-decreasing.
+func TestValHistogramCDFProperties(t *testing.T) {
+	// Heavy per-value counts (each >= the bucket target) so every value forms its own bucket
+	// and the bucket tops are exact cumulative fractions.
+	keys := []float64{10, 20, 30}
+	counts := []uint64{200, 900, 8900} // total 10000
+	h := buildValHistogram(keys, counts, 10000)
+	if h == nil {
+		t.Fatal("nil histogram")
+	}
+	// Exact at each bucket top above the low edge (frac reaches 1 at the boundary). The first
+	// boundary coincides with the low edge, where cdf is 0 by convention (see cdf's comment).
+	for i, b := range h.bound {
+		if b == h.lo {
+			if got := h.cdf(b); got != 0 {
+				t.Errorf("cdf(low edge %.0f) = %.4f, want 0", b, got)
+			}
+			continue
+		}
+		want := float64(h.cum[i]) / 10000
+		if got := h.cdf(b); math.Abs(got-want) > 1e-9 {
+			t.Errorf("cdf(bound %.0f) = %.4f, want %.4f", b, got, want)
+		}
+	}
+	if got := h.cdf(5); got != 0 {
+		t.Errorf("cdf below low edge = %.4f, want 0", got)
+	}
+	if got := h.cdf(1000); got != 1 {
+		t.Errorf("cdf above max = %.4f, want 1", got)
+	}
+	// Monotonic non-decreasing across the range.
+	prev := -1.0
+	for x := 0.0; x <= 40; x++ {
+		v := h.cdf(x)
+		if v < prev-1e-12 || v < 0 || v > 1 {
+			t.Fatalf("cdf not monotone/clamped at %.0f: %.4f (prev %.4f)", x, v, prev)
+		}
+		prev = v
+	}
+	// estRange ops are complementary and clamped.
+	if lo, hi := h.estRange("<=", 20), h.estRange(">", 20); math.Abs(lo+hi-1) > 1e-9 {
+		t.Errorf("<=20 (%.4f) + >20 (%.4f) != 1", lo, hi)
+	}
+}

--- a/collections/index_query.go
+++ b/collections/index_query.go
@@ -954,9 +954,13 @@ func (s *segStats) estEqualFloat(v float64) float64 {
 	return s.avgTailCount()
 }
 
-// estRange returns the estimated fraction of indexable records passing a range
-// comparison against threshold t, by linear interpolation over [min,max].
+// estRange returns the estimated fraction of indexable records passing a range comparison
+// against threshold t. It uses the equi-depth histogram when present (skew-aware), falling
+// back to linear interpolation over [min,max] for a pre-v9 sidecar or a degenerate span.
 func (s *segStats) estRange(op string, t float64) float64 {
+	if s.hist != nil {
+		return s.hist.estRange(op, t)
+	}
 	if !s.hasRange || s.max <= s.min {
 		if cmpFloat(op, s.min, t) {
 			return 1

--- a/collections/segstats.go
+++ b/collections/segstats.go
@@ -78,6 +78,101 @@ type segStats struct {
 	top   []topEntry   // up to topNMax heavy hitters, descending by count
 	bloom *bloomFilter // categorical membership; nil for a value index
 	hll   *hyperLogLog // mergeable distinct-count sketch
+
+	// hist is the equi-depth histogram for a value index's numeric distribution, giving
+	// skew-aware range selectivity instead of uniform [min,max] interpolation. nil for a
+	// categorical attribute, an empty value index, or a pre-v9 sidecar (falls back to the
+	// [min,max] model).
+	hist *valHistogram
+}
+
+// histMaxBuckets bounds the equi-depth histogram kept per value-index attribute per segment:
+// at most this many (value-quantile, cumulative-count) points. 64 gives skew-accurate range
+// selectivity at ~1 KiB/attr/segment, on the order of the HLL's footprint.
+const histMaxBuckets = 64
+
+// valHistogram is an equi-depth (equi-height) histogram over a value index's numeric
+// distribution, built exactly from the segment's postings. It replaces the uniform [min,max]
+// assumption for range selectivity: linear interpolation badly mis-estimates skewed data
+// (e.g. a few huge-Memory nodes stretch max, so `Memory > 4096` estimates ~99% when the truth
+// is ~40%), while the histogram's buckets concentrate where the data is dense. lo is the
+// smallest value (bucket 0's lower edge); bound[i] is the largest value in bucket i
+// (ascending); cum[i] is the count of indexable records with value <= bound[i] (ascending;
+// cum[last] == total indexable).
+type valHistogram struct {
+	lo    float64
+	bound []float64
+	cum   []uint64
+}
+
+// buildValHistogram builds an equi-depth histogram from a value index's ascending distinct
+// keys and their exact per-key record counts. Returns nil for an empty distribution. With
+// fewer distinct values than buckets it degenerates to one bucket per value -- an exact CDF.
+// A single key whose count exceeds the per-bucket target simply forms one heavy bucket (a
+// value cannot be split), and buckets resume at ~target records after it.
+func buildValHistogram(sortedKeys []float64, counts []uint64, indexable uint64) *valHistogram {
+	if len(sortedKeys) == 0 || indexable == 0 {
+		return nil
+	}
+	target := float64(indexable) / float64(histMaxBuckets)
+	if target < 1 {
+		target = 1
+	}
+	h := &valHistogram{lo: sortedKeys[0], bound: make([]float64, 0, histMaxBuckets), cum: make([]uint64, 0, histMaxBuckets)}
+	var running uint64
+	edge := target
+	last := len(sortedKeys) - 1
+	for i, k := range sortedKeys {
+		running += counts[i]
+		if float64(running) >= edge || i == last {
+			h.bound = append(h.bound, k)
+			h.cum = append(h.cum, running)
+			edge = float64(running) + target
+		}
+	}
+	return h
+}
+
+// cdf estimates the fraction of indexable records with value <= t, by piecewise-linear
+// interpolation of the cumulative counts across the bucket the threshold falls in.
+func (h *valHistogram) cdf(t float64) float64 {
+	n := len(h.bound)
+	total := float64(h.cum[n-1])
+	if total <= 0 {
+		return 0
+	}
+	if t < h.lo {
+		return 0
+	}
+	if t >= h.bound[n-1] {
+		return 1
+	}
+	i := sort.Search(n, func(j int) bool { return h.bound[j] >= t }) // first bucket top >= t
+	loB, cumPrev := h.lo, 0.0
+	if i > 0 {
+		loB, cumPrev = h.bound[i-1], float64(h.cum[i-1])
+	}
+	// Interpolate within the bucket. A zero-span bucket only occurs at bucket 0 when the low
+	// value equals the first boundary; leaving frac at 0 keeps cdf(min)=0, so `>= min` reads
+	// ~100% (matching the previous uniform model) rather than treating the min as a point mass
+	// -- estRange conflates `>`/`>=`, so a point mass at t would mis-score the inclusive side.
+	frac := 0.0
+	if span := h.bound[i] - loB; span > 0 {
+		frac = (t - loB) / span
+	}
+	return (cumPrev + frac*(float64(h.cum[i])-cumPrev)) / total
+}
+
+// estRange returns the estimated fraction of indexable records passing op against t.
+func (h *valHistogram) estRange(op string, t float64) float64 {
+	f := h.cdf(t)
+	switch op {
+	case "<", "<=":
+		return math.Max(0, math.Min(1, f))
+	case ">", ">=":
+		return math.Max(0, math.Min(1, 1-f))
+	}
+	return 1
 }
 
 // avgTailCount estimates the record count of a value that is NOT one of the kept
@@ -134,6 +229,13 @@ func (vp *valPostings) finishStats() {
 		vp.sortedKeys = append(vp.sortedKeys, k)
 	}
 	sort.Float64s(vp.sortedKeys)
+	// Equi-depth histogram over the exact (value, count) distribution, for skew-aware range
+	// selectivity (replaces uniform [min,max] interpolation in estRange).
+	counts := make([]uint64, len(vp.sortedKeys))
+	for i, k := range vp.sortedKeys {
+		counts[i] = vp.post[k].GetCardinality()
+	}
+	s.hist = buildValHistogram(vp.sortedKeys, counts, indexable)
 }
 
 // finishStats fills the categorical top-N, NDV, bloom and HLL fields from a


### PR DESCRIPTION
## The bug

Value-index range selectivity was estimated by **linear interpolation over `[min, max]`** — a uniform-distribution assumption. Skewed numeric attributes break it badly. Observed on a real `Startd` table:

```
Memory  >  INDEX (value)  est ~99.5% (~13755 of 13828)
htcondordb> select count(*) from Startd where Memory > 4096   -> 5882  (~43%)
htcondordb> select count(*) from Startd where Memory <= 4096  -> 7957  (~57%)
```

A handful of huge-memory nodes stretch `max` to hundreds of GiB, so `4096` lands at ~the 0.5th percentile of `[min,max]` and `Memory > 4096` estimates ~99.5% — while the truth is ~43%. This mis-orders multi-probe plans and makes EXPLAIN untrustworthy. (The `min`/`max` were correct; the *model* was wrong — so recomputing stats wouldn't have helped.)

## The fix

A compact **equi-depth histogram** per value-index attribute per segment, built exactly from the segment's postings (the sorted value→count distribution is already at hand in `finishValStats`), used by `estRange` via a piecewise-linear CDF. Buckets concentrate where data is dense, so skew is handled.

- `segstats.go`: `valHistogram` (`lo` + per-bucket upper bound + cumulative count, ≤64 buckets, ~1 KiB/attr/segment) with `buildValHistogram` / `cdf` / `estRange`; built in `finishValStats`.
- `index_query.go`: `estRange` uses the histogram when present, else the old `[min,max]` fallback.
- `archive_index.go`: histogram serialized into the stats block; **sidecar version 8 → 9**. Old sidecars are rejected and reindexed (never fatal), so histograms roll out as segments are reindexed/compacted — no migration.

`estBand`'s `lo + hi - 1` band formula becomes exact automatically once the one-sided estimates are histogram-based. No mergeable-sketch machinery is needed: compaction and reindex always rebuild stats from postings, never merge them.

Boundary convention: the min value reads as `cdf(min)=0` (bucket 0's low edge), so `>= min` stays ~100% as before — `estRange` conflates `>`/`>=`, so a point mass at the low edge would mis-score the inclusive side (this preserves the existing plan-cost-gate behavior).

## Tests

- `TestHistogramSkewedRangeEstimate` — the regression: skewed Memory, estimate within 0.06 of the true fraction (vs the ~99.5% the uniform model gives).
- `TestHistogramSurvivesReopen` — v9 sidecar round-trip: the skew-aware estimate persists across seal + reopen.
- `TestValHistogramSerializationRoundTrip`, `TestValHistogramCDFProperties` — encode/decode fidelity; CDF exact at boundaries, monotone, clamped.

## On "ANALYZE"

Worth noting for the follow-up discussion: because per-segment stats are derived from **immutable** sealed-segment data, a standalone force-`ANALYZE` (reindex) would recompute *identical* stats — it adds nothing. "Redo statistics" is already covered: `reindex` rebuilds old sidecars **with** histograms (automatic on seal/compaction, or on demand), and `rewrite`/compact refreshes stats past superseded versions. So this PR ships the histogram (the actual fix); whether to add a `.analyze` *alias* for ergonomics is a separate call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
