### PR TITLE
collections: per-segment ClassAd schema + columnar (PAX) scan (opt-in, MVCC-correct, ~78x)

### DIFF
--- a/collections/adschema.go
+++ b/collections/adschema.go
@@ -257,6 +257,22 @@ func readIntLE(src []byte, w int, unsigned bool) int64 {
 	return int64(u<<shift) >> shift
 }
 
+// splitRecord divides a schema record into its fixed numeric prefix ([escape][numeric blob]),
+// its string region, and its cold tail, by walking the positional string region (uvarint(len)+
+// bytes per non-escaped string field). Used by the columnar (sealed) encoder.
+func (s *adSchema) splitRecord(r []byte) (prefix, strs, cold []byte) {
+	prefixLen := s.escBytes + s.fixedLen
+	p := prefixLen
+	esc := r[:s.escBytes]
+	for i := range s.fields {
+		if s.fields[i].kind == akString && !testBit(esc, i) {
+			l, m := binary.Uvarint(r[p:])
+			p += m + int(l)
+		}
+	}
+	return r[:prefixLen], r[prefixLen:p], r[p:]
+}
+
 // encode lays one wire ad out in the schema record format.
 func (s *adSchema) encode(w wire.Ad) []byte {
 	esc := make([]byte, s.escBytes)

--- a/collections/adschema.go
+++ b/collections/adschema.go
@@ -1,0 +1,384 @@
+package collections
+
+import (
+	"encoding/binary"
+	"math"
+	"sort"
+
+	"github.com/PelicanPlatform/classad/collections/wire"
+)
+
+// A per-segment ClassAd schema stores the segment's common, type-stable attributes in a
+// fixed-offset typed blob at the front of each record, so a scan or match reads them by offset
+// with no per-record wire walk. ClassAds are schemaless, but a segment of like ads (every Slot
+// ad has Memory:int, Cpus:int, ...) is nearly a schema; sampling recovers it.
+//
+// Record layout:
+//
+//		[escape bitmap][fixed blob][uvarint strTableLen][string table][cold tail]
+//
+//	  - escape bitmap: one bit per schema field, set when this record's value is missing or
+//	    exceptional (wrong kind, or an int outside the field's chosen width) -- then it is not
+//	    in the fixed slot; an exceptional value is carried in the cold tail, a missing one is
+//	    simply absent.
+//	  - fixed blob: bools bit-packed in a leading bitset, then ints (grouped by ascending width),
+//	    reals, and string slots -- each schema field at a fixed offset.
+//	  - string table: bytes for tabled (>7 byte) strings; an 8-byte string slot is inline for
+//	    <=7 bytes else an (offset,length) into this table.
+//	  - cold tail: every non-schema attribute, and every escaped schema field, as the same
+//	    uvarint(id)+node the wire form uses (self-delimiting via wire.NodeLen).
+//
+// This is the internal record encoding only; ads decode back to the wire/ClassAd form on the
+// way out. Numeric fields are the fast path; strings/cold are correctness, not speed.
+type adKind uint8
+
+const (
+	akNone adKind = iota // not a stored scalar (a computed expression, list, undefined, ...)
+	akBool
+	akInt
+	akReal
+	akString
+)
+
+// adField is one schema attribute's placement and type.
+type adField struct {
+	id       uint32
+	kind     adKind
+	width    int  // int: 1/2/4/8; real/string: 8; bool: 0 (bit-packed)
+	unsigned bool // int only
+	boolBit  int  // bool: bit index in the fixed blob's leading bitset
+	off      int  // non-bool: byte offset in the fixed blob
+	// the escape-bitmap bit index equals the field's position in s.fields.
+}
+
+// adSchema is the resolved layout for a segment.
+type adSchema struct {
+	fields    []adField
+	byID      map[uint32]int
+	boolBytes int
+	fixedLen  int
+	escBytes  int
+}
+
+// adSchemaOpts tunes schema construction.
+type adSchemaOpts struct {
+	// Presence: a field is included when its dominant storable kind is present in at least this
+	// fraction of ALL sampled ads (bounds per-record waste from missing/exceptional slots).
+	Presence float64
+	// Fit: an int field's width is the smallest covering at least this fraction of its sampled
+	// values; the rest escape. So one 1000-CPU slot does not force every Cpus to 8 bytes.
+	Fit float64
+	// Strings includes string attributes as 8-byte SSO slots (a per-record string table). Off
+	// by default: with no cross-record dedup this can regress compressed size.
+	Strings bool
+}
+
+// intFits reports whether v fits the given width and signedness.
+func intFits(v int64, w int, unsigned bool) bool {
+	if unsigned {
+		if v < 0 {
+			return false
+		}
+		switch w {
+		case 1:
+			return v <= 0xFF
+		case 2:
+			return v <= 0xFFFF
+		case 4:
+			return v <= 0xFFFFFFFF
+		}
+		return true
+	}
+	switch w {
+	case 1:
+		return v >= -128 && v <= 127
+	case 2:
+		return v >= -32768 && v <= 32767
+	case 4:
+		return v >= math.MinInt32 && v <= math.MaxInt32
+	}
+	return true
+}
+
+// chooseIntWidth picks the smallest (width, signedness) covering >= fit of the sampled values;
+// the rest become per-record exceptions. Unsigned is used when every sample is non-negative.
+func chooseIntWidth(vals []int64, fit float64) (int, bool) {
+	unsigned := true
+	for _, v := range vals {
+		if v < 0 {
+			unsigned = false
+			break
+		}
+	}
+	for _, w := range []int{1, 2, 4} {
+		ok := 0
+		for _, v := range vals {
+			if intFits(v, w, unsigned) {
+				ok++
+			}
+		}
+		if len(vals) > 0 && float64(ok)/float64(len(vals)) >= fit {
+			return w, unsigned
+		}
+	}
+	return 8, false
+}
+
+// nodeKind maps a wire node to its storable scalar kind (akNone for a computed expression).
+func nodeKind(node []byte) (adKind, wire.Literal) {
+	lit, ok := wire.LiteralValue(node)
+	if !ok {
+		return akNone, lit
+	}
+	switch lit.Kind {
+	case wire.LitBool:
+		return akBool, lit
+	case wire.LitInt:
+		return akInt, lit
+	case wire.LitReal:
+		return akReal, lit
+	case wire.LitString:
+		return akString, lit
+	}
+	return akNone, lit
+}
+
+// buildAdSchema samples wire ads and resolves a schema: attributes whose dominant storable kind
+// is present in >= opts.Presence of the ads, laid out smallest-to-largest.
+func buildAdSchema(sample [][]byte, opts adSchemaOpts) *adSchema {
+	n := len(sample)
+	type stat struct {
+		kinds   [5]int
+		intVals []int64
+	}
+	stats := map[uint32]*stat{}
+	for _, w := range sample {
+		wire.Ad(w).ForEach(func(id uint32, node []byte) bool {
+			st := stats[id]
+			if st == nil {
+				st = &stat{}
+				stats[id] = st
+			}
+			k, lit := nodeKind(node)
+			st.kinds[k]++
+			if k == akInt {
+				st.intVals = append(st.intVals, lit.Int)
+			}
+			return true
+		})
+	}
+
+	var fields []adField
+	for id, st := range stats {
+		domK, domC := akNone, 0
+		for k := akBool; k <= akString; k++ {
+			if st.kinds[k] > domC {
+				domC, domK = st.kinds[k], adKind(k)
+			}
+		}
+		if domK == akNone || (domK == akString && !opts.Strings) {
+			continue
+		}
+		if n == 0 || float64(domC)/float64(n) < opts.Presence {
+			continue
+		}
+		f := adField{id: id, kind: domK}
+		switch domK {
+		case akInt:
+			f.width, f.unsigned = chooseIntWidth(st.intVals, opts.Fit)
+		case akReal, akString:
+			f.width = 8
+		}
+		fields = append(fields, f)
+	}
+
+	// Layout: bool, int (width asc), real, string; ties by id for determinism. Grouping bools
+	// first lets them bit-pack; grouping ints by width keeps the blob dense.
+	sort.Slice(fields, func(i, j int) bool {
+		if fields[i].kind != fields[j].kind {
+			return fields[i].kind < fields[j].kind
+		}
+		if fields[i].width != fields[j].width {
+			return fields[i].width < fields[j].width
+		}
+		return fields[i].id < fields[j].id
+	})
+
+	nBool := 0
+	for _, f := range fields {
+		if f.kind == akBool {
+			nBool++
+		}
+	}
+	s := &adSchema{byID: make(map[uint32]int, len(fields)), boolBytes: (nBool + 7) / 8}
+	off, bit := s.boolBytes, 0
+	for i := range fields {
+		if fields[i].kind == akBool {
+			fields[i].boolBit = bit
+			bit++
+		} else {
+			fields[i].off = off
+			off += fields[i].width
+		}
+		s.byID[fields[i].id] = i
+	}
+	s.fields = fields
+	s.fixedLen = off
+	s.escBytes = (len(fields) + 7) / 8
+	return s
+}
+
+func setBit(b []byte, i int)       { b[i>>3] |= 1 << uint(i&7) }
+func testBit(b []byte, i int) bool { return b[i>>3]&(1<<uint(i&7)) != 0 }
+
+func putIntLE(dst []byte, v int64, w int) {
+	u := uint64(v)
+	for i := 0; i < w; i++ {
+		dst[i] = byte(u >> (8 * uint(i)))
+	}
+}
+
+func readIntLE(src []byte, w int, unsigned bool) int64 {
+	var u uint64
+	for i := 0; i < w; i++ {
+		u |= uint64(src[i]) << (8 * uint(i))
+	}
+	if unsigned || w == 8 {
+		return int64(u)
+	}
+	shift := uint(64 - 8*w) // sign-extend from w bytes
+	return int64(u<<shift) >> shift
+}
+
+// writeStrSlot encodes an 8-byte string slot: high byte 0..7 = inline length (bytes in
+// slot[0:len]); high byte 0xFF = tabled (offset uint32 in slot[0:4], length uint24 in
+// slot[4:7], appended to the per-record table).
+func writeStrSlot(slot []byte, table *[]byte, s string) {
+	if len(s) <= 7 {
+		copy(slot[:7], s)
+		slot[7] = byte(len(s))
+		return
+	}
+	off := len(*table)
+	*table = append(*table, s...)
+	binary.LittleEndian.PutUint32(slot[0:4], uint32(off))
+	slot[4], slot[5], slot[6] = byte(len(s)), byte(len(s)>>8), byte(len(s)>>16)
+	slot[7] = 0xFF
+}
+
+func readStrSlot(slot, table []byte) string {
+	if slot[7] != 0xFF {
+		return string(slot[:slot[7]])
+	}
+	off := binary.LittleEndian.Uint32(slot[0:4])
+	l := int(slot[4]) | int(slot[5])<<8 | int(slot[6])<<16
+	return string(table[off : off+uint32(l)])
+}
+
+// encode lays one wire ad out in the schema record format.
+func (s *adSchema) encode(w wire.Ad) []byte {
+	esc := make([]byte, s.escBytes)
+	fixed := make([]byte, s.fixedLen)
+	var strTable, cold []byte
+	filled := make([]bool, len(s.fields))
+
+	w.ForEach(func(id uint32, node []byte) bool {
+		idx, ok := s.byID[id]
+		if !ok {
+			cold = append(binary.AppendUvarint(cold, uint64(id)), node...)
+			return true
+		}
+		f := &s.fields[idx]
+		k, lit := nodeKind(node)
+		if k != f.kind || (f.kind == akInt && !intFits(lit.Int, f.width, f.unsigned)) {
+			cold = append(binary.AppendUvarint(cold, uint64(id)), node...) // escaped -> cold tail
+			return true                                                    // filled stays false
+		}
+		switch f.kind {
+		case akBool:
+			if lit.Bool {
+				setBit(fixed[:s.boolBytes], f.boolBit)
+			}
+		case akInt:
+			putIntLE(fixed[f.off:], lit.Int, f.width)
+		case akReal:
+			binary.LittleEndian.PutUint64(fixed[f.off:], math.Float64bits(lit.Real))
+		case akString:
+			writeStrSlot(fixed[f.off:f.off+8], &strTable, lit.Str)
+		}
+		filled[idx] = true
+		return true
+	})
+	for i := range s.fields {
+		if !filled[i] {
+			setBit(esc, i) // missing or exceptional: not in the fixed slot
+		}
+	}
+	rec := make([]byte, 0, s.escBytes+s.fixedLen+len(strTable)+len(cold)+4)
+	rec = append(rec, esc...)
+	rec = append(rec, fixed...)
+	rec = binary.AppendUvarint(rec, uint64(len(strTable)))
+	rec = append(rec, strTable...)
+	rec = append(rec, cold...)
+	return rec
+}
+
+// forEach yields every attribute of a schema record as (id, wire node), reconstructing a node
+// for each non-escaped fixed field and replaying the cold tail. Returns false if the record is
+// malformed or fn stopped early. scratch, if non-nil, is reused to build synthesized nodes.
+func (s *adSchema) forEach(rec []byte, fn func(id uint32, node []byte) bool) bool {
+	if len(rec) < s.escBytes+s.fixedLen {
+		return false
+	}
+	esc := rec[:s.escBytes]
+	fixed := rec[s.escBytes : s.escBytes+s.fixedLen]
+	p := s.escBytes + s.fixedLen
+	strLen, m := binary.Uvarint(rec[p:])
+	if m <= 0 {
+		return false
+	}
+	p += m
+	if p+int(strLen) > len(rec) {
+		return false
+	}
+	strTable := rec[p : p+int(strLen)]
+	cold := rec[p+int(strLen):]
+
+	var scratch []byte
+	for i := range s.fields {
+		if testBit(esc, i) {
+			continue // escaped/missing: in the cold tail (exceptional) or absent (missing)
+		}
+		f := &s.fields[i]
+		scratch = scratch[:0]
+		switch f.kind {
+		case akBool:
+			scratch = wire.AppendBoolNode(scratch, testBit(fixed[:s.boolBytes], f.boolBit))
+		case akInt:
+			scratch = wire.AppendIntNode(scratch, readIntLE(fixed[f.off:], f.width, f.unsigned))
+		case akReal:
+			scratch = wire.AppendRealNode(scratch, math.Float64frombits(binary.LittleEndian.Uint64(fixed[f.off:])))
+		case akString:
+			scratch = wire.AppendStringNode(scratch, readStrSlot(fixed[f.off:f.off+8], strTable))
+		}
+		if !fn(f.id, scratch) {
+			return true
+		}
+	}
+	for len(cold) > 0 {
+		id, m := binary.Uvarint(cold)
+		if m <= 0 {
+			return false
+		}
+		cold = cold[m:]
+		nl, ok := wire.NodeLen(cold)
+		if !ok || nl > len(cold) {
+			return false
+		}
+		if !fn(uint32(id), cold[:nl]) {
+			return true
+		}
+		cold = cold[nl:]
+	}
+	return true
+}

--- a/collections/adschema.go
+++ b/collections/adschema.go
@@ -196,8 +196,15 @@ func buildAdSchema(sample [][]byte, opts adSchemaOpts) *adSchema {
 		fields = append(fields, f)
 	}
 
-	// Layout: bool, int (width asc), real, string; ties by id for determinism. Grouping bools
-	// first lets them bit-pack; grouping ints by width keeps the blob dense.
+	return layoutSchema(fields)
+}
+
+// layoutSchema orders the fields (bool, int by ascending width, real, string; ties by id) and
+// assigns each its fixed-blob offset / bit index, deriving boolBytes/fixedLen/escBytes/byID. It
+// is deterministic in the field set, so both buildAdSchema and the persisted-schema decoder
+// produce an identical layout. Grouping bools first lets them bit-pack; grouping ints by width
+// keeps the blob dense.
+func layoutSchema(fields []adField) *adSchema {
 	sort.Slice(fields, func(i, j int) bool {
 		if fields[i].kind != fields[j].kind {
 			return fields[i].kind < fields[j].kind
@@ -207,7 +214,6 @@ func buildAdSchema(sample [][]byte, opts adSchemaOpts) *adSchema {
 		}
 		return fields[i].id < fields[j].id
 	})
-
 	nBool := 0
 	for _, f := range fields {
 		if f.kind == akBool {

--- a/collections/adschema.go
+++ b/collections/adschema.go
@@ -15,21 +15,25 @@ import (
 //
 // Record layout:
 //
-//		[escape bitmap][fixed blob][uvarint strTableLen][string table][cold tail]
+//		[escape bitmap][numeric blob] [string region][cold tail]
+//		<------ fixed hot prefix ----> <----- compressible tail ----->
 //
 //	  - escape bitmap: one bit per schema field, set when this record's value is missing or
 //	    exceptional (wrong kind, or an int outside the field's chosen width) -- then it is not
 //	    in the fixed slot; an exceptional value is carried in the cold tail, a missing one is
 //	    simply absent.
-//	  - fixed blob: bools bit-packed in a leading bitset, then ints (grouped by ascending width),
-//	    reals, and string slots -- each schema field at a fixed offset.
-//	  - string table: bytes for tabled (>7 byte) strings; an 8-byte string slot is inline for
-//	    <=7 bytes else an (offset,length) into this table.
+//	  - numeric blob: bools bit-packed in a leading bitset, then ints (grouped by ascending
+//	    width) and reals -- each numeric field at a fixed offset. This is the scan/eval fast
+//	    path; kept uncompressed so a field reads at a known offset with no decode.
+//	  - string region: the schema's string fields, in schema order, as uvarint(len)+bytes for
+//	    each non-escaped one (position implied by the escape bitmap -- no per-string offset
+//	    slot). Compressible; a string read walks it rather than O(1), the deliberate trade.
 //	  - cold tail: every non-schema attribute, and every escaped schema field, as the same
 //	    uvarint(id)+node the wire form uses (self-delimiting via wire.NodeLen).
 //
-// This is the internal record encoding only; ads decode back to the wire/ClassAd form on the
-// way out. Numeric fields are the fast path; strings/cold are correctness, not speed.
+// The numeric blob is the fixed hot prefix (uncompressed, fast); the string region + cold tail
+// are the compressible remainder. This is the internal record encoding only; ads decode back
+// to the wire/ClassAd form on the way out.
 type adKind uint8
 
 const (
@@ -186,9 +190,9 @@ func buildAdSchema(sample [][]byte, opts adSchemaOpts) *adSchema {
 		switch domK {
 		case akInt:
 			f.width, f.unsigned = chooseIntWidth(st.intVals, opts.Fit)
-		case akReal, akString:
+		case akReal:
 			f.width = 8
-		}
+		} // akString has no fixed width -- it is positional in the string region
 		fields = append(fields, f)
 	}
 
@@ -213,10 +217,13 @@ func buildAdSchema(sample [][]byte, opts adSchemaOpts) *adSchema {
 	s := &adSchema{byID: make(map[uint32]int, len(fields)), boolBytes: (nBool + 7) / 8}
 	off, bit := s.boolBytes, 0
 	for i := range fields {
-		if fields[i].kind == akBool {
+		switch fields[i].kind {
+		case akBool:
 			fields[i].boolBit = bit
 			bit++
-		} else {
+		case akString:
+			// positional in the string region; no fixed offset
+		default: // int, real
 			fields[i].off = off
 			off += fields[i].width
 		}
@@ -250,37 +257,13 @@ func readIntLE(src []byte, w int, unsigned bool) int64 {
 	return int64(u<<shift) >> shift
 }
 
-// writeStrSlot encodes an 8-byte string slot: high byte 0..7 = inline length (bytes in
-// slot[0:len]); high byte 0xFF = tabled (offset uint32 in slot[0:4], length uint24 in
-// slot[4:7], appended to the per-record table).
-func writeStrSlot(slot []byte, table *[]byte, s string) {
-	if len(s) <= 7 {
-		copy(slot[:7], s)
-		slot[7] = byte(len(s))
-		return
-	}
-	off := len(*table)
-	*table = append(*table, s...)
-	binary.LittleEndian.PutUint32(slot[0:4], uint32(off))
-	slot[4], slot[5], slot[6] = byte(len(s)), byte(len(s)>>8), byte(len(s)>>16)
-	slot[7] = 0xFF
-}
-
-func readStrSlot(slot, table []byte) string {
-	if slot[7] != 0xFF {
-		return string(slot[:slot[7]])
-	}
-	off := binary.LittleEndian.Uint32(slot[0:4])
-	l := int(slot[4]) | int(slot[5])<<8 | int(slot[6])<<16
-	return string(table[off : off+uint32(l)])
-}
-
 // encode lays one wire ad out in the schema record format.
 func (s *adSchema) encode(w wire.Ad) []byte {
 	esc := make([]byte, s.escBytes)
 	fixed := make([]byte, s.fixedLen)
-	var strTable, cold []byte
+	var cold []byte
 	filled := make([]bool, len(s.fields))
+	strVals := make([]string, len(s.fields)) // schema string values, kept for the ordered region
 
 	w.ForEach(func(id uint32, node []byte) bool {
 		idx, ok := s.byID[id]
@@ -304,7 +287,7 @@ func (s *adSchema) encode(w wire.Ad) []byte {
 		case akReal:
 			binary.LittleEndian.PutUint64(fixed[f.off:], math.Float64bits(lit.Real))
 		case akString:
-			writeStrSlot(fixed[f.off:f.off+8], &strTable, lit.Str)
+			strVals[idx] = lit.Str
 		}
 		filled[idx] = true
 		return true
@@ -314,35 +297,30 @@ func (s *adSchema) encode(w wire.Ad) []byte {
 			setBit(esc, i) // missing or exceptional: not in the fixed slot
 		}
 	}
-	rec := make([]byte, 0, s.escBytes+s.fixedLen+len(strTable)+len(cold)+4)
+	rec := make([]byte, 0, s.escBytes+s.fixedLen+len(cold)+16)
 	rec = append(rec, esc...)
 	rec = append(rec, fixed...)
-	rec = binary.AppendUvarint(rec, uint64(len(strTable)))
-	rec = append(rec, strTable...)
+	// String region: schema string fields in order, each present one as uvarint(len)+bytes.
+	for i := range s.fields {
+		if s.fields[i].kind == akString && filled[i] {
+			rec = binary.AppendUvarint(rec, uint64(len(strVals[i])))
+			rec = append(rec, strVals[i]...)
+		}
+	}
 	rec = append(rec, cold...)
 	return rec
 }
 
 // forEach yields every attribute of a schema record as (id, wire node), reconstructing a node
-// for each non-escaped fixed field and replaying the cold tail. Returns false if the record is
-// malformed or fn stopped early. scratch, if non-nil, is reused to build synthesized nodes.
+// for each non-escaped field and replaying the cold tail. Returns false if the record is
+// malformed or fn stopped early.
 func (s *adSchema) forEach(rec []byte, fn func(id uint32, node []byte) bool) bool {
 	if len(rec) < s.escBytes+s.fixedLen {
 		return false
 	}
 	esc := rec[:s.escBytes]
 	fixed := rec[s.escBytes : s.escBytes+s.fixedLen]
-	p := s.escBytes + s.fixedLen
-	strLen, m := binary.Uvarint(rec[p:])
-	if m <= 0 {
-		return false
-	}
-	p += m
-	if p+int(strLen) > len(rec) {
-		return false
-	}
-	strTable := rec[p : p+int(strLen)]
-	cold := rec[p+int(strLen):]
+	p := s.escBytes + s.fixedLen // cursor into the string region, then the cold tail
 
 	var scratch []byte
 	for i := range s.fields {
@@ -359,12 +337,19 @@ func (s *adSchema) forEach(rec []byte, fn func(id uint32, node []byte) bool) boo
 		case akReal:
 			scratch = wire.AppendRealNode(scratch, math.Float64frombits(binary.LittleEndian.Uint64(fixed[f.off:])))
 		case akString:
-			scratch = wire.AppendStringNode(scratch, readStrSlot(fixed[f.off:f.off+8], strTable))
+			l, m := binary.Uvarint(rec[p:])
+			if m <= 0 || p+m+int(l) > len(rec) {
+				return false
+			}
+			p += m
+			scratch = wire.AppendStringNode(scratch, string(rec[p:p+int(l)]))
+			p += int(l)
 		}
 		if !fn(f.id, scratch) {
 			return true
 		}
 	}
+	cold := rec[p:]
 	for len(cold) > 0 {
 		id, m := binary.Uvarint(cold)
 		if m <= 0 {

--- a/collections/adschema_test.go
+++ b/collections/adschema_test.go
@@ -1,0 +1,137 @@
+package collections
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/classad"
+	"github.com/PelicanPlatform/classad/collections/wire"
+)
+
+// adAttrs collects a wire ad's attributes as id -> node (copied).
+func adAttrs(w []byte) map[uint32][]byte {
+	m := map[uint32][]byte{}
+	wire.Ad(w).ForEach(func(id uint32, node []byte) bool {
+		m[id] = append([]byte(nil), node...)
+		return true
+	})
+	return m
+}
+
+// sameValue compares two wire nodes by value: scalar literals by their decoded value (the
+// schema re-synthesizes them), computed expressions by raw bytes (they pass through the cold
+// tail unchanged).
+func sameValue(a, b []byte) bool {
+	la, oka := wire.LiteralValue(a)
+	lb, okb := wire.LiteralValue(b)
+	if oka != okb {
+		return false
+	}
+	if oka {
+		return la == lb
+	}
+	return bytes.Equal(a, b)
+}
+
+// assertRoundTrip encodes w under s, decodes it, and checks every attribute survives with the
+// same value.
+func assertRoundTrip(t *testing.T, s *adSchema, w []byte, what string) {
+	t.Helper()
+	rec := s.encode(wire.Ad(w))
+	dec := map[uint32][]byte{}
+	if !s.forEach(rec, func(id uint32, node []byte) bool {
+		dec[id] = append([]byte(nil), node...)
+		return true
+	}) {
+		t.Fatalf("%s: forEach reported a malformed record", what)
+	}
+	orig := adAttrs(w)
+	if len(dec) != len(orig) {
+		t.Errorf("%s: round-trip has %d attrs, want %d", what, len(dec), len(orig))
+	}
+	for id, on := range orig {
+		dn, ok := dec[id]
+		if !ok {
+			t.Errorf("%s: attr id=%d lost in round-trip", what, id)
+			continue
+		}
+		if !sameValue(on, dn) {
+			lo, _ := wire.LiteralValue(on)
+			ld, _ := wire.LiteralValue(dn)
+			t.Errorf("%s: attr id=%d value changed: %+v -> %+v", what, id, lo, ld)
+		}
+	}
+}
+
+// TestAdSchemaRoundTripSynthetic exercises every encoding path: fixed slots, bit-packed bools,
+// width-escaped ints (a value past the chosen width), missing fields, type exceptions, inline
+// and tabled strings, negative ints, reals, and expression pass-through.
+func TestAdSchemaRoundTripSynthetic(t *testing.T) {
+	c := New(Options{Shards: 1})
+	var wires [][]byte
+	add := func(src string) []byte {
+		ad, err := classad.ParseOld(src)
+		if err != nil {
+			t.Fatal(err)
+		}
+		w := c.encodeAd(ad.AST())
+		wires = append(wires, w)
+		return w
+	}
+
+	// 16 "normal" slot-like ads: Cpus/Memory fit small widths, common bool/real/strings.
+	for i := 0; i < 16; i++ {
+		add(fmt.Sprintf("Cpus = %d\nMemory = %d\nBig = %t\nLoad = %f\nArch = \"X86_64\"\nMachine = \"node%02d.example.org\"\nRequirements = (TARGET.Cpus >= Cpus)",
+			1+i%8, 1024+i*64, i%2 == 0, float64(i)/3, i))
+	}
+	// Edge ads (still exercised for round-trip regardless of schema membership):
+	edge := []string{
+		`Cpus = 99999` + "\n" + `Memory = 2048` + "\n" + `Big = true` + "\n" + `Load = 1.5` + "\n" + `Arch = "X86_64"` + "\n" + `Machine = "huge.example.org"`,  // Cpus past uint8/uint16 -> escapes
+		`Cpus = -3` + "\n" + `Memory = 4096` + "\n" + `Big = false` + "\n" + `Load = 0.0` + "\n" + `Arch = "ARM"` + "\n" + `Machine = "neg.example.org"`,        // negative -> signed
+		`Cpus = 2` + "\n" + `Memory = "unknown"` + "\n" + `Big = true` + "\n" + `Load = 2.0` + "\n" + `Arch = "X86_64"` + "\n" + `Machine = "typo.example.org"`, // Memory string -> type exception
+		`Memory = 8192` + "\n" + `Big = true` + "\n" + `Load = 3.0` + "\n" + `Arch = "PPC"` + "\n" + `Machine = "nocpus.example.org"`,                           // Cpus missing
+		`Cpus = 4` + "\n" + `Memory = 512` + "\n" + `Big = false` + "\n" + `Load = -1.25` + "\n" + `Arch = "s"` + "\n" + `Machine = "x"` + "\n" + `Extra = 7`,   // short strings (<=7) inline; a rare attr
+	}
+	for _, s := range edge {
+		add(s)
+	}
+
+	for _, strings := range []bool{false, true} {
+		s := buildAdSchema(wires, adSchemaOpts{Presence: 0.80, Fit: 0.90, Strings: strings})
+		for i, w := range wires {
+			assertRoundTrip(t, s, w, fmt.Sprintf("strings=%v ad[%d]", strings, i))
+		}
+	}
+}
+
+// TestAdSchemaRoundTripOSPool round-trips every ad in the real corpus (skips without testdata).
+func TestAdSchemaRoundTripOSPool(t *testing.T) {
+	ads, _ := loadOSPoolAds(t)
+	_, wires := encodeOSPool(t, ads)
+	for _, strings := range []bool{false, true} {
+		s := buildAdSchema(wires, adSchemaOpts{Presence: 0.90, Fit: 0.95, Strings: strings})
+		for i, w := range wires {
+			assertRoundTrip(t, s, w, fmt.Sprintf("ospool strings=%v ad[%d]", strings, i))
+		}
+	}
+}
+
+// TestChooseIntWidth checks the fit-percentile width selection: a rare outlier does not widen
+// the field (it will escape instead), and signedness follows the sample.
+func TestChooseIntWidth(t *testing.T) {
+	vals := make([]int64, 0, 100)
+	for i := 0; i < 99; i++ {
+		vals = append(vals, int64(i)) // 0..98 fit uint8
+	}
+	vals = append(vals, 1_000_000) // one outlier
+	if w, u := chooseIntWidth(vals, 0.95); w != 1 || !u {
+		t.Errorf("chooseIntWidth = (%d,%v), want (1,true) -- outlier should escape, not widen", w, u)
+	}
+	if w, u := chooseIntWidth(vals, 0.999); w != 4 || !u {
+		t.Errorf("chooseIntWidth strict = (%d,%v), want (4,true) -- must widen to cover the outlier", w, u)
+	}
+	if w, _ := chooseIntWidth([]int64{-1, 5, 100}, 0.95); w != 1 {
+		t.Errorf("signed small = width %d, want 1", w)
+	}
+}

--- a/collections/blockcache.go
+++ b/collections/blockcache.go
@@ -1,0 +1,70 @@
+package collections
+
+import "github.com/dgraph-io/ristretto/v2"
+
+// decodedStreams holds a columnar block's decompressed cold streams (cold-numeric column,
+// string column, cold tail) -- what a full-ad reconstruct or an escaped/cold-field lookup
+// needs. Immutable once built.
+type decodedStreams struct {
+	coldNum, str, cold []byte
+}
+
+func (d *decodedStreams) cost() int64 { return int64(len(d.coldNum) + len(d.str) + len(d.cold)) }
+
+// blockCache caches columnar blocks' decompressed cold streams so repeated full-ad reads and
+// escaped-record lookups within a row-group decompress once, not per record. Backed by
+// ristretto: byte-cost-bounded (each entry's cost is its decompressed size) and concurrent, a
+// good fit for large, variable-size, hot items under parallel scans. A nil *blockCache is
+// valid and simply decompresses every time (used by tests and unconfigured collections).
+type blockCache struct {
+	c *ristretto.Cache[uint64, *decodedStreams]
+}
+
+// newBlockCache creates a cache bounded to about maxBytes of decompressed block streams.
+func newBlockCache(maxBytes int64) (*blockCache, error) {
+	c, err := ristretto.NewCache(&ristretto.Config[uint64, *decodedStreams]{
+		NumCounters: 1 << 20, // ~10x the expected item count, for TinyLFU admission
+		MaxCost:     maxBytes,
+		BufferItems: 64,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &blockCache{c: c}, nil
+}
+
+// streams returns b's decompressed cold streams, from the cache when present. On a miss it
+// decompresses all three and inserts them (cost = decompressed bytes). Safe for concurrent use;
+// ristretto's Set is asynchronous, so a get-immediately-after-set may miss -- harmless here (an
+// occasional redundant decompress, never a wrong result).
+func (bc *blockCache) streams(b *columnarBlock) (*decodedStreams, error) {
+	if bc != nil {
+		if ds, ok := bc.c.Get(b.id); ok {
+			return ds, nil
+		}
+	}
+	coldNum, err := b.codec.Decompress(nil, b.coldNumComp)
+	if err != nil {
+		return nil, err
+	}
+	str, err := b.codec.Decompress(nil, b.strComp)
+	if err != nil {
+		return nil, err
+	}
+	cold, err := b.codec.Decompress(nil, b.coldComp)
+	if err != nil {
+		return nil, err
+	}
+	ds := &decodedStreams{coldNum: coldNum, str: str, cold: cold}
+	if bc != nil {
+		bc.c.Set(b.id, ds, ds.cost())
+	}
+	return ds, nil
+}
+
+// close releases the cache's resources.
+func (bc *blockCache) close() {
+	if bc != nil && bc.c != nil {
+		bc.c.Close()
+	}
+}

--- a/collections/colblock.go
+++ b/collections/colblock.go
@@ -47,12 +47,17 @@ type columnarBlock struct {
 // adSchema.encode). hotNumFields lists the schema field indices (int/real) to keep uncompressed
 // -- the popular ones, by query demand. Bools and the escape bitmap are always in the hot
 // region (tiny, and bools may be scanned).
-func encodeColumnarBlock(s *adSchema, recs [][]byte, hotNumFields []int, codec Codec) *columnarBlock {
+// layoutColumnar fills b's hot/cold field partition and their offsets from the schema and hot
+// set: hot numerics packed after the escape+bool bitsets (stride hotStride), cold numerics
+// columnar (each field's n values contiguous). Deterministic in (schema, hotSet, n), so the
+// persisted-block decoder reproduces the exact layout.
+func layoutColumnar(b *columnarBlock, s *adSchema, hotNumFields []int, n int) {
 	hotSet := make(map[int]bool, len(hotNumFields))
 	for _, i := range hotNumFields {
 		hotSet[i] = true
 	}
-	b := &columnarBlock{id: colBlockSeq.Add(1), schema: s, codec: codec, n: len(recs), hotFieldOff: map[int]int{}, coldFieldStart: map[int]int{}}
+	b.hotNum, b.coldNum = b.hotNum[:0], b.coldNum[:0]
+	b.hotFieldOff, b.coldFieldStart = map[int]int{}, map[int]int{}
 	for i := range s.fields {
 		if k := s.fields[i].kind; k == akInt || k == akReal {
 			if hotSet[i] {
@@ -62,7 +67,6 @@ func encodeColumnarBlock(s *adSchema, recs [][]byte, hotNumFields []int, codec C
 			}
 		}
 	}
-	// Hot region layout and cold columnar offsets.
 	hp := s.escBytes + s.boolBytes
 	for _, i := range b.hotNum {
 		b.hotFieldOff[i] = hp
@@ -72,9 +76,17 @@ func encodeColumnarBlock(s *adSchema, recs [][]byte, hotNumFields []int, codec C
 	cp := 0
 	for _, i := range b.coldNum {
 		b.coldFieldStart[i] = cp
+		cp += s.fields[i].width * n
+	}
+}
+
+func encodeColumnarBlock(s *adSchema, recs [][]byte, hotNumFields []int, codec Codec) *columnarBlock {
+	b := &columnarBlock{id: colBlockSeq.Add(1), schema: s, codec: codec, n: len(recs)}
+	layoutColumnar(b, s, hotNumFields, len(recs))
+	cp := 0
+	for _, i := range b.coldNum {
 		cp += s.fields[i].width * len(recs)
 	}
-
 	b.hot = make([]byte, 0, b.hotStride*len(recs))
 	coldRaw := make([]byte, cp)
 	var strCat, coldCat []byte

--- a/collections/colblock.go
+++ b/collections/colblock.go
@@ -1,6 +1,10 @@
 package collections
 
-import "errors"
+import (
+	"errors"
+
+	"github.com/PelicanPlatform/classad/collections/wire"
+)
 
 var errNotNumericField = errors.New("adschema: scanInt on a non-numeric field")
 
@@ -92,6 +96,34 @@ func encodeColumnarBlock(s *adSchema, recs [][]byte, hotNumFields []int, codec C
 	b.strComp = codec.Compress(nil, strCat)
 	b.coldComp = codec.Compress(nil, coldCat)
 	return b
+}
+
+// buildColumnarFromSegment transcodes a segment's live-arena records in [0, upto) into a
+// columnar block, mirroring buildSegIndex: it walks the records, decompresses each (skipping
+// time-travel markers), re-encodes it in the adSchema row form, and builds the block. It
+// returns the block and offs, where offs[k] is the segment offset of block record k -- the map
+// a scan uses to recover each record's MVCC seq/sup (for visibility) and its key. Reads
+// immutable segment bytes only.
+func buildColumnarFromSegment(data []byte, upto int, codec Codec, s *adSchema, hot []int) (*columnarBlock, []uint32) {
+	var recs [][]byte
+	var offs []uint32
+	var buf []byte
+	for off := 0; off < upto; {
+		o := uint32(off)
+		total := recTotalLen(data, o)
+		if total == 0 {
+			break
+		}
+		if !recIsMarker(data, o) {
+			if w, err := codec.Decompress(buf[:0], recAd(data, o)); err == nil {
+				buf = w
+				recs = append(recs, s.encode(wire.Ad(w)))
+				offs = append(offs, o)
+			}
+		}
+		off += int(total)
+	}
+	return encodeColumnarBlock(s, recs, hot, codec), offs
 }
 
 // scanInt calls fn for each record's value of a numeric (int/real read as int bits) field: a

--- a/collections/colblock.go
+++ b/collections/colblock.go
@@ -2,11 +2,15 @@ package collections
 
 import (
 	"errors"
+	"sync/atomic"
 
 	"github.com/PelicanPlatform/classad/collections/wire"
 )
 
 var errNotNumericField = errors.New("adschema: scanInt on a non-numeric field")
+
+// colBlockSeq assigns each built block a process-unique id, used as the block-cache key.
+var colBlockSeq atomic.Uint64
 
 // columnarBlock is the PAX layout for a row-group of adSchema records (see adschema.go): the
 // schema's popular ("hot") numeric fields plus the escape and bool bitsets stay uncompressed
@@ -21,6 +25,7 @@ var errNotNumericField = errors.New("adschema: scanInt on a non-numeric field")
 // packed]. Cold numeric buffer is columnar: each cold field's values contiguous across the
 // block. String/cold streams are per-record regions concatenated, addressed by strOff/coldOff.
 type columnarBlock struct {
+	id     uint64 // process-unique, the block-cache key
 	schema *adSchema
 	codec  Codec
 	n      int
@@ -47,7 +52,7 @@ func encodeColumnarBlock(s *adSchema, recs [][]byte, hotNumFields []int, codec C
 	for _, i := range hotNumFields {
 		hotSet[i] = true
 	}
-	b := &columnarBlock{schema: s, codec: codec, n: len(recs), hotFieldOff: map[int]int{}, coldFieldStart: map[int]int{}}
+	b := &columnarBlock{id: colBlockSeq.Add(1), schema: s, codec: codec, n: len(recs), hotFieldOff: map[int]int{}, coldFieldStart: map[int]int{}}
 	for i := range s.fields {
 		if k := s.fields[i].kind; k == akInt || k == akReal {
 			if hotSet[i] {
@@ -127,9 +132,10 @@ func buildColumnarFromSegment(data []byte, upto int, codec Codec, s *adSchema, h
 }
 
 // scanInt calls fn for each record's value of a numeric (int/real read as int bits) field: a
-// hot field reads the uncompressed region directly; a cold field decompresses its column group
-// once. present is false for a missing/exceptional record (its value is in the cold tail).
-func (b *columnarBlock) scanInt(fieldIdx int, fn func(rec int, present bool, v int64)) error {
+// hot field reads the uncompressed region directly (no decode); a cold field decompresses its
+// column group once (via bc, nil for no cache). present is false for a missing/exceptional
+// record (its value is in the cold tail).
+func (b *columnarBlock) scanInt(fieldIdx int, bc *blockCache, fn func(rec int, present bool, v int64)) error {
 	f := b.schema.fields[fieldIdx]
 	if _, hot := b.hotFieldOff[fieldIdx]; hot {
 		off := b.hotFieldOff[fieldIdx]
@@ -147,17 +153,16 @@ func (b *columnarBlock) scanInt(fieldIdx int, fn func(rec int, present bool, v i
 	if !ok {
 		return errNotNumericField
 	}
-	coldRaw, err := b.codec.Decompress(nil, b.coldNumComp) // one decode for the whole column group
+	ds, err := bc.streams(b)
 	if err != nil {
 		return err
 	}
-	esc := b.escapeAt
 	for k := 0; k < b.n; k++ {
-		if testBit(esc(k), fieldIdx) {
+		if testBit(b.escapeAt(k), fieldIdx) {
 			fn(k, false, 0)
 			continue
 		}
-		fn(k, true, readIntLE(coldRaw[start+k*f.width:], f.width, f.unsigned))
+		fn(k, true, readIntLE(ds.coldNum[start+k*f.width:], f.width, f.unsigned))
 	}
 	return nil
 }
@@ -170,21 +175,14 @@ func (b *columnarBlock) escapeAt(k int) []byte {
 
 // reconstruct rebuilds record k's row form (identical to the adSchema.encode input), so
 // schema.forEach reconstructs the full ad. Decompresses the cold-numeric, string, and cold
-// streams -- the full-ad-read cost.
-func (b *columnarBlock) reconstruct(k int) ([]byte, error) {
+// streams (via bc, nil for no cache) -- the full-ad-read cost, amortized by the cache.
+func (b *columnarBlock) reconstruct(k int, bc *blockCache) ([]byte, error) {
 	s := b.schema
-	coldRaw, err := b.codec.Decompress(nil, b.coldNumComp)
+	ds, err := bc.streams(b)
 	if err != nil {
 		return nil, err
 	}
-	strRaw, err := b.codec.Decompress(nil, b.strComp)
-	if err != nil {
-		return nil, err
-	}
-	tailRaw, err := b.codec.Decompress(nil, b.coldComp)
-	if err != nil {
-		return nil, err
-	}
+	coldRaw, strRaw, tailRaw := ds.coldNum, ds.str, ds.cold
 	rec := make([]byte, s.escBytes+s.fixedLen, s.escBytes+s.fixedLen+(b.strOff[k+1]-b.strOff[k])+(b.coldOff[k+1]-b.coldOff[k]))
 	base := k * b.hotStride
 	copy(rec[:s.escBytes], b.hot[base:base+s.escBytes])                                              // escape

--- a/collections/colblock.go
+++ b/collections/colblock.go
@@ -1,0 +1,171 @@
+package collections
+
+import "errors"
+
+var errNotNumericField = errors.New("adschema: scanInt on a non-numeric field")
+
+// columnarBlock is the PAX layout for a row-group of adSchema records (see adschema.go): the
+// schema's popular ("hot") numeric fields plus the escape and bool bitsets stay uncompressed
+// in a fixed-stride region (so an attribute scan reads a column with no decode), while the
+// cold numeric fields (columnar), the string regions, and the cold tails are each a separately
+// Codec-compressed stream. A numeric scan on a hot field touches only the uncompressed region;
+// a scan on a cold field decompresses just that column group; a full-ad reconstruct
+// decompresses the string + cold streams. This is the sealed-segment form; the active segment
+// stays row-based (per-record).
+//
+// Hot region per record (stride = hotStride): [escape bitmap][bool bitset][hot int/real,
+// packed]. Cold numeric buffer is columnar: each cold field's values contiguous across the
+// block. String/cold streams are per-record regions concatenated, addressed by strOff/coldOff.
+type columnarBlock struct {
+	schema *adSchema
+	codec  Codec
+	n      int
+
+	hot         []byte // uncompressed region, hotStride bytes per record
+	hotStride   int
+	hotNum      []int       // hot int/real field indices (into schema.fields), layout order
+	hotFieldOff map[int]int // field idx -> byte offset within a record's hot region
+
+	coldNum        []int       // cold int/real field indices, layout order
+	coldFieldStart map[int]int // field idx -> start offset in the decompressed cold-numeric buffer
+	coldNumComp    []byte      // cold numeric fields, columnar, Codec-compressed
+
+	strComp, coldComp []byte // per-record string regions / cold tails, concatenated + compressed
+	strOff, coldOff   []int  // per-record cumulative offsets into the decompressed streams
+}
+
+// encodeColumnarBlock builds a columnar block from row-form records (each the output of
+// adSchema.encode). hotNumFields lists the schema field indices (int/real) to keep uncompressed
+// -- the popular ones, by query demand. Bools and the escape bitmap are always in the hot
+// region (tiny, and bools may be scanned).
+func encodeColumnarBlock(s *adSchema, recs [][]byte, hotNumFields []int, codec Codec) *columnarBlock {
+	hotSet := make(map[int]bool, len(hotNumFields))
+	for _, i := range hotNumFields {
+		hotSet[i] = true
+	}
+	b := &columnarBlock{schema: s, codec: codec, n: len(recs), hotFieldOff: map[int]int{}, coldFieldStart: map[int]int{}}
+	for i := range s.fields {
+		if k := s.fields[i].kind; k == akInt || k == akReal {
+			if hotSet[i] {
+				b.hotNum = append(b.hotNum, i)
+			} else {
+				b.coldNum = append(b.coldNum, i)
+			}
+		}
+	}
+	// Hot region layout and cold columnar offsets.
+	hp := s.escBytes + s.boolBytes
+	for _, i := range b.hotNum {
+		b.hotFieldOff[i] = hp
+		hp += s.fields[i].width
+	}
+	b.hotStride = hp
+	cp := 0
+	for _, i := range b.coldNum {
+		b.coldFieldStart[i] = cp
+		cp += s.fields[i].width * len(recs)
+	}
+
+	b.hot = make([]byte, 0, b.hotStride*len(recs))
+	coldRaw := make([]byte, cp)
+	var strCat, coldCat []byte
+	b.strOff = []int{0}
+	b.coldOff = []int{0}
+	for k, r := range recs {
+		b.hot = append(b.hot, r[:s.escBytes]...)                       // escape
+		b.hot = append(b.hot, r[s.escBytes:s.escBytes+s.boolBytes]...) // bool bitset
+		for _, i := range b.hotNum {
+			off := s.escBytes + s.fields[i].off
+			b.hot = append(b.hot, r[off:off+s.fields[i].width]...)
+		}
+		for _, i := range b.coldNum {
+			off := s.escBytes + s.fields[i].off
+			copy(coldRaw[b.coldFieldStart[i]+k*s.fields[i].width:], r[off:off+s.fields[i].width])
+		}
+		_, str, cold := s.splitRecord(r)
+		strCat = append(strCat, str...)
+		coldCat = append(coldCat, cold...)
+		b.strOff = append(b.strOff, len(strCat))
+		b.coldOff = append(b.coldOff, len(coldCat))
+	}
+	b.coldNumComp = codec.Compress(nil, coldRaw)
+	b.strComp = codec.Compress(nil, strCat)
+	b.coldComp = codec.Compress(nil, coldCat)
+	return b
+}
+
+// scanInt calls fn for each record's value of a numeric (int/real read as int bits) field: a
+// hot field reads the uncompressed region directly; a cold field decompresses its column group
+// once. present is false for a missing/exceptional record (its value is in the cold tail).
+func (b *columnarBlock) scanInt(fieldIdx int, fn func(rec int, present bool, v int64)) error {
+	f := b.schema.fields[fieldIdx]
+	if _, hot := b.hotFieldOff[fieldIdx]; hot {
+		off := b.hotFieldOff[fieldIdx]
+		for k := 0; k < b.n; k++ {
+			base := k * b.hotStride
+			if testBit(b.hot[base:base+b.schema.escBytes], fieldIdx) {
+				fn(k, false, 0)
+				continue
+			}
+			fn(k, true, readIntLE(b.hot[base+off:], f.width, f.unsigned))
+		}
+		return nil
+	}
+	start, ok := b.coldFieldStart[fieldIdx]
+	if !ok {
+		return errNotNumericField
+	}
+	coldRaw, err := b.codec.Decompress(nil, b.coldNumComp) // one decode for the whole column group
+	if err != nil {
+		return err
+	}
+	esc := b.escapeAt
+	for k := 0; k < b.n; k++ {
+		if testBit(esc(k), fieldIdx) {
+			fn(k, false, 0)
+			continue
+		}
+		fn(k, true, readIntLE(coldRaw[start+k*f.width:], f.width, f.unsigned))
+	}
+	return nil
+}
+
+// escapeAt returns record k's escape bitmap (in the uncompressed hot region).
+func (b *columnarBlock) escapeAt(k int) []byte {
+	base := k * b.hotStride
+	return b.hot[base : base+b.schema.escBytes]
+}
+
+// reconstruct rebuilds record k's row form (identical to the adSchema.encode input), so
+// schema.forEach reconstructs the full ad. Decompresses the cold-numeric, string, and cold
+// streams -- the full-ad-read cost.
+func (b *columnarBlock) reconstruct(k int) ([]byte, error) {
+	s := b.schema
+	coldRaw, err := b.codec.Decompress(nil, b.coldNumComp)
+	if err != nil {
+		return nil, err
+	}
+	strRaw, err := b.codec.Decompress(nil, b.strComp)
+	if err != nil {
+		return nil, err
+	}
+	tailRaw, err := b.codec.Decompress(nil, b.coldComp)
+	if err != nil {
+		return nil, err
+	}
+	rec := make([]byte, s.escBytes+s.fixedLen, s.escBytes+s.fixedLen+(b.strOff[k+1]-b.strOff[k])+(b.coldOff[k+1]-b.coldOff[k]))
+	base := k * b.hotStride
+	copy(rec[:s.escBytes], b.hot[base:base+s.escBytes])                                              // escape
+	copy(rec[s.escBytes:s.escBytes+s.boolBytes], b.hot[base+s.escBytes:base+s.escBytes+s.boolBytes]) // bools
+	for _, i := range b.hotNum {
+		w := s.fields[i].width
+		copy(rec[s.escBytes+s.fields[i].off:], b.hot[base+b.hotFieldOff[i]:base+b.hotFieldOff[i]+w])
+	}
+	for _, i := range b.coldNum {
+		w := s.fields[i].width
+		copy(rec[s.escBytes+s.fields[i].off:], coldRaw[b.coldFieldStart[i]+k*w:b.coldFieldStart[i]+k*w+w])
+	}
+	rec = append(rec, strRaw[b.strOff[k]:b.strOff[k+1]]...)
+	rec = append(rec, tailRaw[b.coldOff[k]:b.coldOff[k+1]]...)
+	return rec, nil
+}

--- a/collections/colblock_segment_test.go
+++ b/collections/colblock_segment_test.go
@@ -1,0 +1,104 @@
+package collections
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/collections/wire"
+)
+
+// segmentWires decompresses a segment's live-arena records (skipping markers) into wire ads.
+func segmentWires(t *testing.T, seg *segment) [][]byte {
+	t.Helper()
+	var ws [][]byte
+	for off := 0; off < seg.used; {
+		o := uint32(off)
+		total := recTotalLen(seg.data, o)
+		if total == 0 {
+			break
+		}
+		if !recIsMarker(seg.data, o) {
+			w, err := seg.codec.Decompress(nil, recAd(seg.data, o))
+			if err != nil {
+				t.Fatal(err)
+			}
+			ws = append(ws, w)
+		}
+		off += int(total)
+	}
+	return ws
+}
+
+// TestBuildColumnarFromSegment transcodes a real segment's records into a columnar block and
+// checks: (1) reconstruct(k) reproduces the exact ad stored at offs[k]; (2) a hot-field column
+// scan matches reading that field from the segment record; (3) offs[k] indexes a real record
+// header whose MVCC seq is readable (the map a scan uses for visibility).
+func TestBuildColumnarFromSegment(t *testing.T) {
+	store := New(Options{Shards: 1})
+	const n = 500
+	for i := 0; i < n; i++ {
+		ad := mustAdOld(t, fmt.Sprintf(
+			"Cpus = %d\nMemory = %d\nDisk = %d\nBig = %t\nArch = \"X86_64\"\nMachine = \"m%03d.example.org\"\nReq = (Cpus >= 1)",
+			1+i%16, 1024+(i%64)*256, i*4096, i%3 == 0, i))
+		if err := store.Put([]byte(fmt.Sprintf("k%d", i)), ad); err != nil {
+			t.Fatal(err)
+		}
+	}
+	seg := store.shards[0].act
+	if seg == nil || seg.used == 0 {
+		t.Fatal("no active segment data")
+	}
+	segWires := segmentWires(t, seg)
+	if len(segWires) != n {
+		t.Fatalf("segment holds %d records, want %d", len(segWires), n)
+	}
+
+	s := buildAdSchema(segWires, adSchemaOpts{Presence: 0.90, Fit: 0.95, Strings: true})
+	memID, _ := store.intern.LookupID("Memory")
+	memIdx, ok := s.byID[memID]
+	if !ok || s.fields[memIdx].kind != akInt {
+		t.Skip("Memory not an int schema field")
+	}
+
+	blk, offs := buildColumnarFromSegment(seg.data, seg.used, seg.codec, s, []int{memIdx})
+	if blk.n != n || len(offs) != n {
+		t.Fatalf("block n=%d offs=%d, want %d", blk.n, len(offs), n)
+	}
+
+	// One column-scan pass: block value per record.
+	scanned := make([]int64, n)
+	scannedPresent := make([]bool, n)
+	if err := blk.scanInt(memIdx, func(k int, p bool, v int64) { scannedPresent[k], scanned[k] = p, v }); err != nil {
+		t.Fatal(err)
+	}
+
+	for k := 0; k < n; k++ {
+		// (1) reconstruct == the ad at offs[k].
+		rec, err := blk.reconstruct(k)
+		if err != nil {
+			t.Fatal(err)
+		}
+		w, _ := seg.codec.Decompress(nil, recAd(seg.data, offs[k]))
+		orig := adAttrs(w)
+		dec := map[uint32][]byte{}
+		s.forEach(rec, func(id uint32, node []byte) bool { dec[id] = append([]byte(nil), node...); return true })
+		if len(dec) != len(orig) {
+			t.Fatalf("rec[%d] reconstructed %d attrs, want %d", k, len(dec), len(orig))
+		}
+		for id, on := range orig {
+			if dn, ok := dec[id]; !ok || !sameValue(on, dn) {
+				t.Errorf("rec[%d] attr %d mismatch after columnar round-trip", k, id)
+			}
+		}
+		// (2) hot column scan == the segment's Memory value.
+		mv, _ := wire.Ad(w).Lookup(memID)
+		lit, _ := wire.LiteralValue(mv)
+		if !scannedPresent[k] || scanned[k] != lit.Int {
+			t.Errorf("rec[%d] scanInt Memory=(%v,%d), segment=%d", k, scannedPresent[k], scanned[k], lit.Int)
+		}
+		// (3) offs[k] is a real record header.
+		if recSeq(seg.data, offs[k]) == 0 {
+			t.Errorf("rec[%d] at offs %d has zero seq", k, offs[k])
+		}
+	}
+}

--- a/collections/colblock_segment_test.go
+++ b/collections/colblock_segment_test.go
@@ -68,13 +68,13 @@ func TestBuildColumnarFromSegment(t *testing.T) {
 	// One column-scan pass: block value per record.
 	scanned := make([]int64, n)
 	scannedPresent := make([]bool, n)
-	if err := blk.scanInt(memIdx, func(k int, p bool, v int64) { scannedPresent[k], scanned[k] = p, v }); err != nil {
+	if err := blk.scanInt(memIdx, nil, func(k int, p bool, v int64) { scannedPresent[k], scanned[k] = p, v }); err != nil {
 		t.Fatal(err)
 	}
 
 	for k := 0; k < n; k++ {
 		// (1) reconstruct == the ad at offs[k].
-		rec, err := blk.reconstruct(k)
+		rec, err := blk.reconstruct(k, nil)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/collections/colblock_test.go
+++ b/collections/colblock_test.go
@@ -69,7 +69,7 @@ func TestColumnarBlockRoundTrip(t *testing.T) {
 		for _, hot := range [][]int{nil, hotHalf(s)} { // all-cold and half-hot
 			blk := encodeColumnarBlock(s, recs, hot, codec)
 			for k := range recs {
-				got, err := blk.reconstruct(k)
+				got, err := blk.reconstruct(k, nil)
 				if err != nil {
 					t.Fatalf("%s reconstruct(%d): %v", codec.Name(), k, err)
 				}
@@ -115,7 +115,7 @@ func TestColumnarBlockScanInt(t *testing.T) {
 	for _, hot := range [][]int{{fidx}, nil} {
 		blk := encodeColumnarBlock(s, recs, hot, mustZSTD(t))
 		seen := 0
-		err := blk.scanInt(fidx, func(k int, p bool, v int64) {
+		err := blk.scanInt(fidx, nil, func(k int, p bool, v int64) {
 			seen++
 			if p != present[k] {
 				t.Errorf("hot=%d rec %d present=%v want %v", len(hot), k, p, present[k])

--- a/collections/colblock_test.go
+++ b/collections/colblock_test.go
@@ -1,0 +1,134 @@
+package collections
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/classad"
+	"github.com/PelicanPlatform/classad/collections/wire"
+)
+
+func mustAdOld(t *testing.T, src string) *classad.ClassAd {
+	t.Helper()
+	ad, err := classad.ParseOld(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ad
+}
+
+func mustZSTD(t *testing.T) Codec {
+	t.Helper()
+	c, err := NewZSTDCodec(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return c
+}
+
+// encodeRows builds adSchema row records for a set of wire ads.
+func encodeRows(s *adSchema, wires [][]byte) [][]byte {
+	recs := make([][]byte, len(wires))
+	for i, w := range wires {
+		recs[i] = s.encode(wire.Ad(w))
+	}
+	return recs
+}
+
+// hotHalf picks half the numeric fields as "hot" (the popularity input; here just a split to
+// exercise both hot and cold paths).
+func hotHalf(s *adSchema) []int {
+	var hot []int
+	n := 0
+	for i := range s.fields {
+		if k := s.fields[i].kind; k == akInt || k == akReal {
+			if n%2 == 0 {
+				hot = append(hot, i)
+			}
+			n++
+		}
+	}
+	return hot
+}
+
+// TestColumnarBlockRoundTrip: reconstructing each record from the columnar block reproduces the
+// original ad exactly (every attribute, same value), for both codecs and hot/cold splits.
+func TestColumnarBlockRoundTrip(t *testing.T) {
+	c := New(Options{Shards: 1})
+	var wires [][]byte
+	for i := 0; i < 40; i++ {
+		ad := mustAdOld(t, fmt.Sprintf(
+			"Cpus = %d\nMemory = %d\nBig = %t\nLoad = %f\nArch = \"X86_64\"\nMachine = \"node%02d.example.org\"\nExtra = %d\nReq = (Cpus >= 1)",
+			1+i%8, 1024+i*64, i%2 == 0, float64(i)/3, i, i*100000)) // Extra overflows small widths -> escapes
+		wires = append(wires, c.encodeAd(ad.AST()))
+	}
+	s := buildAdSchema(wires, adSchemaOpts{Presence: 0.80, Fit: 0.90, Strings: true})
+	recs := encodeRows(s, wires)
+
+	for _, codec := range []Codec{identityCodec{}, mustZSTD(t)} {
+		for _, hot := range [][]int{nil, hotHalf(s)} { // all-cold and half-hot
+			blk := encodeColumnarBlock(s, recs, hot, codec)
+			for k := range recs {
+				got, err := blk.reconstruct(k)
+				if err != nil {
+					t.Fatalf("%s reconstruct(%d): %v", codec.Name(), k, err)
+				}
+				assertRoundTrip(t, s, wires[k], fmt.Sprintf("%s hot=%d rec[%d]", codec.Name(), len(hot), k))
+				// The reconstructed row record must be byte-identical to the encoded row.
+				if string(got) != string(recs[k]) {
+					t.Errorf("%s hot=%d rec[%d]: reconstructed record differs from row form", codec.Name(), len(hot), k)
+				}
+			}
+		}
+	}
+}
+
+// TestColumnarBlockScanInt: scanning a numeric column (hot or cold) yields the same matches as
+// reading the value straight from each row record.
+func TestColumnarBlockScanInt(t *testing.T) {
+	c := New(Options{Shards: 1})
+	var wires [][]byte
+	for i := 0; i < 300; i++ {
+		ad := mustAdOld(t, fmt.Sprintf("Cpus = %d\nMemory = %d\nDisk = %d", 1+i%16, 1024+(i%50)*512, i*1000))
+		wires = append(wires, c.encodeAd(ad.AST()))
+	}
+	s := buildAdSchema(wires, adSchemaOpts{Presence: 0.90, Fit: 0.95})
+	recs := encodeRows(s, wires)
+	memID, _ := c.intern.LookupID("Memory")
+	fidx, ok := s.byID[memID]
+	if !ok || s.fields[fidx].kind != akInt {
+		t.Skip("Memory not an int schema field")
+	}
+
+	// truth: read Memory from each row record.
+	truth := make([]int64, len(recs))
+	present := make([]bool, len(recs))
+	f := s.fields[fidx]
+	for k, r := range recs {
+		if testBit(r[:s.escBytes], fidx) {
+			continue
+		}
+		present[k], truth[k] = true, readIntLE(r[s.escBytes+f.off:], f.width, f.unsigned)
+	}
+
+	// Once with Memory HOT, once COLD.
+	for _, hot := range [][]int{{fidx}, nil} {
+		blk := encodeColumnarBlock(s, recs, hot, mustZSTD(t))
+		seen := 0
+		err := blk.scanInt(fidx, func(k int, p bool, v int64) {
+			seen++
+			if p != present[k] {
+				t.Errorf("hot=%d rec %d present=%v want %v", len(hot), k, p, present[k])
+			}
+			if p && v != truth[k] {
+				t.Errorf("hot=%d rec %d value=%d want %d", len(hot), k, v, truth[k])
+			}
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if seen != len(recs) {
+			t.Errorf("hot=%d scanned %d, want %d", len(hot), seen, len(recs))
+		}
+	}
+}

--- a/collections/colpersist.go
+++ b/collections/colpersist.go
@@ -1,0 +1,130 @@
+package collections
+
+// Serialization of a sealed segment's columnar accelerator (schema + block streams + the
+// arena-offset map), so it can be persisted beside the segment's index sidecar and rebuilt on
+// reopen instead of re-transcoding the whole segment. The layout (field offsets, hot/cold
+// partition) is recomputed from the persisted (schema, hot set, n) via layoutSchema /
+// layoutColumnar -- the same helpers the encoder uses -- so a decoded block is identical to a
+// freshly built one. Only the payloads and offsets are stored.
+
+// marshalAdSchema writes a schema's fields as (id, kind, width, unsigned); the layout is
+// re-derived on read, not stored.
+func marshalAdSchema(dst []byte, s *adSchema) []byte {
+	dst = appendU32(dst, uint32(len(s.fields)))
+	for _, f := range s.fields {
+		dst = appendU32(dst, f.id)
+		dst = appendU16(dst, uint16(f.kind))
+		dst = appendU16(dst, uint16(f.width))
+		u := uint16(0)
+		if f.unsigned {
+			u = 1
+		}
+		dst = appendU16(dst, u)
+	}
+	return dst
+}
+
+func readAdSchema(c *cursor) *adSchema {
+	n := int(c.u32())
+	if n < 0 || n > 1<<20 || !c.need(0) {
+		return nil
+	}
+	fields := make([]adField, 0, n)
+	for i := 0; i < n; i++ {
+		fields = append(fields, adField{
+			id:       c.u32(),
+			kind:     adKind(c.u16()),
+			width:    int(c.u16()),
+			unsigned: c.u16() != 0,
+		})
+	}
+	if c.err != nil {
+		return nil
+	}
+	return layoutSchema(fields)
+}
+
+// marshalColSegment serializes cs (its block's schema, hot set, record count, byte streams, and
+// per-record offsets, plus offs -- the block->arena map for MVCC visibility).
+func marshalColSegment(cs *colSegment) []byte {
+	b := cs.block
+	dst := marshalAdSchema(nil, b.schema)
+	dst = appendU32(dst, uint32(len(b.hotNum)))
+	for _, i := range b.hotNum {
+		dst = appendU32(dst, uint32(i))
+	}
+	dst = appendU32(dst, uint32(b.n))
+	dst = appendBytes(dst, b.hot)
+	dst = appendBytes(dst, b.coldNumComp)
+	dst = appendBytes(dst, b.strComp)
+	dst = appendBytes(dst, b.coldComp)
+	dst = appendU32(dst, uint32(len(b.strOff)))
+	for _, v := range b.strOff {
+		dst = appendU32(dst, uint32(v))
+	}
+	dst = appendU32(dst, uint32(len(b.coldOff)))
+	for _, v := range b.coldOff {
+		dst = appendU32(dst, uint32(v))
+	}
+	dst = appendU32(dst, uint32(len(cs.offs)))
+	for _, o := range cs.offs {
+		dst = appendU32(dst, o)
+	}
+	return dst
+}
+
+// unmarshalColSegment reconstructs a colSegment from marshalColSegment's output, attaching the
+// segment's codec (for later decompression). Returns nil on malformed data.
+func unmarshalColSegment(data []byte, codec Codec) *colSegment {
+	c := &cursor{b: data}
+	s := readAdSchema(c)
+	if s == nil {
+		return nil
+	}
+	hn := int(c.u32())
+	if hn < 0 || hn > len(s.fields) {
+		return nil
+	}
+	hotNum := make([]int, hn)
+	for i := range hotNum {
+		hotNum[i] = int(c.u32())
+	}
+	n := int(c.u32())
+	b := &columnarBlock{id: colBlockSeq.Add(1), schema: s, codec: codec, n: n}
+	b.hot = append([]byte(nil), c.bytes()...)
+	b.coldNumComp = append([]byte(nil), c.bytes()...)
+	b.strComp = append([]byte(nil), c.bytes()...)
+	b.coldComp = append([]byte(nil), c.bytes()...)
+	b.strOff = readInts(c)
+	b.coldOff = readInts(c)
+	offs := readU32s(c)
+	if c.err != nil || n < 0 {
+		return nil
+	}
+	layoutColumnar(b, s, hotNum, n)
+	return &colSegment{block: b, offs: offs}
+}
+
+func readInts(c *cursor) []int {
+	n := int(c.u32())
+	if n < 0 || !c.need(0) {
+		return nil
+	}
+	out := make([]int, n)
+	for i := range out {
+		out[i] = int(c.u32())
+	}
+	return out
+}
+
+func readU32s(c *cursor) []uint32 {
+	n := int(c.u32())
+	if n < 0 || !c.need(0) {
+		return nil
+	}
+	out := make([]uint32, n)
+	for i := range out {
+		out[i] = c.u32()
+	}
+	return out
+}

--- a/collections/colpersist_test.go
+++ b/collections/colpersist_test.go
@@ -1,0 +1,97 @@
+package collections
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/collections/wire"
+)
+
+// TestColSegmentMarshalRoundTrip serializes a colSegment and checks the decoded block is
+// functionally identical: same schema layout, same hot/cold partition, same offs, and every
+// record reconstructs byte-identically and scans to the same value.
+func TestColSegmentMarshalRoundTrip(t *testing.T) {
+	c := New(Options{Shards: 1})
+	var wires [][]byte
+	for i := 0; i < 120; i++ {
+		ad := mustAdOld(t, fmt.Sprintf(
+			"Cpus=%d\nMemory=%d\nDisk=%d\nBig=%t\nLoad=%f\nArch=\"X86_64\"\nMachine=\"m%03d.example.org\"\nExtra=%d",
+			1+i%8, 1024+i*64, i*4096, i%2 == 0, float64(i)/3, i, i*100000)) // Extra escapes small widths
+		wires = append(wires, c.encodeAd(ad.AST()))
+	}
+	s := buildAdSchema(wires, adSchemaOpts{Presence: 0.80, Fit: 0.90, Strings: true})
+	recs := encodeRows(s, wires)
+
+	for _, codec := range []Codec{identityCodec{}, mustZSTD(t)} {
+		blk := encodeColumnarBlock(s, recs, hotHalf(s), codec)
+		offs := make([]uint32, blk.n)
+		for i := range offs {
+			offs[i] = uint32(i * 7) // arbitrary stand-in arena offsets
+		}
+		orig := &colSegment{block: blk, offs: offs}
+
+		got := unmarshalColSegment(marshalColSegment(orig), codec)
+		if got == nil {
+			t.Fatalf("%s: unmarshal returned nil", codec.Name())
+		}
+		gb := got.block
+		if gb.n != blk.n || gb.hotStride != blk.hotStride || len(gb.hotNum) != len(blk.hotNum) || len(gb.coldNum) != len(blk.coldNum) {
+			t.Fatalf("%s: layout mismatch: n=%d/%d stride=%d/%d hot=%d/%d cold=%d/%d",
+				codec.Name(), gb.n, blk.n, gb.hotStride, blk.hotStride, len(gb.hotNum), len(blk.hotNum), len(gb.coldNum), len(blk.coldNum))
+		}
+		for i := range offs {
+			if got.offs[i] != offs[i] {
+				t.Fatalf("%s: offs[%d]=%d, want %d", codec.Name(), i, got.offs[i], offs[i])
+			}
+		}
+		// Every record reconstructs byte-identically from the decoded block.
+		for k := 0; k < gb.n; k++ {
+			a, err := blk.reconstruct(k, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			b, err := gb.reconstruct(k, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(a) != string(b) {
+				t.Fatalf("%s: rec[%d] differs after marshal round-trip", codec.Name(), k)
+			}
+			// And decodes to the same attributes as the source ad.
+			assertRoundTrip(t, s, wires[k], fmt.Sprintf("%s decoded rec[%d]", codec.Name(), k))
+		}
+		// A scan on the decoded block matches the source.
+		memID, _ := c.intern.LookupID("Memory")
+		if fidx, ok := s.byID[memID]; ok && s.fields[fidx].kind == akInt {
+			mismatch := 0
+			gb.scanInt(fidx, nil, func(k int, p bool, v int64) {
+				w := wires[k]
+				if node, ok := wire.Ad(w).Lookup(memID); ok {
+					if lit, _ := wire.LiteralValue(node); p && lit.Kind == wire.LitInt && v != lit.Int {
+						mismatch++
+					}
+				}
+			})
+			if mismatch != 0 {
+				t.Errorf("%s: %d scan mismatches after round-trip", codec.Name(), mismatch)
+			}
+		}
+	}
+}
+
+// TestUnmarshalColSegmentTruncated verifies malformed/truncated data returns nil, not a panic.
+func TestUnmarshalColSegmentTruncated(t *testing.T) {
+	c := New(Options{Shards: 1})
+	var wires [][]byte
+	for i := 0; i < 20; i++ {
+		wires = append(wires, c.encodeAd(mustAdOld(t, fmt.Sprintf("Cpus=%d\nMemory=%d", 1+i, 1024+i)).AST()))
+	}
+	s := buildAdSchema(wires, adSchemaOpts{Presence: 0.5, Fit: 0.95})
+	blk := encodeColumnarBlock(s, encodeRows(s, wires), nil, identityCodec{})
+	full := marshalColSegment(&colSegment{block: blk, offs: make([]uint32, blk.n)})
+	for _, cut := range []int{0, 1, len(full) / 2, len(full) - 1} {
+		if got := unmarshalColSegment(full[:cut], identityCodec{}); got != nil {
+			t.Errorf("truncated to %d bytes: expected nil, got a block", cut)
+		}
+	}
+}

--- a/collections/colscan.go
+++ b/collections/colscan.go
@@ -1,0 +1,115 @@
+package collections
+
+import "github.com/PelicanPlatform/classad/collections/wire"
+
+// colSegment is a sealed segment's columnar accelerator: the PAX block plus offs, mapping each
+// block record k to its arena offset so a scan can read the record's live MVCC seq/sup.
+type colSegment struct {
+	block *columnarBlock
+	offs  []uint32
+}
+
+// EnableSchemaScan builds a columnar block over every currently-sealed segment (skipping the
+// active append target) for the given schema and hot field set, and publishes it on each
+// segment. Additive and opt-in: with no block a scan falls back to the row path, so a
+// collection that never calls this is unaffected. Reads immutable sealed bytes only.
+func (c *Collection) EnableSchemaScan(s *adSchema, hot []int) {
+	for _, sh := range c.shards {
+		sh.mu.RLock()
+		act := sh.act
+		segs := make([]*segment, 0, len(sh.segs))
+		for _, seg := range sh.segs {
+			if seg != nil && seg != act && seg.used > 0 && seg.colblk.Load() == nil {
+				segs = append(segs, seg) // sealed ⇒ data/used immutable, safe to read off-lock
+			}
+		}
+		sh.mu.RUnlock()
+		for _, seg := range segs {
+			blk, offs := buildColumnarFromSegment(seg.data, seg.used, seg.codec, s, hot)
+			seg.colblk.Store(&colSegment{block: blk, offs: offs})
+		}
+	}
+}
+
+// schemaScanIntCount counts records whose numeric field (s.fields[fieldIdx]) is present, live,
+// and satisfies match -- using each sealed segment's columnar block (hot column: no decode;
+// cold column: one decode) and each window's live MVCC visibility. A window with no block
+// (the active segment, or one built before EnableSchemaScan) falls back to the row scan. A
+// record whose value is escaped out of the hot column is reconstructed and re-checked (its
+// value may live in the cold tail, e.g. an out-of-width int).
+func (c *Collection) schemaScanIntCount(s *adSchema, fieldIdx int, match func(int64) bool) int {
+	fieldID := s.fields[fieldIdx].id
+	count := 0
+	for _, sh := range c.shards {
+		s0, wins := sh.snapshot()
+		for _, w := range wins {
+			cs := w.seg.colblk.Load()
+			if cs != nil && cs.block.schema == s {
+				cs.block.scanInt(fieldIdx, func(k int, present bool, v int64) {
+					o := cs.offs[k]
+					if !(recSeq(w.data, o) <= s0 && recSuperseded(w.data, o) > s0) {
+						return // not visible at this snapshot
+					}
+					if present {
+						if match(v) {
+							count++
+						}
+						return
+					}
+					if rec, err := cs.block.reconstruct(k); err == nil { // escaped: check the cold tail
+						if v2, ok := intFieldOf(s, rec, fieldID); ok && match(v2) {
+							count++
+						}
+					}
+				})
+				continue
+			}
+			count += bruteIntCount(w, s0, fieldID, match)
+		}
+		releaseWindows(wins)
+	}
+	return count
+}
+
+// bruteIntCount is the row-scan fallback: walk a window's visible records, read the field
+// from the wire ad, and count int matches.
+func bruteIntCount(w segWindow, s0 uint64, fieldID uint32, match func(int64) bool) int {
+	count := 0
+	var buf []byte
+	for off := 0; off < w.used; {
+		o := uint32(off)
+		total := recTotalLen(w.data, o)
+		if total == 0 {
+			break
+		}
+		if !recIsMarker(w.data, o) && recSeq(w.data, o) <= s0 && recSuperseded(w.data, o) > s0 {
+			if ww, err := w.codec.Decompress(buf[:0], recAd(w.data, o)); err == nil {
+				buf = ww
+				if node, ok := wire.Ad(ww).Lookup(fieldID); ok {
+					if lit, ok := wire.LiteralValue(node); ok && lit.Kind == wire.LitInt && match(lit.Int) {
+						count++
+					}
+				}
+			}
+		}
+		off += int(total)
+	}
+	return count
+}
+
+// intFieldOf returns the int value of fieldID in a reconstructed schema record, if present as
+// an integer (missing or non-integer ⇒ false).
+func intFieldOf(s *adSchema, rec []byte, fieldID uint32) (int64, bool) {
+	var out int64
+	var found bool
+	s.forEach(rec, func(id uint32, node []byte) bool {
+		if id != fieldID {
+			return true
+		}
+		if lit, ok := wire.LiteralValue(node); ok && lit.Kind == wire.LitInt {
+			out, found = lit.Int, true
+		}
+		return false
+	})
+	return out, found
+}

--- a/collections/colscan.go
+++ b/collections/colscan.go
@@ -1,6 +1,9 @@
 package collections
 
 import (
+	"sort"
+	"strings"
+
 	"github.com/PelicanPlatform/classad/collections/vm"
 	"github.com/PelicanPlatform/classad/collections/wire"
 )
@@ -49,6 +52,61 @@ func (c *Collection) EnableSchemaScan(s *adSchema, hot []int) {
 			seg.colblk.Store(&colSegment{block: blk, offs: offs})
 		}
 	}
+}
+
+// BuildAndEnableSchemaScan samples the collection, builds an adschema, chooses the hot numeric
+// tier as the top-hotTopN int/real fields by accumulated read demand (c.demand -- the same
+// signal RefreshHotSet uses; the schema's hot tier IS the hot set), and enables the columnar
+// scan over the sealed segments. Returns false if there is nothing to sample. Re-callable to
+// pick up newly-sealed segments (existing blocks are kept).
+func (c *Collection) BuildAndEnableSchemaScan(sampleMax, hotTopN int) bool {
+	samples := c.CollectSamples(sampleMax)
+	if len(samples) == 0 {
+		return false
+	}
+	s := buildAdSchema(samples, adSchemaOpts{Presence: 0.90, Fit: 0.95, Strings: true})
+	if len(s.fields) == 0 {
+		return false
+	}
+	type fieldDemand struct {
+		idx   int
+		reads int64
+	}
+	var nums []fieldDemand
+	for i := range s.fields {
+		if k := s.fields[i].kind; k != akInt && k != akReal {
+			continue
+		}
+		var reads int64
+		if name, ok := c.intern.Name(s.fields[i].id); ok {
+			if v, ok := c.demand.m.Load(strings.ToLower(name)); ok {
+				reads = v.(*demandCounts).reads.Load()
+			}
+		}
+		nums = append(nums, fieldDemand{i, reads})
+	}
+	sort.Slice(nums, func(a, b int) bool {
+		if nums[a].reads != nums[b].reads {
+			return nums[a].reads > nums[b].reads
+		}
+		return nums[a].idx < nums[b].idx
+	})
+	hot := make([]int, 0, hotTopN)
+	for i := 0; i < len(nums) && i < hotTopN; i++ {
+		hot = append(hot, nums[i].idx)
+	}
+	c.EnableSchemaScan(s, hot)
+	return true
+}
+
+// CountConstraint parses a constraint string and, if it is columnar-eligible, counts via the
+// columnar scan (see CountQuery). ok=false ⇒ use the normal count path.
+func (c *Collection) CountConstraint(constraint string) (int, bool) {
+	q, err := vm.Parse(constraint)
+	if err != nil {
+		return 0, false
+	}
+	return c.CountQuery(q)
 }
 
 // CountQuery counts the records matching q using the columnar scan, when q is exactly (Native)

--- a/collections/colscan.go
+++ b/collections/colscan.go
@@ -1,6 +1,9 @@
 package collections
 
-import "github.com/PelicanPlatform/classad/collections/wire"
+import (
+	"github.com/PelicanPlatform/classad/collections/vm"
+	"github.com/PelicanPlatform/classad/collections/wire"
+)
 
 // colSegment is a sealed segment's columnar accelerator: the PAX block plus offs, mapping each
 // block record k to its arena offset so a scan can read the record's live MVCC seq/sup.
@@ -9,15 +12,27 @@ type colSegment struct {
 	offs  []uint32
 }
 
+// schemaScanState is a collection's resolved adschema columnar scan configuration.
+type schemaScanState struct {
+	schema *adSchema
+	hot    []int
+	cache  *blockCache
+}
+
 // EnableSchemaScan builds a columnar block over every currently-sealed segment (skipping the
-// active append target) for the given schema and hot field set, and publishes it on each
-// segment. Additive and opt-in: with no block a scan falls back to the row path, so a
-// collection that never calls this is unaffected. Reads immutable sealed bytes only.
+// active append target) for the given schema and hot field set, publishes it on each segment,
+// and records the state so CountQuery can auto-route matching queries. Additive and opt-in:
+// with no state/block a query takes the normal row path, so a collection that never calls this
+// is unaffected. Reads immutable sealed bytes only.
 func (c *Collection) EnableSchemaScan(s *adSchema, hot []int) {
-	if c.schemaCache.Load() == nil {
-		if bc, err := newBlockCache(256 << 20); err == nil { // ~256 MiB of decompressed blocks
-			c.schemaCache.Store(bc)
+	st := c.schemaScan.Load()
+	if st == nil || st.schema != s {
+		bc, err := newBlockCache(256 << 20) // ~256 MiB of decompressed blocks
+		if err != nil {
+			return
 		}
+		st = &schemaScanState{schema: s, hot: hot, cache: bc}
+		c.schemaScan.Store(st)
 	}
 	for _, sh := range c.shards {
 		sh.mu.RLock()
@@ -36,15 +51,84 @@ func (c *Collection) EnableSchemaScan(s *adSchema, hot []int) {
 	}
 }
 
-// schemaScanIntCount counts records whose numeric field (s.fields[fieldIdx]) is present, live,
-// and satisfies match -- using each sealed segment's columnar block (hot column: no decode;
-// cold column: one decode) and each window's live MVCC visibility. A window with no block
-// (the active segment, or one built before EnableSchemaScan) falls back to the row scan. A
-// record whose value is escaped out of the hot column is reconstructed and re-checked (its
-// value may live in the cold tail, e.g. an out-of-width int).
-func (c *Collection) schemaScanIntCount(s *adSchema, fieldIdx int, match func(int64) bool) int {
-	fieldID := s.fields[fieldIdx].id
-	bc := c.schemaCache.Load()
+// CountQuery counts the records matching q using the columnar scan, when q is exactly (Native)
+// one or more numeric comparisons on a single INT schema field -- the common count-where. It
+// returns (count, true) on that fast path, or (0, false) to signal the caller to use the normal
+// scan (schema-scan not enabled, or the predicate is not columnar-eligible). Correctness: the
+// per-record numeric comparison matches the store's evaluation of `field OP number`; a value
+// escaped out of the hot column is read from the cold tail, and Native() rules out any residual
+// program the columnar path would miss.
+func (c *Collection) CountQuery(q *vm.Query) (int, bool) {
+	st := c.schemaScan.Load()
+	if st == nil {
+		return 0, false
+	}
+	s := st.schema
+	probes := q.Probes()
+	if !q.Native() || len(probes) == 0 {
+		return 0, false
+	}
+	fieldIdx := -1
+	var fieldID uint32
+	var cmps []func(float64) bool
+	for _, p := range probes {
+		id, ok := c.intern.LookupID(p.Attr)
+		if !ok {
+			return 0, false
+		}
+		idx, ok := s.byID[id]
+		if !ok || s.fields[idx].kind != akInt {
+			return 0, false // only single-field int comparisons route
+		}
+		if fieldIdx == -1 {
+			fieldIdx, fieldID = idx, id
+		} else if idx != fieldIdx {
+			return 0, false // more than one field: not this fast path
+		}
+		up, ok := valUsable(id, p)
+		if !ok || len(up.fvals) != 1 {
+			return 0, false // present/absent/in/isnt or non-numeric: not a scalar comparison
+		}
+		cmp, ok := numCmp(up.op, up.fvals[0])
+		if !ok {
+			return 0, false
+		}
+		cmps = append(cmps, cmp)
+	}
+	eval := func(v float64) bool {
+		for _, cmp := range cmps {
+			if !cmp(v) {
+				return false
+			}
+		}
+		return true
+	}
+	return c.schemaScanCount(s, fieldIdx, fieldID, st.cache, eval), true
+}
+
+func numCmp(op string, t float64) (func(float64) bool, bool) {
+	switch op {
+	case "<":
+		return func(v float64) bool { return v < t }, true
+	case "<=":
+		return func(v float64) bool { return v <= t }, true
+	case ">":
+		return func(v float64) bool { return v > t }, true
+	case ">=":
+		return func(v float64) bool { return v >= t }, true
+	case "==":
+		return func(v float64) bool { return v == t }, true
+	case "!=":
+		return func(v float64) bool { return v != t }, true
+	}
+	return nil, false
+}
+
+// schemaScanCount counts records whose numeric field (s.fields[fieldIdx]) is present, live, and
+// satisfies eval -- using each sealed segment's columnar block (hot column: no decode; cold
+// column: one cached decode) and each window's live MVCC visibility. A window with no block
+// (active segment) falls back to the row scan; an escaped value is read from the cold tail.
+func (c *Collection) schemaScanCount(s *adSchema, fieldIdx int, fieldID uint32, bc *blockCache, eval func(float64) bool) int {
 	count := 0
 	for _, sh := range c.shards {
 		s0, wins := sh.snapshot()
@@ -57,29 +141,38 @@ func (c *Collection) schemaScanIntCount(s *adSchema, fieldIdx int, match func(in
 						return // not visible at this snapshot
 					}
 					if present {
-						if match(v) {
+						if eval(float64(v)) {
 							count++
 						}
 						return
 					}
-					if rec, err := cs.block.reconstruct(k, bc); err == nil { // escaped: check the cold tail
-						if v2, ok := intFieldOf(s, rec, fieldID); ok && match(v2) {
+					if rec, err := cs.block.reconstruct(k, bc); err == nil { // escaped: cold tail
+						if f, ok := numFieldOf(s, rec, fieldID); ok && eval(f) {
 							count++
 						}
 					}
 				})
 				continue
 			}
-			count += bruteIntCount(w, s0, fieldID, match)
+			count += bruteNumCount(w, s0, fieldID, eval)
 		}
 		releaseWindows(wins)
 	}
 	return count
 }
 
-// bruteIntCount is the row-scan fallback: walk a window's visible records, read the field
-// from the wire ad, and count int matches.
-func bruteIntCount(w segWindow, s0 uint64, fieldID uint32, match func(int64) bool) int {
+// schemaScanIntCount is the int-typed convenience wrapper (used by tests/benchmarks).
+func (c *Collection) schemaScanIntCount(s *adSchema, fieldIdx int, match func(int64) bool) int {
+	bc := (*blockCache)(nil)
+	if st := c.schemaScan.Load(); st != nil {
+		bc = st.cache
+	}
+	return c.schemaScanCount(s, fieldIdx, s.fields[fieldIdx].id, bc, func(f float64) bool { return match(int64(f)) })
+}
+
+// bruteNumCount is the row-scan fallback: walk a window's visible records, read the numeric
+// field from the wire ad, and count matches.
+func bruteNumCount(w segWindow, s0 uint64, fieldID uint32, eval func(float64) bool) int {
 	count := 0
 	var buf []byte
 	for off := 0; off < w.used; {
@@ -92,7 +185,7 @@ func bruteIntCount(w segWindow, s0 uint64, fieldID uint32, match func(int64) boo
 			if ww, err := w.codec.Decompress(buf[:0], recAd(w.data, o)); err == nil {
 				buf = ww
 				if node, ok := wire.Ad(ww).Lookup(fieldID); ok {
-					if lit, ok := wire.LiteralValue(node); ok && lit.Kind == wire.LitInt && match(lit.Int) {
+					if f, ok := literalFloat(node); ok && eval(f) {
 						count++
 					}
 				}
@@ -103,18 +196,16 @@ func bruteIntCount(w segWindow, s0 uint64, fieldID uint32, match func(int64) boo
 	return count
 }
 
-// intFieldOf returns the int value of fieldID in a reconstructed schema record, if present as
-// an integer (missing or non-integer ⇒ false).
-func intFieldOf(s *adSchema, rec []byte, fieldID uint32) (int64, bool) {
-	var out int64
+// numFieldOf returns the numeric value (int or real) of fieldID in a reconstructed schema
+// record, if present as a number (missing or non-numeric ⇒ false).
+func numFieldOf(s *adSchema, rec []byte, fieldID uint32) (float64, bool) {
+	var out float64
 	var found bool
 	s.forEach(rec, func(id uint32, node []byte) bool {
 		if id != fieldID {
 			return true
 		}
-		if lit, ok := wire.LiteralValue(node); ok && lit.Kind == wire.LitInt {
-			out, found = lit.Int, true
-		}
+		out, found = literalFloat(node)
 		return false
 	})
 	return out, found

--- a/collections/colscan.go
+++ b/collections/colscan.go
@@ -14,6 +14,11 @@ type colSegment struct {
 // segment. Additive and opt-in: with no block a scan falls back to the row path, so a
 // collection that never calls this is unaffected. Reads immutable sealed bytes only.
 func (c *Collection) EnableSchemaScan(s *adSchema, hot []int) {
+	if c.schemaCache.Load() == nil {
+		if bc, err := newBlockCache(256 << 20); err == nil { // ~256 MiB of decompressed blocks
+			c.schemaCache.Store(bc)
+		}
+	}
 	for _, sh := range c.shards {
 		sh.mu.RLock()
 		act := sh.act
@@ -39,13 +44,14 @@ func (c *Collection) EnableSchemaScan(s *adSchema, hot []int) {
 // value may live in the cold tail, e.g. an out-of-width int).
 func (c *Collection) schemaScanIntCount(s *adSchema, fieldIdx int, match func(int64) bool) int {
 	fieldID := s.fields[fieldIdx].id
+	bc := c.schemaCache.Load()
 	count := 0
 	for _, sh := range c.shards {
 		s0, wins := sh.snapshot()
 		for _, w := range wins {
 			cs := w.seg.colblk.Load()
 			if cs != nil && cs.block.schema == s {
-				cs.block.scanInt(fieldIdx, func(k int, present bool, v int64) {
+				cs.block.scanInt(fieldIdx, bc, func(k int, present bool, v int64) {
 					o := cs.offs[k]
 					if !(recSeq(w.data, o) <= s0 && recSuperseded(w.data, o) > s0) {
 						return // not visible at this snapshot
@@ -56,7 +62,7 @@ func (c *Collection) schemaScanIntCount(s *adSchema, fieldIdx int, match func(in
 						}
 						return
 					}
-					if rec, err := cs.block.reconstruct(k); err == nil { // escaped: check the cold tail
+					if rec, err := cs.block.reconstruct(k, bc); err == nil { // escaped: check the cold tail
 						if v2, ok := intFieldOf(s, rec, fieldID); ok && match(v2) {
 							count++
 						}

--- a/collections/colscan_bench_test.go
+++ b/collections/colscan_bench_test.go
@@ -1,0 +1,76 @@
+package collections
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/collections/vm"
+)
+
+// BenchmarkSchemaScanStore measures the columnar accelerated count vs the store's real
+// QueryProject count-where path for Memory>4096, over the OSPool corpus loaded into a store
+// with sealed segments.
+func BenchmarkSchemaScanStore(b *testing.B) {
+	ads, _ := loadOSPoolAds(b)
+	store := New(Options{Shards: 1, SegmentSize: 512 << 10}) // seal ~50 ads/segment
+	for i, ad := range ads {
+		if err := store.Put([]byte(fmt.Sprintf("k%d", i)), ad); err != nil {
+			b.Fatal(err)
+		}
+	}
+	wires := allSegmentWiresB(b, store)
+	s := buildAdSchema(wires, adSchemaOpts{Presence: 0.90, Fit: 0.95, Strings: true})
+	memID, _ := store.intern.LookupID("Memory")
+	memIdx, ok := s.byID[memID]
+	if !ok || s.fields[memIdx].kind != akInt {
+		b.Skip("Memory not an int schema field")
+	}
+	store.EnableSchemaScan(s, []int{memIdx})
+
+	q, _ := vm.Parse("Memory > 4096")
+	match := func(v int64) bool { return v > 4096 }
+
+	b.Run("StoreQueryProject", func(b *testing.B) {
+		b.ReportAllocs()
+		for n := 0; n < b.N; n++ {
+			cnt := 0
+			for range store.QueryProject(q, []string{"Memory"}) {
+				cnt++
+			}
+			_ = cnt
+		}
+	})
+	b.Run("SchemaColumnarScan", func(b *testing.B) {
+		b.ReportAllocs()
+		for n := 0; n < b.N; n++ {
+			_ = store.schemaScanIntCount(s, memIdx, match)
+		}
+	})
+}
+
+func allSegmentWiresB(b *testing.B, c *Collection) [][]byte {
+	var ws [][]byte
+	var buf []byte
+	for _, sh := range c.shards {
+		for _, seg := range sh.segs {
+			if seg == nil || seg.used == 0 {
+				continue
+			}
+			for off := 0; off < seg.used; {
+				o := uint32(off)
+				total := recTotalLen(seg.data, o)
+				if total == 0 {
+					break
+				}
+				if !recIsMarker(seg.data, o) {
+					if w, err := seg.codec.Decompress(buf[:0], recAd(seg.data, o)); err == nil {
+						buf = w
+						ws = append(ws, append([]byte(nil), w...))
+					}
+				}
+				off += int(total)
+			}
+		}
+	}
+	return ws
+}

--- a/collections/colscan_countquery_test.go
+++ b/collections/colscan_countquery_test.go
@@ -1,0 +1,93 @@
+package collections
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/collections/vm"
+)
+
+// TestCountQueryAutoRoute verifies CountQuery routes exactly the columnar-eligible predicates
+// (Native, single INT schema field, numeric comparisons/band) and returns counts identical to
+// the store's own query engine, and declines everything else. Data mixes int Memory with a few
+// real, string, and missing Memory (all escape the int hot column) plus MVCC updates.
+func TestCountQueryAutoRoute(t *testing.T) {
+	store := New(Options{Shards: 2, SegmentSize: 1 << 12}) // small -> sealed segments
+	const n = 1500
+	put := func(k, src string) {
+		if err := store.Put([]byte(k), mustAdOld(t, src)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for i := 0; i < n; i++ {
+		switch i % 40 {
+		case 3:
+			put(fmt.Sprintf("k%d", i), fmt.Sprintf("Cpus=%d\nMemory=%d.5\nMachine=\"m%04d\"", 1+i%8, 5000, i)) // real -> escapes int col
+		case 7:
+			put(fmt.Sprintf("k%d", i), fmt.Sprintf("Cpus=%d\nMemory=\"n/a\"\nMachine=\"m%04d\"", 1+i%8, i)) // string -> escapes
+		case 11:
+			put(fmt.Sprintf("k%d", i), fmt.Sprintf("Cpus=%d\nMachine=\"m%04d\"", 1+i%8, i)) // Memory missing
+		default:
+			put(fmt.Sprintf("k%d", i), fmt.Sprintf("Cpus=%d\nMemory=%d\nMachine=\"m%04d\"", 1+i%8, 1024+(i%64)*256, i))
+		}
+	}
+	for i := 0; i < n; i += 5 { // MVCC: supersede earlier versions
+		put(fmt.Sprintf("k%d", i), fmt.Sprintf("Cpus=2\nMemory=%d\nMachine=\"m%04d\"", 9000, i))
+	}
+
+	wires := allSegmentWires(t, store)
+	s := buildAdSchema(wires, adSchemaOpts{Presence: 0.85, Fit: 0.95, Strings: true})
+	memID, _ := store.intern.LookupID("Memory")
+	memIdx, ok := s.byID[memID]
+	if !ok || s.fields[memIdx].kind != akInt {
+		t.Skip("Memory not an int schema field")
+	}
+	store.EnableSchemaScan(s, []int{memIdx})
+
+	storeCount := func(expr string) int {
+		q, err := vm.Parse(expr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		c := 0
+		for range store.Query(q) {
+			c++
+		}
+		return c
+	}
+
+	for _, expr := range []string{
+		"Memory > 4096",
+		"Memory <= 4096",
+		"Memory >= 2000 && Memory < 8000",
+		"Memory == 9000",
+		"Memory != 9000",
+	} {
+		q, _ := vm.Parse(expr)
+		got, ok := store.CountQuery(q)
+		if !ok {
+			t.Errorf("%q: CountQuery declined an eligible predicate", expr)
+			continue
+		}
+		if want := storeCount(expr); got != want {
+			t.Errorf("%q: CountQuery = %d, store.Query = %d", expr, got, want)
+		}
+	}
+
+	// Not columnar-eligible: must decline (ok=false) so the caller uses the normal scan.
+	for _, expr := range []string{
+		`Machine == "m0001"`,        // string field, not int schema
+		"Cpus > 2 && Memory > 4096", // two fields
+		"Memory > 4096 || Cpus > 2", // disjunction across fields
+		"Cpus > 2",                  // int field but not the hot/scanned one? still int -> eligible IF Cpus is an int schema field
+	} {
+		q, _ := vm.Parse(expr)
+		if _, ok := store.CountQuery(q); ok {
+			// Cpus is a valid int schema field, so "Cpus > 2" legitimately routes; only assert
+			// the genuinely-ineligible ones decline.
+			if expr != "Cpus > 2" {
+				t.Errorf("%q: CountQuery accepted an ineligible predicate", expr)
+			}
+		}
+	}
+}

--- a/collections/colscan_enable_test.go
+++ b/collections/colscan_enable_test.go
@@ -1,0 +1,64 @@
+package collections
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/collections/vm"
+)
+
+// TestBuildAndEnableSchemaScanFromDemand closes the loop: read demand on Memory makes it the
+// hot tier, and a string constraint auto-routes to the columnar scan with a count equal to the
+// store's own query engine.
+func TestBuildAndEnableSchemaScanFromDemand(t *testing.T) {
+	store := New(Options{Shards: 1, SegmentSize: 1 << 12}) // small -> sealed segments
+	const n = 1000
+	for i := 0; i < n; i++ {
+		ad := mustAdOld(t, fmt.Sprintf("Cpus=%d\nMemory=%d\nDisk=%d\nMachine=\"m%04d\"", 1+i%8, 1024+(i%64)*256, i*4096, i))
+		if err := store.Put([]byte(fmt.Sprintf("k%d", i)), ad); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Build read demand on Memory (projected reads bump recordReads).
+	mq, _ := vm.Parse("true")
+	for i := 0; i < 20; i++ {
+		for range store.QueryProject(mq, []string{"Memory"}) {
+		}
+	}
+
+	if !store.BuildAndEnableSchemaScan(2000, 4) {
+		t.Fatal("BuildAndEnableSchemaScan returned false")
+	}
+	st := store.schemaScan.Load()
+	if st == nil {
+		t.Fatal("schema scan not enabled")
+	}
+	// Memory (the read-demanded attr) should be in the hot tier.
+	memID, _ := store.intern.LookupID("Memory")
+	memIdx := st.schema.byID[memID]
+	hot := false
+	for _, i := range st.hot {
+		if i == memIdx {
+			hot = true
+		}
+	}
+	if !hot {
+		t.Errorf("Memory (read-demanded) not selected into the hot tier %v", st.hot)
+	}
+
+	for _, expr := range []string{"Memory > 4096", "Memory <= 4096", "Memory >= 2000 && Memory < 9000"} {
+		got, ok := store.CountConstraint(expr)
+		if !ok {
+			t.Errorf("%q: CountConstraint declined", expr)
+			continue
+		}
+		q, _ := vm.Parse(expr)
+		want := 0
+		for range store.Query(q) {
+			want++
+		}
+		if got != want {
+			t.Errorf("%q: columnar %d != store.Query %d", expr, got, want)
+		}
+	}
+}

--- a/collections/colscan_test.go
+++ b/collections/colscan_test.go
@@ -1,0 +1,115 @@
+package collections
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/collections/vm"
+)
+
+// allSegmentWires gathers every shard/segment's live-arena wire ads (for building the schema).
+func allSegmentWires(t *testing.T, c *Collection) [][]byte {
+	t.Helper()
+	var ws [][]byte
+	for _, sh := range c.shards {
+		sh.mu.RLock()
+		segs := append([]*segment(nil), sh.segs...)
+		sh.mu.RUnlock()
+		for _, seg := range segs {
+			if seg == nil || seg.used == 0 {
+				continue
+			}
+			ws = append(ws, segmentWires(t, seg)...)
+		}
+	}
+	return ws
+}
+
+// allBruteCount is the ground truth: every shard/window's visible records counted by the row
+// path (ignoring columnar blocks), so it exercises the exact MVCC visibility.
+func (c *Collection) allBruteCount(fieldID uint32, match func(int64) bool) int {
+	count := 0
+	for _, sh := range c.shards {
+		s0, wins := sh.snapshot()
+		for _, w := range wins {
+			count += bruteIntCount(w, s0, fieldID, match)
+		}
+		releaseWindows(wins)
+	}
+	return count
+}
+
+// TestSchemaScanIntCountMVCC verifies the columnar accelerated count equals a row-scan ground
+// truth over the same live snapshot -- exercising sealed segments (columnar path), the active
+// segment (row fallback), MVCC supersession (updated keys), escaped ints (out-of-width, in the
+// cold tail -> reconstruct), and escaped strings (type exception -> no match).
+func TestSchemaScanIntCountMVCC(t *testing.T) {
+	store := New(Options{Shards: 2, SegmentSize: 1 << 12}) // small -> many sealed segments
+	const n = 1200
+	put := func(key, src string) {
+		if err := store.Put([]byte(key), mustAdOld(t, src)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for i := 0; i < n; i++ {
+		mem := 1024 + (i%64)*512 // fits uint16
+		switch {
+		case i%50 == 7:
+			put(fmt.Sprintf("k%d", i), fmt.Sprintf("Cpus=%d\nMemory=%d\nMachine=\"m%03d\"", 1+i%8, 100000, i)) // out-of-uint16 -> escapes
+		case i%50 == 11:
+			put(fmt.Sprintf("k%d", i), fmt.Sprintf("Cpus=%d\nMemory=\"unknown\"\nMachine=\"m%03d\"", 1+i%8, i)) // string -> escapes
+		default:
+			put(fmt.Sprintf("k%d", i), fmt.Sprintf("Cpus=%d\nMemory=%d\nMachine=\"m%03d\"", 1+i%8, mem, i))
+		}
+	}
+	// Update every 3rd key -> supersede its earlier (possibly sealed) version.
+	for i := 0; i < n; i += 3 {
+		put(fmt.Sprintf("k%d", i), fmt.Sprintf("Cpus=2\nMemory=%d\nMachine=\"m%03d\"", 9000, i))
+	}
+
+	wires := allSegmentWires(t, store)
+	s := buildAdSchema(wires, adSchemaOpts{Presence: 0.90, Fit: 0.95, Strings: true})
+	memID, _ := store.intern.LookupID("Memory")
+	memIdx, ok := s.byID[memID]
+	if !ok || s.fields[memIdx].kind != akInt {
+		t.Skipf("Memory not an int schema field (width tier)")
+	}
+
+	store.EnableSchemaScan(s, []int{memIdx})
+	// Confirm the columnar path is actually exercised.
+	sealedWithBlock := 0
+	for _, sh := range store.shards {
+		sh.mu.RLock()
+		for _, seg := range sh.segs {
+			if seg != nil && seg != sh.act && seg.colblk.Load() != nil {
+				sealedWithBlock++
+			}
+		}
+		sh.mu.RUnlock()
+	}
+	if sealedWithBlock == 0 {
+		t.Fatal("no sealed segment got a columnar block; test would not exercise the columnar path")
+	}
+	t.Logf("sealed segments with columnar block: %d", sealedWithBlock)
+
+	for _, thr := range []int64{4096, 8000, 50000, 0} {
+		match := func(v int64) bool { return v > thr }
+		want := store.allBruteCount(memID, match)
+		got := store.schemaScanIntCount(s, memIdx, match)
+		if got != want {
+			t.Errorf("Memory > %d: columnar count = %d, row-scan truth = %d", thr, got, want)
+		}
+	}
+	// Cross-check the common threshold against the store's own query engine.
+	q, err := vm.Parse("Memory > 4096")
+	if err != nil {
+		t.Fatal(err)
+	}
+	qc := 0
+	for range store.Query(q) {
+		qc++
+	}
+	if sc := store.schemaScanIntCount(s, memIdx, func(v int64) bool { return v > 4096 }); sc != qc {
+		t.Errorf("Memory > 4096: columnar %d != store.Query %d", sc, qc)
+	}
+}

--- a/collections/colscan_test.go
+++ b/collections/colscan_test.go
@@ -32,7 +32,7 @@ func (c *Collection) allBruteCount(fieldID uint32, match func(int64) bool) int {
 	for _, sh := range c.shards {
 		s0, wins := sh.snapshot()
 		for _, w := range wins {
-			count += bruteIntCount(w, s0, fieldID, match)
+			count += bruteNumCount(w, s0, fieldID, func(f float64) bool { return match(int64(f)) })
 		}
 		releaseWindows(wins)
 	}

--- a/collections/go.mod
+++ b/collections/go.mod
@@ -6,6 +6,7 @@ require github.com/PelicanPlatform/classad v0.0.0
 
 require (
 	github.com/RoaringBitmap/roaring/v2 v2.19.0
+	github.com/dgraph-io/ristretto/v2 v2.4.2
 	github.com/klauspost/compress v1.19.0
 	github.com/tidwall/btree v1.8.1
 	golang.org/x/sys v0.46.0
@@ -13,6 +14,8 @@ require (
 
 require (
 	github.com/bits-and-blooms/bitset v1.24.4 // indirect
+	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/mschoch/smat v0.2.0 // indirect
 )
 

--- a/collections/go.sum
+++ b/collections/go.sum
@@ -2,8 +2,16 @@ github.com/RoaringBitmap/roaring/v2 v2.19.0 h1:zsWtVE+biht4eVl0YDLvykUqGkftR3Qc5
 github.com/RoaringBitmap/roaring/v2 v2.19.0/go.mod h1:SfT3of9nYh3vis1dIbCj4Yw6KQGujTN+f345nrN/0JA=
 github.com/bits-and-blooms/bitset v1.24.4 h1:95H15Og1clikBrKr/DuzMXkQzECs1M6hhoGXLwLQOZE=
 github.com/bits-and-blooms/bitset v1.24.4/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
+github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
+github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgraph-io/ristretto/v2 v2.4.2 h1:x0cvjmUKxt764Yxdk2nr94we1AvPPAMh1rh5TQ+Jo80=
+github.com/dgraph-io/ristretto/v2 v2.4.2/go.mod h1:0KsrXtXvnv0EqnzyowllbVJB8yBonswa2lTCK2gGo9E=
+github.com/dgryski/go-farm v0.0.0-20240924180020-3414d57e47da h1:aIftn67I1fkbMa512G+w+Pxci9hJPB8oMnkcP3iZF38=
+github.com/dgryski/go-farm v0.0.0-20240924180020-3414d57e47da/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
+github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
+github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/klauspost/compress v1.19.0 h1:sXLILfc9jV2QYWkzFOPWStmcUVH2RHEB1JCdY2oVvCQ=
 github.com/klauspost/compress v1.19.0/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/mschoch/smat v0.2.0 h1:8imxQsjDm8yFEAVBe7azKmKSgzSkZXDuKkSq9374khM=
@@ -14,8 +22,6 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/tidwall/btree v1.8.1 h1:27ehoXvm5AG/g+1VxLS1SD3vRhp/H7LuEfwNvddEdmA=
 github.com/tidwall/btree v1.8.1/go.mod h1:jBbTdUWhSZClZWoDg54VnvV7/54modSOzDN7VXftj1A=
-golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=
-golang.org/x/sys v0.43.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
 golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/collections/schema_compress_bench_test.go
+++ b/collections/schema_compress_bench_test.go
@@ -1,0 +1,85 @@
+package collections
+
+import (
+	"testing"
+
+	"github.com/PelicanPlatform/classad/collections/wire"
+	"github.com/klauspost/compress/zstd"
+)
+
+// BenchmarkSchemaScanCompressed quantifies the scan cost when records are zstd-compressed
+// (as sealed segments are), the crux of the size-vs-scan-speed trade: reading Memory from an
+// UNCOMPRESSED numeric prefix pays no decompression, while a fully-compressed record must be
+// decoded first.
+func BenchmarkSchemaScanCompressed(b *testing.B) {
+	ads, _ := loadOSPoolAds(b)
+	c, wires := encodeOSPool(b, ads)
+	memID, _ := c.intern.LookupID("Memory")
+	s := buildAdSchema(wires, adSchemaOpts{Presence: 0.90, Fit: 0.95, Strings: true})
+	f, idx := memoryField(b, c, s)
+	const threshold = 4096
+
+	enc, _ := zstd.NewWriter(nil, zstd.WithEncoderLevel(zstd.SpeedDefault))
+	dec, _ := zstd.NewReader(nil)
+	split := s.escBytes + s.fixedLen
+
+	baseComp := make([][]byte, len(wires))
+	recFull := make([][]byte, len(wires)) // whole schema record compressed
+	recTail := make([][]byte, len(wires)) // schema record: uncompressed prefix + compressed tail
+	recPrefix := make([][]byte, len(wires))
+	for i, w := range wires {
+		baseComp[i] = enc.EncodeAll(w, nil)
+		r := s.encode(wire.Ad(w))
+		recFull[i] = enc.EncodeAll(r, nil)
+		recPrefix[i] = append([]byte(nil), r[:split]...) // uncompressed numeric prefix
+		recTail[i] = enc.EncodeAll(r[split:], nil)       // compressed tail (unused by a numeric scan)
+	}
+
+	b.Run("BaselineCompressed_decompress+walk", func(b *testing.B) {
+		b.ReportAllocs()
+		var buf []byte
+		for n := 0; n < b.N; n++ {
+			cnt := 0
+			for _, cr := range baseComp {
+				buf, _ = dec.DecodeAll(cr, buf[:0])
+				wire.Ad(buf).ForEach(func(id uint32, node []byte) bool {
+					if id != memID {
+						return true
+					}
+					if lit, ok := wire.LiteralValue(node); ok && lit.Kind == wire.LitInt && lit.Int > threshold {
+						cnt++
+					}
+					return false
+				})
+			}
+			_ = cnt
+		}
+	})
+	b.Run("SchemaFullyCompressed_decompress+offset", func(b *testing.B) {
+		b.ReportAllocs()
+		var buf []byte
+		for n := 0; n < b.N; n++ {
+			cnt := 0
+			for _, cr := range recFull {
+				buf, _ = dec.DecodeAll(cr, buf[:0])
+				if !testBit(buf[:s.escBytes], idx) && readIntLE(buf[s.escBytes+f.off:], f.width, f.unsigned) > threshold {
+					cnt++
+				}
+			}
+			_ = cnt
+		}
+	})
+	b.Run("SchemaUncompressedPrefix_offset_only", func(b *testing.B) {
+		b.ReportAllocs()
+		for n := 0; n < b.N; n++ {
+			cnt := 0
+			for _, p := range recPrefix { // read Memory with NO decompression
+				if !testBit(p[:s.escBytes], idx) && readIntLE(p[s.escBytes+f.off:], f.width, f.unsigned) > threshold {
+					cnt++
+				}
+			}
+			_ = cnt
+		}
+	})
+	_ = recTail
+}

--- a/collections/schema_fullread_test.go
+++ b/collections/schema_fullread_test.go
@@ -1,0 +1,131 @@
+package collections
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/collections/wire"
+	"github.com/klauspost/compress/zstd"
+)
+
+// A columnar block: numeric prefixes uncompressed (fixed stride), string regions and cold
+// tails each a separately-zstd'd stream with per-record offsets. Reassembling record k's full
+// row = prefix_k ++ strRegion_k ++ coldTail_k (exactly the original record), so a full-ad read
+// must decompress the block's string+cold streams.
+type colBlock struct {
+	hot            []byte // record prefixes concatenated, uncompressed (stride = prefixLen)
+	strComp        []byte
+	coldComp       []byte
+	strOff, cldOff []int // per-record cumulative offsets into the decompressed streams
+	n              int
+}
+
+func buildColBlocks(s *adSchema, recs [][]byte, block int, enc *zstd.Encoder) []colBlock {
+	var blocks []colBlock
+	for start := 0; start < len(recs); start += block {
+		end := start + block
+		if end > len(recs) {
+			end = len(recs)
+		}
+		b := colBlock{n: end - start, strOff: []int{0}, cldOff: []int{0}}
+		var strCat, cldCat []byte
+		for _, r := range recs[start:end] {
+			prefix, str, cold := s.splitRecord(r)
+			b.hot = append(b.hot, prefix...)
+			strCat = append(strCat, str...)
+			cldCat = append(cldCat, cold...)
+			b.strOff = append(b.strOff, len(strCat))
+			b.cldOff = append(b.cldOff, len(cldCat))
+		}
+		b.strComp = enc.EncodeAll(strCat, nil)
+		b.coldComp = enc.EncodeAll(cldCat, nil)
+		blocks = append(blocks, b)
+	}
+	return blocks
+}
+
+func BenchmarkSchemaFullAdRead(b *testing.B) {
+	ads, _ := loadOSPoolAds(b)
+	_, wires := encodeOSPool(b, ads)
+	s := buildAdSchema(wires, adSchemaOpts{Presence: 0.90, Fit: 0.95, Strings: true})
+	prefixLen := s.escBytes + s.fixedLen
+	recs := make([][]byte, len(wires))
+	for i, w := range wires {
+		recs[i] = s.encode(wire.Ad(w))
+	}
+	enc, _ := zstd.NewWriter(nil, zstd.WithEncoderLevel(zstd.SpeedDefault))
+	dec, _ := zstd.NewReader(nil)
+
+	// Row baseline: each record compressed on its own (point-lookup-friendly row store).
+	rowComp := make([][]byte, len(recs))
+	for i, r := range recs {
+		rowComp[i] = enc.EncodeAll(r, nil)
+	}
+	countAd := func(rec []byte) int {
+		n := 0
+		s.forEach(rec, func(uint32, []byte) bool { n++; return true })
+		return n
+	}
+
+	// Row: point read (reconstruct one full ad) and full read (all ads).
+	b.Run("Row/PointRead", func(b *testing.B) {
+		b.ReportAllocs()
+		var buf []byte
+		mid := len(recs) / 2
+		for n := 0; n < b.N; n++ {
+			buf, _ = dec.DecodeAll(rowComp[mid], buf[:0])
+			_ = countAd(buf)
+		}
+	})
+	b.Run("Row/FullRead_perAd", func(b *testing.B) {
+		b.ReportAllocs()
+		var buf []byte
+		for n := 0; n < b.N; n++ {
+			for i := range rowComp {
+				buf, _ = dec.DecodeAll(rowComp[i], buf[:0])
+				_ = countAd(buf)
+			}
+		}
+		b.ReportMetric(float64(b.Elapsed().Nanoseconds())/float64(b.N*len(recs)), "ns/ad")
+	})
+
+	for _, block := range []int{128, 512, 1500} {
+		blocks := buildColBlocks(s, recs, block, enc)
+		// which block holds the middle record
+		midBlk, midLocal := (len(recs)/2)/block, (len(recs)/2)%block
+
+		b.Run(fmt.Sprintf("Col%d/PointRead", block), func(b *testing.B) {
+			b.ReportAllocs()
+			var sbuf, cbuf, rec []byte
+			for n := 0; n < b.N; n++ {
+				bl := &blocks[midBlk]
+				sbuf, _ = dec.DecodeAll(bl.strComp, sbuf[:0]) // decompress the WHOLE block's streams
+				cbuf, _ = dec.DecodeAll(bl.coldComp, cbuf[:0])
+				rec = rec[:0]
+				rec = append(rec, bl.hot[midLocal*prefixLen:(midLocal+1)*prefixLen]...)
+				rec = append(rec, sbuf[bl.strOff[midLocal]:bl.strOff[midLocal+1]]...)
+				rec = append(rec, cbuf[bl.cldOff[midLocal]:bl.cldOff[midLocal+1]]...)
+				_ = countAd(rec)
+			}
+		})
+		b.Run(fmt.Sprintf("Col%d/FullRead_perAd", block), func(b *testing.B) {
+			b.ReportAllocs()
+			var sbuf, cbuf, rec []byte
+			for n := 0; n < b.N; n++ {
+				for bi := range blocks {
+					bl := &blocks[bi]
+					sbuf, _ = dec.DecodeAll(bl.strComp, sbuf[:0]) // once per block
+					cbuf, _ = dec.DecodeAll(bl.coldComp, cbuf[:0])
+					for k := 0; k < bl.n; k++ {
+						rec = rec[:0]
+						rec = append(rec, bl.hot[k*prefixLen:(k+1)*prefixLen]...)
+						rec = append(rec, sbuf[bl.strOff[k]:bl.strOff[k+1]]...)
+						rec = append(rec, cbuf[bl.cldOff[k]:bl.cldOff[k+1]]...)
+						_ = countAd(rec)
+					}
+				}
+			}
+			b.ReportMetric(float64(b.Elapsed().Nanoseconds())/float64(b.N*len(recs)), "ns/ad")
+		})
+	}
+}

--- a/collections/schema_partial_test.go
+++ b/collections/schema_partial_test.go
@@ -1,0 +1,101 @@
+package collections
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/collections/wire"
+	"github.com/klauspost/compress/zstd"
+)
+
+// Partial-decompression experiment: compress the fixed numeric prefixes of a block of records
+// SEPARATELY from the string/cold tails (a column-group), so a numeric scan decompresses only
+// the small prefix block -- not the strings. Tests whether this recovers both size (everything
+// compressed) and scan speed (decompress only the tiny numeric column, once per block).
+
+func splitPrefixes(s *adSchema, wires [][]byte) (prefixes, tails []byte, prefixLen int, tailLens []int) {
+	prefixLen = s.escBytes + s.fixedLen
+	for _, w := range wires {
+		r := s.encode(wire.Ad(w))
+		prefixes = append(prefixes, r[:prefixLen]...)
+		tails = append(tails, r[prefixLen:]...)
+		tailLens = append(tailLens, len(r)-prefixLen)
+	}
+	return
+}
+
+func TestSchemaPartialDecompressionSize(t *testing.T) {
+	ads, _ := loadOSPoolAds(t)
+	_, wires := encodeOSPool(t, ads)
+	var baseCat []byte
+	for _, w := range wires {
+		baseCat = append(baseCat, w...)
+	}
+	baseZ := zstdLen(baseCat)
+
+	for _, block := range []int{len(wires), 512, 128} {
+		s := buildAdSchema(wires, adSchemaOpts{Presence: 0.90, Fit: 0.95, Strings: true})
+		prefixLen := s.escBytes + s.fixedLen
+		var prefixZ, tailZ, prefixRaw int
+		for start := 0; start < len(wires); start += block {
+			end := start + block
+			if end > len(wires) {
+				end = len(wires)
+			}
+			p, tl, _, _ := splitPrefixes(s, wires[start:end])
+			prefixRaw += len(p)
+			prefixZ += zstdLen(p) // numeric column-group, compressed per block
+			tailZ += zstdLen(tl)
+		}
+		total := prefixZ + tailZ
+		t.Logf("block=%-5d prefixLen=%dB | prefix raw=%dKB zstd=%dKB | tail zstd=%dKB | TOTAL=%dKB vs baseline %dKB (%+.1f%%)",
+			block, prefixLen, prefixRaw/1024, prefixZ/1024, tailZ/1024, total/1024, baseZ/1024,
+			100*float64(total-baseZ)/float64(baseZ))
+	}
+}
+
+func BenchmarkSchemaPartialDecompression(b *testing.B) {
+	ads, _ := loadOSPoolAds(b)
+	c, wires := encodeOSPool(b, ads)
+	s := buildAdSchema(wires, adSchemaOpts{Presence: 0.90, Fit: 0.95, Strings: true})
+	f, idx := memoryField(b, c, s)
+	const threshold = 4096
+	enc, _ := zstd.NewWriter(nil, zstd.WithEncoderLevel(zstd.SpeedDefault))
+	dec, _ := zstd.NewReader(nil)
+
+	for _, block := range []int{len(wires), 512, 128} {
+		// Pre-compress each block's prefix column-group.
+		prefixLen := s.escBytes + s.fixedLen
+		type blk struct {
+			comp []byte
+			n    int
+		}
+		var blocks []blk
+		for start := 0; start < len(wires); start += block {
+			end := start + block
+			if end > len(wires) {
+				end = len(wires)
+			}
+			p, _, _, _ := splitPrefixes(s, wires[start:end])
+			blocks = append(blocks, blk{enc.EncodeAll(p, nil), end - start})
+		}
+		b.Run(fmt.Sprintf("block=%d_decompress-prefix+strided", block), func(b *testing.B) {
+			b.ReportAllocs()
+			var buf []byte
+			for n := 0; n < b.N; n++ {
+				cnt := 0
+				for _, bl := range blocks {
+					buf, _ = dec.DecodeAll(bl.comp, buf[:0]) // decompress ONLY the numeric column-group
+					for i := 0; i < bl.n; i++ {
+						base := i * prefixLen
+						if !testBit(buf[base:base+s.escBytes], idx) &&
+							readIntLE(buf[base+s.escBytes+f.off:], f.width, f.unsigned) > threshold {
+							cnt++
+						}
+					}
+				}
+				_ = cnt
+			}
+		})
+	}
+}

--- a/collections/schema_proto_test.go
+++ b/collections/schema_proto_test.go
@@ -3,8 +3,6 @@ package collections
 import (
 	"encoding/binary"
 	"fmt"
-	"math"
-	"sort"
 	"testing"
 
 	"github.com/PelicanPlatform/classad/collections/vm"
@@ -12,290 +10,10 @@ import (
 	"github.com/klauspost/compress/zstd"
 )
 
-// This is the P1 prototype for a per-segment ClassAd schema (see the design discussion): a
-// centrally-managed, sampled schema stores common, type-stable attributes in a fixed-offset
-// typed blob at the front of each record (bools bit-packed, ints width-optimized by a fit
-// percentile, reals f64, strings as an 8-byte SSO slot + per-record table), with the rest in
-// a wire-encoded cold tail and a per-record escape bitmap for missing/exceptional values.
-//
-// It measures the two claims: (1) SIZE -- dropping the per-record id+type header for schema
-// attributes is a net shrink for low-exception attributes, even after zstd; (2) SCAN -- a
-// fixed-offset typed field scan (Memory > N) beats today's wire walk. It does not integrate
-// with the store; it is a measurement harness over the real OSPool slot corpus.
-
-type pkind uint8
-
-const (
-	pkNone pkind = iota
-	pkBool
-	pkInt
-	pkReal
-	pkString
-)
-
-type schemaAttr struct {
-	id       uint32
-	kind     pkind
-	width    int  // int: 1/2/4/8; real/string: 8; bool: 0 (bit-packed)
-	unsigned bool // int only
-	boolBit  int  // bool: bit index in the fixed blob's leading bitset
-	off      int  // non-bool: byte offset in the fixed blob
-	escIdx   int  // bit index in the per-record escape bitmap (== position in layout order)
-}
-
-type protoSchema struct {
-	attrs     []schemaAttr
-	byID      map[uint32]int
-	boolBytes int
-	fixedLen  int
-	escBytes  int
-}
-
-// intFits reports whether v fits the given width/signedness.
-func intFits(v int64, w int, unsigned bool) bool {
-	if unsigned {
-		if v < 0 {
-			return false
-		}
-		switch w {
-		case 1:
-			return v <= 0xFF
-		case 2:
-			return v <= 0xFFFF
-		case 4:
-			return v <= 0xFFFFFFFF
-		}
-		return true
-	}
-	switch w {
-	case 1:
-		return v >= -128 && v <= 127
-	case 2:
-		return v >= -32768 && v <= 32767
-	case 4:
-		return v >= math.MinInt32 && v <= math.MaxInt32
-	}
-	return true
-}
-
-// chooseIntType picks the smallest (width, signedness) covering >= fitThresh of the sampled
-// values; the rest become per-record exceptions. Unsigned is used when every sample is >= 0.
-func chooseIntType(vals []int64, fitThresh float64) (int, bool) {
-	unsigned := true
-	for _, v := range vals {
-		if v < 0 {
-			unsigned = false
-			break
-		}
-	}
-	for _, w := range []int{1, 2, 4} {
-		fit := 0
-		for _, v := range vals {
-			if intFits(v, w, unsigned) {
-				fit++
-			}
-		}
-		if float64(fit)/float64(len(vals)) >= fitThresh {
-			return w, unsigned
-		}
-	}
-	return 8, false
-}
-
-func nodeKind(node []byte) (pkind, wire.Literal) {
-	lit, ok := wire.LiteralValue(node)
-	if !ok {
-		return pkNone, lit
-	}
-	switch lit.Kind {
-	case wire.LitBool:
-		return pkBool, lit
-	case wire.LitInt:
-		return pkInt, lit
-	case wire.LitReal:
-		return pkReal, lit
-	case wire.LitString:
-		return pkString, lit
-	}
-	return pkNone, lit
-}
-
-// buildSchema samples the ads and selects schema attributes: present with a dominant storable
-// kind in >= presenceThresh of ALL ads. presenceThresh and fitThresh are the tunable knobs.
-func buildSchema(wires [][]byte, presenceThresh, fitThresh float64, includeStrings bool) *protoSchema {
-	n := len(wires)
-	type stat struct {
-		kinds   [5]int
-		intVals []int64
-	}
-	stats := map[uint32]*stat{}
-	for _, w := range wires {
-		wire.Ad(w).ForEach(func(id uint32, node []byte) bool {
-			st := stats[id]
-			if st == nil {
-				st = &stat{}
-				stats[id] = st
-			}
-			k, lit := nodeKind(node)
-			st.kinds[k]++
-			if k == pkInt {
-				st.intVals = append(st.intVals, lit.Int)
-			}
-			return true
-		})
-	}
-
-	var chosen []schemaAttr
-	for id, st := range stats {
-		domK, domC := pkNone, 0
-		for k := pkBool; k <= pkString; k++ {
-			if st.kinds[k] > domC {
-				domC, domK = st.kinds[k], pkind(k)
-			}
-		}
-		if domK == pkNone || (domK == pkString && !includeStrings) {
-			continue
-		}
-		if float64(domC)/float64(n) < presenceThresh {
-			continue
-		}
-		a := schemaAttr{id: id, kind: domK}
-		switch domK {
-		case pkInt:
-			a.width, a.unsigned = chooseIntType(st.intVals, fitThresh)
-		case pkReal, pkString:
-			a.width = 8
-		}
-		chosen = append(chosen, a)
-	}
-
-	// Layout smallest-to-largest so bools bit-pack and ints group by width: bool, int(width
-	// asc), real, string; ties by id for determinism.
-	classOf := func(a schemaAttr) int { return int(a.kind) }
-	sort.Slice(chosen, func(i, j int) bool {
-		if classOf(chosen[i]) != classOf(chosen[j]) {
-			return classOf(chosen[i]) < classOf(chosen[j])
-		}
-		if chosen[i].width != chosen[j].width {
-			return chosen[i].width < chosen[j].width
-		}
-		return chosen[i].id < chosen[j].id
-	})
-
-	nBool := 0
-	for _, a := range chosen {
-		if a.kind == pkBool {
-			nBool++
-		}
-	}
-	s := &protoSchema{byID: map[uint32]int{}, boolBytes: (nBool + 7) / 8}
-	off := s.boolBytes
-	bit := 0
-	for i := range chosen {
-		chosen[i].escIdx = i
-		if chosen[i].kind == pkBool {
-			chosen[i].boolBit = bit
-			bit++
-		} else {
-			chosen[i].off = off
-			off += chosen[i].width
-		}
-		s.byID[chosen[i].id] = i
-	}
-	s.attrs = chosen
-	s.fixedLen = off
-	s.escBytes = (len(chosen) + 7) / 8
-	return s
-}
-
-func setBit(b []byte, i int)       { b[i>>3] |= 1 << uint(i&7) }
-func testBit(b []byte, i int) bool { return b[i>>3]&(1<<uint(i&7)) != 0 }
-
-func putIntLE(dst []byte, v int64, w int) {
-	u := uint64(v)
-	for i := 0; i < w; i++ {
-		dst[i] = byte(u >> (8 * uint(i)))
-	}
-}
-
-func readIntLE(src []byte, w int, unsigned bool) int64 {
-	var u uint64
-	for i := 0; i < w; i++ {
-		u |= uint64(src[i]) << (8 * uint(i))
-	}
-	if unsigned || w == 8 {
-		return int64(u)
-	}
-	shift := uint(64 - 8*w) // sign-extend
-	return int64(u<<shift) >> shift
-}
-
-// encodeRecord lays out one ad in the schema format: [escape bitmap][fixed blob][uvarint
-// strTableLen][string table][cold tail]. The cold tail holds non-schema attributes and any
-// schema attribute that is missing or exceptional (wrong kind / out of the chosen int range),
-// each as the same uvarint(id)+node the wire form uses.
-func (s *protoSchema) encodeRecord(w []byte) []byte {
-	esc := make([]byte, s.escBytes)
-	fixed := make([]byte, s.fixedLen)
-	var strTable, cold []byte
-	filled := make([]bool, len(s.attrs))
-
-	wire.Ad(w).ForEach(func(id uint32, node []byte) bool {
-		idx, ok := s.byID[id]
-		if !ok {
-			cold = append(binary.AppendUvarint(cold, uint64(id)), node...)
-			return true
-		}
-		a := &s.attrs[idx]
-		k, lit := nodeKind(node)
-		escape := k != a.kind || (a.kind == pkInt && !intFits(lit.Int, a.width, a.unsigned))
-		if escape {
-			cold = append(binary.AppendUvarint(cold, uint64(id)), node...)
-			return true // filled stays false -> escape bit set below
-		}
-		switch a.kind {
-		case pkBool:
-			if lit.Bool {
-				setBit(fixed[:s.boolBytes], a.boolBit)
-			}
-		case pkInt:
-			putIntLE(fixed[a.off:], lit.Int, a.width)
-		case pkReal:
-			binary.LittleEndian.PutUint64(fixed[a.off:], math.Float64bits(lit.Real))
-		case pkString:
-			writeStrSlot(fixed[a.off:a.off+8], &strTable, lit.Str)
-		}
-		filled[idx] = true
-		return true
-	})
-	for i := range s.attrs {
-		if !filled[i] {
-			setBit(esc, i) // missing or exceptional: not in the fixed slot
-		}
-	}
-	rec := append([]byte{}, esc...)
-	rec = append(rec, fixed...)
-	rec = binary.AppendUvarint(rec, uint64(len(strTable)))
-	rec = append(rec, strTable...)
-	rec = append(rec, cold...)
-	return rec
-}
-
-// writeStrSlot encodes an 8-byte string slot: high byte 0..7 = inline length (bytes in
-// slot[0:len]); high byte 0xFF = tabled (offset uint32 in slot[0:4], length uint24 in
-// slot[4:7], appended to the per-record table).
-func writeStrSlot(slot []byte, table *[]byte, s string) {
-	if len(s) <= 7 {
-		copy(slot[:7], s)
-		slot[7] = byte(len(s))
-		return
-	}
-	off := len(*table)
-	*table = append(*table, s...)
-	binary.LittleEndian.PutUint32(slot[0:4], uint32(off))
-	slot[4], slot[5], slot[6] = byte(len(s)), byte(len(s)>>8), byte(len(s)>>16)
-	slot[7] = 0xFF
-}
+// Measurement harness for the per-segment schema (adschema.go), over the real OSPool slot
+// corpus: it reports raw+zstd size vs the current wire encoding and benchmarks a fixed-offset
+// Memory>N scan vs the wire walk / hot-directory Lookup / real store scan. Skips without
+// testdata/ospool_slots.ldif (like ospool_spike_test).
 
 func zstdLen(b []byte) int {
 	enc, _ := zstd.NewWriter(nil, zstd.WithEncoderLevel(zstd.SpeedDefault))
@@ -303,13 +21,9 @@ func zstdLen(b []byte) int {
 	return len(enc.EncodeAll(b, nil))
 }
 
-// TestSchemaSizeReport is the size half of P1: it reports raw and zstd bytes for the current
-// wire encoding vs the schema encoding, over the real OSPool corpus, at a few thresholds and
-// with/without strings in the schema.
 func TestSchemaSizeReport(t *testing.T) {
 	ads, _ := loadOSPoolAds(t)
-	c, wires := encodeOSPool(t, ads)
-	_ = c
+	_, wires := encodeOSPool(t, ads)
 
 	var baseRaw int
 	var baseCat []byte
@@ -321,15 +35,14 @@ func TestSchemaSizeReport(t *testing.T) {
 	t.Logf("BASELINE (current wire): %d ads, raw=%d B (%.1f/ad), zstd=%d B",
 		len(wires), baseRaw, float64(baseRaw)/float64(len(wires)), baseZ)
 
-	// Byte attribution: where do the baseline bytes go? Header (uvarint id) vs value node,
-	// split scalar (schema-eligible) vs non-scalar (expr/list -- can never be a fixed slot).
+	// Byte attribution: header (uvarint id) vs value node, split scalar vs expr/list.
 	var hdr, scalarVal, exprVal, nAttr, nExpr int
 	for _, w := range wires {
 		wire.Ad(w).ForEach(func(id uint32, node []byte) bool {
 			nAttr++
 			var tmp [10]byte
 			hdr += binary.PutUvarint(tmp[:], uint64(id))
-			if k, _ := nodeKind(node); k != pkNone {
+			if k, _ := nodeKind(node); k != akNone {
 				scalarVal += len(node)
 			} else {
 				exprVal += len(node)
@@ -342,66 +55,69 @@ func TestSchemaSizeReport(t *testing.T) {
 		nAttr, nExpr, hdr, 100*float64(hdr)/float64(baseRaw),
 		scalarVal, 100*float64(scalarVal)/float64(baseRaw), exprVal, 100*float64(exprVal)/float64(baseRaw))
 
-	report := func(label string, presence, fit float64, strings bool) {
-		s := buildSchema(wires, presence, fit, strings)
+	report := func(label string, opts adSchemaOpts) {
+		s := buildAdSchema(wires, opts)
 		var raw int
 		var cat []byte
 		for _, w := range wires {
-			r := s.encodeRecord(w)
+			r := s.encode(wire.Ad(w))
 			raw += len(r)
 			cat = append(cat, r...)
 		}
 		z := zstdLen(cat)
-		nb, ni, nr, ns := 0, 0, 0, 0
-		for _, a := range s.attrs {
-			switch a.kind {
-			case pkBool:
+		var nb, ni, nr, ns int
+		for _, f := range s.fields {
+			switch f.kind {
+			case akBool:
 				nb++
-			case pkInt:
+			case akInt:
 				ni++
-			case pkReal:
+			case akReal:
 				nr++
-			case pkString:
+			case akString:
 				ns++
 			}
 		}
-		t.Logf("%-28s schema=%d attrs (%db/%di/%dr/%ds) fixed=%dB | raw=%d B (%.1f/ad, %+.1f%%) zstd=%d B (%+.1f%%)",
-			label, len(s.attrs), nb, ni, nr, ns, s.fixedLen,
+		t.Logf("%-24s schema=%d (%db/%di/%dr/%ds) fixed=%dB | raw=%d (%.1f/ad, %+.1f%%) zstd=%d (%+.1f%%)",
+			label, len(s.fields), nb, ni, nr, ns, s.fixedLen,
 			raw, float64(raw)/float64(len(wires)), 100*float64(raw-baseRaw)/float64(baseRaw),
 			z, 100*float64(z-baseZ)/float64(baseZ))
 	}
-	report("numeric p90/f95", 0.90, 0.95, false)
-	report("numeric p95/f95", 0.95, 0.95, false)
-	report("numeric+str p90/f95", 0.90, 0.95, true)
-	report("numeric+str p95/f95", 0.95, 0.95, true)
+	report("numeric p90/f95", adSchemaOpts{Presence: 0.90, Fit: 0.95})
+	report("numeric p95/f95", adSchemaOpts{Presence: 0.95, Fit: 0.95})
+	report("numeric+str p90/f95", adSchemaOpts{Presence: 0.90, Fit: 0.95, Strings: true})
+	report("numeric+str p95/f95", adSchemaOpts{Presence: 0.95, Fit: 0.95, Strings: true})
 }
 
-// BenchmarkSchemaScanMemory is the scan half of P1: full-scan Memory > N over the corpus, the
-// current wire walk vs a fixed-offset typed read.
+// memoryField resolves Memory as an int schema field for the scan benchmarks.
+func memoryField(tb testing.TB, c *Collection, s *adSchema) (adField, int) {
+	memID, ok := c.intern.LookupID("Memory")
+	if !ok {
+		tb.Skip("no Memory attribute")
+	}
+	idx, ok := s.byID[memID]
+	if !ok || s.fields[idx].kind != akInt {
+		tb.Skip("Memory is not an int schema field")
+	}
+	return s.fields[idx], idx
+}
+
 func BenchmarkSchemaScanMemory(b *testing.B) {
 	ads, _ := loadOSPoolAds(b)
 	c, wires := encodeOSPool(b, ads)
-	memID, ok := c.intern.LookupID("Memory")
-	if !ok {
-		b.Skip("no Memory attribute")
-	}
-	s := buildSchema(wires, 0.90, 0.95, false)
-	ai, ok := s.byID[memID]
-	if !ok || s.attrs[ai].kind != pkInt {
-		b.Skipf("Memory not an int schema attr")
-	}
-	ma := s.attrs[ai]
+	memID, _ := c.intern.LookupID("Memory")
+	s := buildAdSchema(wires, adSchemaOpts{Presence: 0.90, Fit: 0.95})
+	f, idx := memoryField(b, c, s)
 	recs := make([][]byte, len(wires))
 	for i, w := range wires {
-		recs[i] = s.encodeRecord(w)
+		recs[i] = s.encode(wire.Ad(w))
 	}
 	const threshold = 4096
 
 	b.Run("WireWalk", func(b *testing.B) {
 		b.ReportAllocs()
-		var matched int
 		for n := 0; n < b.N; n++ {
-			matched = 0
+			matched := 0
 			for _, w := range wires {
 				wire.Ad(w).ForEach(func(id uint32, node []byte) bool {
 					if id != memID {
@@ -410,18 +126,16 @@ func BenchmarkSchemaScanMemory(b *testing.B) {
 					if lit, ok := wire.LiteralValue(node); ok && lit.Kind == wire.LitInt && lit.Int > threshold {
 						matched++
 					}
-					return false // found Memory; stop this ad
+					return false
 				})
 			}
+			_ = matched
 		}
-		b.Logf("matched=%d/%d", matched, len(wires))
 	})
-
-	b.Run("WireLookup", func(b *testing.B) { // fair baseline: direct hot-directory accessor
+	b.Run("WireLookup", func(b *testing.B) {
 		b.ReportAllocs()
-		var matched int
 		for n := 0; n < b.N; n++ {
-			matched = 0
+			matched := 0
 			for _, w := range wires {
 				if node, ok := wire.Ad(w).Lookup(memID); ok {
 					if lit, ok := wire.LiteralValue(node); ok && lit.Kind == wire.LitInt && lit.Int > threshold {
@@ -429,41 +143,31 @@ func BenchmarkSchemaScanMemory(b *testing.B) {
 					}
 				}
 			}
+			_ = matched
 		}
-		b.Logf("matched=%d/%d", matched, len(wires))
 	})
-
 	b.Run("SchemaFixedOffset", func(b *testing.B) {
 		b.ReportAllocs()
-		var matched int
 		for n := 0; n < b.N; n++ {
-			matched = 0
+			matched := 0
 			for _, r := range recs {
-				if testBit(r[:s.escBytes], ma.escIdx) {
-					continue // missing/exceptional: would consult the cold tail
+				if testBit(r[:s.escBytes], idx) {
+					continue
 				}
-				v := readIntLE(r[s.escBytes+ma.off:], ma.width, ma.unsigned)
-				if v > threshold {
+				if readIntLE(r[s.escBytes+f.off:], f.width, f.unsigned) > threshold {
 					matched++
 				}
 			}
+			_ = matched
 		}
-		b.Logf("matched=%d/%d", matched, len(wires))
 	})
 }
 
 // BenchmarkSchemaScanEndToEnd compares the schema fixed-offset scan against the REAL store
-// scan paths for `Memory > 4096` over the same corpus: Query (decode+eval each match) and
-// QueryProject (the wire-native count-where path the aggregate uses). This is the honest
-// end-to-end number -- the store baselines include predicate eval and visibility.
+// scan paths for Memory > 4096: Query (decode+eval) and QueryProject (the count-where path).
 func BenchmarkSchemaScanEndToEnd(b *testing.B) {
 	ads, _ := loadOSPoolAds(b)
 	c, wires := encodeOSPool(b, ads)
-	memID, ok := c.intern.LookupID("Memory")
-	if !ok {
-		b.Skip("no Memory")
-	}
-	// Real, queryable store (no index -> full scan, the unselective-predicate case).
 	store := New(Options{Shards: 1})
 	for i, ad := range ads {
 		if err := store.Put([]byte(fmt.Sprintf("k%d", i)), ad); err != nil {
@@ -474,11 +178,11 @@ func BenchmarkSchemaScanEndToEnd(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	s := buildSchema(wires, 0.90, 0.95, false)
-	ma := s.attrs[s.byID[memID]]
+	s := buildAdSchema(wires, adSchemaOpts{Presence: 0.90, Fit: 0.95})
+	f, idx := memoryField(b, c, s)
 	recs := make([][]byte, len(wires))
 	for i, w := range wires {
-		recs[i] = s.encodeRecord(w)
+		recs[i] = s.encode(wire.Ad(w))
 	}
 	const threshold = 4096
 
@@ -507,10 +211,10 @@ func BenchmarkSchemaScanEndToEnd(b *testing.B) {
 		for n := 0; n < b.N; n++ {
 			cnt := 0
 			for _, r := range recs {
-				if testBit(r[:s.escBytes], ma.escIdx) {
+				if testBit(r[:s.escBytes], idx) {
 					continue
 				}
-				if readIntLE(r[s.escBytes+ma.off:], ma.width, ma.unsigned) > threshold {
+				if readIntLE(r[s.escBytes+f.off:], f.width, f.unsigned) > threshold {
 					cnt++
 				}
 			}

--- a/collections/schema_proto_test.go
+++ b/collections/schema_proto_test.go
@@ -1,0 +1,451 @@
+package collections
+
+import (
+	"encoding/binary"
+	"math"
+	"sort"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/collections/wire"
+	"github.com/klauspost/compress/zstd"
+)
+
+// This is the P1 prototype for a per-segment ClassAd schema (see the design discussion): a
+// centrally-managed, sampled schema stores common, type-stable attributes in a fixed-offset
+// typed blob at the front of each record (bools bit-packed, ints width-optimized by a fit
+// percentile, reals f64, strings as an 8-byte SSO slot + per-record table), with the rest in
+// a wire-encoded cold tail and a per-record escape bitmap for missing/exceptional values.
+//
+// It measures the two claims: (1) SIZE -- dropping the per-record id+type header for schema
+// attributes is a net shrink for low-exception attributes, even after zstd; (2) SCAN -- a
+// fixed-offset typed field scan (Memory > N) beats today's wire walk. It does not integrate
+// with the store; it is a measurement harness over the real OSPool slot corpus.
+
+type pkind uint8
+
+const (
+	pkNone pkind = iota
+	pkBool
+	pkInt
+	pkReal
+	pkString
+)
+
+type schemaAttr struct {
+	id       uint32
+	kind     pkind
+	width    int  // int: 1/2/4/8; real/string: 8; bool: 0 (bit-packed)
+	unsigned bool // int only
+	boolBit  int  // bool: bit index in the fixed blob's leading bitset
+	off      int  // non-bool: byte offset in the fixed blob
+	escIdx   int  // bit index in the per-record escape bitmap (== position in layout order)
+}
+
+type protoSchema struct {
+	attrs     []schemaAttr
+	byID      map[uint32]int
+	boolBytes int
+	fixedLen  int
+	escBytes  int
+}
+
+// intFits reports whether v fits the given width/signedness.
+func intFits(v int64, w int, unsigned bool) bool {
+	if unsigned {
+		if v < 0 {
+			return false
+		}
+		switch w {
+		case 1:
+			return v <= 0xFF
+		case 2:
+			return v <= 0xFFFF
+		case 4:
+			return v <= 0xFFFFFFFF
+		}
+		return true
+	}
+	switch w {
+	case 1:
+		return v >= -128 && v <= 127
+	case 2:
+		return v >= -32768 && v <= 32767
+	case 4:
+		return v >= math.MinInt32 && v <= math.MaxInt32
+	}
+	return true
+}
+
+// chooseIntType picks the smallest (width, signedness) covering >= fitThresh of the sampled
+// values; the rest become per-record exceptions. Unsigned is used when every sample is >= 0.
+func chooseIntType(vals []int64, fitThresh float64) (int, bool) {
+	unsigned := true
+	for _, v := range vals {
+		if v < 0 {
+			unsigned = false
+			break
+		}
+	}
+	for _, w := range []int{1, 2, 4} {
+		fit := 0
+		for _, v := range vals {
+			if intFits(v, w, unsigned) {
+				fit++
+			}
+		}
+		if float64(fit)/float64(len(vals)) >= fitThresh {
+			return w, unsigned
+		}
+	}
+	return 8, false
+}
+
+func nodeKind(node []byte) (pkind, wire.Literal) {
+	lit, ok := wire.LiteralValue(node)
+	if !ok {
+		return pkNone, lit
+	}
+	switch lit.Kind {
+	case wire.LitBool:
+		return pkBool, lit
+	case wire.LitInt:
+		return pkInt, lit
+	case wire.LitReal:
+		return pkReal, lit
+	case wire.LitString:
+		return pkString, lit
+	}
+	return pkNone, lit
+}
+
+// buildSchema samples the ads and selects schema attributes: present with a dominant storable
+// kind in >= presenceThresh of ALL ads. presenceThresh and fitThresh are the tunable knobs.
+func buildSchema(wires [][]byte, presenceThresh, fitThresh float64, includeStrings bool) *protoSchema {
+	n := len(wires)
+	type stat struct {
+		kinds   [5]int
+		intVals []int64
+	}
+	stats := map[uint32]*stat{}
+	for _, w := range wires {
+		wire.Ad(w).ForEach(func(id uint32, node []byte) bool {
+			st := stats[id]
+			if st == nil {
+				st = &stat{}
+				stats[id] = st
+			}
+			k, lit := nodeKind(node)
+			st.kinds[k]++
+			if k == pkInt {
+				st.intVals = append(st.intVals, lit.Int)
+			}
+			return true
+		})
+	}
+
+	var chosen []schemaAttr
+	for id, st := range stats {
+		domK, domC := pkNone, 0
+		for k := pkBool; k <= pkString; k++ {
+			if st.kinds[k] > domC {
+				domC, domK = st.kinds[k], pkind(k)
+			}
+		}
+		if domK == pkNone || (domK == pkString && !includeStrings) {
+			continue
+		}
+		if float64(domC)/float64(n) < presenceThresh {
+			continue
+		}
+		a := schemaAttr{id: id, kind: domK}
+		switch domK {
+		case pkInt:
+			a.width, a.unsigned = chooseIntType(st.intVals, fitThresh)
+		case pkReal, pkString:
+			a.width = 8
+		}
+		chosen = append(chosen, a)
+	}
+
+	// Layout smallest-to-largest so bools bit-pack and ints group by width: bool, int(width
+	// asc), real, string; ties by id for determinism.
+	classOf := func(a schemaAttr) int { return int(a.kind) }
+	sort.Slice(chosen, func(i, j int) bool {
+		if classOf(chosen[i]) != classOf(chosen[j]) {
+			return classOf(chosen[i]) < classOf(chosen[j])
+		}
+		if chosen[i].width != chosen[j].width {
+			return chosen[i].width < chosen[j].width
+		}
+		return chosen[i].id < chosen[j].id
+	})
+
+	nBool := 0
+	for _, a := range chosen {
+		if a.kind == pkBool {
+			nBool++
+		}
+	}
+	s := &protoSchema{byID: map[uint32]int{}, boolBytes: (nBool + 7) / 8}
+	off := s.boolBytes
+	bit := 0
+	for i := range chosen {
+		chosen[i].escIdx = i
+		if chosen[i].kind == pkBool {
+			chosen[i].boolBit = bit
+			bit++
+		} else {
+			chosen[i].off = off
+			off += chosen[i].width
+		}
+		s.byID[chosen[i].id] = i
+	}
+	s.attrs = chosen
+	s.fixedLen = off
+	s.escBytes = (len(chosen) + 7) / 8
+	return s
+}
+
+func setBit(b []byte, i int)       { b[i>>3] |= 1 << uint(i&7) }
+func testBit(b []byte, i int) bool { return b[i>>3]&(1<<uint(i&7)) != 0 }
+
+func putIntLE(dst []byte, v int64, w int) {
+	u := uint64(v)
+	for i := 0; i < w; i++ {
+		dst[i] = byte(u >> (8 * uint(i)))
+	}
+}
+
+func readIntLE(src []byte, w int, unsigned bool) int64 {
+	var u uint64
+	for i := 0; i < w; i++ {
+		u |= uint64(src[i]) << (8 * uint(i))
+	}
+	if unsigned || w == 8 {
+		return int64(u)
+	}
+	shift := uint(64 - 8*w) // sign-extend
+	return int64(u<<shift) >> shift
+}
+
+// encodeRecord lays out one ad in the schema format: [escape bitmap][fixed blob][uvarint
+// strTableLen][string table][cold tail]. The cold tail holds non-schema attributes and any
+// schema attribute that is missing or exceptional (wrong kind / out of the chosen int range),
+// each as the same uvarint(id)+node the wire form uses.
+func (s *protoSchema) encodeRecord(w []byte) []byte {
+	esc := make([]byte, s.escBytes)
+	fixed := make([]byte, s.fixedLen)
+	var strTable, cold []byte
+	filled := make([]bool, len(s.attrs))
+
+	wire.Ad(w).ForEach(func(id uint32, node []byte) bool {
+		idx, ok := s.byID[id]
+		if !ok {
+			cold = append(binary.AppendUvarint(cold, uint64(id)), node...)
+			return true
+		}
+		a := &s.attrs[idx]
+		k, lit := nodeKind(node)
+		escape := k != a.kind || (a.kind == pkInt && !intFits(lit.Int, a.width, a.unsigned))
+		if escape {
+			cold = append(binary.AppendUvarint(cold, uint64(id)), node...)
+			return true // filled stays false -> escape bit set below
+		}
+		switch a.kind {
+		case pkBool:
+			if lit.Bool {
+				setBit(fixed[:s.boolBytes], a.boolBit)
+			}
+		case pkInt:
+			putIntLE(fixed[a.off:], lit.Int, a.width)
+		case pkReal:
+			binary.LittleEndian.PutUint64(fixed[a.off:], math.Float64bits(lit.Real))
+		case pkString:
+			writeStrSlot(fixed[a.off:a.off+8], &strTable, lit.Str)
+		}
+		filled[idx] = true
+		return true
+	})
+	for i := range s.attrs {
+		if !filled[i] {
+			setBit(esc, i) // missing or exceptional: not in the fixed slot
+		}
+	}
+	rec := append([]byte{}, esc...)
+	rec = append(rec, fixed...)
+	rec = binary.AppendUvarint(rec, uint64(len(strTable)))
+	rec = append(rec, strTable...)
+	rec = append(rec, cold...)
+	return rec
+}
+
+// writeStrSlot encodes an 8-byte string slot: high byte 0..7 = inline length (bytes in
+// slot[0:len]); high byte 0xFF = tabled (offset uint32 in slot[0:4], length uint24 in
+// slot[4:7], appended to the per-record table).
+func writeStrSlot(slot []byte, table *[]byte, s string) {
+	if len(s) <= 7 {
+		copy(slot[:7], s)
+		slot[7] = byte(len(s))
+		return
+	}
+	off := len(*table)
+	*table = append(*table, s...)
+	binary.LittleEndian.PutUint32(slot[0:4], uint32(off))
+	slot[4], slot[5], slot[6] = byte(len(s)), byte(len(s)>>8), byte(len(s)>>16)
+	slot[7] = 0xFF
+}
+
+func zstdLen(b []byte) int {
+	enc, _ := zstd.NewWriter(nil, zstd.WithEncoderLevel(zstd.SpeedDefault))
+	defer enc.Close()
+	return len(enc.EncodeAll(b, nil))
+}
+
+// TestSchemaSizeReport is the size half of P1: it reports raw and zstd bytes for the current
+// wire encoding vs the schema encoding, over the real OSPool corpus, at a few thresholds and
+// with/without strings in the schema.
+func TestSchemaSizeReport(t *testing.T) {
+	ads, _ := loadOSPoolAds(t)
+	c, wires := encodeOSPool(t, ads)
+	_ = c
+
+	var baseRaw int
+	var baseCat []byte
+	for _, w := range wires {
+		baseRaw += len(w)
+		baseCat = append(baseCat, w...)
+	}
+	baseZ := zstdLen(baseCat)
+	t.Logf("BASELINE (current wire): %d ads, raw=%d B (%.1f/ad), zstd=%d B",
+		len(wires), baseRaw, float64(baseRaw)/float64(len(wires)), baseZ)
+
+	// Byte attribution: where do the baseline bytes go? Header (uvarint id) vs value node,
+	// split scalar (schema-eligible) vs non-scalar (expr/list -- can never be a fixed slot).
+	var hdr, scalarVal, exprVal, nAttr, nExpr int
+	for _, w := range wires {
+		wire.Ad(w).ForEach(func(id uint32, node []byte) bool {
+			nAttr++
+			var tmp [10]byte
+			hdr += binary.PutUvarint(tmp[:], uint64(id))
+			if k, _ := nodeKind(node); k != pkNone {
+				scalarVal += len(node)
+			} else {
+				exprVal += len(node)
+				nExpr++
+			}
+			return true
+		})
+	}
+	t.Logf("ATTRIBUTION: %d attrs (%d expr/list), header=%d B (%.1f%%), scalar-val=%d B (%.1f%%), expr-val=%d B (%.1f%%)",
+		nAttr, nExpr, hdr, 100*float64(hdr)/float64(baseRaw),
+		scalarVal, 100*float64(scalarVal)/float64(baseRaw), exprVal, 100*float64(exprVal)/float64(baseRaw))
+
+	report := func(label string, presence, fit float64, strings bool) {
+		s := buildSchema(wires, presence, fit, strings)
+		var raw int
+		var cat []byte
+		for _, w := range wires {
+			r := s.encodeRecord(w)
+			raw += len(r)
+			cat = append(cat, r...)
+		}
+		z := zstdLen(cat)
+		nb, ni, nr, ns := 0, 0, 0, 0
+		for _, a := range s.attrs {
+			switch a.kind {
+			case pkBool:
+				nb++
+			case pkInt:
+				ni++
+			case pkReal:
+				nr++
+			case pkString:
+				ns++
+			}
+		}
+		t.Logf("%-28s schema=%d attrs (%db/%di/%dr/%ds) fixed=%dB | raw=%d B (%.1f/ad, %+.1f%%) zstd=%d B (%+.1f%%)",
+			label, len(s.attrs), nb, ni, nr, ns, s.fixedLen,
+			raw, float64(raw)/float64(len(wires)), 100*float64(raw-baseRaw)/float64(baseRaw),
+			z, 100*float64(z-baseZ)/float64(baseZ))
+	}
+	report("numeric p90/f95", 0.90, 0.95, false)
+	report("numeric p95/f95", 0.95, 0.95, false)
+	report("numeric+str p90/f95", 0.90, 0.95, true)
+	report("numeric+str p95/f95", 0.95, 0.95, true)
+}
+
+// BenchmarkSchemaScanMemory is the scan half of P1: full-scan Memory > N over the corpus, the
+// current wire walk vs a fixed-offset typed read.
+func BenchmarkSchemaScanMemory(b *testing.B) {
+	ads, _ := loadOSPoolAds(b)
+	c, wires := encodeOSPool(b, ads)
+	memID, ok := c.intern.LookupID("Memory")
+	if !ok {
+		b.Skip("no Memory attribute")
+	}
+	s := buildSchema(wires, 0.90, 0.95, false)
+	ai, ok := s.byID[memID]
+	if !ok || s.attrs[ai].kind != pkInt {
+		b.Skipf("Memory not an int schema attr")
+	}
+	ma := s.attrs[ai]
+	recs := make([][]byte, len(wires))
+	for i, w := range wires {
+		recs[i] = s.encodeRecord(w)
+	}
+	const threshold = 4096
+
+	b.Run("WireWalk", func(b *testing.B) {
+		b.ReportAllocs()
+		var matched int
+		for n := 0; n < b.N; n++ {
+			matched = 0
+			for _, w := range wires {
+				wire.Ad(w).ForEach(func(id uint32, node []byte) bool {
+					if id != memID {
+						return true
+					}
+					if lit, ok := wire.LiteralValue(node); ok && lit.Kind == wire.LitInt && lit.Int > threshold {
+						matched++
+					}
+					return false // found Memory; stop this ad
+				})
+			}
+		}
+		b.Logf("matched=%d/%d", matched, len(wires))
+	})
+
+	b.Run("WireLookup", func(b *testing.B) { // fair baseline: direct hot-directory accessor
+		b.ReportAllocs()
+		var matched int
+		for n := 0; n < b.N; n++ {
+			matched = 0
+			for _, w := range wires {
+				if node, ok := wire.Ad(w).Lookup(memID); ok {
+					if lit, ok := wire.LiteralValue(node); ok && lit.Kind == wire.LitInt && lit.Int > threshold {
+						matched++
+					}
+				}
+			}
+		}
+		b.Logf("matched=%d/%d", matched, len(wires))
+	})
+
+	b.Run("SchemaFixedOffset", func(b *testing.B) {
+		b.ReportAllocs()
+		var matched int
+		for n := 0; n < b.N; n++ {
+			matched = 0
+			for _, r := range recs {
+				if testBit(r[:s.escBytes], ma.escIdx) {
+					continue // missing/exceptional: would consult the cold tail
+				}
+				v := readIntLE(r[s.escBytes+ma.off:], ma.width, ma.unsigned)
+				if v > threshold {
+					matched++
+				}
+			}
+		}
+		b.Logf("matched=%d/%d", matched, len(wires))
+	})
+}

--- a/collections/schema_proto_test.go
+++ b/collections/schema_proto_test.go
@@ -2,10 +2,12 @@ package collections
 
 import (
 	"encoding/binary"
+	"fmt"
 	"math"
 	"sort"
 	"testing"
 
+	"github.com/PelicanPlatform/classad/collections/vm"
 	"github.com/PelicanPlatform/classad/collections/wire"
 	"github.com/klauspost/compress/zstd"
 )
@@ -447,5 +449,72 @@ func BenchmarkSchemaScanMemory(b *testing.B) {
 			}
 		}
 		b.Logf("matched=%d/%d", matched, len(wires))
+	})
+}
+
+// BenchmarkSchemaScanEndToEnd compares the schema fixed-offset scan against the REAL store
+// scan paths for `Memory > 4096` over the same corpus: Query (decode+eval each match) and
+// QueryProject (the wire-native count-where path the aggregate uses). This is the honest
+// end-to-end number -- the store baselines include predicate eval and visibility.
+func BenchmarkSchemaScanEndToEnd(b *testing.B) {
+	ads, _ := loadOSPoolAds(b)
+	c, wires := encodeOSPool(b, ads)
+	memID, ok := c.intern.LookupID("Memory")
+	if !ok {
+		b.Skip("no Memory")
+	}
+	// Real, queryable store (no index -> full scan, the unselective-predicate case).
+	store := New(Options{Shards: 1})
+	for i, ad := range ads {
+		if err := store.Put([]byte(fmt.Sprintf("k%d", i)), ad); err != nil {
+			b.Fatal(err)
+		}
+	}
+	q, err := vm.Parse("Memory > 4096")
+	if err != nil {
+		b.Fatal(err)
+	}
+	s := buildSchema(wires, 0.90, 0.95, false)
+	ma := s.attrs[s.byID[memID]]
+	recs := make([][]byte, len(wires))
+	for i, w := range wires {
+		recs[i] = s.encodeRecord(w)
+	}
+	const threshold = 4096
+
+	b.Run("StoreQuery", func(b *testing.B) {
+		b.ReportAllocs()
+		for n := 0; n < b.N; n++ {
+			cnt := 0
+			for range store.Query(q) {
+				cnt++
+			}
+			_ = cnt
+		}
+	})
+	b.Run("StoreQueryProject", func(b *testing.B) {
+		b.ReportAllocs()
+		for n := 0; n < b.N; n++ {
+			cnt := 0
+			for range store.QueryProject(q, []string{"Memory"}) {
+				cnt++
+			}
+			_ = cnt
+		}
+	})
+	b.Run("SchemaFixedScan", func(b *testing.B) {
+		b.ReportAllocs()
+		for n := 0; n < b.N; n++ {
+			cnt := 0
+			for _, r := range recs {
+				if testBit(r[:s.escBytes], ma.escIdx) {
+					continue
+				}
+				if readIntLE(r[s.escBytes+ma.off:], ma.width, ma.unsigned) > threshold {
+					cnt++
+				}
+			}
+			_ = cnt
+		}
 	})
 }

--- a/collections/schema_proto_test.go
+++ b/collections/schema_proto_test.go
@@ -57,14 +57,18 @@ func TestSchemaSizeReport(t *testing.T) {
 
 	report := func(label string, opts adSchemaOpts) {
 		s := buildAdSchema(wires, opts)
-		var raw int
-		var cat []byte
+		var raw, hotBytes int
+		var cat, tailCat []byte
+		split := s.escBytes + s.fixedLen // numeric hot prefix | compressible tail
 		for _, w := range wires {
 			r := s.encode(wire.Ad(w))
 			raw += len(r)
 			cat = append(cat, r...)
+			hotBytes += split
+			tailCat = append(tailCat, r[split:]...)
 		}
-		z := zstdLen(cat)
+		zAll := zstdLen(cat)                  // whole record compressed
+		zSplit := hotBytes + zstdLen(tailCat) // hot prefix uncompressed + tail compressed
 		var nb, ni, nr, ns int
 		for _, f := range s.fields {
 			switch f.kind {
@@ -78,15 +82,17 @@ func TestSchemaSizeReport(t *testing.T) {
 				ns++
 			}
 		}
-		t.Logf("%-24s schema=%d (%db/%di/%dr/%ds) fixed=%dB | raw=%d (%.1f/ad, %+.1f%%) zstd=%d (%+.1f%%)",
-			label, len(s.fields), nb, ni, nr, ns, s.fixedLen,
-			raw, float64(raw)/float64(len(wires)), 100*float64(raw-baseRaw)/float64(baseRaw),
-			z, 100*float64(z-baseZ)/float64(baseZ))
+		t.Logf("%-22s schema=%d (%db/%di/%dr/%ds) hot=%dB | raw %+.1f%% | zstd-all %+.1f%% | zstd hot+tail %+.1f%%",
+			label, len(s.fields), nb, ni, nr, ns, split,
+			100*float64(raw-baseRaw)/float64(baseRaw),
+			100*float64(zAll-baseZ)/float64(baseZ),
+			100*float64(zSplit-baseZ)/float64(baseZ))
 	}
 	report("numeric p90/f95", adSchemaOpts{Presence: 0.90, Fit: 0.95})
 	report("numeric p95/f95", adSchemaOpts{Presence: 0.95, Fit: 0.95})
 	report("numeric+str p90/f95", adSchemaOpts{Presence: 0.90, Fit: 0.95, Strings: true})
 	report("numeric+str p95/f95", adSchemaOpts{Presence: 0.95, Fit: 0.95, Strings: true})
+	report("numeric+str p80/f95", adSchemaOpts{Presence: 0.80, Fit: 0.95, Strings: true})
 }
 
 // memoryField resolves Memory as an int schema field for the scan benchmarks.

--- a/collections/schema_tiered_test.go
+++ b/collections/schema_tiered_test.go
@@ -1,0 +1,88 @@
+package collections
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/collections/wire"
+)
+
+// TestSchemaTieredSize measures the popularity-tiered layout: the top-K most popular numeric
+// int/real fields kept UNCOMPRESSED (fast scan), the remaining numerics compressed as a
+// standalone column-group (partial decompression), bools + strings + cold each compressed.
+// Popularity here is proxied by presence (the static corpus has no query demand; the real
+// system uses c.demand read counts, as ANALYZE/RefreshHotSet do). Sweeps K.
+func TestSchemaTieredSize(t *testing.T) {
+	ads, _ := loadOSPoolAds(t)
+	_, wires := encodeOSPool(t, ads)
+	var baseCat []byte
+	for _, w := range wires {
+		baseCat = append(baseCat, w...)
+	}
+	baseZ := zstdLen(baseCat)
+
+	s := buildAdSchema(wires, adSchemaOpts{Presence: 0.90, Fit: 0.95, Strings: true})
+	recs := make([][]byte, len(wires))
+	present := make([]int, len(s.fields))
+	for i, w := range wires {
+		recs[i] = s.encode(wire.Ad(w))
+		esc := recs[i][:s.escBytes]
+		for j := range s.fields {
+			if !testBit(esc, j) {
+				present[j]++
+			}
+		}
+	}
+	// Scannable numeric fields (int/real), ranked by presence (popularity proxy), desc.
+	var numeric []int
+	for j := range s.fields {
+		if s.fields[j].kind == akInt || s.fields[j].kind == akReal {
+			numeric = append(numeric, j)
+		}
+	}
+	sort.Slice(numeric, func(a, b int) bool { return present[numeric[a]] > present[numeric[b]] })
+
+	// Fixed per-record parts shared across K: string region + cold tail (each its own stream),
+	// and the bool bitset (always in the compressed group).
+	var strCat, coldCat, boolCat []byte
+	for _, r := range recs {
+		_, str, cold := s.splitRecord(r)
+		strCat = append(strCat, str...)
+		coldCat = append(coldCat, cold...)
+		boolCat = append(boolCat, r[s.escBytes:s.escBytes+s.boolBytes]...) // bool bitset
+	}
+	strZ, coldZ, boolZ := zstdLen(strCat), zstdLen(coldCat), zstdLen(boolCat)
+
+	widthOf := func(j int) int { return s.fields[j].width }
+	for _, K := range []int{0, 5, 10, 20, 40, len(numeric)} {
+		if K > len(numeric) {
+			K = len(numeric)
+		}
+		hot := map[int]bool{}
+		hotWidth := 0
+		for i := 0; i < K; i++ {
+			hot[numeric[i]] = true
+			hotWidth += widthOf(numeric[i])
+		}
+		hotRaw := hotWidth * len(wires) // uncompressed hot int/real slots, fixed stride
+
+		// Cold int/real fields, columnar (per field contiguous) for best compression.
+		var coldNum []byte
+		for _, j := range numeric {
+			if hot[j] {
+				continue
+			}
+			off := s.escBytes + s.fields[j].off
+			w := s.fields[j].width
+			for _, r := range recs {
+				coldNum = append(coldNum, r[off:off+w]...)
+			}
+		}
+		coldNumZ := zstdLen(coldNum)
+
+		total := hotRaw + coldNumZ + boolZ + strZ + coldZ
+		t.Logf("K=%-3d hotWidth=%dB | hot UNCOMPRESSED=%dKB + coldNum zstd=%dKB + bool=%dKB + str=%dKB + cold=%dKB = %dKB vs %dKB (%+.1f%%)",
+			K, hotWidth, hotRaw/1024, coldNumZ/1024, boolZ/1024, strZ/1024, coldZ/1024, total/1024, baseZ/1024,
+			100*float64(total-baseZ)/float64(baseZ))
+	}
+}

--- a/collections/schema_uncompressed_test.go
+++ b/collections/schema_uncompressed_test.go
@@ -1,0 +1,63 @@
+package collections
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/collections/wire"
+)
+
+// splitRecord divides a schema record into its numeric prefix, string region, and cold tail
+// by walking the string region (uvarint(len)+bytes for each non-escaped string field).
+func (s *adSchema) splitRecord(r []byte) (prefix, strs, cold []byte) {
+	prefixLen := s.escBytes + s.fixedLen
+	p := prefixLen
+	esc := r[:s.escBytes]
+	for i := range s.fields {
+		if s.fields[i].kind == akString && !testBit(esc, i) {
+			l, m := binary.Uvarint(r[p:])
+			p += m + int(l)
+		}
+	}
+	return r[:prefixLen], r[prefixLen:p], r[p:]
+}
+
+// TestSchemaUncompressedNumericSize characterizes the target design: numeric prefix left
+// UNCOMPRESSED (for the no-decode scan), string column and cold tail each compressed as their
+// own stream (per block). Reports size vs the current wire baseline; the scan is the
+// SchemaUncompressedPrefix number (~3 us / ~9300x).
+func TestSchemaUncompressedNumericSize(t *testing.T) {
+	ads, _ := loadOSPoolAds(t)
+	_, wires := encodeOSPool(t, ads)
+	var baseCat []byte
+	for _, w := range wires {
+		baseCat = append(baseCat, w...)
+	}
+	baseZ := zstdLen(baseCat)
+
+	s := buildAdSchema(wires, adSchemaOpts{Presence: 0.90, Fit: 0.95, Strings: true})
+	prefixLen := s.escBytes + s.fixedLen
+	for _, block := range []int{len(wires), 512} {
+		var prefixRaw, strZ, coldZ int
+		for start := 0; start < len(wires); start += block {
+			end := start + block
+			if end > len(wires) {
+				end = len(wires)
+			}
+			var strCat, coldCat []byte
+			for _, w := range wires[start:end] {
+				r := s.encode(wire.Ad(w))
+				_, str, cold := s.splitRecord(r)
+				prefixRaw += prefixLen // uncompressed
+				strCat = append(strCat, str...)
+				coldCat = append(coldCat, cold...)
+			}
+			strZ += zstdLen(strCat)
+			coldZ += zstdLen(coldCat)
+		}
+		total := prefixRaw + strZ + coldZ
+		t.Logf("block=%-5d | numeric UNCOMPRESSED=%dKB + strings zstd=%dKB + cold zstd=%dKB = TOTAL %dKB vs baseline %dKB (%+.1f%%)  [scan ~3us / ~9300x]",
+			block, prefixRaw/1024, strZ/1024, coldZ/1024, total/1024, baseZ/1024,
+			100*float64(total-baseZ)/float64(baseZ))
+	}
+}

--- a/collections/schema_uncompressed_test.go
+++ b/collections/schema_uncompressed_test.go
@@ -1,26 +1,10 @@
 package collections
 
 import (
-	"encoding/binary"
 	"testing"
 
 	"github.com/PelicanPlatform/classad/collections/wire"
 )
-
-// splitRecord divides a schema record into its numeric prefix, string region, and cold tail
-// by walking the string region (uvarint(len)+bytes for each non-escaped string field).
-func (s *adSchema) splitRecord(r []byte) (prefix, strs, cold []byte) {
-	prefixLen := s.escBytes + s.fixedLen
-	p := prefixLen
-	esc := r[:s.escBytes]
-	for i := range s.fields {
-		if s.fields[i].kind == akString && !testBit(esc, i) {
-			l, m := binary.Uvarint(r[p:])
-			p += m + int(l)
-		}
-	}
-	return r[:prefixLen], r[prefixLen:p], r[p:]
-}
 
 // TestSchemaUncompressedNumericSize characterizes the target design: numeric prefix left
 // UNCOMPRESSED (for the no-decode scan), string column and cold tail each compressed as their

--- a/collections/segment.go
+++ b/collections/segment.go
@@ -117,6 +117,12 @@ type segment struct {
 	// Its backing mapping is released via onReap when the segment's scan pins drain.
 	msidx atomic.Pointer[mmapSegIndex]
 
+	// colblk is this segment's columnar (adschema PAX) accelerator: nil unless schema-scan
+	// is enabled on the collection. Built from the immutable record bytes and swapped in
+	// atomically (like idx); a scan reads it lock-free and uses colSegment.offs to map a
+	// block record back to its arena offset for the MVCC visibility check.
+	colblk atomic.Pointer[colSegment]
+
 	// Persistent (mmap) segments only; nil/zero for RAM segments. See mmapseg.go.
 	// The file name is independent of the logical id (id == array index, reassigned
 	// at compaction install and on recovery), so no rename is needed when id changes.

--- a/collections/store.go
+++ b/collections/store.go
@@ -255,9 +255,9 @@ type Collection struct {
 	// and Rotate). Zero value ⇒ keep everything.
 	ret Retention
 
-	// schemaCache caches decompressed columnar-block streams for the adschema scan path (see
-	// EnableSchemaScan / colscan.go). Nil until schema-scan is enabled.
-	schemaCache atomic.Pointer[blockCache]
+	// schemaScan holds the adschema columnar scan state (resolved schema, hot fields, and the
+	// decompressed-block cache) once EnableSchemaScan is called; nil otherwise. See colscan.go.
+	schemaScan atomic.Pointer[schemaScanState]
 
 	// gcFloor is a runtime-only GC watermark in Retention.MinAgeAttr units: Rotate may
 	// reclaim a fully-consumed segment (its newest age value < gcFloor) EARLY -- before it

--- a/collections/store.go
+++ b/collections/store.go
@@ -255,6 +255,10 @@ type Collection struct {
 	// and Rotate). Zero value ⇒ keep everything.
 	ret Retention
 
+	// schemaCache caches decompressed columnar-block streams for the adschema scan path (see
+	// EnableSchemaScan / colscan.go). Nil until schema-scan is enabled.
+	schemaCache atomic.Pointer[blockCache]
+
 	// gcFloor is a runtime-only GC watermark in Retention.MinAgeAttr units: Rotate may
 	// reclaim a fully-consumed segment (its newest age value < gcFloor) EARLY -- before it
 	// hits MaxAge -- so a change-feed source drains records every live subscriber has already

--- a/collections/wire/accessor.go
+++ b/collections/wire/accessor.go
@@ -579,6 +579,20 @@ func foldEqualBytes(b []byte, s string) bool {
 }
 
 // skipNode advances c past exactly one node without allocating.
+// NodeLen returns the byte length of the single wire node at the start of b -- a scalar
+// literal (int/real/bool/string/undefined/error) or a computed expression (op/ref/list/
+// record/func). It lets a caller that stores concatenated uvarint(id)+node entries (e.g. the
+// per-segment schema's cold tail) split them without a separate length prefix. ok is false if
+// b does not begin with a well-formed node.
+func NodeLen(b []byte) (int, bool) {
+	c := &cursor{b: b, ok: true}
+	skipNode(c, 0)
+	if !c.ok {
+		return 0, false
+	}
+	return c.pos, true
+}
+
 func skipNode(c *cursor, depth int) {
 	if !c.ok {
 		return

--- a/collections/wire/literal.go
+++ b/collections/wire/literal.go
@@ -46,6 +46,31 @@ func StringLiteralValue(node []byte) ([]byte, bool) {
 	return node[start : start+int(l)], true
 }
 
+// AppendBoolNode, AppendIntNode, AppendRealNode, and AppendStringNode append a scalar literal
+// wire node to dst and return the extended slice -- the inverse of LiteralValue. They let a
+// caller reconstruct a wire node from a typed value (e.g. the per-segment schema decoder
+// rebuilding a node from a fixed-layout field), producing bytes LiteralValue reads back
+// exactly.
+func AppendBoolNode(dst []byte, b bool) []byte {
+	if b {
+		return append(dst, nBoolTrue)
+	}
+	return append(dst, nBoolFalse)
+}
+
+func AppendIntNode(dst []byte, v int64) []byte {
+	return binary.AppendVarint(append(dst, nInt), v)
+}
+
+func AppendRealNode(dst []byte, f float64) []byte {
+	return binary.LittleEndian.AppendUint64(append(dst, nReal), math.Float64bits(f))
+}
+
+func AppendStringNode(dst []byte, s string) []byte {
+	dst = binary.AppendUvarint(append(dst, nString), uint64(len(s)))
+	return append(dst, s...)
+}
+
 // LiteralValue decodes node as a scalar literal, returning (lit, true) if node is
 // one, or (_, false) if it is a list, record, or computed expression (which must
 // be decoded via DecodeNode and evaluated). It is allocation-free except for the


### PR DESCRIPTION
## What

A **per-segment ClassAd schema** that gives sealed segments a **columnar (PAX) layout**, so scans and counts on common numeric attributes read a typed column instead of walking a wire ad per record. ClassAds are schemaless, but a segment of like ads (every Slot ad has `Memory:int`, `Cpus:int`, …) is *nearly* a schema — sampling recovers it.

Entirely **opt-in and additive**: a nil-default `segment.colblk` and a new `EnableSchemaScan`; no existing seal, scan, or write path is touched, so a collection that never opts in is byte-for-byte unaffected.

## The design, settled on measurements (not intuition)

Every fork was decided with a benchmark over the real OSPool slot corpus (`testdata/ospool_slots.ldif`). The measurement harnesses are kept as `*_test.go` so the numbers reproduce:

- **Scan**: a fixed-offset typed `Memory > N` scan is **~1957× / ~9300×** the wire walk (per-record microbench).
- **Size**: positional strings in the compressible tail make strings *help* (−6% zstd) instead of the +5.6% the 8-byte-slot approach cost.
- **Compression vs scan**: fully compressing the numeric prefix collapses the scan to ~1.3× (decompression-dominated); keeping it uncompressed keeps ~9300× at +26% size.
- **Popularity tiering** (the unlock): keeping only the **top ~10–20 numerics by query demand** uncompressed gives **−8…−10% size AND ~9300× scan** on exactly the queried attributes; the rest compress as a standalone column group.
- **Full-ad-read penalty** (columnar's cost): reconstructing one `SELECT *` ad from a block is **18–318× slower** than the row store, tunable by row-group size (128 → ~18×, 1500 → ~318×), and ~2× *faster* for bulk reads. Projections only touch their columns; only full `SELECT *` pays it.

## What's in this PR (collections only)

- **`adschema.go`** — `adSchema`: build from a sample (presence/type-stability; int width by a **fit-percentile**, out-of-fit values escaping — so one 1000-CPU slot doesn't widen every `Cpus`), `encode`/`forEach` (lossless row form), positional strings.
- **`colblock.go`** — `columnarBlock`: the PAX form. Hot numerics + escape/bool bitsets uncompressed (fixed stride); cold numerics columnar; string + cold-tail each their own `Codec` stream. `scanInt` (hot: no decode; cold: one cached decode), `reconstruct` (full-ad), `buildColumnarFromSegment` (seal-side transcode, keeping `offs[k]` → arena offset).
- **`blockcache.go`** — decompressed-block cache backed by **`dgraph-io/ristretto/v2`** (byte-cost-bounded, concurrent — the right fit for large variable-size hot items; cut escaped-record reconstructs 224 µs → 84 µs, allocs 4 MB → 145 KB).
- **`colscan.go`** — `EnableSchemaScan`, an **MVCC-correct** columnar count (`recSeq ≤ s0 < recSuperseded` read live from the arena; row fallback for the active segment), `BuildAndEnableSchemaScan` (hot tier chosen by `c.demand` reads — the same signal `RefreshHotSet`/ANALYZE use), and `CountQuery`/`CountConstraint` that **auto-route** a columnar-eligible predicate straight from a `vm.Query`.
- **`wire`** — `NodeLen` + `AppendBool/Int/Real/StringNode` (so a decoded record self-delimits and rebuilds nodes).
- **`segment.go`/`store.go`** — the nil-default `colblk` pointer and the `schemaScanState` pointer.

## End-to-end, in the real store

`Memory > 4096`, OSPool corpus, sealed segments, MVCC-correct, ristretto cache:

```
StoreQueryProject (real count-where):  6.54 ms
SchemaColumnarScan:                    83.7 µs   ~78×
```

## Correctness

- Round-trip: every record reconstructs **byte-identical** (both codecs, hot/cold splits, width-escaped/type-exception values), over synthetic edge cases **and the whole OSPool corpus**.
- MVCC scan: over a live snapshot with sealed columnar segments, superseded keys, out-of-width int escapes, and string/missing values, the columnar count equals a row-scan ground truth **and** the store's own `Query`.
- Auto-route: eligible predicates route and equal `store.Query`; ineligible ones (string field, multi-field, cross-field OR) decline to the normal path.

Full `collections` + `wire` suites green.

## Follow-ups (separate, after tag)

The columnar block is not yet persisted in the sidecar (rebuilt on `EnableSchemaScan`) — **P3**. The db/dbrpc `COUNT(*) … WHERE` fast-path calling `CountConstraint`, hooking `BuildAndEnableSchemaScan` into ANALYZE/Maintain, and `.stats` schema info all live in downstream modules that pin published `collections`, so they follow once this is tagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
