### PR TITLE
dbrpc: ANALYZE admin action — on-demand self-tuning (hot set + indexes + histograms)

### DIFF
--- a/dbrpc/analyze_test.go
+++ b/dbrpc/analyze_test.go
@@ -1,0 +1,105 @@
+package dbrpc
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/classad"
+	"github.com/PelicanPlatform/classad/db"
+)
+
+// TestAdminAnalyzeRefreshesHotSet verifies the on-demand "analyze" admin action runs a
+// Maintain pass that refreshes the hot set from accumulated read demand: after many projected
+// reads of Memory, analyze must front-load Memory (the demand-driven, non-redundant part of
+// ANALYSE that a plain reindex would not do).
+func TestAdminAnalyzeRefreshesHotSet(t *testing.T) {
+	cat, err := db.OpenCatalog("") // in-memory
+	if err != nil {
+		t.Fatal(err)
+	}
+	d, err := cat.CreateTable("Startd")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tx := d.Begin()
+	for i := 0; i < 300; i++ {
+		ad, perr := classad.ParseOld(fmt.Sprintf("Name = \"k%d\"\nMemory = %d\nArch = \"X86_64\"\nDisk = %d", i, 1024+i, i*10))
+		if perr != nil {
+			t.Fatal(perr)
+		}
+		tx.NewClassAd(fmt.Sprintf("k%d", i), ad)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Build read demand on Memory: projected reads tally recordReads(projection).
+	for i := 0; i < 30; i++ {
+		seq, qerr := d.QueryProject("true", []string{"Memory"})
+		if qerr != nil {
+			t.Fatal(qerr)
+		}
+		for range seq {
+		}
+	}
+
+	s := NewServerCatalog(cat)
+	defer s.Close()
+	msg, err := s.admin(d, "analyze", nil, true)
+	if err != nil {
+		t.Fatalf("analyze: %v", err)
+	}
+	if !strings.Contains(msg, "analyzed") {
+		t.Errorf("unexpected analyze message %q", msg)
+	}
+
+	hot := d.HotAttrs()
+	found := false
+	for _, h := range hot {
+		if strings.EqualFold(h, "Memory") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("hot set %v does not include Memory after analyze with read demand on it", hot)
+	}
+}
+
+// TestAdminAnalyzeRequiresPrivilege verifies analyze is DAEMON-gated like the other admin
+// actions.
+func TestAdminAnalyzeRequiresPrivilege(t *testing.T) {
+	cat, _ := db.OpenCatalog("")
+	d, _ := cat.CreateTable("t")
+	s := NewServerCatalog(cat)
+	defer s.Close()
+	if _, err := s.admin(d, "analyze", nil, false); err == nil {
+		t.Error("analyze without privilege should be refused")
+	}
+}
+
+// TestArchiveAdminAnalyze verifies analyze on an append-only archive reindexes (rebuilds the
+// per-value histogram / selectivity stats) without error.
+func TestArchiveAdminAnalyze(t *testing.T) {
+	cat, err := db.OpenCatalog(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cat.Close()
+	a, err := cat.CreateArchiveTable("history", db.ArchiveConfig{ValueAttrs: []string{"Memory"}, ZoneAttrs: []string{"Memory"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 100; i++ {
+		if err := a.AppendOld(fmt.Sprintf("Memory = %d", 1024+i)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	msg, err := archiveAdmin(a, "analyze", nil)
+	if err != nil {
+		t.Fatalf("archive analyze: %v", err)
+	}
+	if !strings.Contains(msg, "analyzed") {
+		t.Errorf("unexpected archive analyze message %q", msg)
+	}
+}

--- a/dbrpc/diag.go
+++ b/dbrpc/diag.go
@@ -52,6 +52,11 @@ type Diagnostics struct {
 // diagSampleMax bounds the ad sample the server takes for index suggestions.
 const diagSampleMax = 2000
 
+// defaultAnalyzeHotTopN is the hot-set size an on-demand "analyze" uses when the server was
+// started without a maintenance hot-set target (HotTopN == 0), so analyze still refreshes the
+// hot set from read demand.
+const defaultAnalyzeHotTopN = 32
+
 // diagJSON gathers a table's diagnostics into JSON.
 func (s *Server) diagJSON(t *db.DB) ([]byte, error) {
 	cat, val := t.IndexedAttrs()
@@ -224,6 +229,31 @@ func (s *Server) admin(t *db.DB, action string, args []string, privileged bool) 
 		}
 		n := t.RefreshHotSet(sampleMax, topN)
 		return fmt.Sprintf("refreshed hot set: %d attribute(s)", n), nil
+	case "analyze":
+		// On-demand self-tuning pass ("optimize now"), the manual counterpart to the scheduled
+		// StartMaintenance. Reuses the server's configured maintenance options so it matches the
+		// scheduled pass, but never does the heavy dictionary retrain (that recompacts -- it is
+		// rewrite/codec.retrain's job). Refreshes the hot set from accumulated read demand and,
+		// when auto-index is configured, retunes indexes; then reindexes unconditionally so value
+		// histograms and any index/hot changes take effect even when auto-index is off.
+		opts := s.maintainOpts
+		opts.Retrain = false
+		if opts.SampleMax <= 0 {
+			opts.SampleMax = diagSampleMax
+		}
+		if opts.HotTopN <= 0 {
+			opts.HotTopN = defaultAnalyzeHotTopN
+		}
+		if len(args) == 1 { // optional hot-set size override: analyze <topN>
+			if v, err := strconv.Atoi(args[0]); err == nil && v > 0 {
+				opts.HotTopN = v
+			}
+		}
+		s.maintainMu.Lock()
+		t.Maintain(opts)
+		t.Reindex()
+		s.maintainMu.Unlock()
+		return fmt.Sprintf("analyzed: hot set = %d attribute(s)", len(t.HotAttrs())), nil
 	default:
 		return "", fmt.Errorf("unknown admin action %q", action)
 	}
@@ -267,6 +297,12 @@ func archiveAdmin(a *db.ArchiveTable, action string, args []string) (string, err
 	case "index.reindex":
 		a.Reindex()
 		return "reindexed", nil
+	case "analyze":
+		// An append-only archive has no demand-driven index/hot auto-tune (its layout is fixed
+		// at creation), so "redo statistics" is a reindex: it rebuilds each segment's per-value
+		// histogram and other selectivity stats. Superseded-version drift does not apply.
+		a.Reindex()
+		return "analyzed (reindexed selectivity statistics)", nil
 	case "rewrite":
 		return fmt.Sprintf("rewrote %d record(s) with the current hot set", a.Rewrite()), nil
 	case "codec.retrain":

--- a/dbrpc/server.go
+++ b/dbrpc/server.go
@@ -25,6 +25,13 @@ type Server struct {
 	nextID atomic.Uint64
 	stopBG []func()
 
+	// maintainOpts is the self-tuning configuration StartMaintenance was given; the on-demand
+	// "analyze" admin action reuses it so a manual optimize matches the scheduled pass.
+	// maintainMu serializes any Maintain pass (scheduled or on-demand) on this server so two
+	// do not retune the same table at once.
+	maintainOpts db.MaintainOptions
+	maintainMu   sync.Mutex
+
 	// propose, when set, routes a committing transaction's writes through an external
 	// consensus layer (raft) instead of committing them to the local store: on opCommit
 	// the accumulated ops are handed to propose, which is the store's sole writer. Set by
@@ -240,6 +247,7 @@ func (s *Server) StartMaintenance(interval time.Duration, opts db.MaintainOption
 	if interval <= 0 {
 		interval = defaultMaintenanceInterval
 	}
+	s.maintainOpts = opts // reused by the on-demand "analyze" admin action
 	done := make(chan struct{})
 	go func() {
 		t := time.NewTimer(interval)
@@ -253,7 +261,9 @@ func (s *Server) StartMaintenance(interval time.Duration, opts db.MaintainOption
 			start := time.Now()
 			for _, name := range s.cat.Tables() {
 				if d, ok := s.cat.Table(name); ok {
+					s.maintainMu.Lock()
 					d.Maintain(opts)
+					s.maintainMu.Unlock()
 				}
 			}
 			// Keep the duty cycle under the cap: wait at least pass/dutyCycle before the


### PR DESCRIPTION
## What

Adds an **`analyze`** table admin action — the manual counterpart to the scheduled `StartMaintenance` pass. It runs `DB.Maintain` now (reusing the server's configured maintenance options), so an operator can re-optimize on demand instead of waiting for the background tick.

Follows the histogram PR (#108): together they answer "redo statistics." The key insight is that **`ANALYZE`'s value is the demand-driven half**, which a plain reindex can't reproduce:

- **Data-derived stats** (histograms, min/max, NDV) come from *immutable* segment data → recomputing gives identical results. A force-reindex there is pointless.
- **Demand-derived decisions** (hot set, auto-indexes) are driven by accumulated **query/read telemetry** and genuinely drift with the workload. Recomputing them is real work — exactly what ANALYZE is for.

## Behavior

`analyze`:
- **Refreshes the hot set** from accumulated read demand (`RefreshHotSet` ranks attributes by `demand.reads`), front-loading the most-read attributes.
- **Retunes indexes** when auto-index is configured (`MinIndexDemand`/budget) — respects existing config, so it won't add indexes unless the operator enabled auto-indexing.
- **Reindexes** so value histograms and any hot/index changes take effect even when auto-index is off.
- **Never** does the heavy dictionary retrain (that recompacts — it belongs to `rewrite`/`codec.retrain`). So `analyze` decides; `rewrite` (VACUUM) physically re-packs hot headers + compacts.
- `analyze <topN>` overrides the hot-set size; otherwise it uses the configured `HotTopN` or a default (32).

For an append-only **archive**, `analyze` is a reindex (rebuild the per-value histogram / selectivity stats) — an archive has no demand-driven auto-tune.

## Plumbing

- `Server` now stores the `StartMaintenance` options and serializes any `Maintain` pass (scheduled or on-demand) through a `maintainMu`, so two passes never retune a table at once.
- `admin`: `analyze` case (DAEMON-gated like the other admin actions). `archiveAdmin`: `analyze` case.
- No client change — it flows through the generic `AdminTable(ctx, table, "analyze")`.

## Note on the hot-set payoff

`RefreshHotSet` sets the hot *names*; existing records keep their old hot headers until rewritten, so the full query-speed payoff of a changed hot set lands after a `.rewrite`. `analyze` still immediately fixes the cost model and helps all newly-written records.

## Tests

`analyze` front-loads a read-demanded attribute into the hot set; privilege gate; archive `analyze` reindexes.

Follow-up (htcondordb): a `.analyze` REPL command → `AdminTable(..., "analyze")`, after a v0.21.6 bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
