### PR TITLE
collections,db: make the adschema columnar scan work on persistent stores; auto-enable from Maintain

### DIFF
--- a/collections/colblock.go
+++ b/collections/colblock.go
@@ -121,7 +121,10 @@ func encodeColumnarBlock(s *adSchema, recs [][]byte, hotNumFields []int, codec C
 // returns the block and offs, where offs[k] is the segment offset of block record k -- the map
 // a scan uses to recover each record's MVCC seq/sup (for visibility) and its key. Reads
 // immutable segment bytes only.
-func buildColumnarFromSegment(data []byte, upto int, codec Codec, s *adSchema, hot []int) (*columnarBlock, []uint32) {
+// toInterned canonicalizes a decompressed record into interned wire (identity for an already-
+// interned collection; a decode/re-encode for an inline/persistent one). encode reads the
+// id-keyed form, so a non-interned record must be converted first or the block would be empty.
+func buildColumnarFromSegment(data []byte, upto int, codec Codec, s *adSchema, hot []int, toInterned func(dst, w []byte) ([]byte, bool)) (*columnarBlock, []uint32) {
 	var recs [][]byte
 	var offs []uint32
 	var buf []byte
@@ -134,8 +137,10 @@ func buildColumnarFromSegment(data []byte, upto int, codec Codec, s *adSchema, h
 		if !recIsMarker(data, o) {
 			if w, err := codec.Decompress(buf[:0], recAd(data, o)); err == nil {
 				buf = w
-				recs = append(recs, s.encode(wire.Ad(w)))
-				offs = append(offs, o)
+				if iw, ok := toInterned(nil, w); ok {
+					recs = append(recs, s.encode(wire.Ad(iw)))
+					offs = append(offs, o)
+				}
 			}
 		}
 		off += int(total)

--- a/collections/colblock_segment_test.go
+++ b/collections/colblock_segment_test.go
@@ -60,7 +60,7 @@ func TestBuildColumnarFromSegment(t *testing.T) {
 		t.Skip("Memory not an int schema field")
 	}
 
-	blk, offs := buildColumnarFromSegment(seg.data, seg.used, seg.codec, s, []int{memIdx})
+	blk, offs := buildColumnarFromSegment(seg.data, seg.used, seg.codec, s, []int{memIdx}, store.recordToInterned)
 	if blk.n != n || len(offs) != n {
 		t.Fatalf("block n=%d offs=%d, want %d", blk.n, len(offs), n)
 	}

--- a/collections/colscan.go
+++ b/collections/colscan.go
@@ -48,7 +48,7 @@ func (c *Collection) EnableSchemaScan(s *adSchema, hot []int) {
 		}
 		sh.mu.RUnlock()
 		for _, seg := range segs {
-			blk, offs := buildColumnarFromSegment(seg.data, seg.used, seg.codec, s, hot)
+			blk, offs := buildColumnarFromSegment(seg.data, seg.used, seg.codec, s, hot, c.recordToInterned)
 			seg.colblk.Store(&colSegment{block: blk, offs: offs})
 		}
 	}
@@ -60,9 +60,34 @@ func (c *Collection) EnableSchemaScan(s *adSchema, hot []int) {
 // scan over the sealed segments. Returns false if there is nothing to sample. Re-callable to
 // pick up newly-sealed segments (existing blocks are kept).
 func (c *Collection) BuildAndEnableSchemaScan(sampleMax, hotTopN int) bool {
+	// Already enabled: keep the stable schema and hot set chosen at first enable, and just
+	// extend coverage to any segments sealed since (their blocks are built against this same
+	// schema, so nothing is orphaned). Rebuilding a fresh schema here would give every new
+	// block a different schema pointer, leaving earlier segments' blocks unmatched and
+	// silently demoting them to the brute-scan fallback. Re-schema-ing (with a full block
+	// rebuild) is a separate, heavier operation, not part of a routine maintenance refresh.
+	if st := c.schemaScan.Load(); st != nil {
+		c.EnableSchemaScan(st.schema, st.hot)
+		return true
+	}
 	samples := c.CollectSamples(sampleMax)
 	if len(samples) == 0 {
 		return false
+	}
+	// buildAdSchema reads the id-keyed wire form; a persistent (inline) collection's records
+	// store names, so canonicalize them to interned wire first (else the schema is empty and
+	// the accelerator silently never enables).
+	if c.inline {
+		interned := make([][]byte, 0, len(samples))
+		for _, w := range samples {
+			if iw, ok := c.recordToInterned(nil, w); ok {
+				interned = append(interned, iw)
+			}
+		}
+		samples = interned
+		if len(samples) == 0 {
+			return false
+		}
 	}
 	s := buildAdSchema(samples, adSchemaOpts{Presence: 0.90, Fit: 0.95, Strings: true})
 	if len(s.fields) == 0 {
@@ -187,6 +212,15 @@ func numCmp(op string, t float64) (func(float64) bool, bool) {
 // column: one cached decode) and each window's live MVCC visibility. A window with no block
 // (active segment) falls back to the row scan; an escaped value is read from the cold tail.
 func (c *Collection) schemaScanCount(s *adSchema, fieldIdx int, fieldID uint32, bc *blockCache, eval func(float64) bool) int {
+	// The brute fallback (segments without a matching columnar block -- e.g. the active
+	// segment) reads records straight from the arena, so it must honor the collection's wire
+	// mode: look the field up by inline name on a persistent store, by interned id in memory.
+	lookup := func(a wire.Ad) ([]byte, bool) { return a.Lookup(fieldID) }
+	if c.inline {
+		if name, ok := c.intern.Name(fieldID); ok {
+			lookup = func(a wire.Ad) ([]byte, bool) { return a.LookupByName(name) }
+		}
+	}
 	count := 0
 	for _, sh := range c.shards {
 		s0, wins := sh.snapshot()
@@ -212,7 +246,7 @@ func (c *Collection) schemaScanCount(s *adSchema, fieldIdx int, fieldID uint32, 
 				})
 				continue
 			}
-			count += bruteNumCount(w, s0, fieldID, eval)
+			count += bruteNumCount(w, s0, lookup, eval)
 		}
 		releaseWindows(wins)
 	}
@@ -230,7 +264,7 @@ func (c *Collection) schemaScanIntCount(s *adSchema, fieldIdx int, match func(in
 
 // bruteNumCount is the row-scan fallback: walk a window's visible records, read the numeric
 // field from the wire ad, and count matches.
-func bruteNumCount(w segWindow, s0 uint64, fieldID uint32, eval func(float64) bool) int {
+func bruteNumCount(w segWindow, s0 uint64, lookup func(wire.Ad) ([]byte, bool), eval func(float64) bool) int {
 	count := 0
 	var buf []byte
 	for off := 0; off < w.used; {
@@ -242,7 +276,7 @@ func bruteNumCount(w segWindow, s0 uint64, fieldID uint32, eval func(float64) bo
 		if !recIsMarker(w.data, o) && recSeq(w.data, o) <= s0 && recSuperseded(w.data, o) > s0 {
 			if ww, err := w.codec.Decompress(buf[:0], recAd(w.data, o)); err == nil {
 				buf = ww
-				if node, ok := wire.Ad(ww).Lookup(fieldID); ok {
+				if node, ok := lookup(wire.Ad(ww)); ok {
 					if f, ok := literalFloat(node); ok && eval(f) {
 						count++
 					}

--- a/collections/colscan_refresh_test.go
+++ b/collections/colscan_refresh_test.go
@@ -1,0 +1,138 @@
+package collections
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/collections/vm"
+)
+
+// TestSchemaScanPersistentInline is the regression guard for the inline-record path: a
+// persistent collection stores ads with inline names (not interned ids), so the id-keyed
+// accelerator must canonicalize records before reading them. Without that, buildAdSchema sees
+// zero fields and the accelerator silently never enables. Here it must enable and count
+// correctly over both sealed segments (columnar blocks) and the active segment (brute
+// fallback), matching the row-scan engine.
+func TestSchemaScanPersistentInline(t *testing.T) {
+	dir := t.TempDir()
+	store, err := Open(Options{Dir: dir, Shards: 1, SegmentSize: 1 << 12}) // persistent ⇒ inline names
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	if !store.inline {
+		t.Fatal("expected a persistent collection to be inline-encoded")
+	}
+	const n = 1000
+	for i := 0; i < n; i++ {
+		ad := mustAdOld(t, fmt.Sprintf("Cpus=%d\nMemory=%d\nDisk=%d\nMachine=\"m%05d\"", 1+i%8, 1024+(i%64)*256, i*4096, i))
+		if err := store.Put([]byte(fmt.Sprintf("k%d", i)), ad); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mq, _ := vm.Parse("true")
+	for i := 0; i < 20; i++ {
+		for range store.QueryProject(mq, []string{"Memory"}) {
+		}
+	}
+	if !store.BuildAndEnableSchemaScan(2000, 4) {
+		t.Fatal("BuildAndEnableSchemaScan returned false on a persistent store (inline records not canonicalized?)")
+	}
+	for _, expr := range []string{"Memory > 4096", "Memory <= 4096", "Memory >= 2000 && Memory < 9000"} {
+		got, ok := store.CountConstraint(expr)
+		if !ok {
+			t.Errorf("%q: CountConstraint declined on a persistent store", expr)
+			continue
+		}
+		q, _ := vm.Parse(expr)
+		want := 0
+		for range store.Query(q) {
+			want++
+		}
+		if got != want {
+			t.Errorf("%q: columnar %d != store.Query %d (inline path)", expr, got, want)
+		}
+	}
+}
+
+// TestBuildAndEnableSchemaScanRefreshSafe verifies a second BuildAndEnableSchemaScan (as a
+// repeated Maintain pass would issue) keeps the stable schema chosen at first enable and extends
+// coverage to segments sealed since -- rather than minting a fresh schema that would orphan the
+// earlier segments' blocks onto the brute-scan fallback. It asserts the schema pointer is reused
+// and every sealed segment's block matches it, and that counts stay correct across the refresh.
+func TestBuildAndEnableSchemaScanRefreshSafe(t *testing.T) {
+	store := New(Options{Shards: 1, SegmentSize: 1 << 12}) // small -> sealed segments
+	put := func(lo, hi int) {
+		for i := lo; i < hi; i++ {
+			ad := mustAdOld(t, fmt.Sprintf("Cpus=%d\nMemory=%d\nDisk=%d\nMachine=\"m%05d\"", 1+i%8, 1024+(i%64)*256, i*4096, i))
+			if err := store.Put([]byte(fmt.Sprintf("k%d", i)), ad); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	put(0, 800)
+	mq, _ := vm.Parse("true")
+	for i := 0; i < 20; i++ {
+		for range store.QueryProject(mq, []string{"Memory"}) {
+		}
+	}
+	if !store.BuildAndEnableSchemaScan(2000, 4) {
+		t.Fatal("first BuildAndEnableSchemaScan returned false")
+	}
+	first := store.schemaScan.Load()
+	if first == nil {
+		t.Fatal("schema scan not enabled after first build")
+	}
+
+	// A second batch seals more segments, then a refresh pass runs.
+	put(800, 1600)
+	if !store.BuildAndEnableSchemaScan(2000, 4) {
+		t.Fatal("refresh BuildAndEnableSchemaScan returned false")
+	}
+	second := store.schemaScan.Load()
+	if second.schema != first.schema {
+		t.Fatalf("refresh minted a new schema (%p != %p); it must reuse the stable one", second.schema, first.schema)
+	}
+
+	// Every sealed segment must carry a block built against the live schema -- none orphaned.
+	sealed, orphaned := 0, 0
+	for _, sh := range store.shards {
+		sh.mu.RLock()
+		act := sh.act
+		segs := append([]*segment(nil), sh.segs...)
+		sh.mu.RUnlock()
+		for _, seg := range segs {
+			if seg == nil || seg == act || seg.used == 0 {
+				continue
+			}
+			sealed++
+			cs := seg.colblk.Load()
+			if cs == nil || cs.block.schema != second.schema {
+				orphaned++
+			}
+		}
+	}
+	if sealed == 0 {
+		t.Fatal("expected sealed segments across two batches; got none")
+	}
+	if orphaned != 0 {
+		t.Errorf("%d/%d sealed segments orphaned (block schema != live schema) after refresh", orphaned, sealed)
+	}
+
+	// Counts over the full (both-batch) data stay correct through the columnar path.
+	for _, expr := range []string{"Memory > 4096", "Memory <= 4096", "Memory >= 2000 && Memory < 9000"} {
+		got, ok := store.CountConstraint(expr)
+		if !ok {
+			t.Errorf("%q: CountConstraint declined after refresh", expr)
+			continue
+		}
+		q, _ := vm.Parse(expr)
+		want := 0
+		for range store.Query(q) {
+			want++
+		}
+		if got != want {
+			t.Errorf("%q: columnar %d != store.Query %d after refresh", expr, got, want)
+		}
+	}
+}

--- a/collections/colscan_test.go
+++ b/collections/colscan_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/PelicanPlatform/classad/collections/vm"
+	"github.com/PelicanPlatform/classad/collections/wire"
 )
 
 // allSegmentWires gathers every shard/segment's live-arena wire ads (for building the schema).
@@ -32,7 +33,7 @@ func (c *Collection) allBruteCount(fieldID uint32, match func(int64) bool) int {
 	for _, sh := range c.shards {
 		s0, wins := sh.snapshot()
 		for _, w := range wins {
-			count += bruteNumCount(w, s0, fieldID, func(f float64) bool { return match(int64(f)) })
+			count += bruteNumCount(w, s0, func(a wire.Ad) ([]byte, bool) { return a.Lookup(fieldID) }, func(f float64) bool { return match(int64(f)) })
 		}
 		releaseWindows(wins)
 	}

--- a/collections/inline.go
+++ b/collections/inline.go
@@ -63,6 +63,25 @@ func (c *Collection) decodeNode(node []byte) (ast.Expr, error) {
 	return wire.DecodeNode(node, c.intern)
 }
 
+// recordToInterned re-encodes a decompressed stored record `w` into interned wire that the
+// id-keyed columnar accelerator (buildAdSchema / adSchema.encode / bruteNumCount) can read.
+// An interned (in-memory) collection's records are already interned and returned as-is. An
+// inline (persistent) collection's records store names, not ids -- and may carry encrypted
+// attribute values -- so the record is decoded (opening encryption) and re-encoded against the
+// shared intern table. Returns (nil,false) on a record that fails to decode. Used only at
+// accelerator build time (schema sampling and per-segment block transcode), not on the scan
+// hot path.
+func (c *Collection) recordToInterned(dst, w []byte) ([]byte, bool) {
+	if !c.inline {
+		return w, true
+	}
+	ad, err := c.decodeWire(w)
+	if err != nil {
+		return nil, false
+	}
+	return wire.Encode(dst[:0], ad, c.intern), true
+}
+
 // newStreamEncoder returns a StreamEncoder matching the collection's mode, for the
 // direct old-ClassAd ingest path (UpdateOld).
 func (c *Collection) newStreamEncoder() *wire.StreamEncoder {

--- a/db/db.go
+++ b/db/db.go
@@ -88,6 +88,11 @@ type Config struct {
 	CategoricalAttrs, ValueAttrs []string
 	MatchClosureRoots            []string
 
+	// SegmentSize overrides the arena segment size in bytes (see collections.Options).
+	// 0 uses the default (8 MiB). A smaller value seals segments sooner -- useful for
+	// tests and for tuning the sealed-segment accelerators (columnar scan, sealed indexes).
+	SegmentSize int
+
 	// PoolKeys enables encryption at rest: the DB master key is wrapped under each of
 	// these pool/signing keys (any one opens the DB; a rotated-in key is added on the
 	// next open). Empty ⇒ encryption disabled. See db/encrypt.go.
@@ -124,6 +129,7 @@ func OpenConfig(cfg Config) (*DB, error) {
 		Codec:             chooseBaseCodec(cfg.Dir), // ZSTD by default for new stores
 		DataKey:           enc.data(),
 		EncryptedAttrs:    cfg.EncryptedAttrs,
+		SegmentSize:       cfg.SegmentSize, // 0 ⇒ collections default (8 MiB)
 		// Time travel is a persisted runtime toggle: read it before opening so recovery
 		// rebuilds the time index (and scan-pruning counters) from the segment markers
 		// instead of the directory snapshot. loadIndexConfig below keeps it in sync.
@@ -210,6 +216,13 @@ type MaintainOptions struct {
 	IndexBudgetHighFrac   float64
 	IndexBudgetLowFrac    float64
 	IndexBudgetSlackBytes int64
+	// SchemaScanHotTopN, when > 0, builds/refreshes the per-segment adschema columnar
+	// accelerator (used by CountConstraint's fast path) keeping the topN most query-read
+	// numeric fields uncompressed. The first pass chooses a stable schema and hot set from
+	// the current sample and demand; later passes only extend coverage to newly-sealed
+	// segments, so a table opts into the columnar count path once maintenance runs and stays
+	// covered as it grows. 0 leaves it off.
+	SchemaScanHotTopN int
 }
 
 // Maintain runs one self-tuning pass: it auto-tunes indexes (adds demand-driven ones,
@@ -239,6 +252,11 @@ func (db *DB) Maintain(opts MaintainOptions) {
 	}
 	if opts.Retrain {
 		_, _ = db.c.RetrainDict(opts.SampleMax) // recompacts + reindexes
+	}
+	if opts.SchemaScanHotTopN > 0 {
+		// Build the columnar accelerator on first run, extend it to newly-sealed segments
+		// after (idempotent + refresh-safe -- keeps the stable schema/hot set).
+		db.c.BuildAndEnableSchemaScan(opts.SampleMax, opts.SchemaScanHotTopN)
 	}
 }
 

--- a/db/maintain_test.go
+++ b/db/maintain_test.go
@@ -7,6 +7,69 @@ import (
 	"github.com/PelicanPlatform/classad/classad"
 )
 
+// TestMaintainEnablesSchemaScan: a Maintain pass with SchemaScanHotTopN builds the columnar
+// accelerator so CountConstraint routes an eligible numeric predicate through it, and a second
+// batch + second Maintain keeps the counts correct (refresh extends coverage, no orphaning).
+func TestMaintainEnablesSchemaScan(t *testing.T) {
+	d, err := OpenConfig(Config{Dir: t.TempDir(), SegmentSize: 1 << 9}) // small ⇒ segments seal even across 16 shards
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+	put := func(lo, hi int) {
+		tx := d.Begin()
+		for i := lo; i < hi; i++ {
+			ad, _ := classad.ParseOld(fmt.Sprintf("Memory = %d\nCpus = %d\nName = \"n%05d\"", 1024+(i%64)*256, 1+i%8, i))
+			tx.NewClassAd(fmt.Sprintf("%d.0", i), ad)
+		}
+		if err := tx.Commit(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	countBoth := func(tag, expr string) {
+		got, ok := d.CountConstraint(expr)
+		if !ok {
+			t.Errorf("%s: CountConstraint declined %q", tag, expr)
+			return
+		}
+		seq, err := d.Query(expr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := 0
+		for range seq {
+			want++
+		}
+		if got != want {
+			t.Errorf("%s: columnar count %d != query count %d for %q", tag, got, want, expr)
+		}
+	}
+
+	put(0, 800)
+	// Read demand on Memory so it lands in the hot tier the schema build ranks by.
+	for i := 0; i < 15; i++ {
+		seq, err := d.QueryProject("true", []string{"Memory"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		for range seq {
+		}
+	}
+	// Before Maintain enables it, CountConstraint declines (schema scan off).
+	if _, ok := d.CountConstraint("Memory > 4096"); ok {
+		t.Fatal("CountConstraint should decline before schema scan is enabled")
+	}
+	d.Maintain(MaintainOptions{SchemaScanHotTopN: 4})
+	countBoth("first", "Memory > 4096")
+	countBoth("first", "Memory <= 4096")
+
+	put(800, 1600)
+	d.Maintain(MaintainOptions{SchemaScanHotTopN: 4}) // refresh over the new batch
+	countBoth("refresh", "Memory > 4096")
+	countBoth("refresh", "Memory <= 4096")
+	countBoth("refresh", "Memory >= 2000 && Memory < 9000")
+}
+
 // TestMaintainAutoTunesIndexes: a Maintain pass adds an index for a repeatedly-queried
 // attribute (demand-driven) and refreshes the hot set, and the change persists.
 func TestMaintainAutoTunesIndexes(t *testing.T) {


### PR DESCRIPTION
Follow-up to #111. That PR wired the adschema columnar scan into the count path but landed the wiring only; this fixes a correctness gap and adds auto-enable.

## The persistent-store fix (the important one)
The columnar accelerator read stored records by **interned attribute id**. Only in-memory collections store interned wire; **persistent collections store inline-name wire** (`flagInlineNames`), so on disk the schema built with zero fields, the accelerator silently never enabled, and `CountConstraint` fell back to the projected scan — a correct but unaccelerated answer. Every earlier adschema test used an in-memory store, so it went unseen. (This is why #111's own test passed while a real on-disk DB got no acceleration.) Present in shipped v0.22.0.

- `Collection.recordToInterned` canonicalizes a record into interned wire the id-keyed path reads: identity in-memory; decode (opening encryption) + re-encode against the intern table for inline. Applied at the two **build-time** read sites (schema sample; per-segment block transcode via a new `toInterned` param). Blocks are built interned, so the scan itself is unchanged.
- `bruteNumCount` (scan-time fallback) takes a **mode-aware lookup** — by inline name on disk, by interned id in memory — avoiding a re-encode on the hot path.

I audited the whole `collections` package for the same class of bug (interned-id accessors on stored records without the `c.inline` dispatch): **no other instances** — hot-set/AutoTune use `ForEachNamed`, sealed-index build uses `spec.attrNode`'s inline branch, zone maps use `zoneInline`, match-closure is guarded by `if c.inline`, the raw projector uses `renderInline`.

## Refresh-safety
`BuildAndEnableSchemaScan` is now idempotent: once enabled it reuses the stable schema/hot set and only extends coverage to newly-sealed segments. Minting a fresh schema each call orphaned earlier segments' blocks onto the brute fallback — which a repeated `Maintain` pass would trigger.

## Auto-enable
`MaintainOptions.SchemaScanHotTopN` builds/refreshes the accelerator during a `Maintain`/ANALYZE pass (top-N numeric fields by query-read demand). `Config.SegmentSize` is exposed (needed to seal segments; also makes the sealed-segment accelerators testable — 16 shards otherwise spread test data too thin to fill a default 8 MiB segment).

## Tests
- collections `TestSchemaScanPersistentInline` (asserts an inline store; count == row engine over sealed + active segments), `TestBuildAndEnableSchemaScanRefreshSafe` (same schema pointer, no orphaned blocks across two batches).
- db `TestMaintainEnablesSchemaScan` (persistent store: a Maintain pass enables the count path — declined before — counts match, second batch + second Maintain stay correct).

Full collections + db suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
