### PR TITLE
collections: intern append-only (archive) segments at reseal

### DIFF
--- a/collections/interning_appendonly_test.go
+++ b/collections/interning_appendonly_test.go
@@ -1,0 +1,103 @@
+package collections
+
+import (
+	"fmt"
+	"testing"
+)
+
+// TestAppendOnlyInterning is the acceptance test for interning append-only (archive)
+// collections: RetrainDict reseals each segment INTERNED (asserted via seg.dict), and reads --
+// full scan, filtered query, and zone-pruned range query -- stay correct over those interned
+// segments, before and after a reopen (recovery restores the dicts and recomputes zone maps
+// dict-aware). Ts is monotonic so its per-segment [min,max] zones are disjoint and a range
+// query genuinely prunes segments; a wrong (dict-blind) zone extraction would mis-prune and
+// change the count.
+func TestAppendOnlyInterning(t *testing.T) {
+	if !mmapSupported {
+		t.Skip("persistence is unix-only")
+	}
+	dir := t.TempDir()
+	const n = 4000
+	// AppendOnly + a value-indexed attr (Ts) -> zone maps; small segments -> several sealed.
+	c, err := Open(Options{AppendOnly: true, Dir: dir, SegmentSize: 1 << 16, ValueAttrs: []string{"Ts"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < n; i++ {
+		if err := c.Put([]byte(fmt.Sprintf("k%05d", i)),
+			mustAd(t, fmt.Sprintf("[Id=%d; Ts=%d; Val=%d; Host=\"h%d.example.org\"]", i, i, i%100, i))); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Retrain the dictionary -> reseal every segment (now interned + recompressed).
+	if _, err := c.RetrainDict(n); err != nil {
+		t.Fatalf("RetrainDict: %v", err)
+	}
+
+	assertInterned := func(tag string, col *Collection) {
+		sealed, interned := 0, 0
+		for _, sh := range col.shards {
+			sh.mu.RLock()
+			act := sh.act
+			for _, seg := range sh.segs {
+				if seg == nil || seg == act || seg.used == 0 {
+					continue
+				}
+				sealed++
+				if seg.dict.Load() != nil {
+					interned++
+				}
+			}
+			sh.mu.RUnlock()
+		}
+		if sealed == 0 || interned != sealed {
+			t.Fatalf("%s: %d/%d sealed segments interned (want all)", tag, interned, sealed)
+		}
+		t.Logf("%s: %d sealed segments, all interned", tag, sealed)
+	}
+
+	verify := func(tag string, col *Collection) {
+		// Full scan: exactly n records (append-only keeps every version; keys are unique here).
+		total := 0
+		ids := map[int]int{}
+		for a := range col.Scan() {
+			total++
+			id, _ := a.EvaluateAttrInt("Id")
+			ids[int(id)]++
+		}
+		if total != n || len(ids) != n {
+			t.Fatalf("%s: scan total=%d distinct=%d want %d", tag, total, len(ids), n)
+		}
+		// Filtered query (Val>=50 -> half).
+		cnt := 0
+		for range col.Query(mustQuery(t, "Val >= 50")) {
+			cnt++
+		}
+		if cnt != n/2 {
+			t.Fatalf("%s: Query(Val>=50)=%d want %d", tag, cnt, n/2)
+		}
+		// Zone-pruned range query on the monotonic Ts: Ts >= 3000 -> ids [3000,3999] = 1000.
+		zc := 0
+		for range col.Query(mustQuery(t, "Ts >= 3000")) {
+			zc++
+		}
+		if zc != n-3000 {
+			t.Fatalf("%s: Query(Ts>=3000)=%d want %d (zone pruning mis-extracted?)", tag, zc, n-3000)
+		}
+	}
+
+	assertInterned("post-retrain", c)
+	verify("post-retrain", c)
+	if err := c.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	c2, err := Open(Options{AppendOnly: true, Dir: dir, SegmentSize: 1 << 16, ValueAttrs: []string{"Ts"}})
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer c2.Close()
+	assertInterned("post-reopen", c2)
+	verify("post-reopen", c2)
+}

--- a/collections/persist.go
+++ b/collections/persist.go
@@ -390,7 +390,7 @@ func (c *Collection) loadShard(sh *shard, shardDir string) (uint64, error) {
 			// Recompute the sealed segment's zone map (not persisted separately; cheap to
 			// rebuild from the segment's own records). No-op unless append-only + ZoneAttrs.
 			if sh.appendOnly && len(sh.zoneAttrs) > 0 && seg.zones == nil {
-				seg.zones = computeSegZones(seg.data, seg.used, sh.zoneAttrs, sh.zoneInline, seg.codec)
+				seg.zones = computeSegZones(seg.data, seg.used, sh.zoneAttrs, sh.zoneInline, seg.dict.Load(), seg.codec)
 			}
 			if c.loadSealedIndex(seg, spec) {
 				// Phase 3: the segment's keys are now reachable through the sealed

--- a/collections/retrain_appendonly.go
+++ b/collections/retrain_appendonly.go
@@ -1,5 +1,7 @@
 package collections
 
+import "github.com/PelicanPlatform/classad/collections/wire"
+
 // Append-only recompression. The mutable store recompresses (RetrainDict) and repacks
 // (Rewrite) via compaction -- a live-copy that supersedes old versions, renumbers
 // segments, and rebuilds the key directory. None of that is legal for an append log,
@@ -80,10 +82,35 @@ func (c *Collection) resealOneSegment(sh *shard, src *segment, targetCodec Codec
 	if src == nil || src.used == 0 {
 		return nil
 	}
+	// A persistent, plaintext collection reseals INTERNED: records carry segment-local ids
+	// against a per-segment table + a hot header, and the segment gets a dictionary appended at
+	// the end (see segdict.go / the interning design). In-memory (already global-interned) and
+	// encrypted (only inline has a sealing encoder) reseal via c.encodeAd as before. The two-pass
+	// build means the table is fully populated before the dict is sized, so the segment is sized
+	// EXACTLY -- no dict reserve/waste (unlike the streaming compaction transcode).
+	intern := c.inline && c.sealer == nil
+	var table *wire.InternTable
+	hot := map[uint32]struct{}{}
+	lastLen := 0
+	refreshHot := func() { // add local ids of hot attr names now in the table (case-preserving)
+		if table.Len() == lastLen {
+			return
+		}
+		for name := range c.currentHotNames() {
+			if id, ok := table.LookupID(name); ok {
+				hot[id] = struct{}{}
+			}
+		}
+		lastLen = table.Len()
+	}
+	if intern {
+		table = wire.NewInternTable()
+	}
 	// Pass 1: decode + re-encode + recompress every record, computing the exact size the
 	// new segment needs so it fits in a single segment (append order is 1:1).
 	var entries []resealEntry
 	total := 0
+	var wireBuf []byte
 	for off := 0; off < src.used; {
 		o := uint32(off)
 		rl := recTotalLen(src.data, o)
@@ -104,17 +131,30 @@ func (c *Collection) resealOneSegment(sh *shard, src *segment, targetCodec Codec
 		if err != nil {
 			return nil
 		}
-		ad, err := c.decodeWire(wireBytes)
+		ad, err := c.decodeWireDict(src.dict.Load(), wireBytes) // honor the source's own encoding
 		if err != nil {
 			return nil
 		}
-		stored := targetCodec.Compress(nil, c.encodeAd(ad))
+		var stored []byte
+		if intern {
+			wireBuf = wire.EncodeWithHot(wireBuf[:0], ad, table, hot)
+			refreshHot()
+			stored = targetCodec.Compress(nil, wireBuf)
+		} else {
+			stored = targetCodec.Compress(nil, c.encodeAd(ad))
+		}
 		entries = append(entries, resealEntry{seq: seq, key: key, stored: stored})
 		total += recordLen(len(key), len(stored))
 		off += int(rl)
 	}
 	if total == 0 {
 		return nil
+	}
+	// The dict (interned only) is a trailing record; size the segment to include it exactly.
+	var dictBytes []byte
+	if intern {
+		dictBytes = appendSegDict(nil, table.Names())
+		total += recordLen(0, len(dictBytes))
 	}
 
 	// Allocate a new same-id segment sized to the recompressed data (rounded up by the
@@ -144,6 +184,15 @@ func (c *Collection) resealOneSegment(sh *shard, src *segment, targetCodec Codec
 		if _, ok := newseg.append(e.seq, noLoc, e.key, e.stored); !ok {
 			return nil
 		}
+	}
+	// Interned: append the dictionary as a trailing record and publish the segment's dict so its
+	// records resolve their segment-local ids.
+	if intern {
+		doff, ok := newseg.appendDict(dictBytes)
+		if !ok {
+			return nil
+		}
+		newseg.dict.Store(&segDictHandle{data: newseg.data, base: doff + recKeyOff + 4})
 	}
 	// Persistent segments: flush the written extent so recovery sees a complete segment.
 	if newseg.persistent {

--- a/collections/sealed_index.go
+++ b/collections/sealed_index.go
@@ -142,7 +142,7 @@ func (c *Collection) rezoneSealed(sh *shard, seg *segment) {
 	if !appendOnly || len(attrs) == 0 {
 		return
 	}
-	zones := computeSegZones(seg.data, seg.used, attrs, inline, seg.codec)
+	zones := computeSegZones(seg.data, seg.used, attrs, inline, seg.dict.Load(), seg.codec)
 	sh.mu.Lock()
 	seg.zones = zones
 	sh.mu.Unlock()

--- a/collections/zonemap.go
+++ b/collections/zonemap.go
@@ -29,7 +29,7 @@ type zoneAttr struct {
 // encodes records (persistent collections store inline names; in-memory ones store
 // interned ids). Returns nil when no zone attributes are configured. Caller holds the
 // shard write lock (seal) or runs single-threaded during Open (reopen).
-func computeSegZones(data []byte, upto int, attrs []zoneAttr, inline bool, codec Codec) map[uint32]zoneRange {
+func computeSegZones(data []byte, upto int, attrs []zoneAttr, inline bool, dict *segDictHandle, codec Codec) map[uint32]zoneRange {
 	if len(attrs) == 0 {
 		return nil
 	}
@@ -51,9 +51,14 @@ func computeSegZones(data []byte, upto int, attrs []zoneAttr, inline bool, codec
 			for _, za := range attrs {
 				var node []byte
 				var ok bool
-				if inline {
+				switch {
+				case dict != nil: // interned segment: resolve the zone attr's segment-local id
+					if id, has := dict.lookup(za.name); has {
+						node, ok = ad.Lookup(id)
+					}
+				case inline:
 					node, ok = ad.LookupByName(za.name)
-				} else {
+				default:
 					node, ok = ad.Lookup(za.id)
 				}
 				if !ok {
@@ -137,5 +142,5 @@ func (sh *shard) sealZones(seg *segment) {
 	if seg == nil || !sh.appendOnly || len(sh.zoneAttrs) == 0 || seg.zones != nil {
 		return
 	}
-	seg.zones = computeSegZones(seg.data, seg.used, sh.zoneAttrs, sh.zoneInline, seg.codec)
+	seg.zones = computeSegZones(seg.data, seg.used, sh.zoneAttrs, sh.zoneInline, seg.dict.Load(), seg.codec)
 }


### PR DESCRIPTION
Follow-on to #114 (interning persistent segments). Extends interning to **append-only collections** — the job-history archive, the largest persistent data, which #114 left inline (it uses `resealOneSegment`, not compaction).

## Change
- **`resealOneSegment`** (RetrainDict's per-segment rewrite) now transcodes **interned** on a persistent, plaintext collection: each record is re-encoded with a hot header against a per-segment `InternTable`, and the dictionary is appended as a trailing record with `seg.dict` published. Because the reseal is **two-pass over a single segment** (no MVCC/rolling), the table is fully populated before the dict is sized, so the segment is sized **exactly** — no dict reserve/waste, unlike the streaming compaction transcode in #114. The source is decoded via its own mode (`decodeWireDict`), so re-resealing an already-interned segment works.
- **`computeSegZones`** is dict-aware: an interned archive segment's `[min,max]` zone maps (rebuilt at seal, reseal, and reopen) resolve each zone attribute's segment-local id via the segment dict, so **range-query segment pruning** still works over interned archives.
- Recovery already publishes `seg.dict` for every segment (`publishSegDict`), append-only included.

## Test
`TestAppendOnlyInterning`: an append-only collection with a value-indexed `Ts`; after `RetrainDict` every sealed segment is interned (asserted via `seg.dict`), and full scan, a filtered query, and a **zone-pruned range query** on the monotonic `Ts` all return correct counts — before and after reopen. A dict-blind zone extraction would mis-prune and change the count, so this validates the zone path specifically.

Full collections + db + dbrpc suites green.

## Notes
- Interning activates on **RetrainDict** (the archive's dict-retrain cadence), matching #114's "convert on rewrite" model — not at initial seal. At-seal interning for append-only would be a further step.
- Encrypted append-only collections stay inline (only inline has a sealing encoder — phase 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
