### PR TITLE
collections: correlation-aware selectivity and a cost bound on index intersection

### DIFF
--- a/collections/index_query.go
+++ b/collections/index_query.go
@@ -879,7 +879,8 @@ func (si *segIndex) candidateOffsets(usable []usableProbe) *roaring.Bitmap {
 // AND is commutative, so this never changes the result, only the work. Ties and
 // missing stats fall back to input order for a deterministic plan.
 func (si *segIndex) selectivityOrder(usable []usableProbe) []int {
-	return indexSelectivityOrder(si, usable)
+	order, _ := indexSelectivityOrder(si, usable)
+	return order
 }
 
 // statsFor returns the segStats for a probe's attribute, or nil if that segment
@@ -990,7 +991,6 @@ func (s *segStats) estRange(op string, t float64) float64 {
 func (si *segIndex) skipsPrefix(usable []usableProbe) bool { return indexSkipsPrefix(si, usable) }
 func (si *segIndex) coveredUpto() uint32                   { return si.upto }
 
-// probeOffsets returns a fresh, mutable offset bitmap for one probe.
 func (si *segIndex) probeOffsets(up usableProbe) *roaring.Bitmap {
 	if up.cat {
 		cp := si.cat[up.attrID]

--- a/collections/intersect_earlyout_test.go
+++ b/collections/intersect_earlyout_test.go
@@ -1,0 +1,153 @@
+package collections
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/collections/vm"
+)
+
+// earlyOutCorpus is a shape where the early-out matters: a selective categorical attribute
+// alongside a unique-per-record timestamp, so an `Owner == x && CompletionDate > t` query
+// leaves a few hundred candidates after the first probe and would merge most of the segment
+// for the second.
+func earlyOutCorpus(tb testing.TB, n int) *Collection {
+	tb.Helper()
+	c := New(Options{Shards: 4, CategoricalAttrs: []string{"Owner"},
+		ValueAttrs: []string{"Memory", "CompletionDate"}})
+	for i := 0; i < n; i++ {
+		if err := c.Put([]byte(fmt.Sprintf("k%d", i)), mustAd(tb, fmt.Sprintf(
+			`[ ID=%d; Owner="u%d"; Memory=%d; CompletionDate=%d ]`,
+			i, i%500, (i%64+1)*128, 1700000000+i))); err != nil {
+			tb.Fatal(err)
+		}
+	}
+	c.Reindex()
+	return c
+}
+
+// TestWorthProbing pins the cost bound itself.
+func TestWorthProbing(t *testing.T) {
+	t.Parallel()
+	// A probe cheaper than the verify work it could save is always applied.
+	if !worthProbing(10, 100) {
+		t.Error("a cheap probe against a large accumulator must be applied")
+	}
+	// A probe that would merge more than the accumulator could ever cost to verify is
+	// dropped -- it cannot pay off even if it eliminated every candidate.
+	if worthProbing(100000, 10) {
+		t.Error("a probe costlier than the whole remaining verify must be dropped")
+	}
+	// Exactly at the bound: not worth it (strict less-than).
+	if worthProbing(float64(50*offsetsPerVerify), 50) {
+		t.Error("at the break-even point the probe must not be applied")
+	}
+	// An empty accumulator can never justify any probe, but the caller never asks: the
+	// intersection returns as soon as acc is empty.
+	if worthProbing(1, 0) {
+		t.Error("nothing is worth probing against an empty accumulator")
+	}
+}
+
+// TestEarlyOutMatchesFullIntersection is the correctness anchor: dropping probes only widens
+// a superset the store re-verifies, so results must be identical to a full scan's.
+func TestEarlyOutMatchesFullIntersection(t *testing.T) {
+	t.Parallel()
+	c := earlyOutCorpus(t, 40000)
+	for _, qs := range []string{
+		`Owner == "u7" && CompletionDate > 1700000000`,
+		`Owner == "u7" && Memory > 256 && CompletionDate > 1700000000`,
+		`Owner == "u7" && Memory > 8000`,
+		`Owner == "u7" && CompletionDate > 1700000000 && CompletionDate < 1700039999`,
+		`Owner == "nobody" && CompletionDate > 1700000000`,
+		`Memory > 8000 && CompletionDate > 1700039000`,
+	} {
+		q := mustQuery(t, qs)
+		indexed := 0
+		for range c.Query(q) {
+			indexed++
+		}
+		brute := 0
+		for ad := range c.Scan() {
+			if b, err := q.Eval(ad).BoolValue(); err == nil && b {
+				brute++
+			}
+		}
+		if indexed != brute {
+			t.Errorf("%s: indexed returned %d ads, full scan %d", qs, indexed, brute)
+		}
+	}
+}
+
+// TestEarlyOutTierParity checks that both index tiers make the SAME skip decisions. They
+// price a probe from segStats, which the sidecar carries verbatim, so they must -- if they
+// ever diverged, a sealed segment would answer with a different candidate set than the same
+// data in RAM.
+func TestEarlyOutTierParity(t *testing.T) {
+	t.Parallel()
+	c := earlyOutCorpus(t, 20000)
+	queries := []string{
+		`Owner == "u7" && CompletionDate > 1700000000`,
+		`Owner == "u7" && Memory > 256 && CompletionDate > 1700000000`,
+		`Memory > 8000 && CompletionDate > 1700019000`,
+	}
+	segs := 0
+	for _, sh := range c.shards {
+		for _, seg := range sh.segs {
+			if seg == nil {
+				continue
+			}
+			live := seg.idx.Load()
+			if live == nil {
+				continue
+			}
+			path := filepath.Join(t.TempDir(), fmt.Sprintf("seg-%d.idx", seg.id))
+			if err := writeSidecarIndex(path, live); err != nil {
+				t.Fatalf("write sidecar: %v", err)
+			}
+			data, closer, err := mapFile(path)
+			if err != nil {
+				t.Fatalf("map sidecar: %v", err)
+			}
+			mm, err := parseMmapSidecar(data)
+			if err != nil {
+				t.Fatalf("parse sidecar: %v", err)
+			}
+			for _, qs := range queries {
+				q, err := vm.Parse(qs)
+				if err != nil {
+					t.Fatalf("parse %q: %v", qs, err)
+				}
+				u := c.planIndex(q.Probes())
+				if !bmEqual(live.candidateOffsets(u), mm.candidateOffsets(u)) {
+					t.Errorf("seg %d %q: tiers disagree on the candidate set", seg.id, qs)
+				}
+			}
+			_ = closer()
+			segs++
+		}
+	}
+	if segs == 0 {
+		t.Fatal("no segments compared")
+	}
+}
+
+// BenchmarkIntersectEarlyOut measures the shape the early-out targets: a selective probe
+// followed by one that would merge most of the segment to remove a handful of candidates.
+func BenchmarkIntersectEarlyOut(b *testing.B) {
+	c := earlyOutCorpus(b, 200000)
+	for _, qs := range []string{
+		`Owner == "u7" && CompletionDate > 1700000000`,
+		`Owner == "u7" && Memory > 256 && CompletionDate > 1700000000`,
+	} {
+		q := mustQuery(b, qs)
+		b.Run(qs, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				for range c.Query(q) {
+				}
+			}
+		})
+	}
+}

--- a/collections/match_index.go
+++ b/collections/match_index.go
@@ -776,30 +776,74 @@ func (c *Collection) slotMatchPlan(job *classad.ClassAd, jobVals map[string]clas
 // not worth its overhead (the plan barely prunes), so the caller full-scans instead.
 const maxPushdownFrac = 0.95
 
-// planFrac estimates the fraction of records the DNF groups' candidate union visits,
-// under an independence assumption: a group's fraction is the product of its probes'
-// selectivities and the union is 1 - prod(1 - group_frac). estimable is false when any
-// probe lacks a selectivity estimate (e.g. the segment indexes aren't built yet) -- the
-// caller must then NOT gate, since it cannot tell whether the pushdown prunes.
+// planFrac estimates the fraction of records the DNF groups' candidate union visits: a
+// group's fraction is its probes' selectivities combined by conjunctSelectivity, and the
+// union is 1 - prod(1 - group_frac). estimable is false when any probe lacks a selectivity
+// estimate (e.g. the segment indexes aren't built yet) -- the caller must then NOT gate,
+// since it cannot tell whether the pushdown prunes.
 func (c *Collection) planFrac(groups [][]usableProbe) (frac float64, estimable bool) {
 	total := float64(c.Len())
 	if total <= 0 {
 		return 0, false
 	}
 	prodComplement := 1.0
+	sel := make([]float64, 0, 8)
 	for _, g := range groups {
-		gf := 1.0
+		sel = sel[:0]
 		for _, up := range g {
 			cand, covered := c.estimateCandidates(up)
 			if !covered {
 				return 0, false // no stats: don't gate (default to pushing down)
 			}
-			gf *= math.Min(1, cand/total)
+			sel = append(sel, math.Min(1, cand/total))
 		}
-		prodComplement *= 1 - gf
+		prodComplement *= 1 - conjunctSelectivity(sel)
 	}
 	return 1 - prodComplement, true
 }
+
+// conjunctSelectivity combines per-probe selectivities into one for the conjunction,
+// damping the independence assumption rather than taking the raw product.
+//
+// Multiplying is right only if the attributes are independent, and in the ads this store
+// holds they emphatically are not: a slot's Memory, Cpus, and Disk scale together with the
+// machine, Arch and OpSys are near-constant within a pool, and a job's RequestMemory and
+// RequestCpus move together. The raw product therefore compounds an error once per extra
+// conjunct -- `Memory >= 4096 && Cpus >= 8 && Disk >= 100000` reads as 0.1% selective when
+// the three conditions largely pick out the same big machines and the truth is nearer 5%.
+// Underestimating that badly is what makes the pushdown gate (maxPushdownFrac) believe an
+// index will prune when it will not.
+//
+// So: sort ascending and damp each successive term by a square root -- s1 * s2^(1/2) *
+// s3^(1/4) * s4^(1/8), the most selective probe counting in full. It interpolates between
+// full independence and full correlation (where the answer would be s1 alone), needs no
+// multi-column statistics, and is monotone: adding a conjunct never raises the estimate.
+// The same exponential-backoff form SQL Server adopted in 2014 for the same reason.
+//
+// This is an estimate used only to ORDER work and to decide scan-vs-pushdown; it never
+// changes a result. sel is reordered in place.
+func conjunctSelectivity(sel []float64) float64 {
+	switch len(sel) {
+	case 0:
+		return 1
+	case 1:
+		return sel[0]
+	}
+	sort.Float64s(sel)
+	frac, exp := 1.0, 1.0
+	for _, s := range sel {
+		frac *= math.Pow(s, exp)
+		exp /= 2
+		if exp < minDampExp {
+			break // the remaining terms cannot move the estimate materially
+		}
+	}
+	return frac
+}
+
+// minDampExp stops the backoff once a conjunct's exponent makes it a no-op: at 1/64 even a
+// selectivity of 0.001 contributes a factor of 0.9. Bounds the loop on a wide conjunction.
+const minDampExp = 1.0 / 64
 
 // valueToLiteral converts a scalar classad.Value to its literal AST node, or nil for
 // undefined/error/list/nested-ad values (which cannot serve as an index constant).

--- a/collections/readindex.go
+++ b/collections/readindex.go
@@ -260,7 +260,7 @@ func (s *segStats) estBand(up usableProbe) float64 {
 // indexSelectivityOrder returns indices into usable ordered by ascending estimated candidate
 // count (most selective first). Pure ordering heuristic: the AND is commutative, so it never
 // changes the result, only the work. Deterministic (stable, ties keep input order).
-func indexSelectivityOrder(ix indexPrimitives, usable []usableProbe) []int {
+func indexSelectivityOrder(ix indexPrimitives, usable []usableProbe) ([]int, []float64) {
 	order := make([]int, len(usable))
 	est := make([]float64, len(usable))
 	for i, up := range usable {
@@ -268,7 +268,7 @@ func indexSelectivityOrder(ix indexPrimitives, usable []usableProbe) []int {
 		est[i] = indexEstCandidates(ix, up)
 	}
 	sort.SliceStable(order, func(a, b int) bool { return est[order[a]] < est[order[b]] })
-	return order
+	return order, est
 }
 
 // indexCandidateOffsets returns the offsets satisfying every usable probe (a superset the
@@ -288,9 +288,12 @@ func indexCandidateOffsets(ix indexPrimitives, usable []usableProbe) *roaring.Bi
 	case 1:
 		return ix.probeOffsets(usable[0])
 	}
-	order := indexSelectivityOrder(ix, usable)
+	order, est := indexSelectivityOrder(ix, usable)
 	var acc *roaring.Bitmap
 	for _, i := range order {
+		if acc != nil && !worthProbing(est[i], acc.GetCardinality()) {
+			continue
+		}
 		bm := ix.probeOffsets(usable[i])
 		if acc == nil {
 			acc = bm
@@ -302,6 +305,33 @@ func indexCandidateOffsets(ix indexPrimitives, usable []usableProbe) *roaring.Bi
 		}
 	}
 	return acc
+}
+
+// offsetsPerVerify is how many record offsets can be merged into a candidate bitmap in the
+// time it takes to re-verify one candidate record. A roaring merge runs at a few nanoseconds
+// per offset; a verify costs a decompress plus a wire-native match, on the order of a
+// microsecond. 200 is that ratio, rounded to the conservative side -- it over-claims what a
+// probe is worth, so a probe is dropped only when it is clearly not worth building.
+const offsetsPerVerify = 200
+
+// worthProbing reports whether intersecting a probe that would merge about `est` record
+// offsets can pay for itself against an accumulator already down to `card` candidates.
+//
+// This is a bound, not a guess. The candidate set is a superset the store re-verifies record
+// by record, so dropping a probe is always correct -- it only widens the superset. The MOST
+// a probe can save is the entire remaining verify cost, `card` verifies, and only if it
+// eliminates every candidate. So once building its bitmap costs more than that, applying it
+// cannot pay off even in the best case. `Owner == "alice" && CompletionDate > <t>` is the
+// shape that matters: the equality leaves a few hundred candidates, and the range would
+// merge most of the segment to remove a handful of them.
+//
+// est is the planner's estimated candidate count for the probe -- already computed to order
+// the probes -- which tracks merge cost better than a posting-list count would: a
+// low-cardinality attribute reaches 200k offsets in 60 postings, a unique one in 200k.
+//
+// The first (most selective) probe always runs; there is no accumulator to price against.
+func worthProbing(est float64, card uint64) bool {
+	return est < float64(card)*offsetsPerVerify
 }
 
 // indexCandidateOffsetsGroups returns the DNF union over groups of each group's candidate

--- a/collections/selectivity_test.go
+++ b/collections/selectivity_test.go
@@ -1,0 +1,175 @@
+package collections
+
+import (
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/collections/vm"
+)
+
+// TestConjunctSelectivityProperties pins the invariants the damped combiner must hold,
+// independently of how well it happens to estimate any particular corpus.
+func TestConjunctSelectivityProperties(t *testing.T) {
+	t.Parallel()
+	cases := [][]float64{
+		{}, {0.5}, {1, 1, 1}, {0, 0.5}, {0.5, 0},
+		{0.9, 0.9, 0.9}, {0.001, 0.9}, {0.3, 0.3, 0.3, 0.3, 0.3},
+		{0.25, 0.5, 0.75}, {0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999},
+	}
+	for _, sel := range cases {
+		name := fmt.Sprint(sel)
+		got := conjunctSelectivity(append([]float64(nil), sel...))
+		if got < 0 || got > 1 {
+			t.Errorf("%s: selectivity %v out of [0,1]", name, got)
+		}
+		if len(sel) == 0 {
+			continue
+		}
+		// A conjunction cannot match more than its most selective conjunct does.
+		lo := math.Inf(1)
+		prod := 1.0
+		for _, s := range sel {
+			lo = math.Min(lo, s)
+			prod *= s
+		}
+		if got > lo+1e-12 {
+			t.Errorf("%s: %v exceeds the most selective conjunct %v", name, got, lo)
+		}
+		// Damping only ever raises the independence product; it never claims MORE
+		// pruning than independence would.
+		if got < prod-1e-12 {
+			t.Errorf("%s: %v is below the independence product %v", name, got, prod)
+		}
+		// Order must not matter (the combiner sorts).
+		rev := make([]float64, len(sel))
+		for i := range sel {
+			rev[i] = sel[len(sel)-1-i]
+		}
+		if r := conjunctSelectivity(rev); math.Abs(r-got) > 1e-12 {
+			t.Errorf("%s: order-dependent (%v vs %v)", name, got, r)
+		}
+	}
+
+	// Monotone: adding a conjunct never raises the estimate.
+	base := []float64{0.4, 0.6}
+	with := []float64{0.4, 0.6, 0.7}
+	if a, b := conjunctSelectivity(append([]float64(nil), base...)),
+		conjunctSelectivity(append([]float64(nil), with...)); b > a+1e-12 {
+		t.Errorf("adding a conjunct raised the estimate: %v -> %v", a, b)
+	}
+	// An impossible conjunct still yields zero.
+	if got := conjunctSelectivity([]float64{0, 0.9, 0.9}); got != 0 {
+		t.Errorf("a zero-selectivity conjunct must zero the conjunction, got %v", got)
+	}
+	// The most selective conjunct counts in full: with one very selective probe the
+	// estimate stays near it rather than collapsing further.
+	if got := conjunctSelectivity([]float64{0.001, 0.9, 0.9}); got > 0.001 || got < 0.0005 {
+		t.Errorf("dominant conjunct not preserved: %v", got)
+	}
+}
+
+// TestConjunctSelectivityOnCorrelatedAds is the reason the damping exists: the ads this
+// store holds have strongly correlated attributes -- a machine's Memory, Cpus and Disk all
+// scale with its size -- so multiplying per-probe selectivities compounds an error once per
+// conjunct. The damped combiner must land materially closer to the truth.
+func TestConjunctSelectivityOnCorrelatedAds(t *testing.T) {
+	t.Parallel()
+	// Six machine shapes; every attribute is a function of the shape, so the three
+	// conjuncts below select the same slots rather than independent thirds of the pool.
+	shapes := [][3]int{
+		{2048, 1, 20000}, {4096, 2, 40000}, {8192, 4, 80000},
+		{16384, 8, 160000}, {65536, 32, 640000}, {262144, 128, 2560000},
+	}
+	const n = 6000
+	c := New(Options{Shards: 4, ValueAttrs: []string{"Memory", "Cpus", "Disk"}})
+	for i := 0; i < n; i++ {
+		s := shapes[i%len(shapes)]
+		if err := c.Put([]byte(fmt.Sprintf("s%d", i)), mustAd(t, fmt.Sprintf(
+			`[ Id=%d; Memory=%d; Cpus=%d; Disk=%d ]`, i, s[0], s[1], s[2]))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	c.Reindex()
+
+	for _, qs := range []string{
+		`Memory >= 16384 && Cpus >= 8`,
+		`Memory >= 16384 && Cpus >= 8 && Disk >= 160000`,
+		`Memory >= 4096 && Cpus >= 2 && Disk >= 40000`,
+	} {
+		q := mustQuery(t, qs)
+		actual := 0
+		for range c.Query(q) {
+			actual++
+		}
+		want := float64(actual) / n
+
+		sel := probeSelectivities(t, c, q, n)
+		if len(sel) < 2 {
+			t.Fatalf("%s: expected several usable probes, got %d", qs, len(sel))
+		}
+		product := 1.0
+		for _, s := range sel {
+			product *= s
+		}
+		damped := conjunctSelectivity(append([]float64(nil), sel...))
+
+		if math.Abs(damped-want) >= math.Abs(product-want) {
+			t.Errorf("%s: damped %.4f is no closer to the actual %.4f than the product %.4f",
+				qs, damped, want, product)
+		}
+		t.Logf("%s: actual %.3f, product %.4f, damped %.4f", qs, want, product, damped)
+	}
+}
+
+// TestConjunctSelectivityKeepsIndependentGate is the regression guard for the trade the
+// damping makes: it RAISES estimates, and the pushdown gate refuses to push down above
+// maxPushdownFrac. On uncorrelated attributes that must not start refusing pushdowns that
+// the independence product would have allowed.
+func TestConjunctSelectivityKeepsIndependentGate(t *testing.T) {
+	t.Parallel()
+	// Three attributes cycling on coprime periods: as close to independent as a
+	// deterministic corpus gets.
+	const n = 6000
+	c := New(Options{Shards: 4, ValueAttrs: []string{"A", "B", "D"}})
+	for i := 0; i < n; i++ {
+		if err := c.Put([]byte(fmt.Sprintf("s%d", i)), mustAd(t, fmt.Sprintf(
+			`[ Id=%d; A=%d; B=%d; D=%d ]`, i, i%7, (i/7)%11, (i/77)%13))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	c.Reindex()
+
+	for _, qs := range []string{
+		`A >= 4 && B >= 6`,
+		`A >= 4 && B >= 6 && D >= 7`,
+		`A >= 1 && B >= 1 && D >= 1`,
+	} {
+		q := mustQuery(t, qs)
+		sel := probeSelectivities(t, c, q, n)
+		product := 1.0
+		for _, s := range sel {
+			product *= s
+		}
+		damped := conjunctSelectivity(append([]float64(nil), sel...))
+		if damped > maxPushdownFrac && product <= maxPushdownFrac {
+			t.Errorf("%s: damping pushed the estimate over the gate (%.4f > %.2f) where the "+
+				"product (%.4f) would have pushed down", qs, damped, maxPushdownFrac, product)
+		}
+	}
+}
+
+// probeSelectivities returns each usable probe's estimated selectivity for q, as a fraction
+// of total.
+func probeSelectivities(t *testing.T, c *Collection, q *vm.Query, total int) []float64 {
+	t.Helper()
+	var sel []float64
+	for _, up := range c.planIndex(q.Probes()) {
+		cand, covered := c.estimateCandidates(up)
+		if !covered {
+			t.Fatal("probe has no selectivity estimate")
+		}
+		sel = append(sel, math.Min(1, cand/float64(total)))
+	}
+	return sel
+}


### PR DESCRIPTION
Two independent planner changes. Neither can alter a result — selectivity estimates only order work and choose scan-vs-pushdown, and the candidate set is a superset the store re-verifies record by record.

## 1. Damp the independence assumption (`4ec4fa9`)

`planFrac` multiplied per-probe selectivities. That is right only if the attributes are independent, and the ads this store holds are the opposite: a slot's `Memory`, `Cpus` and `Disk` all scale with the machine, `Arch`/`OpSys` are near-constant within a pool, and a job's `RequestMemory`/`RequestCpus` move together. The product compounds an error once per conjunct — and it is exactly what the pushdown gate (`maxPushdownFrac`) reads to decide whether the negotiator pushes down or scans.

`conjunctSelectivity` sorts ascending and damps each successive term by a square root — `s₁ · s₂^½ · s₃^¼ · …` — so the most selective probe counts in full and the rest contribute progressively less. It interpolates between full independence and full correlation, needs no multi-column statistics, and is the exponential-backoff form SQL Server adopted in 2014 for the same reason.

Six correlated machine shapes, three-conjunct predicate whose true selectivity is 0.500:

| | estimate | error |
|---|---|---|
| independence product | 0.037 | 13x under |
| damped | 0.146 | 3.4x under |

The trade to review is the other direction: damping **raises** estimates, and the gate refuses pushdown above `maxPushdownFrac`. `TestConjunctSelectivityKeepsIndependentGate` guards it — on coprime independent attributes the gate decision is unchanged in every case. The invariants that make the combiner safe regardless of corpus are pinned separately: bounded to [0,1], never above the most selective conjunct (a conjunction cannot match more than its narrowest term), never below the independence product, order-independent, monotone under added conjuncts, zero-preserving.

## 2. A cost bound on index intersection (`0d21eb0`)

`indexCandidateOffsets` built a bitmap for **every** usable probe and ANDed them all, stopping only once the accumulator hit empty. `Owner == "alice" && CompletionDate > t` left a few hundred candidates after the equality, then merged most of the segment's postings for the range to remove a handful of them.

Because the candidate set is a superset the store re-verifies anyway, dropping a probe is always correct — it only widens the superset. That turns this into a bound rather than a heuristic: the most a probe can save is the entire remaining verify cost, `card` verifies, and only if it eliminates every candidate. Once building its bitmap costs more than that, applying it cannot pay off *even in the best case*.

Cost is priced off the planner's existing per-probe candidate estimate — already computed to order the probes — so there is no new statistic, no new primitive, and no extra work on the hot path.

| 200k records, 500 owners, unique timestamps | before | after |
|---|---|---|
| `Owner == u7 && CompletionDate > t` | 14.06ms / 4.4 MiB | **0.76ms / 310 KiB** |
| `Owner == u7 && Memory > 256 && CompletionDate > t` | 20.25ms / 5.5 MiB | **0.64ms / 333 KiB** |

Worth noting how the cost model got there: the first attempt counted posting *lists*, which let a 64-value `Memory` index through at 63 keys — 190k offsets — and the benchmark came out 13x slower than the simpler query. Estimated offsets is the right proxy because it degenerates correctly at both ends of cardinality.

Both tiers price from `segStats`, which the sidecar carries verbatim, so they make identical skip decisions and reach identical candidate sets. `TestEarlyOutTierParity` pins that alongside the existing parity test; `TestEarlyOutMatchesFullIntersection` checks results against a full scan, including the empty-result and no-early-out cases.

## Testing

All four modules green, and green under `-race` (`collections` 275s) — run on this branch rather than carried over from an earlier commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
