### PR TITLE
db,dbrpc: route constrained COUNT(*) through the adschema columnar scan

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -279,6 +279,20 @@ func (db *DB) Len() int { return db.c.Len() }
 // caller knows when Len equals the match-all row count (the COUNT(*) fast path).
 func (db *DB) Chained() bool { return db.c.Chained() }
 
+// EnableSchemaScan builds the per-segment adschema columnar accelerator over the table's sealed
+// segments and enables it, choosing the uncompressed hot numeric tier as the top-hotTopN
+// int/real fields by query demand (see collections.Collection.BuildAndEnableSchemaScan).
+// sampleMax bounds the ad sample. Opt-in; a table that never calls this is unaffected.
+func (db *DB) EnableSchemaScan(sampleMax, hotTopN int) bool {
+	return db.c.BuildAndEnableSchemaScan(sampleMax, hotTopN)
+}
+
+// CountConstraint counts the rows matching constraint via the columnar schema scan when the
+// constraint is columnar-eligible (Native, numeric comparisons on one int schema field) and
+// schema-scan is enabled; ok=false ⇒ the caller should use the normal count path. See
+// collections.Collection.CountConstraint.
+func (db *DB) CountConstraint(constraint string) (int, bool) { return db.c.CountConstraint(constraint) }
+
 // LookupClassAd returns the committed ad for key (the hash table, outside any
 // transaction), or (nil, false).
 func (db *DB) LookupClassAd(key string) (*classad.ClassAd, bool) {

--- a/db/go.mod
+++ b/db/go.mod
@@ -11,6 +11,9 @@ require (
 require (
 	github.com/RoaringBitmap/roaring/v2 v2.19.0 // indirect
 	github.com/bits-and-blooms/bitset v1.24.4 // indirect
+	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/dgraph-io/ristretto/v2 v2.4.2 // indirect
+	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/mschoch/smat v0.2.0 // indirect
 	github.com/tidwall/btree v1.8.1 // indirect
 	golang.org/x/sys v0.46.0 // indirect

--- a/db/go.sum
+++ b/db/go.sum
@@ -2,8 +2,16 @@ github.com/RoaringBitmap/roaring/v2 v2.19.0 h1:zsWtVE+biht4eVl0YDLvykUqGkftR3Qc5
 github.com/RoaringBitmap/roaring/v2 v2.19.0/go.mod h1:SfT3of9nYh3vis1dIbCj4Yw6KQGujTN+f345nrN/0JA=
 github.com/bits-and-blooms/bitset v1.24.4 h1:95H15Og1clikBrKr/DuzMXkQzECs1M6hhoGXLwLQOZE=
 github.com/bits-and-blooms/bitset v1.24.4/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
+github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
+github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgraph-io/ristretto/v2 v2.4.2 h1:x0cvjmUKxt764Yxdk2nr94we1AvPPAMh1rh5TQ+Jo80=
+github.com/dgraph-io/ristretto/v2 v2.4.2/go.mod h1:0KsrXtXvnv0EqnzyowllbVJB8yBonswa2lTCK2gGo9E=
+github.com/dgryski/go-farm v0.0.0-20240924180020-3414d57e47da h1:aIftn67I1fkbMa512G+w+Pxci9hJPB8oMnkcP3iZF38=
+github.com/dgryski/go-farm v0.0.0-20240924180020-3414d57e47da/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
+github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
+github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/klauspost/compress v1.19.0 h1:sXLILfc9jV2QYWkzFOPWStmcUVH2RHEB1JCdY2oVvCQ=
 github.com/klauspost/compress v1.19.0/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/mschoch/smat v0.2.0 h1:8imxQsjDm8yFEAVBe7azKmKSgzSkZXDuKkSq9374khM=

--- a/dbrpc/aggregate.go
+++ b/dbrpc/aggregate.go
@@ -259,6 +259,21 @@ func (s *Server) aggregate(ctx context.Context, reqID uint64, table, constraint 
 		return
 	}
 
+	// Fast path: a constrained COUNT(*) WHERE <numeric comparison on one int schema field> runs
+	// as the adschema columnar scan when the table has schema-scan enabled and the predicate is
+	// eligible. CountConstraint returns ok=false otherwise (schema-scan off, or a predicate the
+	// columnar path can't handle), and we fall through to the projected scan.
+	if len(groupCols) == 0 && len(aggs) == 1 && aggs[0].Func == AggCount && aggs[0].Arg == "*" &&
+		!db.IsMatchAll(constraint) {
+		if n, ok := d.CountConstraint(constraint); ok {
+			frame := respHead(reqID, stStream)
+			frame = putStr(frame, strconv.Itoa(n))
+			write(frame)
+			write(respHead(reqID, stStreamEnd))
+			return
+		}
+	}
+
 	seq, err := d.QueryProject(constraint, attrs)
 	if err != nil {
 		write(respErr(reqID, err.Error()))

--- a/dbrpc/countconstraint_test.go
+++ b/dbrpc/countconstraint_test.go
@@ -1,0 +1,69 @@
+package dbrpc
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/classad"
+	"github.com/PelicanPlatform/classad/db"
+)
+
+// TestAggregateCountConstraintColumnar checks the dbrpc COUNT(*)-WHERE fast path routes through
+// the columnar schema scan when enabled and returns counts identical to the projected scan.
+func TestAggregateCountConstraintColumnar(t *testing.T) {
+	d, err := db.Open("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tx := d.Begin()
+	for i := 0; i < 800; i++ {
+		ad, perr := classad.ParseOld(fmt.Sprintf("Memory = %d\nCpus = %d\nName = \"n%03d\"", 1024+(i%64)*256, 1+i%8, i))
+		if perr != nil {
+			t.Fatal(perr)
+		}
+		tx.NewClassAd(fmt.Sprintf("k%d", i), ad)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	// Read demand on Memory so it lands in the hot tier, then enable the columnar scan.
+	for i := 0; i < 15; i++ {
+		seq, err := d.QueryProject("true", []string{"Memory"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		for range seq {
+		}
+	}
+	d.EnableSchemaScan(2000, 4)
+	if _, ok := d.CountConstraint("Memory > 4096"); !ok {
+		t.Fatal("CountConstraint declined an eligible predicate after EnableSchemaScan")
+	}
+
+	s := NewServer(d)
+	cconn, sconn := netPipe()
+	go func() { _ = s.ServeConn(sconn) }()
+	c := NewClient(cconn)
+	defer func() { c.Close(); s.Close(); d.Close() }()
+	ctx := context.Background()
+
+	for _, expr := range []string{"Memory > 4096", "Memory <= 4096", "Memory >= 2000 && Memory < 9000"} {
+		rows, err := c.Aggregate(ctx, expr, nil, []AggSpec{{Func: AggCount, Arg: "*"}})
+		if err != nil {
+			t.Fatalf("%s: aggregate: %v", expr, err)
+		}
+		want := 0
+		seq, err := d.QueryProject(expr, []string{"Memory"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		for range seq {
+			want++
+		}
+		if len(rows) != 1 || len(rows[0].Values) != 1 || rows[0].Values[0] != strconv.Itoa(want) {
+			t.Errorf("%s: aggregate COUNT(*) = %+v, want %d", expr, rows, want)
+		}
+	}
+}

--- a/dbrpc/go.mod
+++ b/dbrpc/go.mod
@@ -12,6 +12,9 @@ require (
 require (
 	github.com/RoaringBitmap/roaring/v2 v2.19.0 // indirect
 	github.com/bits-and-blooms/bitset v1.24.4 // indirect
+	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/dgraph-io/ristretto/v2 v2.4.2 // indirect
+	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/klauspost/compress v1.19.0 // indirect
 	github.com/mschoch/smat v0.2.0 // indirect
 	github.com/tidwall/btree v1.8.1 // indirect

--- a/dbrpc/go.sum
+++ b/dbrpc/go.sum
@@ -2,8 +2,16 @@ github.com/RoaringBitmap/roaring/v2 v2.19.0 h1:zsWtVE+biht4eVl0YDLvykUqGkftR3Qc5
 github.com/RoaringBitmap/roaring/v2 v2.19.0/go.mod h1:SfT3of9nYh3vis1dIbCj4Yw6KQGujTN+f345nrN/0JA=
 github.com/bits-and-blooms/bitset v1.24.4 h1:95H15Og1clikBrKr/DuzMXkQzECs1M6hhoGXLwLQOZE=
 github.com/bits-and-blooms/bitset v1.24.4/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
+github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
+github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgraph-io/ristretto/v2 v2.4.2 h1:x0cvjmUKxt764Yxdk2nr94we1AvPPAMh1rh5TQ+Jo80=
+github.com/dgraph-io/ristretto/v2 v2.4.2/go.mod h1:0KsrXtXvnv0EqnzyowllbVJB8yBonswa2lTCK2gGo9E=
+github.com/dgryski/go-farm v0.0.0-20240924180020-3414d57e47da h1:aIftn67I1fkbMa512G+w+Pxci9hJPB8oMnkcP3iZF38=
+github.com/dgryski/go-farm v0.0.0-20240924180020-3414d57e47da/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
+github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
+github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/klauspost/compress v1.19.0 h1:sXLILfc9jV2QYWkzFOPWStmcUVH2RHEB1JCdY2oVvCQ=
 github.com/klauspost/compress v1.19.0/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/mschoch/smat v0.2.0 h1:8imxQsjDm8yFEAVBe7azKmKSgzSkZXDuKkSq9374khM=


### PR DESCRIPTION
Wires the `collections` adschema columnar scan (v0.22.0, #110) into the count path so `SELECT COUNT(*) … WHERE <numeric>` can use it.

## Changes
- `db.DB.EnableSchemaScan` / `db.DB.CountConstraint` delegate to the collection.
- `dbrpc.Server.aggregate` gains a constrained-`COUNT(*)` fast path (after the #107 unconstrained `Len()` one): tries `d.CountConstraint`, falls through to the projected scan otherwise.

`ristretto` is indirect via `collections`.

## Follow-up
This lands the wiring only. A **persistent-store correctness fix** (the accelerator silently no-opped on inline/on-disk records), `Maintain` auto-enable, and refresh-safety follow in a separate PR — those commits are **not** part of this merge.
