### PR TITLE
collections: intern persistent segments (per-segment dictionaries) — phase 1

### DIFF
--- a/collections/codec_stats.go
+++ b/collections/codec_stats.go
@@ -43,7 +43,7 @@ func (c *Collection) CodecStats(sampleMax int) CodecStats {
 			break
 		}
 		s0, wins := sh.snapshot()
-		forEachVisible(s0, wins, func(ad []byte, codec Codec) bool {
+		forEachVisible(s0, wins, func(ad []byte, codec Codec, _ *segDictHandle) bool {
 			w, err := codec.Decompress(buf[:0], ad)
 			if err != nil {
 				return true

--- a/collections/colscan.go
+++ b/collections/colscan.go
@@ -48,7 +48,9 @@ func (c *Collection) EnableSchemaScan(s *adSchema, hot []int) {
 		}
 		sh.mu.RUnlock()
 		for _, seg := range segs {
-			blk, offs := buildColumnarFromSegment(seg.data, seg.used, seg.codec, s, hot, c.recordToInterned)
+			d := seg.dict.Load() // interned segment -> resolve its local ids during transcode
+			blk, offs := buildColumnarFromSegment(seg.data, seg.used, seg.codec, s, hot,
+				func(dst, w []byte) ([]byte, bool) { return c.recordToInternedDict(d, dst, w) })
 			seg.colblk.Store(&colSegment{block: blk, offs: offs})
 		}
 	}

--- a/collections/compact.go
+++ b/collections/compact.go
@@ -2,7 +2,26 @@ package collections
 
 import (
 	"time"
+
+	"github.com/PelicanPlatform/classad/ast"
+	"github.com/PelicanPlatform/classad/collections/wire"
 )
+
+// compactDictReserve is the arena space held back at the end of an interned destination
+// segment for its attribute dictionary (appended at finalize). Generous: a typical dict is
+// ~30-60KB (hundreds of names); this covers a few thousand distinct names. If a dict ever
+// exceeds it (pathological attribute cardinality), the interned compaction round aborts and
+// the shard is left uncompacted rather than publishing an unreadable segment.
+const compactDictReserve = 256 * 1024
+
+// internReserve is the dict reserve when interning, else 0 (used inline in the marker-roll fit
+// check so a history segment carrying only checkpoints still leaves room for its dict).
+func internReserve(intern bool) int {
+	if intern {
+		return compactDictReserve
+	}
+	return 0
+}
 
 // Compaction reclaims space consumed by superseded/deleted records.
 //
@@ -393,6 +412,73 @@ func (c *Collection) compactShard(sh *shard, target Codec) {
 		}
 		return ad, seg.codec
 	}
+
+	// Interning: on a persistent, plaintext collection each destination segment is written
+	// INTERNED -- its records carry segment-local attribute ids and it carries a per-segment
+	// dictionary appended at finalize (see segdict.go / the interning design). In-memory
+	// (already global-interned) and encrypted (only inline has a sealing encoder) collections
+	// keep the recompress-only path. A destination becomes uniformly interned; a source may be
+	// inline or already-interned (re-compaction) -- each record is decoded via its own segment
+	// mode. abort stops the round on a decode failure or dict-reserve overflow so a shard is
+	// never left with an unreadable segment.
+	intern := c.inline && c.sealer == nil
+	var curTable, hcurTable *wire.InternTable
+	var wireBuf []byte
+	abort := false
+	// finalizeInterned appends seg's dictionary (from table) and publishes seg.dict, sealing it
+	// as a readable interned segment. Called on roll and at the end of the copy.
+	finalizeInterned := func(seg *segment, table *wire.InternTable) {
+		if seg == nil || table == nil {
+			return
+		}
+		off, ok := seg.appendDict(appendSegDict(nil, table.Names()))
+		if !ok {
+			abort = true // dict outgrew the reserve; do not publish an unresolvable segment
+			return
+		}
+		// A keyless dict record's body (the serialized dict) starts after the 32-byte header
+		// and the adLen u32 -- the base a segDictHandle probes.
+		seg.dict.Store(&segDictHandle{data: seg.data, base: off + recKeyOff + 4})
+	}
+	// decodeSrc decodes a source record to an ast, honoring the source segment's own encoding
+	// (inline or interned). Returns nil on any decompress/decode failure.
+	decodeSrc := func(seg *segment, o uint32) *ast.ClassAd {
+		w, err := seg.codec.Decompress(decBuf[:0], recAd(seg.data, o))
+		if err != nil {
+			return nil
+		}
+		decBuf = w
+		ad, err := c.decodeWireDict(seg.dict.Load(), w)
+		if err != nil {
+			return nil
+		}
+		return ad
+	}
+	// appendInterned encodes ad interned against *tablep and appends it to stream *curp,
+	// rolling to a fresh segment+table (finalizing the old one's dict) when it would not fit
+	// with the dict reserve. Returns the destination segment and record offset.
+	appendInterned := func(streamSegs *[]*segment, curp **segment, tablep **wire.InternTable, seq uint64, key []byte, ad *ast.ClassAd) (*segment, uint32) {
+		if *curp == nil {
+			*curp = newDst(streamSegs, compactDictReserve, target)
+			*tablep = wire.NewInternTable()
+		}
+		wireBuf = wire.Encode(wireBuf[:0], ad, *tablep)
+		body := target.Compress(encBuf[:0], wireBuf)
+		encBuf = body
+		rl := recordLen(len(key), len(body))
+		if (*curp).used+rl+compactDictReserve > len((*curp).data) {
+			finalizeInterned(*curp, *tablep)
+			*curp = newDst(streamSegs, rl+compactDictReserve, target)
+			*tablep = wire.NewInternTable()
+			wireBuf = wire.Encode(wireBuf[:0], ad, *tablep)
+			body = target.Compress(encBuf[:0], wireBuf)
+			encBuf = body
+			rl = recordLen(len(key), len(body))
+		}
+		off, _ := (*curp).append(seq, noLoc, key, body)
+		return *curp, off
+	}
+
 	for _, seg := range sources {
 		for off := 0; off < seg.used; {
 			o := uint32(off)
@@ -403,8 +489,12 @@ func (c *Collection) compactShard(sh *shard, target Codec) {
 			seq := recSeq(seg.data, o)
 			if recIsMarker(seg.data, o) {
 				if seq > retain { // carry an in-window checkpoint forward (to history)
-					if hcur == nil || hcur.used+recordLen(0, 8) > len(hcur.data) {
-						hcur = newDst(&histSegs, recordLen(0, 8), target)
+					if hcur == nil || hcur.used+recordLen(0, 8)+internReserve(intern) > len(hcur.data) {
+						finalizeInterned(hcur, hcurTable) // no-op unless interning
+						hcur = newDst(&histSegs, recordLen(0, 8)+internReserve(intern), target)
+						if intern {
+							hcurTable = wire.NewInternTable()
+						}
 					}
 					hcur.appendMarker(seq, recMarkerMillis(seg.data, o))
 				}
@@ -415,15 +505,30 @@ func (c *Collection) compactShard(sh *shard, target Codec) {
 			if sup == seqMax {
 				// Current version -> live stream (rebuilt into the directory).
 				key := recKey(seg.data, o)
-				outAd, outCodec := recompress(seg, recAd(seg.data, o))
-				rl := recordLen(len(key), len(outAd))
-				if cur == nil || cur.codec != outCodec || cur.used+rl > len(cur.data) {
-					cur = newDst(&dstSegs, rl, outCodec)
+				var dstSeg *segment
+				var dstOff uint32
+				if intern {
+					ad := decodeSrc(seg, o)
+					if ad == nil {
+						abort = true
+						break
+					}
+					dstSeg, dstOff = appendInterned(&dstSegs, &cur, &curTable, seq, key, ad)
+					if abort {
+						break
+					}
+				} else {
+					outAd, outCodec := recompress(seg, recAd(seg.data, o))
+					rl := recordLen(len(key), len(outAd))
+					if cur == nil || cur.codec != outCodec || cur.used+rl > len(cur.data) {
+						cur = newDst(&dstSegs, rl, outCodec)
+					}
+					dstOff, _ = cur.append(seq, noLoc, key, outAd)
+					dstSeg = cur
 				}
-				dstOff, _ := cur.append(seq, noLoc, key, outAd)
 				moved = append(moved, movedRec{
 					srcSeg: seg, srcOff: o,
-					dstSeg: cur, dstOff: dstOff,
+					dstSeg: dstSeg, dstOff: dstOff,
 					key:  append([]byte(nil), key...),
 					hash: c.h.Hash(key),
 				})
@@ -432,17 +537,48 @@ func (c *Collection) compactShard(sh *shard, target Codec) {
 				// preserving its original supersededBySeq (supersedeRec keeps the
 				// segment's live/dead counters right: appended live, then retired).
 				key := recKey(seg.data, o)
-				outAd, outCodec := recompress(seg, recAd(seg.data, o))
-				rl := recordLen(len(key), len(outAd))
-				if hcur == nil || hcur.codec != outCodec || hcur.used+rl > len(hcur.data) {
-					hcur = newDst(&histSegs, rl, outCodec)
+				if intern {
+					ad := decodeSrc(seg, o)
+					if ad == nil {
+						abort = true
+						break
+					}
+					hseg, hoff := appendInterned(&histSegs, &hcur, &hcurTable, seq, key, ad)
+					if abort {
+						break
+					}
+					hseg.supersedeRec(hoff, sup)
+				} else {
+					outAd, outCodec := recompress(seg, recAd(seg.data, o))
+					rl := recordLen(len(key), len(outAd))
+					if hcur == nil || hcur.codec != outCodec || hcur.used+rl > len(hcur.data) {
+						hcur = newDst(&histSegs, rl, outCodec)
+					}
+					dstOff, _ := hcur.append(seq, noLoc, key, outAd)
+					hcur.supersedeRec(dstOff, sup)
 				}
-				dstOff, _ := hcur.append(seq, noLoc, key, outAd)
-				hcur.supersedeRec(dstOff, sup)
 			}
 			// else: superseded at or below the retain floor -> reclaimed (dropped).
 			off += int(total)
 		}
+		if abort {
+			break
+		}
+	}
+	if intern && !abort {
+		finalizeInterned(cur, curTable)
+		finalizeInterned(hcur, hcurTable)
+	}
+	if abort {
+		// Unpublished destinations: unmap + unlink them and leave the shard uncompacted (its
+		// sources remain in place; sh.act stays as Phase 1 / concurrent writes left it).
+		for _, s := range dstSegs {
+			_ = s.reap()
+		}
+		for _, s := range histSegs {
+			_ = s.reap()
+		}
+		return
 	}
 
 	// Make destination records durable BEFORE any source is retired (crash safety).
@@ -545,7 +681,10 @@ func (c *Collection) compactShard(sh *shard, target Codec) {
 	}
 	sh.dir = newDir
 	sh.count = count
-	if len(dstSegs) > 0 {
+	// Reuse the last live destination as the new append target -- but NOT when interning: an
+	// interned destination is sealed with a dictionary and cannot take new inline writes.
+	// Leaving sh.act nil makes the next write allocate a fresh inline active segment.
+	if !intern && len(dstSegs) > 0 {
 		sh.act = dstSegs[len(dstSegs)-1]
 	}
 	// Superseded/delete evidence at or below the retain floor was just dropped; raise

--- a/collections/compact.go
+++ b/collections/compact.go
@@ -412,7 +412,7 @@ func (c *Collection) compactShard(sh *shard, target Codec) {
 	// inline or already-interned (re-compaction) -- each record is decoded via its own segment
 	// mode. abort stops the round on a decode failure or dict-reserve overflow so a shard is
 	// never left with an unreadable segment.
-	intern := c.inline && c.sealer == nil
+	intern := c.inline && c.sealer == nil && !sh.appendOnly
 	// reserve is the arena held back for the dict, capped to a quarter of the segment so a
 	// segment always fits many records plus its dict (compactDictReserve alone could exceed a
 	// small SegmentSize and force one record per segment). A dict larger than the reserve

--- a/collections/compact.go
+++ b/collections/compact.go
@@ -14,15 +14,6 @@ import (
 // the shard is left uncompacted rather than publishing an unreadable segment.
 const compactDictReserve = 256 * 1024
 
-// internReserve is the dict reserve when interning, else 0 (used inline in the marker-roll fit
-// check so a history segment carrying only checkpoints still leaves room for its dict).
-func internReserve(intern bool) int {
-	if intern {
-		return compactDictReserve
-	}
-	return 0
-}
-
 // Compaction reclaims space consumed by superseded/deleted records.
 //
 // It is driven by the per-shard dead-byte ratio (never by age: ClassAds are
@@ -422,6 +413,14 @@ func (c *Collection) compactShard(sh *shard, target Codec) {
 	// mode. abort stops the round on a decode failure or dict-reserve overflow so a shard is
 	// never left with an unreadable segment.
 	intern := c.inline && c.sealer == nil
+	// reserve is the arena held back for the dict, capped to a quarter of the segment so a
+	// segment always fits many records plus its dict (compactDictReserve alone could exceed a
+	// small SegmentSize and force one record per segment). A dict larger than the reserve
+	// aborts the round (see finalizeInterned).
+	reserve := compactDictReserve
+	if q := sh.segSize / 4; q < reserve {
+		reserve = q
+	}
 	var curTable, hcurTable *wire.InternTable
 	var wireBuf []byte
 	abort := false
@@ -459,16 +458,16 @@ func (c *Collection) compactShard(sh *shard, target Codec) {
 	// with the dict reserve. Returns the destination segment and record offset.
 	appendInterned := func(streamSegs *[]*segment, curp **segment, tablep **wire.InternTable, seq uint64, key []byte, ad *ast.ClassAd) (*segment, uint32) {
 		if *curp == nil {
-			*curp = newDst(streamSegs, compactDictReserve, target)
+			*curp = newDst(streamSegs, 0, target)
 			*tablep = wire.NewInternTable()
 		}
 		wireBuf = wire.Encode(wireBuf[:0], ad, *tablep)
 		body := target.Compress(encBuf[:0], wireBuf)
 		encBuf = body
 		rl := recordLen(len(key), len(body))
-		if (*curp).used+rl+compactDictReserve > len((*curp).data) {
+		if (*curp).used+rl+reserve > len((*curp).data) {
 			finalizeInterned(*curp, *tablep)
-			*curp = newDst(streamSegs, rl+compactDictReserve, target)
+			*curp = newDst(streamSegs, rl+reserve, target)
 			*tablep = wire.NewInternTable()
 			wireBuf = wire.Encode(wireBuf[:0], ad, *tablep)
 			body = target.Compress(encBuf[:0], wireBuf)
@@ -489,9 +488,13 @@ func (c *Collection) compactShard(sh *shard, target Codec) {
 			seq := recSeq(seg.data, o)
 			if recIsMarker(seg.data, o) {
 				if seq > retain { // carry an in-window checkpoint forward (to history)
-					if hcur == nil || hcur.used+recordLen(0, 8)+internReserve(intern) > len(hcur.data) {
+					markerReserve := 0
+					if intern {
+						markerReserve = reserve
+					}
+					if hcur == nil || hcur.used+recordLen(0, 8)+markerReserve > len(hcur.data) {
 						finalizeInterned(hcur, hcurTable) // no-op unless interning
-						hcur = newDst(&histSegs, recordLen(0, 8)+internReserve(intern), target)
+						hcur = newDst(&histSegs, recordLen(0, 8)+markerReserve, target)
 						if intern {
 							hcurTable = wire.NewInternTable()
 						}

--- a/collections/compact.go
+++ b/collections/compact.go
@@ -14,6 +14,17 @@ import (
 // the shard is left uncompacted rather than publishing an unreadable segment.
 const compactDictReserve = 256 * 1024
 
+// internStream is one compaction destination stream's interning state: the InternTable the
+// current destination segment is written against, the segment-local ids of the collection's hot
+// attributes present in it (so the interned records carry a hot header for O(1) match lookups,
+// as the inline records they replace did), and the table length at the last hot refresh (hot
+// ids change only when a new name is interned).
+type internStream struct {
+	table   *wire.InternTable
+	hot     map[uint32]struct{}
+	lastLen int
+}
+
 // Compaction reclaims space consumed by superseded/deleted records.
 //
 // It is driven by the per-shard dead-byte ratio (never by age: ClassAds are
@@ -421,16 +432,34 @@ func (c *Collection) compactShard(sh *shard, target Codec) {
 	if q := sh.segSize / 4; q < reserve {
 		reserve = q
 	}
-	var curTable, hcurTable *wire.InternTable
+	var curStream, hcurStream internStream // zero value: table nil until first use
 	var wireBuf []byte
 	abort := false
-	// finalizeInterned appends seg's dictionary (from table) and publishes seg.dict, sealing it
-	// as a readable interned segment. Called on roll and at the end of the copy.
-	finalizeInterned := func(seg *segment, table *wire.InternTable) {
-		if seg == nil || table == nil {
+	newStream := func() internStream {
+		return internStream{table: wire.NewInternTable(), hot: map[uint32]struct{}{}}
+	}
+	// refreshHot adds the local ids of the collection's hot attribute names that are now present
+	// in st.table (canonical casing preserved -- records intern their own attrs). Cheap: a no-op
+	// unless the table grew since the last refresh. The first record to introduce a hot attr name
+	// misses its own hot header; every later record with it gets it.
+	refreshHot := func(st *internStream) {
+		if st.table.Len() == st.lastLen {
 			return
 		}
-		off, ok := seg.appendDict(appendSegDict(nil, table.Names()))
+		for name := range c.currentHotNames() { // folded; LookupID folds again to find the id
+			if id, ok := st.table.LookupID(name); ok {
+				st.hot[id] = struct{}{}
+			}
+		}
+		st.lastLen = st.table.Len()
+	}
+	// finalizeInterned appends seg's dictionary (from st.table) and publishes seg.dict, sealing it
+	// as a readable interned segment. Called on roll and at the end of the copy.
+	finalizeInterned := func(seg *segment, st *internStream) {
+		if seg == nil || st.table == nil {
+			return
+		}
+		off, ok := seg.appendDict(appendSegDict(nil, st.table.Names()))
 		if !ok {
 			abort = true // dict outgrew the reserve; do not publish an unresolvable segment
 			return
@@ -453,23 +482,25 @@ func (c *Collection) compactShard(sh *shard, target Codec) {
 		}
 		return ad
 	}
-	// appendInterned encodes ad interned against *tablep and appends it to stream *curp,
-	// rolling to a fresh segment+table (finalizing the old one's dict) when it would not fit
-	// with the dict reserve. Returns the destination segment and record offset.
-	appendInterned := func(streamSegs *[]*segment, curp **segment, tablep **wire.InternTable, seq uint64, key []byte, ad *ast.ClassAd) (*segment, uint32) {
+	// appendInterned encodes ad interned (with a hot header) against st and appends it to stream
+	// *curp, rolling to a fresh segment+stream (finalizing the old one's dict) when it would not
+	// fit with the dict reserve. Returns the destination segment and record offset.
+	appendInterned := func(streamSegs *[]*segment, curp **segment, st *internStream, seq uint64, key []byte, ad *ast.ClassAd) (*segment, uint32) {
 		if *curp == nil {
 			*curp = newDst(streamSegs, 0, target)
-			*tablep = wire.NewInternTable()
+			*st = newStream()
 		}
-		wireBuf = wire.Encode(wireBuf[:0], ad, *tablep)
+		wireBuf = wire.EncodeWithHot(wireBuf[:0], ad, st.table, st.hot)
+		refreshHot(st) // pick up any hot names this ad interned, for later records
 		body := target.Compress(encBuf[:0], wireBuf)
 		encBuf = body
 		rl := recordLen(len(key), len(body))
 		if (*curp).used+rl+reserve > len((*curp).data) {
-			finalizeInterned(*curp, *tablep)
+			finalizeInterned(*curp, st)
 			*curp = newDst(streamSegs, rl+reserve, target)
-			*tablep = wire.NewInternTable()
-			wireBuf = wire.Encode(wireBuf[:0], ad, *tablep)
+			*st = newStream()
+			wireBuf = wire.EncodeWithHot(wireBuf[:0], ad, st.table, st.hot)
+			refreshHot(st)
 			body = target.Compress(encBuf[:0], wireBuf)
 			encBuf = body
 			rl = recordLen(len(key), len(body))
@@ -493,10 +524,10 @@ func (c *Collection) compactShard(sh *shard, target Codec) {
 						markerReserve = reserve
 					}
 					if hcur == nil || hcur.used+recordLen(0, 8)+markerReserve > len(hcur.data) {
-						finalizeInterned(hcur, hcurTable) // no-op unless interning
+						finalizeInterned(hcur, &hcurStream) // no-op unless interning
 						hcur = newDst(&histSegs, recordLen(0, 8)+markerReserve, target)
 						if intern {
-							hcurTable = wire.NewInternTable()
+							hcurStream = newStream()
 						}
 					}
 					hcur.appendMarker(seq, recMarkerMillis(seg.data, o))
@@ -516,7 +547,7 @@ func (c *Collection) compactShard(sh *shard, target Codec) {
 						abort = true
 						break
 					}
-					dstSeg, dstOff = appendInterned(&dstSegs, &cur, &curTable, seq, key, ad)
+					dstSeg, dstOff = appendInterned(&dstSegs, &cur, &curStream, seq, key, ad)
 					if abort {
 						break
 					}
@@ -546,7 +577,7 @@ func (c *Collection) compactShard(sh *shard, target Codec) {
 						abort = true
 						break
 					}
-					hseg, hoff := appendInterned(&histSegs, &hcur, &hcurTable, seq, key, ad)
+					hseg, hoff := appendInterned(&histSegs, &hcur, &hcurStream, seq, key, ad)
 					if abort {
 						break
 					}
@@ -569,8 +600,8 @@ func (c *Collection) compactShard(sh *shard, target Codec) {
 		}
 	}
 	if intern && !abort {
-		finalizeInterned(cur, curTable)
-		finalizeInterned(hcur, hcurTable)
+		finalizeInterned(cur, &curStream)
+		finalizeInterned(hcur, &hcurStream)
 	}
 	if abort {
 		// Unpublished destinations: unmap + unlink them and leave the shard uncompacted (its

--- a/collections/docs/design/interning-persistent-segments.md
+++ b/collections/docs/design/interning-persistent-segments.md
@@ -90,16 +90,25 @@ see §4.
 
 ## 3. Interned write at seal + read-both (phase 1 core)
 
-- **Seal transcode:** add an interned-persistent seal path that emits `[dict][interned
-  records]`. Gate per collection (opt-in) initially; the active segment and all existing
-  segments are untouched.
-- **Encoding tag per segment:** a segment is uniform in encoding (one seal produced it). Tag
-  it (a byte in the segment header / dir entry) so index/zone/adschema/decoder dispatch
-  per-segment. Old segments read as inline; new sealed segments read as interned-with-dict.
-- **Reads:** route decode through the per-segment encoding: inline → `DecodeInline`;
-  interned → decode against the segment's dict. `decodeWire`/`wireLookup`/`ForEachNamed`
-  stop consulting `c.inline` and consult the segment's tag (or the per-ad flag) + the
-  segment's dict.
+- **Seal transcode = a segment rewrite.** The active segment is written inline as records
+  arrive; at seal it is rewritten into `[segment header][dict][records with interned bodies]`,
+  mirroring the compaction rewrite (build a new arena, copy each record preserving its
+  seq/superseded/key header while swapping the body inline→interned, write + msync + swap in).
+  The active segment and all existing sealed segments are untouched; only the sealing pass
+  changes. Folds into the existing seal walk (buildSegIndex reads every record already).
+- **Encoding tag = a byte in the segment header** (DECIDED). A segment is uniform in encoding
+  (one seal produced it); a version/flags byte at the start of the segment makes it fully
+  **self-describing** — recovery reads the encoding (and, if interned, the dict) from the
+  segment alone, no directory/external state. Old segments (no/inline tag) read as inline; new
+  sealed segments read as interned-with-dict.
+- **Rollout = on by default for persistent collections** (DECIDED). Every new seal on a
+  persistent collection is interned; existing inline segments stay inline and are read via the
+  per-segment dispatch (read-both), converting naturally as segments seal/compact. No opt-in
+  flag — so phase 1 correctness must be airtight before it lands (heavy mixed-segment tests).
+- **Reads:** route decode through the per-segment encoding tag: inline → `DecodeInline`;
+  interned → `DecodeResolve` against the segment's dict (`segDictName`). `decodeWire`/
+  `wireLookup`/`ForEachNamed` stop consulting the collection-level `c.inline` and consult the
+  **segment's** tag + dict (threaded to each call site).
 
 ## 4. Dictionary lookup structures & query-side name↔id (phase 1 care)
 
@@ -208,9 +217,11 @@ Each phase: branch → PR → tag; db/dbrpc bump as usual.
    from the mmap, zero per-segment heap; `id→name` via an id-ordered name blob + offset table
    (also mmap). Active/global table stays a Go map. (Supersedes the earlier local→global-id
    array; adschema schema binds by name.)
-2. **Encoding tag location:** segment header byte vs directory-entry field — wherever the
-   seal/recovery path most cheaply carries it per segment.
-3. **Opt-in surface:** a collection Option (`InternSealedSegments bool`) for phase 1, later
-   defaulted on for persistent collections once proven.
+2. **Encoding tag location: RESOLVED** — a byte in the segment header; the segment is
+   self-describing (recovery reads encoding + dict from the segment alone).
+3. **Rollout: RESOLVED** — on by default for persistent collections (no opt-in flag); existing
+   inline segments read via per-segment dispatch and convert as they seal/compact. Correctness
+   must be airtight before landing.
 4. **Encrypted-interned priority:** phase 2 soon, or encrypted collections stay inline
-   indefinitely (acceptable; just no RAM/decode win there)?
+   indefinitely (acceptable; just no RAM/decode win there)? (Encrypted collections keep sealing
+   inline until phase 2 regardless, since only inline has a sealing encoder today.)

--- a/collections/docs/design/interning-persistent-segments.md
+++ b/collections/docs/design/interning-persistent-segments.md
@@ -1,5 +1,13 @@
 # Design: interning persistent segments (per-segment dictionaries)
 
+> **Status (phase 1: implemented & live).** Persistent, plaintext collections now write
+> interned segments at compaction, with per-segment dictionaries; recovery restores them; every
+> read path (scan, point lookup, index build, adschema) resolves segment-local ids. On by
+> default; validated by the full collections suite plus `TestInterningEndToEnd` /
+> `TestInterningSchemaScan`. Follow-ups: hot-header on the interned encode, corrupt-dict
+> auto-rebuild, tighter dict reserve, then phase 2 (encryption) / phase 3 (migrate + retire
+> inline).
+
 ## Motivation
 
 Persistent collections today store records **inline-name encoded** (`flagInlineNames`):

--- a/collections/docs/design/interning-persistent-segments.md
+++ b/collections/docs/design/interning-persistent-segments.md
@@ -1,0 +1,216 @@
+# Design: interning persistent segments (per-segment dictionaries)
+
+## Motivation
+
+Persistent collections today store records **inline-name encoded** (`flagInlineNames`):
+every attribute key is a literal name string in every record. This is self-describing
+(segments recover with no external table) but costs on three axes. Measured on the 1500-ad
+OSPool slot corpus (`collections/interning_measure_test.go`):
+
+- **Decompressed size: −56%** (inline 32.4MB → interned 14.35MB). Halves the RAM footprint
+  of the active (uncompressed) segment, the block cache, and mmap-resident pages.
+- **Decode: ~26% faster, −20% bytes allocated, −29% allocs** (26 994ns vs 36 410ns/ad) —
+  integer-id lookups instead of name compares. On the decompressed path, so zstd doesn't
+  erode it.
+- **Feature reach.** Every id-keyed accelerator (adschema columnar scan, future ones) must
+  currently *canonicalize* inline records to interned wire first (`recordToInterned`).
+  Interned-at-rest makes that a no-op and lets id-keyed **persisted** structures work.
+
+**On-disk (zstd) size is only ~7–9% smaller**, because zstd already dedups the repeated
+inline names — so compressed footprint alone does **not** justify this work; RAM + decode +
+feature-reach do. Decide against the actual bottleneck (hot working-set RAM, scan/decode
+throughput) rather than disk.
+
+## The pivotal choice: per-segment dictionaries, not a global table
+
+An earlier draft proposed one durable **global** intern table for the whole collection.
+Measurement (same harness, segments compressed independently = on-disk reality) shows a
+**per-segment** dictionary (each sealed segment carries its own id→name dict, Parquet/ORC
+style) is the better design:
+
+| segment size | global zstd | per-seg zstd | per-seg overhead |
+|---|---|---|---|
+| K=128 (12 segs) | 1.02MB | 1.06MB | +5.8% |
+| K=512 (3 segs)  | 968KB  | 981KB  | +1.4% |
+| K≥2048 (1 seg)  | 962KB  | 962KB  | ~0%   |
+
+The 8MB default segment holds ~840 of these ads, so the **realistic operating point is
+K≈512–2048 → per-segment costs ≤1%** over global. Decode and decompressed size are
+**identical** between the two (both use integer ids). In exchange for that ≤1%, per-segment
+**eliminates the sharpest risks** of a global table:
+
+| | global table | per-segment dict |
+|---|---|---|
+| self-contained segments | ✗ global load-bearing state | **✓** |
+| write-ordering crux (names durable before records) | ✗ the hard part | **✓ gone — dict sealed with segment** |
+| recovery | load table first | per-segment, no ordering |
+| corruption blast radius | whole store | one segment |
+| adschema block persistence | needs stable global ids | **self-contained** |
+| cross-segment id space | one | per-segment (minor indirection) |
+
+So: **per-segment dictionaries.** A segment stays self-describing (its own dict + interned
+records) — the same durability property inline has today, minus the per-record name cost —
+with no global durable table, no recover-first ordering, and no fsync-before-msync crux.
+
+## 1. Coexistence is already free (per-ad flag)
+
+The wire header carries `flagInlineNames` **per ad** (`wire/format.go`), and `wire.Decode(b,
+t)` already dispatches on it. So the transition is incremental and safe:
+
+- New segments can be written interned while **every existing inline segment stays
+  readable** — no migration, no rewrite.
+- The read path stops branching on the collection-level `c.inline`; the **per-ad flag** (or
+  a per-segment encoding tag) decides. For interned ads the decoder needs *that segment's*
+  dictionary; for inline ads it needs nothing.
+
+This does mean interned decode is **dictionary-scoped to the segment**, not the collection —
+see §4.
+
+## 2. Per-segment dictionary — format & build (phase 1)
+
+- **Where:** in the sealed segment's on-disk container, beside the records. The dict section
+  is fully **mmap-backed and heap-free per segment** (§4 details the structures):
+  `[u32 count][id→offset table: count×u32][name blob: length-prefixed names in id order][name→id MPH (appendMPH)]`.
+  Id `k` = the k-th name. Self-contained; a reader mmaps it and probes zero-copy — it builds
+  **no** Go map or slice per segment, so loading thousands of sealed dicts does not claw back
+  interning's RAM win. Dict is small (~900 names, ~26KB raw / ~6KB zstd for this corpus; MPH
+  ~1KB; offsets ~3.6KB).
+- **When built:** at **seal**. The active (unsealed) segment stays inline (point writes,
+  recent data — never pays transcode), exactly mirroring adschema's active=row / sealed=PAX
+  split. Seal already walks every record (buildSegIndex, adschema block build); interning
+  folds into that pass: decode each inline record, intern its names into a fresh per-segment
+  table, re-encode interned, and emit `[dict][interned records]`.
+- **Durability:** the dict is written **inside** the segment via the segment's existing
+  atomic write / msync — no separate file, no cross-file ordering. A torn segment is
+  detected and rebuilt exactly as today (the segment is derived-at-seal from the active
+  log). Recovery reads the dict then the records; a corrupt dict fails only that segment.
+- **No global state.** `c.intern` (the in-memory table) is still used for the active segment
+  and query-side name↔id, but it is **not** persisted and **not** load-bearing for any
+  sealed segment.
+
+## 3. Interned write at seal + read-both (phase 1 core)
+
+- **Seal transcode:** add an interned-persistent seal path that emits `[dict][interned
+  records]`. Gate per collection (opt-in) initially; the active segment and all existing
+  segments are untouched.
+- **Encoding tag per segment:** a segment is uniform in encoding (one seal produced it). Tag
+  it (a byte in the segment header / dir entry) so index/zone/adschema/decoder dispatch
+  per-segment. Old segments read as inline; new sealed segments read as interned-with-dict.
+- **Reads:** route decode through the per-segment encoding: inline → `DecodeInline`;
+  interned → decode against the segment's dict. `decodeWire`/`wireLookup`/`ForEachNamed`
+  stop consulting `c.inline` and consult the segment's tag (or the per-ad flag) + the
+  segment's dict.
+
+## 4. Dictionary lookup structures & query-side name↔id (phase 1 care)
+
+Per-segment interning makes **ids segment-local**, so a query's attribute name resolves to a
+*different* id in each segment. The resolution structures must not reintroduce the per-segment
+Go heap that interning is meant to remove — so both directions live in the mmap.
+
+**Active / global in-memory table (`c.intern`): Go map, unchanged.** It is *mutable* (Intern
+grows it during ingest), so a static perfect hash cannot back it; it is the warm working set
+anyway. Its hot direction (`id→name` at encode) is already a slice index.
+
+**Sealed per-segment dict: fully mmap-backed, zero per-segment heap** (reuses the existing
+sealed-index machinery — `mph.go` + the key-index's blob+verify+fallback pattern):
+
+- **`name→id` → mmap MPH** (`buildMPH`/`appendMPH`/`mphLookupBytes`). Lookup is *rare* (once
+  per probed-attr per segment at planning), so the driver is **not** speed but RAM: a Go
+  `map[string]uint32` per dict is ~50–70 B/entry of GC-scanned resident heap (~60 KB/segment
+  → hundreds of MB across a large store); the MPH is ~1 KB of pageable mmap. MPH is
+  non-authoritative (member→its slot; non-member may false-hit), so verify the name at the
+  resolved slot against the name blob and fall back (linear scan of the ~900-name dict, or a
+  small sorted index) on a miss — exactly the key-index contract.
+- **`id→name` → id-ordered name blob + `id→offset` table**, both serialized in the segment.
+  `id→name` = `nameAt(offsets[id])`, two zero-copy mmap reads. Static, GC-free, pageable. The
+  naive `[]string`/`map[uint32]string` at load is the heap-resident anti-pattern we avoid.
+  `id→name` is usually **off the hot path** — scan/count/filter work in ids/positions and
+  never resolve names; it's paid only when materializing a full ad back to named form.
+
+**Query-side `name→local-id` via the per-segment MPH** (this *replaces* the earlier
+local→global-id array idea): a probe carries the attribute name; each segment resolves
+`name→local-id` directly from its mmap MPH (zero heap), then scans by that local id. No
+per-segment translation array, no global-id coupling for the sealed tier.
+
+- **Accelerators (adschema) that want a stable id space:** the adschema *schema* is
+  collection-level and can stay keyed by **name** (each segment's block maps schema-name →
+  that segment's local id via the same MPH at block-build time). The block's hot columns are
+  position-based (schema order), so most of the scan never touches the dict at all.
+
+## 5. adschema payoff (folds P3(2) in)
+
+With per-segment dicts (§4):
+- A sealed segment's columnar block references segment-local ids, persisted **inside the
+  same segment container** as the dict — self-contained, no global table needed. The block's
+  fields bind to the collection schema by **name** (resolved to that segment's local id via
+  the dict MPH at block-build), so a reloaded block matches the collection schema with no
+  global-id table.
+- `marshalColSegment`/`unmarshalColSegment` (already built) persist the block; the schema is
+  re-derivable/name-keyed. Persist the schema-scan config (enabled + schema + hot) at the
+  collection level (mirror `TimeTravel` in `db/indexpersist.go`); reload sets
+  `schemaScanState`, then attach each segment's reloaded block. **No rebuild on reopen.**
+- `recordToInterned` becomes identity for interned segments (kept only for legacy inline).
+
+## 6. Encryption-at-rest interplay (sequence explicitly)
+
+Only inline has a sealing encoder today (`EncodeInlineWithHotEnc`); `EncodeWithHot*` is
+plaintext. So **interned seal is plaintext-only first**; an encrypted collection stays on
+inline+enc until an interned+enc encode/decode pair (`EncodeWithHotEnc`) lands. Gate:
+don't seal-to-interned an encrypted collection until then. Existing encrypted inline data is
+unaffected throughout.
+
+## 7. Phasing & release
+
+1. **Phase 1 — per-segment interned seal.** Dict format inside the segment container;
+   interned seal transcode (opt-in per collection); per-segment encoding tag; read-both
+   (inline old, interned new); query-side `name→local-id` via the per-segment MPH (§4). Tests: write a
+   mix of inline + interned segments in one collection, identical query results vs all-inline
+   control; measured size/decode delta; reopen; corrupt-dict → that segment rebuilt, others
+   fine. **Also unblocks adschema P3(2)** (self-contained blocks).
+2. **Phase 1b — adschema block persistence** rides on phase 1: persist colSegment in the
+   segment container + schema-scan config; reload without rebuild.
+3. **Phase 2 — encryption** (`EncodeWithHotEnc`/decode), then allow encrypted collections to
+   seal interned.
+4. **Phase 3 (later) — migration lever + retire inline write path.** A recompaction re-emits
+   sealed segments interned with zero operator action (compaction already re-encodes forward);
+   optionally expose `.rewrite`-to-interned. Eventually collapse `inline.go` dual-paths once
+   every seal is interned.
+
+Each phase: branch → PR → tag; db/dbrpc bump as usual.
+
+## 8. Risks & mitigations
+
+- **Per-segment dict adds a small on-disk cost (~1% at realistic segment size, up to ~6% at
+  tiny K).** Mitigation: dicts only exist on sealed segments (K large); don't seal-interned
+  tiny segments if it ever matters.
+- **Query-side per-segment id translation is new surface.** Mitigation: option (b) confines
+  it to a per-segment array built once at dict-load; accelerators keep global ids.
+- **Encoding tag must be honored everywhere a body is decoded.** Audit every `c.inline`
+  read: decode-time ones move to the per-segment tag; write-mode ones stay. This is the bulk
+  of phase-1 care (same audit the global design needed, minus the durability crux).
+- **On-disk win is modest (~7–9% zstd).** Not a disk-savings project; justify on RAM/decode.
+  Documented up front so the decision is honest.
+
+## 9. Verification
+
+- **Phase 1:** a collection with both inline (pre-flip) and interned (post-flip) sealed
+  segments returns identical results to an all-inline control across queries/aggregates;
+  reopen round-trips (segments self-describe — no global table to reload); corrupt one
+  segment's dict → only that segment rebuilds; measured size + decode deltas reproduce the
+  harness numbers on a live store.
+- **Phase 1b:** adschema persistent tests reload blocks (no rebuild) and match the row
+  engine; reopen preserves the accelerator.
+- **Cross-module:** db + dbrpc suites green against the bumped collections.
+
+## Open questions
+
+1. **Query id-translation: RESOLVED** — per-segment MPH (`mph.go`) resolves `name→local-id`
+   from the mmap, zero per-segment heap; `id→name` via an id-ordered name blob + offset table
+   (also mmap). Active/global table stays a Go map. (Supersedes the earlier local→global-id
+   array; adschema schema binds by name.)
+2. **Encoding tag location:** segment header byte vs directory-entry field — wherever the
+   seal/recovery path most cheaply carries it per segment.
+3. **Opt-in surface:** a collection Option (`InternSealedSegments bool`) for phase 1, later
+   defaulted on for persistent collections once proven.
+4. **Encrypted-interned priority:** phase 2 soon, or encrypted collections stay inline
+   indefinitely (acceptable; just no RAM/decode win there)?

--- a/collections/docs/design/interning-persistent-segments.md
+++ b/collections/docs/design/interning-persistent-segments.md
@@ -197,6 +197,23 @@ Each phase: branch → PR → tag; db/dbrpc bump as usual.
 
 ## 8. Risks & mitigations
 
+> **Implementation notes (phase 1, as built).**
+> - **Dict corruption is a per-segment single point of failure.** An interned segment's records
+>   are id-keyed, so a lost/corrupt dict record makes the whole segment unreadable (an inline
+>   segment loses only its trailing torn records). The dict rides as a CRC-protected record, so
+>   bit-rot/torn writes are *detected*; but there is no auto-rebuild yet (you cannot re-derive a
+>   dict from records that need it to decode). This is the honest cost of interning; inline
+>   segments remain the fallback during the transition. Future hardening: double-write the dict
+>   (start + end) or protect it more strongly. Corruption of a data record behaves as today.
+> - **The dict reserve tail is sparse, not wasted disk.** A destination segment reserves
+>   `min(256KB, segSize/4)` for its dict, so records fill to `segSize − reserve` and leave a
+>   zero tail. The segment file is created at `segSize` via `Truncate` and never written in that
+>   tail, so on a sparse-file filesystem it consumes no real blocks — the reserve costs address
+>   space, not disk. (So tightening the reserve to the actual dict size buys ~nothing; skipped.)
+> - **Hot header on the interned encode.** Compaction encodes interned records *with* a hot
+>   header (`EncodeWithHot`, segment-local hot ids), so match lookups stay O(1) as they were on
+>   the inline records — no read regression.
+
 - **Per-segment dict adds a small on-disk cost (~1% at realistic segment size, up to ~6% at
   tiny K).** Mitigation: dicts only exist on sealed segments (K large); don't seal-interned
   tiny segments if it ever matters.

--- a/collections/index.go
+++ b/collections/index.go
@@ -108,7 +108,16 @@ func (s *indexSpec) inlineID(name string) uint32 {
 
 // attrNode returns the value node for the attribute with id id in ad, reading it by
 // name for an inline record or by interned id otherwise.
-func (s *indexSpec) attrNode(ad wire.Ad, id uint32) ([]byte, bool) {
+func (s *indexSpec) attrNode(ad wire.Ad, id uint32, dict *segDictHandle) ([]byte, bool) {
+	if dict != nil {
+		// Interned segment: the record carries segment-local ids. Resolve the indexed
+		// attribute's name (always available -- a persistent collection uses an inline spec)
+		// to this segment's local id, then read it.
+		if localid, ok := dict.lookup(s.names[id]); ok {
+			return ad.Lookup(localid)
+		}
+		return nil, false
+	}
 	if s.inline {
 		return ad.LookupByName(s.names[id])
 	}
@@ -267,7 +276,7 @@ type segIndex struct {
 // the given spec. Reads immutable segment bytes only (no lock needed); decompresses
 // each record to read the indexed attributes. It has no Collection dependency, so
 // both the live store (Reindex) and the Archive build indexes with it.
-func buildSegIndex(data []byte, upto int, codec Codec, spec *indexSpec) *segIndex {
+func buildSegIndex(data []byte, upto int, codec Codec, spec *indexSpec, dict *segDictHandle) *segIndex {
 	si := &segIndex{
 		upto:    uint32(upto),
 		specGen: spec.gen,
@@ -296,7 +305,7 @@ func buildSegIndex(data []byte, upto int, codec Codec, spec *indexSpec) *segInde
 		si.all.Add(o)
 		if w, err := codec.Decompress(buf[:0], recAd(data, o)); err == nil {
 			buf = w
-			si.indexRecord(o, wire.Ad(w), spec)
+			si.indexRecord(o, wire.Ad(w), spec, dict)
 		}
 		off += int(total)
 	}
@@ -314,10 +323,10 @@ func buildSegIndex(data []byte, upto int, codec Codec, spec *indexSpec) *segInde
 
 // indexRecord adds record offset o to the postings for each configured attribute,
 // classifying the attribute value as indexable, exceptional, or absent.
-func (si *segIndex) indexRecord(o uint32, ad wire.Ad, spec *indexSpec) {
+func (si *segIndex) indexRecord(o uint32, ad wire.Ad, spec *indexSpec, dict *segDictHandle) {
 	for _, id := range spec.catIDs {
 		cp := si.cat[id]
-		node, ok := spec.attrNode(ad, id)
+		node, ok := spec.attrNode(ad, id, dict)
 		if !ok {
 			continue // absent
 		}
@@ -346,7 +355,7 @@ func (si *segIndex) indexRecord(o uint32, ad wire.Ad, spec *indexSpec) {
 	}
 	for _, id := range spec.valIDs {
 		vp := si.val[id]
-		node, ok := spec.attrNode(ad, id)
+		node, ok := spec.attrNode(ad, id, dict)
 		if !ok {
 			continue
 		}

--- a/collections/index_query.go
+++ b/collections/index_query.go
@@ -1092,12 +1092,15 @@ func cmpFloat(op string, k, t float64) bool {
 // cover (a segment with no index, or the tail beyond its build watermark). Every
 // visited record is MVCC-visibility filtered and full-query re-verified, so the
 // result is identical to a full scan. Returns false if the consumer stopped.
-func (c *Collection) scanShardIndexed(sh *shard, usable []usableProbe, qp queryPlan, emit func(w []byte) bool) bool {
-	return c.scanShardCandidates(sh, usable, c.reverseScan, func(w []byte) bool {
+func (c *Collection) scanShardIndexed(sh *shard, usable []usableProbe, qp queryPlan, emit scanEmit) bool {
+	return c.scanShardCandidates(sh, usable, c.reverseScan, func(w []byte, dict *segDictHandle) bool {
+		if qp.ws != nil {
+			qp.ws.dict = dict
+		}
 		if !matchWire(w, qp) {
 			return true // not a match: keep scanning
 		}
-		return emit(w)
+		return emit(w, dict)
 	})
 }
 
@@ -1113,7 +1116,7 @@ func (c *Collection) scanShardIndexed(sh *shard, usable []usableProbe, qp queryP
 // newest-first: segments from the last backward, and within a segment the un-indexed tail
 // (written last) before the indexed prefix, each in descending offset order. A consumer
 // that stops early then gets the newest matches -- a pushed-down LIMIT through the index.
-func (c *Collection) scanShardCandidates(sh *shard, usable []usableProbe, reverse bool, onCand func(w []byte) bool) bool {
+func (c *Collection) scanShardCandidates(sh *shard, usable []usableProbe, reverse bool, onCand scanEmit) bool {
 	if unsatisfiable(usable) {
 		// The conjunction is impossible on its face; nothing in this shard -- indexed
 		// prefix, un-indexed tail, or exception set -- can match. Skip the snapshot too,
@@ -1140,7 +1143,7 @@ func (c *Collection) scanShardCandidates(sh *shard, usable []usableProbe, revers
 			return false
 		}
 		dbuf = ww
-		return !onCand(ww)
+		return !onCand(ww, w.dict())
 	}
 	// scanRange full-scans records in [from, to).
 	scanRange := func(w segWindow, from, to int) bool {
@@ -1258,12 +1261,15 @@ func scanShardCandidatesReverse(wins []segWindow, usable []usableProbe, visit fu
 
 // scanShardIndexedGroups is scanShardIndexed for a DNF plan: it visits the union of
 // the groups' candidates and re-verifies each against the full query.
-func (c *Collection) scanShardIndexedGroups(sh *shard, groups [][]usableProbe, qp queryPlan, emit func(w []byte) bool) bool {
-	return c.scanShardCandidatesGroups(sh, groups, c.reverseScan, func(w []byte) bool {
+func (c *Collection) scanShardIndexedGroups(sh *shard, groups [][]usableProbe, qp queryPlan, emit scanEmit) bool {
+	return c.scanShardCandidatesGroups(sh, groups, c.reverseScan, func(w []byte, dict *segDictHandle) bool {
+		if qp.ws != nil {
+			qp.ws.dict = dict
+		}
 		if !matchWire(w, qp) {
 			return true
 		}
-		return emit(w)
+		return emit(w, dict)
 	})
 }
 
@@ -1274,7 +1280,7 @@ func (c *Collection) scanShardIndexedGroups(sh *shard, groups [][]usableProbe, q
 // only when EVERY disjunct is empty, and visiting a few extra candidates is cheaper
 // than proving that per group -- but a window whose index does not cover all groups,
 // and every covered window's un-indexed tail, are still full-scanned.
-func (c *Collection) scanShardCandidatesGroups(sh *shard, groups [][]usableProbe, reverse bool, onCand func(w []byte) bool) bool {
+func (c *Collection) scanShardCandidatesGroups(sh *shard, groups [][]usableProbe, reverse bool, onCand scanEmit) bool {
 	if unsatisfiableGroups(groups) {
 		return true // every disjunct is impossible: the union is empty (see scanShardCandidates)
 	}
@@ -1309,7 +1315,7 @@ func (c *Collection) scanShardCandidatesGroups(sh *shard, groups [][]usableProbe
 			return false
 		}
 		dbuf = ww
-		return !onCand(ww)
+		return !onCand(ww, w.dict())
 	}
 	scanRange := func(w segWindow, from, to int) bool {
 		for off := from; off < to; {

--- a/collections/index_query.go
+++ b/collections/index_query.go
@@ -94,7 +94,7 @@ func (c *Collection) Reindex() {
 			}
 			si := t.seg.idx.Load()
 			if si == nil || int(si.upto) < t.used || si.specGen != spec.gen {
-				si = buildSegIndex(t.seg.data, t.used, t.seg.codec, spec)
+				si = buildSegIndex(t.seg.data, t.used, t.seg.codec, spec, t.seg.dict.Load())
 				t.seg.idx.Store(si)
 			}
 			// Sealed segment: move its index off the heap into the mmap sidecar (reclaimable,

--- a/collections/inline.go
+++ b/collections/inline.go
@@ -73,10 +73,19 @@ func (c *Collection) decodeNode(node []byte) (ast.Expr, error) {
 // accelerator build time (schema sampling and per-segment block transcode), not on the scan
 // hot path.
 func (c *Collection) recordToInterned(dst, w []byte) ([]byte, bool) {
-	if !c.inline {
-		return w, true
+	return c.recordToInternedDict(nil, dst, w)
+}
+
+// recordToInternedDict is recordToInterned honoring a per-segment interned record: dict!=nil
+// resolves segment-local ids (via decodeWireDict) before re-encoding to the collection's
+// GLOBAL intern table. dict==nil is the legacy path (in-memory already global-interned -> as
+// is; inline -> decode + re-encode). Used by the adschema block build over sealed segments,
+// which may now be interned.
+func (c *Collection) recordToInternedDict(dict *segDictHandle, dst, w []byte) ([]byte, bool) {
+	if dict == nil && !c.inline {
+		return w, true // in-memory: already global-interned
 	}
-	ad, err := c.decodeWire(w)
+	ad, err := c.decodeWireDict(dict, w)
 	if err != nil {
 		return nil, false
 	}

--- a/collections/inline.go
+++ b/collections/inline.go
@@ -82,6 +82,42 @@ func (c *Collection) recordToInterned(dst, w []byte) ([]byte, bool) {
 	return wire.Encode(dst[:0], ad, c.intern), true
 }
 
+// --- per-segment interned dispatch (interning) ---
+//
+// A sealed segment may be INTERNED with its own attribute dictionary (segment.dict != nil):
+// its records carry segment-local ids resolved to names via that dict, not inline names and
+// not the collection's global table. These wrappers take the segment's dict handle and, when
+// it is non-nil, resolve through it (zero-copy over the mmap); a nil handle means the segment
+// is inline/global -- the legacy path, byte-for-byte unchanged. Scan/read call sites thread
+// the segment's dict (segment.dict.Load()) from the visibility window. An interned segment is
+// never encrypted (encrypted collections keep sealing inline), so the resolver path needs no
+// sealer.
+
+func (c *Collection) decodeWireDict(dict *segDictHandle, w []byte) (*ast.ClassAd, error) {
+	if dict != nil {
+		return wire.DecodeResolve(w, dict.resolve)
+	}
+	return c.decodeWire(w)
+}
+
+func (c *Collection) wireLookupDict(dict *segDictHandle, a wire.Ad, name string) ([]byte, bool) {
+	if dict != nil {
+		id, ok := dict.lookup(name)
+		if !ok {
+			return nil, false
+		}
+		return a.Lookup(id)
+	}
+	return c.wireLookup(a, name)
+}
+
+func (c *Collection) decodeNodeDict(dict *segDictHandle, node []byte) (ast.Expr, error) {
+	if dict != nil {
+		return wire.DecodeNodeResolve(node, dict.resolve)
+	}
+	return c.decodeNode(node)
+}
+
 // newStreamEncoder returns a StreamEncoder matching the collection's mode, for the
 // direct old-ClassAd ingest path (UpdateOld).
 func (c *Collection) newStreamEncoder() *wire.StreamEncoder {

--- a/collections/inline.go
+++ b/collections/inline.go
@@ -2,6 +2,7 @@ package collections
 
 import (
 	"github.com/PelicanPlatform/classad/ast"
+	"github.com/PelicanPlatform/classad/classad"
 	"github.com/PelicanPlatform/classad/collections/wire"
 )
 
@@ -116,6 +117,48 @@ func (c *Collection) decodeNodeDict(dict *segDictHandle, node []byte) (ast.Expr,
 		return wire.DecodeNodeResolve(node, dict.resolve)
 	}
 	return c.decodeNode(node)
+}
+
+// decodeAdDict is decodeAd (decompress + decode to a ClassAd) that resolves an interned
+// segment's ids via its dict. dict==nil => the existing decodeAd path (inline/global).
+func (c *Collection) decodeAdDict(dict *segDictHandle, stored []byte, codec Codec) (*classad.ClassAd, error) {
+	if dict == nil {
+		return c.decodeAd(stored, codec)
+	}
+	dec, err := codec.Decompress(nil, stored)
+	if err != nil {
+		return nil, err
+	}
+	a, err := wire.DecodeResolve(dec, dict.resolve)
+	if err != nil {
+		return nil, err
+	}
+	return classad.FromAST(a), nil
+}
+
+// toSelfContained converts a stored record's (compressed) ad bytes into a form that decodes
+// WITHOUT the source segment's dict, for DEFERRED/cold paths (e.g. a watch event) that copy ad
+// bytes out of the scan and decode them later, when the segment and its dict are no longer in
+// scope. For an inline segment or an in-memory (global-interned) collection -- dict==nil -- the
+// bytes already self-decode, so they are returned unchanged. For an interned segment the record
+// is decoded via the dict, re-encoded inline, and recompressed under the SAME codec, so a later
+// decodeAd(bytes, codec) yields the identical ad. Best-effort: returns the input unchanged on
+// any decode/encode error (a later decode then fails exactly as it would have anyway). The hot
+// scan paths do NOT use this -- they thread the dict and dispatch -- so its decode+re-encode
+// cost lands only on cold event capture.
+func (c *Collection) toSelfContained(dict *segDictHandle, ad []byte, codec Codec) []byte {
+	if dict == nil {
+		return ad
+	}
+	dec, err := codec.Decompress(nil, ad)
+	if err != nil {
+		return ad
+	}
+	a, err := wire.DecodeResolve(dec, dict.resolve)
+	if err != nil {
+		return ad
+	}
+	return codec.Compress(nil, wire.EncodeInline(nil, a))
 }
 
 // newStreamEncoder returns a StreamEncoder matching the collection's mode, for the

--- a/collections/inline.go
+++ b/collections/inline.go
@@ -136,6 +136,21 @@ func (c *Collection) decodeAdDict(dict *segDictHandle, stored []byte, codec Code
 	return classad.FromAST(a), nil
 }
 
+// wireToInline is toSelfContained for already-DECOMPRESSED wire (no codec): an interned
+// segment's decompressed record becomes inline wire so a downstream consumer that reads it by
+// name -- CollectSamples -> buildAdSchema / ForEachNamed(c.intern) -- works without the dict.
+// nil dict (inline segment / in-memory global) returns w unchanged.
+func (c *Collection) wireToInline(dict *segDictHandle, w []byte) []byte {
+	if dict == nil {
+		return w
+	}
+	a, err := wire.DecodeResolve(w, dict.resolve)
+	if err != nil {
+		return w
+	}
+	return wire.EncodeInline(nil, a)
+}
+
 // toSelfContained converts a stored record's (compressed) ad bytes into a form that decodes
 // WITHOUT the source segment's dict, for DEFERRED/cold paths (e.g. a watch event) that copy ad
 // bytes out of the scan and decode them later, when the segment and its dict are no longer in

--- a/collections/inline_dict_test.go
+++ b/collections/inline_dict_test.go
@@ -1,0 +1,70 @@
+package collections
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/classad"
+	"github.com/PelicanPlatform/classad/collections/wire"
+)
+
+// TestDecodeAdDictAndSelfContained covers the two per-segment-interned decode helpers:
+// decodeAdDict resolves an interned record via its dict, and toSelfContained rewrites an
+// interned record into inline bytes that decode later WITHOUT the dict (the deferred/cold-path
+// conversion watch-style captures need).
+func TestDecodeAdDictAndSelfContained(t *testing.T) {
+	c := New(Options{Shards: 1})
+	table := wire.NewInternTable()
+	ad, err := classad.ParseOld("Memory=4096\nCpus=8\nName=\"slot1@h\"\nRank=Memory*1.0\nReq=(Arch==\"X86_64\")")
+	if err != nil {
+		t.Fatal(err)
+	}
+	interned := wire.Encode(nil, ad.AST(), table)
+	codec := identityCodec{}
+	stored := codec.Compress(nil, interned)
+	dict := appendSegDict(nil, table.Names())
+	h := &segDictHandle{data: dict, base: 0}
+
+	// Reference: the same interned record decoded with the in-memory table.
+	refAST, err := wire.Decode(interned, table)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := wire.EncodeInline(nil, refAST)
+
+	// decodeAdDict resolves ids via the dict, yielding the same ad.
+	got, err := c.decodeAdDict(h, stored, codec)
+	if err != nil {
+		t.Fatalf("decodeAdDict: %v", err)
+	}
+	if !bytes.Equal(want, wire.EncodeInline(nil, got.AST())) {
+		t.Errorf("decodeAdDict != table decode")
+	}
+
+	// toSelfContained rewrites to inline bytes that decode with no dict at all.
+	sc := c.toSelfContained(h, stored, codec)
+	dec, err := codec.Decompress(nil, sc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	scAST, err := wire.DecodeInline(dec) // no dict / no table
+	if err != nil {
+		t.Fatalf("DecodeInline(self-contained): %v", err)
+	}
+	if !bytes.Equal(want, wire.EncodeInline(nil, scAST)) {
+		t.Errorf("toSelfContained bytes decode differently than the original")
+	}
+	// And the self-contained bytes flow through the ordinary (dict-less) decodeAd.
+	got2, err := c.decodeAdDict(nil, sc, codec)
+	if err != nil {
+		t.Fatalf("decodeAd(self-contained): %v", err)
+	}
+	if !bytes.Equal(want, wire.EncodeInline(nil, got2.AST())) {
+		t.Errorf("decodeAd(self-contained) != original")
+	}
+
+	// dict==nil is a pass-through: toSelfContained returns the input unchanged.
+	if sc2 := c.toSelfContained(nil, stored, codec); !bytes.Equal(sc2, stored) {
+		t.Errorf("toSelfContained(nil) should be identity")
+	}
+}

--- a/collections/interning_e2e_test.go
+++ b/collections/interning_e2e_test.go
@@ -1,0 +1,144 @@
+package collections
+
+import (
+	"fmt"
+	"testing"
+)
+
+// TestInterningEndToEnd is the phase-1 acceptance test: a persistent collection compacts its
+// segments to the INTERNED form (asserted directly via seg.dict), and every read path returns
+// correct results over those interned segments -- before AND after a reopen (recovery restores
+// the dictionaries). It exercises current + superseded records (updates), multiple sealed
+// segments, and multiple shards.
+func TestInterningEndToEnd(t *testing.T) {
+	if !mmapSupported {
+		t.Skip("persistence is unix-only")
+	}
+	dir := t.TempDir()
+	const n = 3000
+	// Small segments so the data seals into several segments per shard (each compacted to an
+	// interned segment), exercising the roll/finalize path.
+	c, err := Open(Options{Shards: 2, Dir: dir, SegmentSize: 1 << 16})
+	if err != nil {
+		t.Fatal(err)
+	}
+	key := func(i int) []byte { return []byte(fmt.Sprintf("k%05d", i)) }
+	// Val = i%100 is stable per key across updates, so a range query has a known count.
+	ad := func(i, rev int) string {
+		return fmt.Sprintf(`[Id=%d; Val=%d; Name="host-%d.example.org"; Rev=%d; Req=(Val>=50)]`, i, i%100, i, rev)
+	}
+	for i := 0; i < n; i++ {
+		if err := c.Put(key(i), mustAd(t, ad(i, 0))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Update every key (creates superseded versions -> dead space -> compaction rewrites).
+	for i := 0; i < n; i++ {
+		if err := c.Put(key(i), mustAd(t, ad(i, 1))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Force every shard to compact (bypass the dead-ratio threshold) so the transcode runs
+	// deterministically regardless of how the data happened to fragment.
+	for _, sh := range c.shards {
+		c.compactShard(sh, c.currentCodec())
+	}
+	c.reindexAfterCompaction()
+
+	assertInterned := func(tag string, col *Collection) {
+		sealed, interned := 0, 0
+		for _, sh := range col.shards {
+			sh.mu.RLock()
+			act := sh.act
+			for _, seg := range sh.segs {
+				if seg == nil || seg == act || seg.used == 0 {
+					continue
+				}
+				sealed++
+				if seg.dict.Load() != nil {
+					interned++
+				}
+			}
+			sh.mu.RUnlock()
+		}
+		if sealed == 0 {
+			t.Fatalf("%s: no sealed segments (test did not seal)", tag)
+		}
+		if interned == 0 {
+			t.Fatalf("%s: %d sealed segments but none interned -- transcode did not run", tag, sealed)
+		}
+		if interned != sealed {
+			t.Fatalf("%s: %d/%d sealed segments interned (expected all after compaction)", tag, interned, sealed)
+		}
+		t.Logf("%s: %d sealed segments, all interned", tag, sealed)
+	}
+
+	// verify checks every read path against the known state (latest rev=1 for every key).
+	verify := func(tag string, col *Collection) {
+		if got := col.Len(); got != n {
+			t.Fatalf("%s: Len=%d want %d", tag, got, n)
+		}
+		// Point lookups.
+		for i := 0; i < n; i++ {
+			a, ok := col.Get(key(i))
+			if !ok {
+				t.Fatalf("%s: Get(%s) missing", tag, key(i))
+			}
+			if v, _ := a.EvaluateAttrInt("Id"); int(v) != i {
+				t.Fatalf("%s: Get(%s) Id=%d", tag, key(i), v)
+			}
+			if v, _ := a.EvaluateAttrInt("Rev"); v != 1 {
+				t.Fatalf("%s: Get(%s) Rev=%d want 1 (stale version?)", tag, key(i), v)
+			}
+			if s, _ := a.EvaluateAttrString("Name"); s != fmt.Sprintf("host-%d.example.org", i) {
+				t.Fatalf("%s: Get(%s) Name=%q", tag, key(i), s)
+			}
+		}
+		// Full scan: exactly n distinct keys.
+		seen := map[int]int{}
+		for a := range col.Scan() {
+			id, _ := a.EvaluateAttrInt("Id")
+			seen[int(id)]++
+		}
+		if len(seen) != n {
+			t.Fatalf("%s: Scan distinct=%d want %d", tag, len(seen), n)
+		}
+		for id, cnt := range seen {
+			if cnt != 1 {
+				t.Fatalf("%s: Scan yielded id %d %d times", tag, id, cnt)
+			}
+		}
+		// Filtered query: Val>=50 -> ids with i%100 in [50,99] -> exactly half.
+		q := mustQuery(t, "Val >= 50")
+		cnt := 0
+		for range col.Query(q) {
+			cnt++
+		}
+		if cnt != n/2 {
+			t.Fatalf("%s: Query(Val>=50)=%d want %d", tag, cnt, n/2)
+		}
+		// Raw scan path (wireToInline for interned): same n rows.
+		raw := 0
+		for range col.ScanRaw() {
+			raw++
+		}
+		if raw != n {
+			t.Fatalf("%s: ScanRaw=%d want %d", tag, raw, n)
+		}
+	}
+
+	assertInterned("post-compact", c)
+	verify("post-compact", c)
+	if err := c.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Reopen: recovery must restore the dictionaries; every read path must still be correct.
+	c2, err := Open(Options{Shards: 2, Dir: dir, SegmentSize: 1 << 16})
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer c2.Close()
+	assertInterned("post-reopen", c2)
+	verify("post-reopen", c2)
+}

--- a/collections/interning_e2e_test.go
+++ b/collections/interning_e2e_test.go
@@ -142,3 +142,65 @@ func TestInterningEndToEnd(t *testing.T) {
 	assertInterned("post-reopen", c2)
 	verify("post-reopen", c2)
 }
+
+// TestInterningSchemaScan checks the adschema columnar accelerator over INTERNED segments: the
+// per-segment block build must resolve segment-local ids (recordToInternedDict), so a
+// CountConstraint routed through the columnar scan matches the query engine.
+func TestInterningSchemaScan(t *testing.T) {
+	if !mmapSupported {
+		t.Skip("persistence is unix-only")
+	}
+	dir := t.TempDir()
+	const n = 4000
+	c, err := Open(Options{Shards: 2, Dir: dir, SegmentSize: 1 << 16})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+	for i := 0; i < n; i++ {
+		if err := c.Put([]byte(fmt.Sprintf("k%05d", i)), mustAd(t, fmt.Sprintf("[Id=%d; Val=%d]", i, i%100))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Read demand on Val so the schema build ranks it into the hot tier.
+	tq := mustQuery(t, "true")
+	for r := 0; r < 20; r++ {
+		for range c.QueryProject(tq, []string{"Val"}) {
+		}
+	}
+	// Force compaction -> interned segments, then enable the columnar scan over them.
+	for _, sh := range c.shards {
+		c.compactShard(sh, c.currentCodec())
+	}
+	c.reindexAfterCompaction()
+	interned := 0
+	for _, sh := range c.shards {
+		sh.mu.RLock()
+		for _, seg := range sh.segs {
+			if seg != nil && seg != sh.act && seg.used > 0 && seg.dict.Load() != nil {
+				interned++
+			}
+		}
+		sh.mu.RUnlock()
+	}
+	if interned == 0 {
+		t.Fatal("no interned segments to scan")
+	}
+	if !c.BuildAndEnableSchemaScan(n, 4) {
+		t.Fatal("BuildAndEnableSchemaScan returned false over interned segments")
+	}
+	for _, expr := range []string{"Val >= 50", "Val < 25", "Val >= 10 && Val < 90"} {
+		got, ok := c.CountConstraint(expr)
+		if !ok {
+			t.Errorf("%q: CountConstraint declined over interned segments", expr)
+			continue
+		}
+		want := 0
+		for range c.Query(mustQuery(t, expr)) {
+			want++
+		}
+		if got != want {
+			t.Errorf("%q: columnar %d != query %d over interned segments", expr, got, want)
+		}
+	}
+}

--- a/collections/interning_measure_test.go
+++ b/collections/interning_measure_test.go
@@ -1,0 +1,170 @@
+package collections
+
+import (
+	"encoding/binary"
+	"fmt"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/ast"
+	"github.com/PelicanPlatform/classad/collections/wire"
+	"github.com/klauspost/compress/zstd"
+)
+
+// This measurement answers: for persistent segments, what is the size/speed tradeoff of
+// GLOBAL interning (one id space for the whole collection) vs PER-SEGMENT interning (each
+// sealed segment carries its own id->name dictionary, Parquet/ORC style)? Baseline is the
+// current INLINE encoding (attribute names in every record). Segments are compressed
+// INDEPENDENTLY (on-disk reality), so per-segment interning includes its dict inside the
+// compressed segment and gets no cross-segment name dedup.
+//
+// Run: go test -run TestInterningSizeTradeoff -v ./  (needs testdata/ospool_slots.ldif)
+
+func zstdAll(b []byte) []byte {
+	enc, _ := zstd.NewWriter(nil, zstd.WithEncoderLevel(zstd.SpeedDefault))
+	defer enc.Close()
+	return enc.EncodeAll(b, nil)
+}
+
+// dictBytes is the serialized size of an id->name dictionary: each name length-prefixed.
+func dictBytes(names []string) int {
+	n := 0
+	var tmp [binary.MaxVarintLen64]byte
+	for _, s := range names {
+		n += binary.PutUvarint(tmp[:], uint64(len(s))) + len(s)
+	}
+	return n
+}
+
+func TestInterningSizeTradeoff(t *testing.T) {
+	ads, _ := loadOSPoolAds(t)
+	asts := make([]*ast.ClassAd, len(ads))
+	for i, a := range ads {
+		asts[i] = a.AST()
+	}
+	N := len(asts)
+
+	// --- INLINE baseline: names in every record; segment = concat, zstd per segment.
+	inlineRaw, inlineZ := 0, 0
+	// --- GLOBAL interned: one table for all; dict once (zstd once); records zstd per segment.
+	gt := wire.NewInternTable()
+	globalRecRaw := 0
+	// --- PER-SEGMENT interned: fresh table per segment; [dict||records] zstd per segment.
+	// All three measured at several segment sizes K.
+	for _, K := range []int{128, 256, 512, 2048, N} {
+		inlineRaw, inlineZ = 0, 0
+		gRaw, gZ := 0, 0     // global-interned records (zstd per seg) -- dict added once below
+		psRaw, psZ := 0, 0   // per-segment interned incl. dict, zstd per seg
+		var gDistinct int    // recomputed identically each K (cheap); dict size added once
+		psDictRaw := 0       // total per-segment dict bytes (raw)
+		perSegNames := 0     // sum of distinct-names-per-segment (for reporting)
+
+		for lo := 0; lo < N; lo += K {
+			hi := lo + K
+			if hi > N {
+				hi = N
+			}
+			var inlineSeg, gSeg, psRecs []byte
+			pt := wire.NewInternTable() // per-segment table
+			for _, a := range asts[lo:hi] {
+				inlineSeg = wire.EncodeInline(inlineSeg, a)
+				gSeg = appendRec(gSeg, wire.Encode(nil, a, gt))
+				psRecs = appendRec(psRecs, wire.Encode(nil, a, pt))
+			}
+			// per-segment dict = the names this segment interned.
+			pnames := pt.Names()
+			perSegNames += len(pnames)
+			d := dictBytes(pnames)
+			psDictRaw += d
+			psSeg := append(marshalDict(pnames), psRecs...)
+
+			inlineRaw += len(inlineSeg)
+			inlineZ += len(zstdAll(inlineSeg))
+			gRaw += len(gSeg)
+			gZ += len(zstdAll(gSeg))
+			psRaw += len(psSeg)
+			psZ += len(zstdAll(psSeg))
+		}
+		gDistinct = gt.Len()
+		gDictRaw := dictBytes(gt.Names())
+		gDictZ := len(zstdAll(marshalDict(gt.Names())))
+		globalRecRaw = gRaw
+
+		// Global totals include the single dict (stored/compressed once).
+		gTotRaw := gRaw + gDictRaw
+		gTotZ := gZ + gDictZ
+
+		fmt.Printf("\n===== segment size K=%d (%d segments) =====\n", K, (N+K-1)/K)
+		fmt.Printf("  global distinct names=%d dict=%s(raw) %s(zstd);  per-seg dict total=%s(raw), avg names/seg=%d\n",
+			gDistinct, human(gDictRaw), human(gDictZ), human(psDictRaw), perSegNames*K/max(1, N))
+		fmt.Printf("  %-22s raw=%-10s zstd=%-10s\n", "INLINE (names/rec)", human(inlineRaw), human(inlineZ))
+		fmt.Printf("  %-22s raw=%-10s zstd=%-10s   (records only=%s raw)\n", "GLOBAL interned", human(gTotRaw), human(gTotZ), human(globalRecRaw))
+		fmt.Printf("  %-22s raw=%-10s zstd=%-10s\n", "PER-SEGMENT interned", human(psRaw), human(psZ))
+		fmt.Printf("  --> interning zstd win vs inline:  global %.1f%%   per-seg %.1f%%\n",
+			100*(1-float64(gTotZ)/float64(inlineZ)), 100*(1-float64(psZ)/float64(inlineZ)))
+		fmt.Printf("  --> per-seg zstd overhead vs global: %+.2f%% (%s)\n",
+			100*(float64(psZ)/float64(gTotZ)-1), human(psZ-gTotZ))
+	}
+	_ = inlineRaw
+	_ = inlineZ
+	_ = globalRecRaw
+}
+
+// appendRec length-prefixes a record so a concatenated segment self-delimits (models a real
+// segment's record framing; adds the same few bytes to global and per-segment alike).
+func appendRec(dst, rec []byte) []byte {
+	var tmp [binary.MaxVarintLen64]byte
+	n := binary.PutUvarint(tmp[:], uint64(len(rec)))
+	dst = append(dst, tmp[:n]...)
+	return append(dst, rec...)
+}
+
+func marshalDict(names []string) []byte {
+	var b []byte
+	var tmp [binary.MaxVarintLen64]byte
+	n := binary.PutUvarint(tmp[:], uint64(len(names)))
+	b = append(b, tmp[:n]...)
+	for _, s := range names {
+		n = binary.PutUvarint(tmp[:], uint64(len(s)))
+		b = append(b, tmp[:n]...)
+		b = append(b, s...)
+	}
+	return b
+}
+
+func human(n int) string {
+	switch {
+	case n >= 1<<20:
+		return fmt.Sprintf("%.2fMB", float64(n)/(1<<20))
+	case n >= 1<<10:
+		return fmt.Sprintf("%.1fKB", float64(n)/(1<<10))
+	}
+	return fmt.Sprintf("%dB", n)
+}
+
+// BenchmarkDecodeInlineVsInterned compares full-ad decode cost of an inline record vs an
+// interned one (global table), the read-side speed axis of the tradeoff.
+func BenchmarkDecodeEncodings(b *testing.B) {
+	ads, _ := loadOSPoolAds(b)
+	if len(ads) == 0 {
+		return
+	}
+	a := ads[len(ads)/2].AST()
+	t := wire.NewInternTable()
+	interned := wire.Encode(nil, a, t)
+	inline := wire.EncodeInline(nil, a)
+
+	b.Run("inline", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			if _, err := wire.DecodeInline(inline); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+	b.Run("interned", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			if _, err := wire.Decode(interned, t); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}

--- a/collections/interning_measure_test.go
+++ b/collections/interning_measure_test.go
@@ -52,11 +52,11 @@ func TestInterningSizeTradeoff(t *testing.T) {
 	// All three measured at several segment sizes K.
 	for _, K := range []int{128, 256, 512, 2048, N} {
 		inlineRaw, inlineZ = 0, 0
-		gRaw, gZ := 0, 0     // global-interned records (zstd per seg) -- dict added once below
-		psRaw, psZ := 0, 0   // per-segment interned incl. dict, zstd per seg
-		var gDistinct int    // recomputed identically each K (cheap); dict size added once
-		psDictRaw := 0       // total per-segment dict bytes (raw)
-		perSegNames := 0     // sum of distinct-names-per-segment (for reporting)
+		gRaw, gZ := 0, 0   // global-interned records (zstd per seg) -- dict added once below
+		psRaw, psZ := 0, 0 // per-segment interned incl. dict, zstd per seg
+		var gDistinct int  // recomputed identically each K (cheap); dict size added once
+		psDictRaw := 0     // total per-segment dict bytes (raw)
+		perSegNames := 0   // sum of distinct-names-per-segment (for reporting)
 
 		for lo := 0; lo < N; lo += K {
 			hi := lo + K

--- a/collections/match.go
+++ b/collections/match.go
@@ -444,13 +444,14 @@ func (c *Collection) taskMatches(job *classad.ClassAd, jp *jobPlan, deferMat boo
 // matchWindow visits each visible record in one window, matching each via
 // matchCandidate.
 func (c *Collection) matchWindow(t scanTask, mw *matchWorker, dbuf *[]byte, out *[]rankedMatch) {
+	dict := t.win.dict()
 	forEachVisibleWindow(t.s0, t.win, func(adBytes []byte, codec Codec) bool {
 		w, err := codec.Decompress((*dbuf)[:0], adBytes)
 		if err != nil {
 			return true
 		}
 		*dbuf = w
-		c.matchCandidate(w, mw, out)
+		c.matchCandidate(c.wireToInline(dict, w), mw, out)
 		return true
 	})
 }

--- a/collections/match_index.go
+++ b/collections/match_index.go
@@ -846,8 +846,8 @@ func (c *Collection) indexedMatches(job *classad.ClassAd, groups [][]usableProbe
 		mw := newMatchWorker(job, c, jp, deferMat)
 		var out []rankedMatch
 		for _, sh := range shards {
-			c.scanShardCandidatesGroups(sh, groups, false, func(w []byte) bool {
-				c.matchCandidate(w, mw, &out)
+			c.scanShardCandidatesGroups(sh, groups, false, func(w []byte, dict *segDictHandle) bool {
+				c.matchCandidate(c.wireToInline(dict, w), mw, &out)
 				return true
 			})
 		}
@@ -874,8 +874,8 @@ func (c *Collection) indexedMatches(job *classad.ClassAd, groups [][]usableProbe
 				if idx >= len(shards) {
 					break
 				}
-				c.scanShardCandidatesGroups(shards[idx], groups, false, func(w []byte) bool {
-					c.matchCandidate(w, mw, &local)
+				c.scanShardCandidatesGroups(shards[idx], groups, false, func(w []byte, dict *segDictHandle) bool {
+					c.matchCandidate(c.wireToInline(dict, w), mw, &local)
 					return true
 				})
 			}

--- a/collections/ordered.go
+++ b/collections/ordered.go
@@ -411,13 +411,13 @@ func (c *Collection) rebuildOrdered() {
 	for _, sh := range c.shards {
 		s0, wins := sh.snapshot()
 		var dbuf []byte
-		forEachVisibleKeyed(s0, wins, func(key, ad []byte, codec Codec) bool {
+		forEachVisibleKeyed(s0, wins, func(key, ad []byte, codec Codec, dict *segDictHandle) bool {
 			w, err := codec.Decompress(dbuf[:0], ad)
 			if err != nil {
 				return true
 			}
 			dbuf = w
-			node, err := c.decodeWire(w)
+			node, err := c.decodeWireDict(dict, w)
 			if err != nil {
 				return true
 			}

--- a/collections/ospool_spike_test.go
+++ b/collections/ospool_spike_test.go
@@ -88,7 +88,7 @@ func BenchmarkOSPoolSlotDecode(b *testing.B) {
 
 	// Report the closure size vs the full ad, once, so the ratio is on the record.
 	full0 := c.mustDecode(b, wires[0])
-	part0 := partialDecodeWire(c, wires[0], seeds)
+	part0 := partialDecodeWire(c, nil, wires[0], seeds)
 	b.Logf("ad[0]: full=%d attrs, Requirements closure=%d attrs",
 		len(full0.AST().Attributes), len(part0.AST().Attributes))
 
@@ -106,7 +106,7 @@ func BenchmarkOSPoolSlotDecode(b *testing.B) {
 	b.Run("PartialDecode", func(b *testing.B) {
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
-			_ = partialDecodeWire(c, wires[i%len(wires)], seeds)
+			_ = partialDecodeWire(c, nil, wires[i%len(wires)], seeds)
 		}
 	})
 	b.Run("FullDecode+Eval", func(b *testing.B) {
@@ -125,7 +125,7 @@ func BenchmarkOSPoolSlotDecode(b *testing.B) {
 	b.Run("PartialDecode+Eval", func(b *testing.B) {
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
-			ad := partialDecodeWire(c, wires[i%len(wires)], seeds)
+			ad := partialDecodeWire(c, nil, wires[i%len(wires)], seeds)
 			m.ReplaceRightAd(ad)
 			_ = m.EvaluateAttrRight("Requirements")
 			ad.SetTarget(nil)

--- a/collections/parallel_scan.go
+++ b/collections/parallel_scan.go
@@ -189,6 +189,7 @@ func (c *Collection) runParallelQuery(q *vm.Query, yield func(*classad.ClassAd) 
 					}
 					return
 				}
+				dict := tasks[idx].win.dict() // one window per task: constant for this walk
 				forEachVisibleWindowKeyed(tasks[idx].s0, tasks[idx].win, func(key, ad []byte, codec Codec) bool {
 					if stopped.Load() {
 						return false
@@ -201,10 +202,11 @@ func (c *Collection) runParallelQuery(q *vm.Query, yield func(*classad.ClassAd) 
 						return true
 					}
 					dbuf = w
+					qp.ws.dict = dict
 					if !matchWire(w, qp) {
 						return true
 					}
-					a, err := c.decodeWire(w)
+					a, err := c.decodeWireDict(dict, w)
 					if err != nil {
 						return true
 					}
@@ -239,6 +241,7 @@ func (c *Collection) scanTasksSerial(tasks []scanTask, qp queryPlan, yield func(
 	var dbuf []byte
 	for _, t := range tasks {
 		stop := false
+		dict := t.win.dict()
 		forEachVisibleWindowKeyed(t.s0, t.win, func(key, ad []byte, codec Codec) bool {
 			if isSystemKeyBytes(key) {
 				return true // internal system record: hidden from client queries
@@ -248,10 +251,11 @@ func (c *Collection) scanTasksSerial(tasks []scanTask, qp queryPlan, yield func(
 				return true
 			}
 			dbuf = w
+			qp.ws.dict = dict
 			if !matchWire(w, qp) {
 				return true
 			}
-			a, err := c.decodeWire(w)
+			a, err := c.decodeWireDict(dict, w)
 			if err != nil {
 				return true
 			}

--- a/collections/persist.go
+++ b/collections/persist.go
@@ -371,6 +371,19 @@ func (c *Collection) loadShard(sh *shard, shardDir string) (uint64, error) {
 	// and matching the current spec, its attribute index. Runs regardless of whether
 	// attribute indexes are configured. A missing/invalid sidecar is left unmapped and
 	// rebuilt later; the directory stays authoritative.
+	// Restore each segment's attribute dictionary (interned segments only) BEFORE any body
+	// decode below, so zone/index rebuilds and scans resolve segment-local ids. Done across
+	// ALL segments, including whichever one recovery picked as active. An interned segment is
+	// sealed and cannot take new inline writes, so if recovery made one the active target,
+	// demote it -- the next write then allocates a fresh inline active segment.
+	for _, seg := range sh.segs {
+		if seg != nil {
+			publishSegDict(seg)
+		}
+	}
+	if sh.act != nil && sh.act.dict.Load() != nil {
+		sh.act = nil
+	}
 	spec := c.spec.Load()
 	for _, seg := range sh.segs {
 		if seg != nil && seg != sh.act {

--- a/collections/project.go
+++ b/collections/project.go
@@ -92,7 +92,7 @@ func (c *Collection) projectInto(rs *wireScope, w []byte, attrs []string, out []
 	rs.fellBack = false
 	needDecode := false
 	for i, name := range attrs {
-		v, found := rs.tryResolve(ad, name)
+		v, found := rs.tryResolve(ad, rs.dict, name)
 		if rs.fellBack {
 			needDecode = true
 			break

--- a/collections/project.go
+++ b/collections/project.go
@@ -60,7 +60,8 @@ func (c *Collection) QueryProject(q *vm.Query, attrs []string) iter.Seq[[]classa
 		scratch := make([]classad.Value, len(attrs))
 		rs := &wireScope{ctx: c} // projection resolver, distinct from the match ws
 		stopped := false
-		emit := func(w []byte) bool {
+		emit := func(w []byte, dict *segDictHandle) bool {
+			rs.dict = dict
 			c.projectInto(rs, w, attrs, scratch)
 			if !yield(scratch) {
 				stopped = true

--- a/collections/rawdecode.go
+++ b/collections/rawdecode.go
@@ -99,11 +99,12 @@ func (c *Collection) scanRaw(redact bool) iter.Seq[RawAd] {
 // wire bytes straight to old-ClassAd text and yield them. The buf/offs/exprs
 // scratch is reused across the whole scan (single-threaded), so no per-ad
 // expression bytes are allocated.
-func (c *Collection) yieldRaw(yield func(RawAd) bool, redact bool) func(w []byte) bool {
+func (c *Collection) yieldRaw(yield func(RawAd) bool, redact bool) scanEmit {
 	var buf []byte
 	var offs []int
 	var exprs [][]byte
-	return func(w []byte) bool {
+	return func(w []byte, dict *segDictHandle) bool {
+		w = c.wireToInline(dict, w) // interned segment -> inline for the mode-aware renderer
 		var mt, tt string
 		var ok bool
 		buf, offs, mt, tt, ok = c.appendWireAd(w, buf, offs, redact)

--- a/collections/rawdecode_test.go
+++ b/collections/rawdecode_test.go
@@ -18,7 +18,7 @@ func TestDecodeRawMatchesFull(t *testing.T) {
 	checked := 0
 	for _, sh := range c.shards {
 		s0, wins := sh.snapshot()
-		forEachVisible(s0, wins, func(ad []byte, codec Codec) bool {
+		forEachVisible(s0, wins, func(ad []byte, codec Codec, _ *segDictHandle) bool {
 			full, err := c.decodeAd(ad, codec)
 			if err != nil {
 				t.Fatalf("decodeAd: %v", err)
@@ -81,7 +81,7 @@ func BenchmarkDecodeSend(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			for _, sh := range c.shards {
 				s0, wins := sh.snapshot()
-				forEachVisible(s0, wins, func(ad []byte, codec Codec) bool {
+				forEachVisible(s0, wins, func(ad []byte, codec Codec, _ *segDictHandle) bool {
 					a, err := c.decodeAd(ad, codec)
 					if err != nil {
 						b.Fatal(err)
@@ -105,7 +105,7 @@ func BenchmarkDecodeSend(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			for _, sh := range c.shards {
 				s0, wins := sh.snapshot()
-				forEachVisible(s0, wins, func(ad []byte, codec Codec) bool {
+				forEachVisible(s0, wins, func(ad []byte, codec Codec, _ *segDictHandle) bool {
 					exprs, _, _, ok := c.decodeAdRaw(ad, codec, buf[:0])
 					if !ok {
 						b.Fatal("decodeAdRaw ok=false")

--- a/collections/rawprojected.go
+++ b/collections/rawprojected.go
@@ -178,8 +178,9 @@ func (c *Collection) newRawProjector(projection []string, chaseRefs, redact bool
 	return p
 }
 
-func (c *Collection) yieldRawProjected(yield func(RawAd) bool, p *rawProjector) func(w []byte) bool {
-	return func(w []byte) bool {
+func (c *Collection) yieldRawProjected(yield func(RawAd) bool, p *rawProjector) scanEmit {
+	return func(w []byte, dict *segDictHandle) bool {
+		w = c.wireToInline(dict, w) // interned segment -> inline for the mode-aware projector
 		ra, ok := p.render(w)
 		if !ok {
 			return true // inline-name or undecodable record: skip, keep scanning

--- a/collections/rawwire_parallel.go
+++ b/collections/rawwire_parallel.go
@@ -115,6 +115,7 @@ func (c *Collection) runParallelWireScan(sel *wireSubsetSelector, needed int, yi
 					flush()
 					return
 				}
+				dict := tasks[idx].win.dict()
 				forEachVisibleWindowKeyed(tasks[idx].s0, tasks[idx].win, func(key, ad []byte, codec Codec) bool {
 					if stopped.Load() {
 						return false
@@ -123,6 +124,26 @@ func (c *Collection) runParallelWireScan(sel *wireSubsetSelector, needed int, yi
 						return true
 					}
 					start := len(batch.buf)
+					if dict != nil {
+						// Interned segment: the prefix/hot-first inline renderer needs inline
+						// wire, so fully decompress and flatten via the dict, then subset.
+						w, err := codec.Decompress(dbuf[:0], ad)
+						dbuf = w
+						if err != nil {
+							return true
+						}
+						out, ok := wire.AppendAdSubsetInlineHotFirst(batch.buf, wire.Ad(c.wireToInline(dict, w)), sel.keep, needed, nil, &sc)
+						if !ok {
+							batch.buf = out[:start]
+							return true
+						}
+						batch.buf = out
+						batch.offs = append(batch.offs, len(out))
+						if len(batch.buf) >= wireBatchArena {
+							flush()
+						}
+						return true
+					}
 					// Projected reads try a PREFIX decompress first: the hot region is
 					// a physical prefix of the record, so a hot-covered projection
 					// never decompresses the rest. A truncated parse (or an unmet

--- a/collections/rawwire_subset.go
+++ b/collections/rawwire_subset.go
@@ -90,11 +90,12 @@ func (sel *wireSubsetSelector) neededCount() int {
 	return len(sel.names) + 2
 }
 
-func (c *Collection) yieldWireRow(yield func([]byte) bool, sel *wireSubsetSelector) func(w []byte) bool {
+func (c *Collection) yieldWireRow(yield func([]byte) bool, sel *wireSubsetSelector) scanEmit {
 	var scratch []byte
 	var sc wire.SubsetScratch
 	needed := sel.neededCount()
-	return func(w []byte) bool {
+	return func(w []byte, dict *segDictHandle) bool {
+		w = c.wireToInline(dict, w) // AppendAdSubsetInlineHotFirst needs inline-name wire
 		out, ok := wire.AppendAdSubsetInlineHotFirst(scratch[:0], wire.Ad(w), sel.keep, needed, c.sealer, &sc)
 		scratch = out
 		if !ok {

--- a/collections/rawwire_subset_test.go
+++ b/collections/rawwire_subset_test.go
@@ -147,7 +147,7 @@ func TestHotPrefixDecodable(t *testing.T) {
 	checked := 0
 	for _, sh := range c.shards {
 		s0, wins := sh.snapshot()
-		forEachVisible(s0, wins, func(rec []byte, codec Codec) bool {
+		forEachVisible(s0, wins, func(rec []byte, codec Codec, _ *segDictHandle) bool {
 			full, ferr := codec.Decompress(nil, rec)
 			if ferr != nil {
 				t.Fatal(ferr)

--- a/collections/sealed_index.go
+++ b/collections/sealed_index.go
@@ -116,7 +116,7 @@ func (c *Collection) sealSegmentIndex(seg *segment, si *segIndex) {
 // error the existing sidecar is left in place and false is returned, so the segment keeps
 // serving queries under its older (still correct, just less selective) index.
 func (c *Collection) reindexSealed(sh *shard, seg *segment, spec *indexSpec) bool {
-	si := buildSegIndex(seg.data, seg.used, seg.codec, spec)
+	si := buildSegIndex(seg.data, seg.used, seg.codec, spec, seg.dict.Load())
 	if si == nil {
 		return false
 	}

--- a/collections/segdict.go
+++ b/collections/segdict.go
@@ -88,6 +88,28 @@ func appendSegDict(dst []byte, names []string) []byte {
 	return dst
 }
 
+// segDictHandle binds a serialized dict to the bytes it lives in (a segment's mmap arena) at
+// offset base, so reads probe it zero-copy. It is immutable once published; a segment holds
+// one via an atomic pointer (nil => the segment is inline-encoded). All methods are safe for
+// concurrent readers.
+type segDictHandle struct {
+	data []byte // the segment arena (or any buffer) the dict is embedded in
+	base uint32 // offset of the dict's first byte within data
+}
+
+func (h *segDictHandle) lookup(name string) (uint32, bool) { return segDictLookup(h.data, h.base, name) }
+func (h *segDictHandle) name(id uint32) []byte             { return segDictName(h.data, h.base, id) }
+func (h *segDictHandle) count() uint32                     { return segDictCount(h.data, h.base) }
+
+// resolve is the id->name function form for wire.DecodeResolve, so an interned record decodes
+// straight over the mmap with no in-memory table.
+func (h *segDictHandle) resolve(id uint32) (string, bool) {
+	if b := h.name(id); b != nil {
+		return string(b), true
+	}
+	return "", false
+}
+
 // segDictCount returns the number of names in the dict at base.
 func segDictCount(data []byte, base uint32) uint32 { return le32(data, base) }
 

--- a/collections/segdict.go
+++ b/collections/segdict.go
@@ -97,9 +97,11 @@ type segDictHandle struct {
 	base uint32 // offset of the dict's first byte within data
 }
 
-func (h *segDictHandle) lookup(name string) (uint32, bool) { return segDictLookup(h.data, h.base, name) }
-func (h *segDictHandle) name(id uint32) []byte             { return segDictName(h.data, h.base, id) }
-func (h *segDictHandle) count() uint32                     { return segDictCount(h.data, h.base) }
+func (h *segDictHandle) lookup(name string) (uint32, bool) {
+	return segDictLookup(h.data, h.base, name)
+}
+func (h *segDictHandle) name(id uint32) []byte { return segDictName(h.data, h.base, id) }
+func (h *segDictHandle) count() uint32         { return segDictCount(h.data, h.base) }
 
 // resolve is the id->name function form for wire.DecodeResolve, so an interned record decodes
 // straight over the mmap with no in-memory table.

--- a/collections/segdict.go
+++ b/collections/segdict.go
@@ -1,0 +1,150 @@
+package collections
+
+import (
+	"sort"
+	"strings"
+)
+
+// segDict is a sealed segment's per-segment attribute-name dictionary in its serialized,
+// mmap-probed form. A segment written interned stores its attribute names once, in a dict
+// carried inside the segment container; records then reference names by a small segment-LOCAL
+// id (its position in the dict). This file is the dict's build + zero-copy probe layer.
+//
+// The whole dict is probed directly over the mapped bytes -- no Go map or slice is
+// materialized per segment -- so loading many sealed dicts does not reintroduce the heap that
+// interning removes. name->id is a minimal perfect hash (mph.go) with an authoritative
+// sorted-name fallback; id->name is an offset table into the name blob. All lookups are
+// case-insensitive (ClassAd attribute names fold), matching InternTable.
+//
+// Layout (every offset is relative to the dict's start `base`):
+//
+//	u32 count
+//	u32 idOffTableOff  -- id -> offset (into the name blob) table
+//	u32 nameBlobOff    -- start of the name blob
+//	u32 slotIdOff      -- MPH slot -> id table (nAssigned entries)
+//	u32 sortedIdOff    -- ids sorted by folded name (authoritative binary-search fallback)
+//	u32 mphOff         -- name->slot MPH (appendMPH); a non-authoritative accelerator
+//	[count]u32   idToNameOff    (each relative to nameBlobOff)
+//	[nAssigned]u32 slotToId
+//	[count]u32   sortedIds
+//	name blob: [count] { u32 len; name bytes }   -- canonical (first-seen) casing
+//	MPH bytes (appendMPH)
+const segDictHeaderBytes = 6 * 4
+
+// appendSegDict serializes the dictionary for names (names[id] is the canonical casing of
+// local id `id`; ids are 0..len-1 in seal/first-seen order). Folded names must be distinct,
+// which they are for an InternTable's Names() (one entry per fold-equal group).
+func appendSegDict(dst []byte, names []string) []byte {
+	count := uint32(len(names))
+	folded := make([]string, count)
+	for i, n := range names {
+		folded[i] = strings.ToLower(n)
+	}
+	m, slots := buildMPH(folded) // slots[id] = MPH slot, or -1 if unassigned (fallback resolves)
+
+	slotToId := make([]uint32, m.nAssigned)
+	for id, s := range slots {
+		if s >= 0 {
+			slotToId[s] = uint32(id)
+		}
+	}
+	sortedIds := make([]uint32, count)
+	for i := range sortedIds {
+		sortedIds[i] = uint32(i)
+	}
+	sort.Slice(sortedIds, func(a, b int) bool { return folded[sortedIds[a]] < folded[sortedIds[b]] })
+
+	var nameBlob []byte
+	idToNameOff := make([]uint32, count)
+	for id, n := range names {
+		idToNameOff[id] = uint32(len(nameBlob))
+		nameBlob = appendU32(nameBlob, uint32(len(n)))
+		nameBlob = append(nameBlob, n...)
+	}
+
+	idOffTableOff := uint32(segDictHeaderBytes)
+	slotIdOff := idOffTableOff + count*4
+	sortedIdOff := slotIdOff + uint32(len(slotToId))*4
+	nameBlobOff := sortedIdOff + count*4
+	mphOff := nameBlobOff + uint32(len(nameBlob))
+
+	dst = appendU32(dst, count)
+	dst = appendU32(dst, idOffTableOff)
+	dst = appendU32(dst, nameBlobOff)
+	dst = appendU32(dst, slotIdOff)
+	dst = appendU32(dst, sortedIdOff)
+	dst = appendU32(dst, mphOff)
+	for _, o := range idToNameOff {
+		dst = appendU32(dst, o)
+	}
+	for _, v := range slotToId {
+		dst = appendU32(dst, v)
+	}
+	for _, v := range sortedIds {
+		dst = appendU32(dst, v)
+	}
+	dst = append(dst, nameBlob...)
+	dst = appendMPH(dst, m)
+	return dst
+}
+
+// segDictCount returns the number of names in the dict at base.
+func segDictCount(data []byte, base uint32) uint32 { return le32(data, base) }
+
+// segDictName returns the canonical name bytes for local id, aliasing data (an mmap). Returns
+// nil if id is out of range. Two zero-copy reads (offset table, then the length-prefixed name).
+func segDictName(data []byte, base, id uint32) []byte {
+	if id >= le32(data, base) {
+		return nil
+	}
+	idOffTableOff := le32(data, base+4)
+	nameBlobOff := le32(data, base+8)
+	nameOff := le32(data, base+idOffTableOff+id*4)
+	p := base + nameBlobOff + nameOff
+	n := le32(data, p)
+	return data[p+4 : p+4+n]
+}
+
+// segDictLookup resolves a name (case-insensitive) to its local id. The MPH gives an O(1)
+// candidate that is verified against the stored name; on any miss (unassigned member, verify
+// mismatch, or non-member) it falls back to an authoritative binary search over the
+// folded-name-sorted index, so a build/probe discrepancy can only cost a redundant search,
+// never a wrong answer. ok=false means the name is not in this segment's dict.
+func segDictLookup(data []byte, base uint32, name string) (id uint32, ok bool) {
+	count := le32(data, base)
+	if count == 0 {
+		return 0, false
+	}
+	slotIdOff := le32(data, base+12)
+	mphOff := le32(data, base+20)
+	folded := strings.ToLower(name)
+	if slot, hit := mphLookupBytes(data, base+mphOff, folded); hit {
+		cid := le32(data, base+slotIdOff+slot*4)
+		if strings.EqualFold(string(segDictName(data, base, cid)), name) {
+			return cid, true
+		}
+	}
+	return segDictSearch(data, base, folded)
+}
+
+// segDictSearch is the authoritative fallback: binary search over the folded-name-sorted id
+// index. `folded` must already be lower-cased.
+func segDictSearch(data []byte, base uint32, folded string) (uint32, bool) {
+	count := le32(data, base)
+	sortedIdOff := le32(data, base+16)
+	lo, hi := uint32(0), count
+	for lo < hi {
+		mid := (lo + hi) / 2
+		id := le32(data, base+sortedIdOff+mid*4)
+		nm := strings.ToLower(string(segDictName(data, base, id)))
+		switch {
+		case nm == folded:
+			return id, true
+		case nm < folded:
+			lo = mid + 1
+		default:
+			hi = mid
+		}
+	}
+	return 0, false
+}

--- a/collections/segdict.go
+++ b/collections/segdict.go
@@ -110,6 +110,30 @@ func (h *segDictHandle) resolve(id uint32) (string, bool) {
 	return "", false
 }
 
+// publishSegDict scans a recovered segment for its dictionary record (an interned segment
+// carries one, appended at compaction/seal via appendDict) and, if found, publishes the
+// segment's dict handle so its records resolve segment-local ids. A segment with no dict record
+// is inline -- seg.dict stays nil. Called during Open before any body decode. The dict record
+// is a trailer, so this walks to it; the walk reads only record headers (no decompress).
+func publishSegDict(seg *segment) {
+	if seg == nil || seg.dict.Load() != nil {
+		return
+	}
+	for off := 0; off < seg.used; {
+		o := uint32(off)
+		total := recTotalLen(seg.data, o)
+		if total == 0 {
+			break
+		}
+		if recIsDict(seg.data, o) {
+			// The keyless dict record's body (the serialized dict) starts after the header + adLen.
+			seg.dict.Store(&segDictHandle{data: seg.data, base: o + recKeyOff + 4})
+			return
+		}
+		off += int(total)
+	}
+}
+
 // segDictCount returns the number of names in the dict at base.
 func segDictCount(data []byte, base uint32) uint32 { return le32(data, base) }
 

--- a/collections/segdict_segment_test.go
+++ b/collections/segdict_segment_test.go
@@ -1,0 +1,92 @@
+package collections
+
+import (
+	"testing"
+
+	"github.com/PelicanPlatform/classad/classad"
+	"github.com/PelicanPlatform/classad/collections/wire"
+)
+
+// TestSegDictRecordInSegment verifies the on-arena dict record: appendDict writes a keyless
+// record that every ordinary walk skips (recIsMarker) yet recovery can find (recIsDict), whose
+// body is a serialized dict a segDictHandle probes zero-copy over the arena -- and an interned
+// data record in the same segment decodes through that handle. This is the interned segment's
+// self-describing layout in miniature.
+func TestSegDictRecordInSegment(t *testing.T) {
+	table := wire.NewInternTable()
+	src := []string{
+		`Memory=4096
+Cpus=8
+Name="slot1@h"
+Requirements=(Arch=="X86_64")`,
+		`Memory=2048
+Cpus=4
+Owner="user"
+Rank=Memory*1.0`,
+	}
+	var recs [][]byte
+	for _, s := range src {
+		ad, err := classad.ParseOld(s)
+		if err != nil {
+			t.Fatal(err)
+		}
+		recs = append(recs, wire.Encode(nil, ad.AST(), table))
+	}
+	dict := appendSegDict(nil, table.Names())
+
+	seg := newSegment(1, 1<<16, identityCodec{})
+	// Dict record first (as the compaction transcode will emit it), then the interned records.
+	dictOff, ok := seg.appendDict(dict)
+	if !ok {
+		t.Fatal("appendDict did not fit")
+	}
+	var recOffs []uint32
+	for i, r := range recs {
+		off, ok := seg.append(uint64(i+1), noLoc, []byte{byte('a' + i)}, r)
+		if !ok {
+			t.Fatal("append record did not fit")
+		}
+		recOffs = append(recOffs, off)
+	}
+
+	// The dict record is a marker (skipped by every ordinary walk) AND a dict (found by
+	// recovery), keyless, and its body is exactly the serialized dict.
+	if !recIsMarker(seg.data, dictOff) || !recIsDict(seg.data, dictOff) {
+		t.Fatalf("dict record: recIsMarker=%v recIsDict=%v, want true,true", recIsMarker(seg.data, dictOff), recIsDict(seg.data, dictOff))
+	}
+	if recKeyLen(seg.data, dictOff) != 0 {
+		t.Errorf("dict record keyLen=%d, want 0", recKeyLen(seg.data, dictOff))
+	}
+	if string(recAd(seg.data, dictOff)) != string(dict) {
+		t.Errorf("dict record body != serialized dict")
+	}
+
+	// A handle over the arena at the dict body's offset resolves names and backs a resolver
+	// decode of the interned data records -- identical to a table-backed decode.
+	h := &segDictHandle{data: seg.data, base: recStart(seg.data, dictOff)}
+	if int(h.count()) != len(table.Names()) {
+		t.Fatalf("handle count=%d want %d", h.count(), len(table.Names()))
+	}
+	for i, off := range recOffs {
+		if recIsMarker(seg.data, off) {
+			t.Fatalf("data record %d wrongly reads as marker", i)
+		}
+		got, err := wire.DecodeResolve(recAd(seg.data, off), h.resolve)
+		if err != nil {
+			t.Fatalf("rec %d DecodeResolve: %v", i, err)
+		}
+		ref, err := wire.Decode(recs[i], table)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(wire.EncodeInline(nil, ref)) != string(wire.EncodeInline(nil, got)) {
+			t.Errorf("rec %d: handle-decode != table-decode", i)
+		}
+	}
+}
+
+// recStart returns the arena offset of a record's ad body -- the probe base for a dict record.
+func recStart(b []byte, off uint32) uint32 {
+	kl := recKeyLen(b, off)
+	return off + recKeyOff + kl + 4 // skip header, (empty) key, adLen u32
+}

--- a/collections/segdict_test.go
+++ b/collections/segdict_test.go
@@ -1,0 +1,106 @@
+package collections
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// buildDictAt serializes names into a buffer at a non-zero base (a filler prefix) so the test
+// exercises base-relative offset handling exactly as an embedded-in-segment dict would.
+func buildDictAt(names []string, prefix int) ([]byte, uint32) {
+	buf := make([]byte, prefix)
+	for i := range buf {
+		buf[i] = 0xEE
+	}
+	base := uint32(len(buf))
+	return appendSegDict(buf, names), base
+}
+
+func TestSegDictRoundTrip(t *testing.T) {
+	names := []string{
+		"Memory", "Cpus", "Disk", "Name", "Machine", "Requirements", "Rank",
+		"StartdIpAddr", "OpSysAndVer", "TotalSlotMemory", "X", "A_very_long_attribute_name_indeed",
+	}
+	data, base := buildDictAt(names, 37)
+
+	if got := segDictCount(data, base); int(got) != len(names) {
+		t.Fatalf("count=%d want %d", got, len(names))
+	}
+	for id, want := range names {
+		// id -> name
+		if got := string(segDictName(data, base, uint32(id))); got != want {
+			t.Errorf("segDictName(%d)=%q want %q", id, got, want)
+		}
+		// name -> id, canonical casing
+		if got, ok := segDictLookup(data, base, want); !ok || got != uint32(id) {
+			t.Errorf("lookup(%q)=%d,%v want %d,true", want, got, ok, id)
+		}
+		// name -> id, case-insensitive
+		for _, cased := range []string{strings.ToUpper(want), strings.ToLower(want)} {
+			if got, ok := segDictLookup(data, base, cased); !ok || got != uint32(id) {
+				t.Errorf("lookup(%q)=%d,%v want %d,true (case-insensitive)", cased, got, ok, id)
+			}
+		}
+	}
+	// absent names
+	for _, absent := range []string{"", "Nope", "Memoryy", "emory", "Zzz"} {
+		if got, ok := segDictLookup(data, base, absent); ok {
+			t.Errorf("lookup(%q)=%d,true but should be absent", absent, got)
+		}
+	}
+	// out-of-range id
+	if segDictName(data, base, uint32(len(names))) != nil {
+		t.Errorf("segDictName(out-of-range) should be nil")
+	}
+}
+
+func TestSegDictEmpty(t *testing.T) {
+	data, base := buildDictAt(nil, 8)
+	if segDictCount(data, base) != 0 {
+		t.Fatalf("empty dict count != 0")
+	}
+	if _, ok := segDictLookup(data, base, "anything"); ok {
+		t.Errorf("empty dict lookup should miss")
+	}
+	if segDictName(data, base, 0) != nil {
+		t.Errorf("empty dict name(0) should be nil")
+	}
+}
+
+// TestSegDictLarge stresses the MPH (with some keys likely unassigned -> fallback) and the
+// authoritative binary-search path over a high-cardinality dict, verifying every member
+// resolves and a swath of non-members miss.
+func TestSegDictLarge(t *testing.T) {
+	const n = 4000
+	names := make([]string, n)
+	seen := map[string]bool{}
+	for i := 0; i < n; i++ {
+		nm := fmt.Sprintf("Attr_%d_%x", i, i*2654435761&0xffff)
+		if seen[strings.ToLower(nm)] {
+			t.Fatalf("duplicate folded name in fixture: %q", nm)
+		}
+		seen[strings.ToLower(nm)] = true
+		names[i] = nm
+	}
+	data, base := buildDictAt(names, 3)
+
+	for id, want := range names {
+		got, ok := segDictLookup(data, base, want)
+		if !ok || got != uint32(id) {
+			t.Fatalf("member lookup(%q)=%d,%v want %d", want, got, ok, id)
+		}
+		if got != uint32(id) || string(segDictName(data, base, got)) != want {
+			t.Fatalf("id<->name mismatch at id %d", id)
+		}
+	}
+	misses := 0
+	for i := 0; i < n; i++ {
+		if _, ok := segDictLookup(data, base, fmt.Sprintf("Absent_%d", i)); !ok {
+			misses++
+		}
+	}
+	if misses != n {
+		t.Errorf("expected all %d non-members to miss, got %d misses", n, misses)
+	}
+}

--- a/collections/segdict_wire_test.go
+++ b/collections/segdict_wire_test.go
@@ -1,0 +1,121 @@
+package collections
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/ast"
+	"github.com/PelicanPlatform/classad/classad"
+	"github.com/PelicanPlatform/classad/collections/wire"
+)
+
+// TestSegDictWireRoundTrip is the phase-1 core proof: a record encoded with segment-LOCAL
+// interned ids (a fresh per-segment table) decodes back to an identical ad using ONLY the
+// serialized dictionary as the id->name resolver -- no in-memory InternTable on the read side.
+// This is what makes an interned sealed segment self-contained and heap-free to read.
+func TestSegDictWireRoundTrip(t *testing.T) {
+	src := []string{
+		`Memory=4096
+Cpus=8
+Name="slot1@host.example.org"
+Rank=Memory*1.5+Cpus
+Requirements=(Arch=="X86_64")&&(OpSys=="LINUX")
+Load=0.75
+Big=true
+Child=[a=1;b="x";Deep=[q=Memory+1]]`,
+		`Memory=2048
+Cpus=4
+Disk=1000000
+Name="slot2@host2"
+Requirements=TARGET.Memory>1024
+StartdIpAddr="<1.2.3.4:9618>"
+Rank=0.0`,
+		`Owner="user"
+JobStatus=2
+Cmd="/bin/sleep"
+Args="600"
+Environment=""`,
+	}
+	pt := wire.NewInternTable()
+	var recs [][]byte
+	var orig []*ast.ClassAd
+	for _, s := range src {
+		ad, err := classad.ParseOld(s)
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		orig = append(orig, ad.AST())
+		recs = append(recs, wire.Encode(nil, ad.AST(), pt))
+	}
+
+	// Serialize the dict from the per-segment table, then read it back through the mmap probe.
+	dict := appendSegDict(nil, pt.Names())
+	resolve := func(id uint32) (string, bool) {
+		b := segDictName(dict, 0, id)
+		if b == nil {
+			return "", false
+		}
+		return string(b), true
+	}
+
+	for i, rec := range recs {
+		got, err := wire.DecodeResolve(rec, resolve)
+		if err != nil {
+			t.Fatalf("rec %d: DecodeResolve: %v", i, err)
+		}
+		// Ground truth: the SAME interned record decoded with the in-memory table. segdict's
+		// job is to be an equivalent id->name resolver, so dict-decode must match table-decode
+		// exactly (this isolates the dict from any interned round-trip quirk of the ad itself).
+		ref, err := wire.Decode(rec, pt)
+		if err != nil {
+			t.Fatalf("rec %d: Decode(table): %v", i, err)
+		}
+		if want, gotB := wire.EncodeInline(nil, ref), wire.EncodeInline(nil, got); !bytes.Equal(want, gotB) {
+			t.Errorf("rec %d: dict-decode != table-decode:\n want %x\n got  %x", i, want, gotB)
+		}
+		_ = orig
+	}
+
+	// Every attribute name the records use must resolve name<->id both ways via the dict.
+	for id := uint32(0); id < segDictCount(dict, 0); id++ {
+		name := string(segDictName(dict, 0, id))
+		if gotID, ok := segDictLookup(dict, 0, name); !ok || gotID != id {
+			t.Errorf("dict name<->id inconsistency: id=%d name=%q -> %d,%v", id, name, gotID, ok)
+		}
+	}
+}
+
+// TestSegDictWireRoundTripCorpus runs the same round-trip over a segment's worth of real
+// OSPool slot ads when the corpus is present (skips otherwise).
+func TestSegDictWireRoundTripCorpus(t *testing.T) {
+	ads, _ := loadOSPoolAds(t)
+	if len(ads) > 300 {
+		ads = ads[:300]
+	}
+	pt := wire.NewInternTable()
+	recs := make([][]byte, len(ads))
+	for i, a := range ads {
+		recs[i] = wire.Encode(nil, a.AST(), pt)
+	}
+	dict := appendSegDict(nil, pt.Names())
+	resolve := func(id uint32) (string, bool) {
+		if b := segDictName(dict, 0, id); b != nil {
+			return string(b), true
+		}
+		return "", false
+	}
+	for i, rec := range recs {
+		got, err := wire.DecodeResolve(rec, resolve)
+		if err != nil {
+			t.Fatalf("rec %d: %v", i, err)
+		}
+		ref, err := wire.Decode(rec, pt)
+		if err != nil {
+			t.Fatalf("rec %d: Decode(table): %v", i, err)
+		}
+		if !bytes.Equal(wire.EncodeInline(nil, ref), wire.EncodeInline(nil, got)) {
+			t.Fatalf("rec %d: dict-decode != table-decode", i)
+		}
+	}
+	t.Logf("round-tripped %d real ads through a %d-name dict (%d bytes)", len(recs), segDictCount(dict, 0), len(dict))
+}

--- a/collections/segment.go
+++ b/collections/segment.go
@@ -51,7 +51,14 @@ const (
 	// length and existing on-disk records (flag clear) read as ordinary records --
 	// the discriminator is backward compatible and needs no header growth.
 	markerFlag = uint32(1) << 31
-	keyLenMask = markerFlag - 1
+	// dictFlag (the next bit down) marks the per-segment attribute DICTIONARY record of an
+	// interned segment (see segdict.go / interning): a keyless record whose body is the
+	// serialized segDict. It also sets markerFlag, so every marker-skipping walk skips it
+	// uniformly; dictFlag lets recovery recognize it (vs a time checkpoint) and publish the
+	// segment's dict. Real keys are tiny, so masking the low 30 bits still yields the true
+	// key length for ordinary records.
+	dictFlag   = uint32(1) << 30
+	keyLenMask = dictFlag - 1
 
 	noSeg  = ^uint32(0)
 	seqMax = ^uint64(0)
@@ -122,6 +129,13 @@ type segment struct {
 	// atomically (like idx); a scan reads it lock-free and uses colSegment.offs to map a
 	// block record back to its arena offset for the MVCC visibility check.
 	colblk atomic.Pointer[colSegment]
+
+	// dict is this segment's per-segment attribute dictionary when the segment is INTERNED
+	// (interning: records carry segment-local ids, resolved to names via this dict). nil means
+	// the segment is inline-name encoded (the legacy/default form). Published once -- at the
+	// compaction transcode that produced the interned segment, or at load from the segment's
+	// dictFlag record -- and read lock-free to dispatch decode (segDictHandle over the mmap).
+	dict atomic.Pointer[segDictHandle]
 
 	// Persistent (mmap) segments only; nil/zero for RAM segments. See mmapseg.go.
 	// The file name is independent of the logical id (id == array index, reassigned
@@ -484,6 +498,38 @@ func (s *segment) appendMarker(seq uint64, millis uint64) (uint32, bool) {
 	return uint32(off), true
 }
 
+// appendDict writes an interned segment's dictionary record: a keyless record whose body is
+// the serialized segDict `dict`. Its keyLen field carries markerFlag|dictFlag so every
+// marker-skipping walk ignores it while recovery (recIsDict) can find it and publish the
+// segment's dict. seq is irrelevant to reads (a marker is never visible) -- 0 is used. The
+// caller holds the shard lock; returns the record offset (where the dict body's probe base is
+// recAd(off)) and false if it does not fit.
+func (s *segment) appendDict(dict []byte) (uint32, bool) {
+	rl := recordLen(0, len(dict))
+	off := s.used
+	if off+rl > len(s.data) {
+		return 0, false
+	}
+	b := s.data[off : off+rl]
+	s.used = off + rl
+	binary.LittleEndian.PutUint64(b[recSeqOff:], 0)
+	binary.LittleEndian.PutUint64(b[recSupOff:], seqMax)
+	binary.LittleEndian.PutUint32(b[recNextSegOff:], noSeg)
+	binary.LittleEndian.PutUint32(b[recNextOffOff:], 0)
+	binary.LittleEndian.PutUint32(b[recTotalLenOff:], uint32(rl))
+	binary.LittleEndian.PutUint32(b[recKeyLenOff:], markerFlag|dictFlag) // keyless; skipped like a marker
+	adLenOff := recKeyOff
+	binary.LittleEndian.PutUint32(b[adLenOff:], uint32(len(dict)))
+	copy(b[adLenOff+4:], dict)
+	if s.persistent {
+		crcOff := adLenOff + 4 + len(dict)
+		binary.LittleEndian.PutUint32(b[crcOff:], recCRC(b, crcOff))
+	}
+	// Not live data: count as dead so dead>=used accounting is unaffected by the dict.
+	s.dead += int64(rl)
+	return uint32(off), true
+}
+
 // supersedeRec marks the record at off superseded at seq: it stamps the field, adds
 // its bytes to the dead total, and advances maxSup. Caller holds the shard write lock.
 // This is the one place a record leaves the "current" set, so the scan-pruning
@@ -582,9 +628,17 @@ func recIsMarker(b []byte, off uint32) bool {
 }
 
 // recMarkerMillis reads a marker's wall-clock payload (unixMillis). Only valid when
-// recIsMarker(b, off) is true.
+// recIsMarker(b, off) is true AND recIsDict(b, off) is false (a dict record also sets
+// markerFlag but carries a serialized dict, not a millis payload).
 func recMarkerMillis(b []byte, off uint32) uint64 {
 	return binary.LittleEndian.Uint64(recAd(b, off))
+}
+
+// recIsDict reports whether the record at off is an interned segment's dictionary record
+// (its body is the serialized segDict). Such a record also sets markerFlag, so ordinary
+// record walks skip it; recovery uses recIsDict to publish the segment's dict instead.
+func recIsDict(b []byte, off uint32) bool {
+	return binary.LittleEndian.Uint32(b[off+recKeyLenOff:])&dictFlag != 0
 }
 
 func recKey(b []byte, off uint32) []byte {

--- a/collections/shard.go
+++ b/collections/shard.go
@@ -563,6 +563,16 @@ type segWindow struct {
 	zones map[uint32]zoneRange // sealed segment's zone map (nil ⇒ never prunable)
 }
 
+// dict is the window's segment attribute dictionary when the segment is interned, else nil
+// (inline/global -- decode via the legacy path). Loaded lock-free; callers pass it to the
+// dict-aware decode/eval touchpoints. Nil-safe for a window with no backing segment.
+func (w segWindow) dict() *segDictHandle {
+	if w.seg == nil {
+		return nil
+	}
+	return w.seg.dict.Load()
+}
+
 // snapshot captures the shard's scan state under the read lock: the commit
 // sequence S0 and a frozen window over each live segment. The windows hold the
 // segments' immutable backing arrays directly. A RAM segment retired by a later
@@ -618,8 +628,9 @@ func releaseWindows(wins []segWindow) {
 // codec they were compressed with) of each record visible at S0
 // (seq <= S0 < supersededBySeq) — exactly one version per key that existed at S0.
 // fn returns false to stop early.
-func forEachVisible(s0 uint64, wins []segWindow, fn func(ad []byte, codec Codec) bool) {
+func forEachVisible(s0 uint64, wins []segWindow, fn func(ad []byte, codec Codec, dict *segDictHandle) bool) {
 	for _, w := range wins {
+		d := w.dict()
 		for off := 0; off < w.used; {
 			o := uint32(off)
 			total := recTotalLen(w.data, o)
@@ -633,7 +644,7 @@ func forEachVisible(s0 uint64, wins []segWindow, fn func(ad []byte, codec Codec)
 			seq := recSeq(w.data, o)
 			sup := recSuperseded(w.data, o)
 			if seq <= s0 && sup > s0 {
-				if !fn(recAd(w.data, o), w.codec) {
+				if !fn(recAd(w.data, o), w.codec, d) {
 					return
 				}
 			}
@@ -645,8 +656,9 @@ func forEachVisible(s0 uint64, wins []segWindow, fn func(ad []byte, codec Codec)
 // forEachVisibleKeyed is forEachVisible that also passes each record's key (a
 // view into the frozen window; the callback must not retain it). Used by the
 // chained scan, which needs a record's key to find its parent.
-func forEachVisibleKeyed(s0 uint64, wins []segWindow, fn func(key, ad []byte, codec Codec) bool) {
+func forEachVisibleKeyed(s0 uint64, wins []segWindow, fn func(key, ad []byte, codec Codec, dict *segDictHandle) bool) {
 	for _, w := range wins {
+		d := w.dict()
 		for off := 0; off < w.used; {
 			o := uint32(off)
 			total := recTotalLen(w.data, o)
@@ -660,7 +672,7 @@ func forEachVisibleKeyed(s0 uint64, wins []segWindow, fn func(key, ad []byte, co
 			seq := recSeq(w.data, o)
 			sup := recSuperseded(w.data, o)
 			if seq <= s0 && sup > s0 {
-				if !fn(recKey(w.data, o), recAd(w.data, o), w.codec) {
+				if !fn(recKey(w.data, o), recAd(w.data, o), w.codec, d) {
 					return
 				}
 			}
@@ -676,10 +688,11 @@ func forEachVisibleKeyed(s0 uint64, wins []segWindow, fn func(key, ad []byte, co
 // collected in a single forward pass, then replayed in reverse -- so the whole
 // walk is still O(records), just with a per-segment offset slice. A caller that
 // stops early after K records therefore receives the K most recently appended.
-func forEachVisibleKeyedReverse(s0 uint64, wins []segWindow, fn func(key, ad []byte, codec Codec) bool) {
+func forEachVisibleKeyedReverse(s0 uint64, wins []segWindow, fn func(key, ad []byte, codec Codec, dict *segDictHandle) bool) {
 	var offs []uint32 // reused across windows
 	for wi := len(wins) - 1; wi >= 0; wi-- {
 		w := wins[wi]
+		d := w.dict()
 		offs = offs[:0]
 		for off := 0; off < w.used; {
 			o := uint32(off)
@@ -698,7 +711,7 @@ func forEachVisibleKeyedReverse(s0 uint64, wins []segWindow, fn func(key, ad []b
 			seq := recSeq(w.data, o)
 			sup := recSuperseded(w.data, o)
 			if seq <= s0 && sup > s0 {
-				if !fn(recKey(w.data, o), recAd(w.data, o), w.codec) {
+				if !fn(recKey(w.data, o), recAd(w.data, o), w.codec, d) {
 					return
 				}
 			}

--- a/collections/shard.go
+++ b/collections/shard.go
@@ -394,20 +394,20 @@ func (sh *shard) writeMarker(seq, millis uint64) bool {
 
 // get returns a private copy of the current ad bytes for key and the codec they
 // were compressed with, or (nil, nil, false).
-func (sh *shard) get(h uint64, key []byte) ([]byte, Codec, bool) {
+func (sh *shard) get(h uint64, key []byte) ([]byte, Codec, *segDictHandle, bool) {
 	sh.mu.RLock()
 	defer sh.mu.RUnlock()
 	l, ok := sh.findCurrent(sh.dirGet(h), key)
 	if !ok {
 		if l, ok = sh.lookupSealed(key, h); !ok {
-			return nil, nil, false
+			return nil, nil, nil, false
 		}
 	}
 	seg := sh.segs[l.seg]
 	ad := recAd(seg.data, l.off)
 	out := make([]byte, len(ad))
 	copy(out, ad)
-	return out, seg.codec, true
+	return out, seg.codec, seg.dict.Load(), true
 }
 
 // forEachSealedRecord calls fn for every record in this shard's SEALED, indexed

--- a/collections/store.go
+++ b/collections/store.go
@@ -694,11 +694,11 @@ func (c *Collection) Delete(key []byte) bool {
 func (c *Collection) Get(key []byte) (*classad.ClassAd, bool) {
 	h := c.h.Hash(key)
 	sh := c.shards[c.shardOf(key, h)]
-	stored, codec, ok := sh.get(h, key)
+	stored, codec, dict, ok := sh.get(h, key)
 	if !ok {
 		return nil, false
 	}
-	ad, err := c.decodeAd(stored, codec)
+	ad, err := c.decodeAdDict(dict, stored, codec)
 	if err != nil {
 		return nil, false
 	}
@@ -707,8 +707,8 @@ func (c *Collection) Get(key []byte) (*classad.ClassAd, bool) {
 	if c.parentKeyFor != nil {
 		if pk := c.parentKeyFor(key); pk != nil {
 			ph := c.h.Hash(pk)
-			if pad, pcodec, ok := sh.get(ph, pk); ok {
-				if parent, err := c.decodeAd(pad, pcodec); err == nil {
+			if pad, pcodec, pdict, ok := sh.get(ph, pk); ok {
+				if parent, err := c.decodeAdDict(pdict, pad, pcodec); err == nil {
 					c.mergeParent(ad, parent)
 				}
 			}

--- a/collections/store.go
+++ b/collections/store.go
@@ -755,7 +755,7 @@ func (c *Collection) Keys() []string {
 	var out []string
 	for _, sh := range c.shards {
 		s0, wins := sh.snapshot()
-		forEachVisibleKeyed(s0, wins, func(key, _ []byte, _ Codec) bool {
+		forEachVisibleKeyed(s0, wins, func(key, _ []byte, _ Codec, _ *segDictHandle) bool {
 			if c.isStructural != nil && c.isStructural(key) {
 				return true // parent-only ads are hidden, as in Scan
 			}
@@ -921,7 +921,7 @@ func (c *Collection) scanShardAt(sh *shard, s0 uint64, qp queryPlan, emit func(w
 func (c *Collection) scanWindows(s0 uint64, wins []segWindow, qp queryPlan, emit func(w []byte) bool) bool {
 	cont := true
 	var dbuf []byte // decompression buffer reused across ads (single-threaded scan)
-	visit := func(key, ad []byte, codec Codec) bool {
+	visit := func(key, ad []byte, codec Codec, dict *segDictHandle) bool {
 		if isSystemKeyBytes(key) {
 			return true // internal system record: hidden from client scans/queries
 		}
@@ -930,6 +930,12 @@ func (c *Collection) scanWindows(s0 uint64, wins []segWindow, qp queryPlan, emit
 			return true // skip a record we cannot decode rather than abort the scan
 		}
 		dbuf = w // retain the (possibly grown) backing for the next ad
+		// Publish the record's segment dict on the wireScope so the match eval resolves an
+		// interned segment's ids (nil for inline; ws is nil on a plain no-query scan). The
+		// emit consumer gets the dict via a separate channel (emit-widening; TODO make-live).
+		if qp.ws != nil {
+			qp.ws.dict = dict
+		}
 		if qp.q != nil && !matchWire(w, qp) {
 			return true
 		}
@@ -999,14 +1005,18 @@ func (c *Collection) scanShardChained(sh *shard, qp queryPlan, yield func(*class
 
 	// Pass 1: collect structural (parent) ads' decompressed wire bytes. Parents
 	// are few (one per family), so this map stays small.
-	parents := map[string][]byte{}
-	forEachVisibleKeyed(s0, wins, func(key, ad []byte, codec Codec) bool {
+	parents := map[string]parentWire{}
+	forEachVisibleKeyed(s0, wins, func(key, ad []byte, codec Codec, dict *segDictHandle) bool {
 		if isSystemKeyBytes(key) {
 			return true // internal system record: never a family parent
 		}
 		if c.isStructural != nil && c.isStructural(key) {
 			if w, err := codec.Decompress(nil, ad); err == nil {
-				parents[string(key)] = w // owns its buffer (nil dst)
+				// Capture the parent's segment dict too: the parent may live in an interned
+				// segment while the child is inline (or a different interned segment), and
+				// pass 2 resolves the parent's wire through THIS dict. Same snapshot pins the
+				// segment, so the handle stays valid across both passes.
+				parents[string(key)] = parentWire{w: w, dict: dict} // owns its buffer (nil dst)
 			}
 		}
 		return true
@@ -1015,7 +1025,7 @@ func (c *Collection) scanShardChained(sh *shard, qp queryPlan, yield func(*class
 	// Pass 2: evaluate children (and standalone ads); skip structural ads.
 	cont := true
 	var dbuf []byte
-	forEachVisibleKeyed(s0, wins, func(key, ad []byte, codec Codec) bool {
+	forEachVisibleKeyed(s0, wins, func(key, ad []byte, codec Codec, dict *segDictHandle) bool {
 		if isSystemKeyBytes(key) {
 			return true // internal system record: hidden from client scans/queries
 		}
@@ -1028,20 +1038,24 @@ func (c *Collection) scanShardChained(sh *shard, qp queryPlan, yield func(*class
 		}
 		dbuf = w
 		var parentW []byte
+		var parentDict *segDictHandle
 		if pk := c.parentKeyFor(key); pk != nil {
-			parentW = parents[string(pk)]
+			if pe, ok := parents[string(pk)]; ok {
+				parentW, parentDict = pe.w, pe.dict
+			}
 		}
 		qp.ws.parent = wire.Ad(parentW) // nil ⇒ no parent
+		qp.ws.dict, qp.ws.parentDict = dict, parentDict
 		if qp.q != nil && !matchWire(w, qp) {
 			return true
 		}
-		a, err := c.decodeWire(w)
+		a, err := c.decodeWireDict(dict, w)
 		if err != nil {
 			return true
 		}
 		child := classad.FromAST(a)
 		if parentW != nil {
-			if pa, err := c.decodeWire(parentW); err == nil {
+			if pa, err := c.decodeWireDict(parentDict, parentW); err == nil {
 				c.mergeParent(child, classad.FromAST(pa))
 			}
 		}
@@ -1051,8 +1065,16 @@ func (c *Collection) scanShardChained(sh *shard, qp queryPlan, yield func(*class
 		}
 		return true
 	})
-	qp.ws.parent = nil
+	qp.ws.parent, qp.ws.dict, qp.ws.parentDict = nil, nil, nil
 	return cont
+}
+
+// parentWire is a captured chained-parent ad's decompressed wire bytes plus the segment
+// dictionary needed to resolve them (nil for an inline/global parent). Held only for the
+// lifetime of one scanShardChained snapshot, which pins the parent's segment.
+type parentWire struct {
+	w    []byte
+	dict *segDictHandle
 }
 
 // yieldAd is the emit callback for the classic Query/Scan path: decode w to a
@@ -1158,14 +1180,17 @@ func (c *Collection) CollectSamples(max int) [][]byte {
 			break
 		}
 		s0, wins := sh.snapshot()
-		forEachVisible(s0, wins, func(ad []byte, codec Codec) bool {
+		forEachVisible(s0, wins, func(ad []byte, codec Codec, dict *segDictHandle) bool {
 			w, err := codec.Decompress(buf[:0], ad)
 			if err != nil {
 				return true
 			}
 			buf = w
-			cp := make([]byte, len(w))
-			copy(cp, w)
+			// Samples are consumed later (schema build / ForEachNamed) with no segment in
+			// scope, so an interned record must be flattened to inline wire now.
+			iw := c.wireToInline(dict, w)
+			cp := make([]byte, len(iw))
+			copy(cp, iw)
 			out = append(out, cp)
 			return len(out) < max
 		})

--- a/collections/store.go
+++ b/collections/store.go
@@ -1082,21 +1082,21 @@ func matchWire(w []byte, qp queryPlan) bool {
 		// A queried attribute was a non-literal expression; fall back.
 	}
 	if qp.plan.PartialSafe {
-		child := partialDecodeWire(qp.ws.ctx, w, qp.plan.Seeds)
+		child := partialDecodeWire(qp.ws.ctx, qp.ws.dict, w, qp.plan.Seeds)
 		if qp.ws.parent != nil {
 			// The child inherits any seed it lacks from the parent, so decode the
 			// same seeds from the parent and chain.
-			child.SetParent(partialDecodeWire(qp.ws.ctx, []byte(qp.ws.parent), qp.plan.Seeds))
+			child.SetParent(partialDecodeWire(qp.ws.ctx, qp.ws.parentDict, []byte(qp.ws.parent), qp.plan.Seeds))
 		}
 		return qp.m.Matches(child)
 	}
-	a, err := qp.ws.ctx.decodeWire(w)
+	a, err := decodeWireDictCtx(qp.ws.ctx, qp.ws.dict, w)
 	if err != nil {
 		return false
 	}
 	child := classad.FromAST(a)
 	if qp.ws.parent != nil {
-		if pa, err := qp.ws.ctx.decodeWire([]byte(qp.ws.parent)); err == nil {
+		if pa, err := decodeWireDictCtx(qp.ws.ctx, qp.ws.parentDict, []byte(qp.ws.parent)); err == nil {
 			child.SetParent(classad.FromAST(pa))
 		}
 	}
@@ -1108,7 +1108,7 @@ func matchWire(w []byte, qp queryPlan) bool {
 // bytes without materializing its other (potentially many) attributes. An
 // attribute the ad lacks is simply omitted, so a reference to it evaluates to
 // undefined — exactly as it would against a full decode.
-func partialDecodeWire(ctx wireCtx, w []byte, seeds []string) *classad.ClassAd {
+func partialDecodeWire(ctx wireCtx, dict *segDictHandle, w []byte, seeds []string) *classad.ClassAd {
 	a := wire.Ad(w)
 	out := classad.New()
 	done := make(map[string]bool, len(seeds))
@@ -1121,11 +1121,11 @@ func partialDecodeWire(ctx wireCtx, w []byte, seeds []string) *classad.ClassAd {
 			continue
 		}
 		done[fold] = true
-		node, ok := ctx.wireLookup(a, name)
+		node, ok := wireLookupDictCtx(ctx, dict, a, name)
 		if !ok {
 			continue // this ad lacks it -> undefined
 		}
-		expr, err := ctx.decodeNode(node)
+		expr, err := decodeNodeDictCtx(ctx, dict, node)
 		if err != nil {
 			continue
 		}

--- a/collections/store.go
+++ b/collections/store.go
@@ -795,6 +795,13 @@ func (c *Collection) Scan() iter.Seq[*classad.ClassAd] {
 
 // queryPlan bundles a compiled query with everything a scan needs to evaluate it,
 // including reusable per-scan state.
+// scanEmit consumes each visible record's decompressed wire bytes w and its segment dict
+// (nil for an inline/global segment; non-nil resolves segment-local interned ids). The
+// consumer decodes/renders w -- via dict when set -- so one scan path serves Query, QueryRaw,
+// projection, and aggregates over both inline and interned segments. w aliases a reused
+// buffer; the consumer must not retain it.
+type scanEmit = func(w []byte, dict *segDictHandle) bool
+
 type queryPlan struct {
 	q        *vm.Query
 	plan     vm.ReadPlan
@@ -901,7 +908,7 @@ func (c *Collection) Query(q *vm.Query) iter.Seq[*classad.ClassAd] {
 // Decoding w (to a *classad.ClassAd, or straight to wire text for QueryRaw) is the
 // caller's job, so one scan path serves both Query and QueryRaw. w aliases a
 // reused buffer -- emit must not retain it.
-func (c *Collection) scanShard(sh *shard, qp queryPlan, emit func(w []byte) bool) bool {
+func (c *Collection) scanShard(sh *shard, qp queryPlan, emit scanEmit) bool {
 	s0, wins := sh.snapshot()
 	defer releaseWindows(wins)
 	return c.scanWindows(s0, wins, qp, emit)
@@ -910,7 +917,7 @@ func (c *Collection) scanShard(sh *shard, qp queryPlan, emit func(w []byte) bool
 // scanShardAt is scanShard for a historical snapshot sequence s0 (point-in-time / AS
 // OF queries): it scans the versions visible at s0 rather than the current commit
 // sequence.
-func (c *Collection) scanShardAt(sh *shard, s0 uint64, qp queryPlan, emit func(w []byte) bool) bool {
+func (c *Collection) scanShardAt(sh *shard, s0 uint64, qp queryPlan, emit scanEmit) bool {
 	wins := sh.snapshotAt(s0)
 	defer releaseWindows(wins)
 	return c.scanWindows(s0, wins, qp, emit)
@@ -918,7 +925,7 @@ func (c *Collection) scanShardAt(sh *shard, s0 uint64, qp queryPlan, emit func(w
 
 // scanWindows match-tests and emits the visible records of a frozen window set at
 // snapshot s0. Shared by the current-time and AS OF scan paths.
-func (c *Collection) scanWindows(s0 uint64, wins []segWindow, qp queryPlan, emit func(w []byte) bool) bool {
+func (c *Collection) scanWindows(s0 uint64, wins []segWindow, qp queryPlan, emit scanEmit) bool {
 	cont := true
 	var dbuf []byte // decompression buffer reused across ads (single-threaded scan)
 	visit := func(key, ad []byte, codec Codec, dict *segDictHandle) bool {
@@ -939,7 +946,7 @@ func (c *Collection) scanWindows(s0 uint64, wins []segWindow, qp queryPlan, emit
 		if qp.q != nil && !matchWire(w, qp) {
 			return true
 		}
-		if !emit(w) {
+		if !emit(w, dict) {
 			cont = false
 			return false
 		}
@@ -1079,9 +1086,9 @@ type parentWire struct {
 
 // yieldAd is the emit callback for the classic Query/Scan path: decode w to a
 // *classad.ClassAd (skipping malformed records) and yield it.
-func (c *Collection) yieldAd(yield func(*classad.ClassAd) bool) func(w []byte) bool {
-	return func(w []byte) bool {
-		a, err := c.decodeWire(w)
+func (c *Collection) yieldAd(yield func(*classad.ClassAd) bool) scanEmit {
+	return func(w []byte, dict *segDictHandle) bool {
+		a, err := c.decodeWireDict(dict, w)
 		if err != nil {
 			return true // skip malformed record, keep scanning
 		}

--- a/collections/truncate.go
+++ b/collections/truncate.go
@@ -62,11 +62,11 @@ func (c *Collection) ForEachAd(fn func(key string, ad *classad.ClassAd) bool) {
 	for _, sh := range c.shards {
 		s0, wins := sh.snapshot()
 		stop := false
-		forEachVisibleKeyed(s0, wins, func(key, ad []byte, codec Codec) bool {
+		forEachVisibleKeyed(s0, wins, func(key, ad []byte, codec Codec, dict *segDictHandle) bool {
 			if isSystemKeyBytes(key) {
 				return true // internal system record: hidden from client iteration
 			}
-			decoded, err := c.decodeAd(ad, codec)
+			decoded, err := c.decodeAdDict(dict, ad, codec)
 			if err != nil {
 				return true // skip an undecodable record rather than abort the backup
 			}
@@ -91,11 +91,11 @@ func (c *Collection) ForEachSystemAd(fn func(key string, ad *classad.ClassAd) bo
 	for _, sh := range c.shards {
 		s0, wins := sh.snapshot()
 		stop := false
-		forEachVisibleKeyed(s0, wins, func(key, ad []byte, codec Codec) bool {
+		forEachVisibleKeyed(s0, wins, func(key, ad []byte, codec Codec, dict *segDictHandle) bool {
 			if !isSystemKeyBytes(key) {
 				return true // only system records
 			}
-			decoded, err := c.decodeAd(ad, codec)
+			decoded, err := c.decodeAdDict(dict, ad, codec)
 			if err != nil {
 				return true // skip an undecodable record rather than abort the sweep
 			}

--- a/collections/txn.go
+++ b/collections/txn.go
@@ -45,20 +45,20 @@ func (sh *shard) findVisible(head loc, key []byte, s0 uint64) (loc, bool) {
 
 // getAt returns a private copy of key's ad bytes as of snapshot s0, or (nil, nil,
 // false) if the key had no version live at s0.
-func (sh *shard) getAt(h uint64, key []byte, s0 uint64) ([]byte, Codec, bool) {
+func (sh *shard) getAt(h uint64, key []byte, s0 uint64) ([]byte, Codec, *segDictHandle, bool) {
 	sh.mu.RLock()
 	defer sh.mu.RUnlock()
 	l, ok := sh.findVisible(sh.dirGet(h), key, s0)
 	if !ok {
 		if l, ok = sh.lookupSealedAt(key, h, s0); !ok {
-			return nil, nil, false
+			return nil, nil, nil, false
 		}
 	}
 	seg := sh.segs[l.seg]
 	ad := recAd(seg.data, l.off)
 	out := make([]byte, len(ad))
 	copy(out, ad)
-	return out, seg.codec, true
+	return out, seg.codec, seg.dict.Load(), true
 }
 
 // conflictSince reports whether key was modified after snapshot s0 -- the write-
@@ -285,11 +285,11 @@ func (tx *Txn) getOwn(key []byte) (*classad.ClassAd, bool) {
 	h := tx.c.h.Hash(key)
 	idx := tx.c.shardOf(key, h)
 	s0 := tx.snapOf(idx)
-	stored, codec, ok := tx.c.shards[idx].getAt(h, key, s0)
+	stored, codec, dict, ok := tx.c.shards[idx].getAt(h, key, s0)
 	if !ok {
 		return nil, false
 	}
-	ad, err := tx.c.decodeAd(stored, codec)
+	ad, err := tx.c.decodeAdDict(dict, stored, codec)
 	if err != nil {
 		return nil, false
 	}

--- a/collections/watch.go
+++ b/collections/watch.go
@@ -600,9 +600,9 @@ func (c *Collection) seedParentSig() map[string]map[string]string {
 	}
 	for _, sh := range c.shards {
 		s0, wins := sh.snapshot()
-		forEachVisibleKeyed(s0, wins, func(key, ad []byte, codec Codec) bool {
+		forEachVisibleKeyed(s0, wins, func(key, ad []byte, codec Codec, dict *segDictHandle) bool {
 			if c.isStructural(key) {
-				if pad, err := c.decodeAd(ad, codec); err == nil {
+				if pad, err := c.decodeAdDict(dict, ad, codec); err == nil {
 					sig[string(key)] = c.nonPrivateSig(pad)
 				}
 			}
@@ -638,16 +638,19 @@ func (c *Collection) fanoutChildren(parent rawEvent, sig map[string]map[string]s
 	s0, wins := sh.snapshot()
 	defer releaseWindows(wins)
 	var out []rawEvent
-	forEachVisibleKeyed(s0, wins, func(k, ad []byte, codec Codec) bool {
+	forEachVisibleKeyed(s0, wins, func(k, ad []byte, codec Codec, dict *segDictHandle) bool {
 		if c.isStructural != nil && c.isStructural(k) {
 			return true
 		}
 		if pk := c.parentKeyFor(k); pk != nil && bytes.Equal(pk, parent.key) {
+			// This event's ad bytes outlive the scan (decoded later by watchAd, when the
+			// segment/dict is gone), so make an interned record self-contained now.
+			sc := c.toSelfContained(dict, ad, codec)
 			out = append(out, rawEvent{
 				shard: parent.shard,
 				seq:   parent.seq,
 				key:   append([]byte(nil), k...),
-				ad:    append([]byte(nil), ad...),
+				ad:    append([]byte(nil), sc...),
 				codec: codec,
 			})
 		}

--- a/collections/watch.go
+++ b/collections/watch.go
@@ -542,8 +542,8 @@ func (c *Collection) watchAd(key, rawAd []byte, codec Codec) (*classad.ClassAd, 
 		if pk := c.parentKeyFor(key); pk != nil {
 			ph := c.h.Hash(pk)
 			sh := c.shards[c.shardOf(pk, ph)]
-			if pad, pcodec, ok := sh.get(ph, pk); ok {
-				if parent, err := c.decodeAd(pad, pcodec); err == nil {
+			if pad, pcodec, pdict, ok := sh.get(ph, pk); ok {
+				if parent, err := c.decodeAdDict(pdict, pad, pcodec); err == nil {
 					c.mergeParent(ad, parent)
 				}
 			}

--- a/collections/wire/accessor.go
+++ b/collections/wire/accessor.go
@@ -485,6 +485,14 @@ func DecodeNode(node []byte, t *InternTable) (ast.Expr, error) {
 	return d.node(0)
 }
 
+// DecodeNodeResolve decodes raw node bytes from an interned ad (as returned by Lookup),
+// resolving interned ids via `resolve` instead of an *InternTable -- e.g. backed by a sealed
+// segment's mmap dictionary. Counterpart to DecodeNode for the per-segment interned path.
+func DecodeNodeResolve(node []byte, resolve func(uint32) (string, bool)) (ast.Expr, error) {
+	d := &decoder{b: node, resolve: resolve}
+	return d.node(0)
+}
+
 // DecodeNodeInline decodes raw node bytes from an inline-names ad (as returned by
 // LookupByName), which need no intern table.
 func DecodeNodeInline(node []byte) (ast.Expr, error) {

--- a/collections/wire/decode.go
+++ b/collections/wire/decode.go
@@ -47,6 +47,29 @@ func Decode(b []byte, t *InternTable) (*ast.ClassAd, error) {
 	return d.adBody(0)
 }
 
+// DecodeResolve parses an interned ad (Encode/EncodeWithHot), resolving attribute ids to
+// names via `resolve` instead of an *InternTable -- e.g. backed by a sealed segment's mmap
+// dictionary (id -> name), so no in-memory table is materialized to read the segment. The ad
+// must be interned (not inline -- those are self-contained, use DecodeInline; not standalone).
+// The resolver is inherited by nested ad decoders, so it covers sub-ads too.
+func DecodeResolve(b []byte, resolve func(uint32) (string, bool)) (*ast.ClassAd, error) {
+	if resolve == nil {
+		return nil, fmt.Errorf("%w: interned ad requires a resolver", ErrMalformed)
+	}
+	d := &decoder{b: b, resolve: resolve}
+	flags, err := d.headerFlags()
+	if err != nil {
+		return nil, err
+	}
+	if flags&flagStandalone != 0 {
+		return nil, fmt.Errorf("%w: standalone ad; use DecodeStandalone", ErrMalformed)
+	}
+	if flags&flagInlineNames != 0 {
+		return nil, fmt.Errorf("%w: inline ad; use DecodeInline", ErrMalformed)
+	}
+	return d.adBody(0)
+}
+
 // DecodeInline parses a self-contained inline-names ad (EncodeInline), requiring no
 // intern table.
 func DecodeInline(b []byte) (*ast.ClassAd, error) {

--- a/collections/wire/intern.go
+++ b/collections/wire/intern.go
@@ -165,6 +165,11 @@ func (t *InternTable) Len() int {
 
 // snapshotNames returns a copy of the id->name slice, for embedding a standalone
 // intern table into a self-contained ad.
+// Names returns the canonical (first-seen casing) names in id order, so Names()[id]
+// is the name for id. Re-interning these in order into an empty table reproduces the
+// exact id assignment -- the basis for serializing/reloading the table.
+func (t *InternTable) Names() []string { return t.snapshotNames() }
+
 func (t *InternTable) snapshotNames() []string {
 	canon := *t.canon.Load()
 	out := make([]string, len(canon))

--- a/collections/wireeval.go
+++ b/collections/wireeval.go
@@ -28,6 +28,42 @@ type wireScope struct {
 	parent   wire.Ad // the chained parent ad's wire bytes, or nil (no parent)
 	ctx      wireCtx // for mode-aware attribute lookup (interned id vs inline name)
 	fellBack bool
+	// dict / parentDict are the segment dictionaries of ad / parent when those come from an
+	// INTERNED segment (records carry segment-local ids); nil => inline/global via ctx. ad and
+	// its chained parent may live in different segments, hence two handles. Set per record by
+	// the scan alongside ad/parent; the dict-aware touchpoints (wireLookupDictCtx etc.) resolve
+	// through them so an interned segment filters/decodes correctly.
+	dict       *segDictHandle
+	parentDict *segDictHandle
+}
+
+// wireLookupDictCtx / decodeNodeDictCtx / decodeWireDictCtx are the dict-aware wire touchpoints
+// used across the wire-native match path. When dict != nil the ad is interned with
+// segment-local ids (resolve name->id via the dict, then Lookup(id); decode via the resolver);
+// else they fall to the mode-aware ctx (inline/global) -- byte-for-byte the prior behavior.
+func wireLookupDictCtx(ctx wireCtx, dict *segDictHandle, a wire.Ad, name string) ([]byte, bool) {
+	if dict != nil {
+		id, ok := dict.lookup(name)
+		if !ok {
+			return nil, false
+		}
+		return a.Lookup(id)
+	}
+	return ctx.wireLookup(a, name)
+}
+
+func decodeNodeDictCtx(ctx wireCtx, dict *segDictHandle, node []byte) (ast.Expr, error) {
+	if dict != nil {
+		return wire.DecodeNodeResolve(node, dict.resolve)
+	}
+	return ctx.decodeNode(node)
+}
+
+func decodeWireDictCtx(ctx wireCtx, dict *segDictHandle, w []byte) (*ast.ClassAd, error) {
+	if dict != nil {
+		return wire.DecodeResolve(w, dict.resolve)
+	}
+	return ctx.decodeWire(w)
 }
 
 // resolve is the attribute resolver handed to vm.Matcher.EvalResolved.
@@ -41,16 +77,16 @@ func (ws *wireScope) resolve(name string, scope ast.AttributeScope) classad.Valu
 		if ws.parent == nil {
 			return classad.NewUndefinedValue()
 		}
-		v, _ := ws.tryResolve(ws.parent, name)
+		v, _ := ws.tryResolve(ws.parent, ws.parentDict, name)
 		return v
 	default:
 		// Unscoped: this ad, then fall through to its parent (chaining), matching
 		// the ClassAd evaluator's parent walk.
-		if v, found := ws.tryResolve(ws.ad, name); found {
+		if v, found := ws.tryResolve(ws.ad, ws.dict, name); found {
 			return v
 		}
 		if ws.parent != nil {
-			if v, found := ws.tryResolve(ws.parent, name); found {
+			if v, found := ws.tryResolve(ws.parent, ws.parentDict, name); found {
 				return v
 			}
 		}
@@ -63,8 +99,8 @@ func (ws *wireScope) resolve(name string, scope ast.AttributeScope) classad.Valu
 // non-literal value sets fellBack (the caller retries with a full decode) and
 // still counts as found -- the ad has the attribute, it just can't be read from
 // wire alone.
-func (ws *wireScope) tryResolve(ad wire.Ad, name string) (classad.Value, bool) {
-	node, ok := ws.ctx.wireLookup(ad, name)
+func (ws *wireScope) tryResolve(ad wire.Ad, dict *segDictHandle, name string) (classad.Value, bool) {
+	node, ok := wireLookupDictCtx(ws.ctx, dict, ad, name)
 	if !ok {
 		return classad.NewUndefinedValue(), false
 	}


### PR DESCRIPTION
Phase 1 of **interning persistent segments**: a persistent, plaintext collection now writes its sealed segments in an **interned** form — records carry small segment-local attribute ids and each segment carries its own attribute **dictionary** — instead of repeating attribute *names* inline in every record. On by default; existing inline segments stay readable and convert as they compact.

Measured on the OSPool corpus: interning is **−56% decompressed size** and **~26% faster decode**; per-segment dictionaries cost ≤1% on disk vs a global table at realistic segment sizes while keeping each segment self-contained. (Full rationale, the per-segment-vs-global measurement, and the MPH-vs-map decision are in `collections/docs/design/interning-persistent-segments.md`.)

## How it works
- **Dictionary** (`segdict.go`): each sealed segment embeds a serialized dict — `name→id` via an mmap **MPH** (`mph.go`) with an authoritative sorted fallback, `id→name` via an offset table — probed zero-copy, **no per-segment Go heap**. It rides the segment as a marker-flagged **dict record** (`dictFlag`), so every existing record walk skips it and the segment stays self-describing.
- **Write (compaction transcode)**: `compactShard` decodes each source record (via its own segment's mode — inline or already-interned), re-encodes it against a per-destination-segment intern table, and appends the dict at finalize (`appendDict` + publish `seg.dict`). A dict reserve (`min(256KB, segSize/4)`) keeps room for the trailer; a decode failure or reserve overflow **aborts the round** (reap dest files, leave the shard uncompacted) so a segment is never left unreadable. Gated on `c.inline && c.sealer==nil && !sh.appendOnly`.
- **Read (dict-complete)**: the scan/emit path, wire-native match eval (`wireScope.dict`/`parentDict`), parallel + index + raw paths, point lookups (`Get`/`getAt`), sealed-index build (`attrNode`), and the adschema columnar block build all resolve segment-local ids via the segment's dict; the rarer raw-render / negotiator paths flatten to inline (`wireToInline`) at entry. Deferred captures (watch events, `CollectSamples`) flatten to self-contained inline while the dict is in scope. All of this was landed **no-op first** (dicts nil) so each step kept the suite green.
- **Recovery**: `publishSegDict` restores each segment's dict from its dict record before any body decode, and demotes an interned segment that recovery picked as the active write target.

## Validation
- **Full `collections` suite green with interning on by default** — the existing persistent compact/retrain + crash/clean reopen tests exercise the transcode, proving it MVCC-correct and recovery-safe. `db` + `dbrpc` suites green.
- **`TestInterningEndToEnd`**: asserts *every sealed segment is interned* (proves interning happens, not just that data stays correct), and Get/Scan/Query(filter)/ScanRaw all return correct results over current + superseded records across shards — before and after reopen.
- **`TestInterningSchemaScan`**: the adschema columnar scan matches the query engine over interned segments.

## Not in this PR (follow-ups)
- Hot-header on the interned encode (compaction uses plain `wire.Encode`, so interned match lookups linear-scan — restore the O(1) accelerator with `EncodeWithHot` + local hot ids).
- Corrupt-dict auto-rebuild (the dict record is CRC-protected, but a corrupt one truncates the segment rather than triggering a rebuild).
- Tighten the dict reserve to the actual dict size.
- Interning for append-only segments (they use `resealAppendOnly`, not compaction).
- Phase 2 (interned + encryption), phase 3 (recompaction-to-interned migration + retire the inline write path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
