### PR TITLE
collections: intern encryption-at-rest segments

### DIFF
--- a/collections/colscan.go
+++ b/collections/colscan.go
@@ -28,6 +28,12 @@ type schemaScanState struct {
 // with no state/block a query takes the normal row path, so a collection that never calls this
 // is unaffected. Reads immutable sealed bytes only.
 func (c *Collection) EnableSchemaScan(s *adSchema, hot []int) {
+	if c.sealer != nil {
+		// A columnar block stores attribute values in the clear; over an encryption-at-rest
+		// collection it would materialize sealed values as plaintext on disk. The two are
+		// mutually exclusive -- an encrypted collection always takes the row path.
+		return
+	}
 	st := c.schemaScan.Load()
 	if st == nil || st.schema != s {
 		bc, err := newBlockCache(256 << 20) // ~256 MiB of decompressed blocks
@@ -62,6 +68,9 @@ func (c *Collection) EnableSchemaScan(s *adSchema, hot []int) {
 // scan over the sealed segments. Returns false if there is nothing to sample. Re-callable to
 // pick up newly-sealed segments (existing blocks are kept).
 func (c *Collection) BuildAndEnableSchemaScan(sampleMax, hotTopN int) bool {
+	if c.sealer != nil {
+		return false // see EnableSchemaScan: incompatible with encryption at rest
+	}
 	// Already enabled: keep the stable schema and hot set chosen at first enable, and just
 	// extend coverage to any segments sealed since (their blocks are built against this same
 	// schema, so nothing is orphaned). Rebuilding a fresh schema here would give every new

--- a/collections/compact.go
+++ b/collections/compact.go
@@ -423,7 +423,7 @@ func (c *Collection) compactShard(sh *shard, target Codec) {
 	// inline or already-interned (re-compaction) -- each record is decoded via its own segment
 	// mode. abort stops the round on a decode failure or dict-reserve overflow so a shard is
 	// never left with an unreadable segment.
-	intern := c.inline && c.sealer == nil && !sh.appendOnly
+	intern := c.inline && !sh.appendOnly
 	// reserve is the arena held back for the dict, capped to a quarter of the segment so a
 	// segment always fits many records plus its dict (compactDictReserve alone could exceed a
 	// small SegmentSize and force one record per segment). A dict larger than the reserve
@@ -490,7 +490,7 @@ func (c *Collection) compactShard(sh *shard, target Codec) {
 			*curp = newDst(streamSegs, 0, target)
 			*st = newStream()
 		}
-		wireBuf = wire.EncodeWithHot(wireBuf[:0], ad, st.table, st.hot)
+		wireBuf = c.encodeInterned(wireBuf[:0], ad, st.table, st.hot)
 		refreshHot(st) // pick up any hot names this ad interned, for later records
 		body := target.Compress(encBuf[:0], wireBuf)
 		encBuf = body
@@ -499,7 +499,7 @@ func (c *Collection) compactShard(sh *shard, target Codec) {
 			finalizeInterned(*curp, st)
 			*curp = newDst(streamSegs, rl+reserve, target)
 			*st = newStream()
-			wireBuf = wire.EncodeWithHot(wireBuf[:0], ad, st.table, st.hot)
+			wireBuf = c.encodeInterned(wireBuf[:0], ad, st.table, st.hot)
 			refreshHot(st)
 			body = target.Compress(encBuf[:0], wireBuf)
 			encBuf = body

--- a/collections/inline.go
+++ b/collections/inline.go
@@ -99,15 +99,28 @@ func (c *Collection) recordToInternedDict(dict *segDictHandle, dst, w []byte) ([
 // not the collection's global table. These wrappers take the segment's dict handle and, when
 // it is non-nil, resolve through it (zero-copy over the mmap); a nil handle means the segment
 // is inline/global -- the legacy path, byte-for-byte unchanged. Scan/read call sites thread
-// the segment's dict (segment.dict.Load()) from the visibility window. An interned segment is
-// never encrypted (encrypted collections keep sealing inline), so the resolver path needs no
-// sealer.
+// the segment's dict (segment.dict.Load()) from the visibility window. An interned segment of
+// an encryption-at-rest collection carries SEALED value nodes, so the resolver paths pass the
+// collection's sealer to open them (nil for a plaintext collection -- opens nothing).
 
 func (c *Collection) decodeWireDict(dict *segDictHandle, w []byte) (*ast.ClassAd, error) {
 	if dict != nil {
-		return wire.DecodeResolve(w, dict.resolve)
+		// c.sealer is nil for a plaintext collection (opens nothing) and set for an
+		// encrypted one (opens the sealed value nodes an interned+encrypted segment carries).
+		return wire.DecodeResolveEnc(w, dict.resolve, c.sealer)
 	}
 	return c.decodeWire(w)
+}
+
+// encodeInterned encodes ad in the form the compaction/reseal transcode writes an interned
+// segment: segment-local ids against `table` with a hot header, sealing designated attribute
+// values when the collection encrypts at rest. Mirrors encodeAd's persistent branch, but
+// interned rather than inline.
+func (c *Collection) encodeInterned(dst []byte, ad *ast.ClassAd, table *wire.InternTable, hot map[uint32]struct{}) []byte {
+	if c.sealer != nil {
+		return wire.EncodeWithHotEnc(dst, ad, table, hot, c.shouldEncrypt, c.sealer)
+	}
+	return wire.EncodeWithHot(dst, ad, table, hot)
 }
 
 func (c *Collection) wireLookupDict(dict *segDictHandle, a wire.Ad, name string) ([]byte, bool) {
@@ -123,7 +136,7 @@ func (c *Collection) wireLookupDict(dict *segDictHandle, a wire.Ad, name string)
 
 func (c *Collection) decodeNodeDict(dict *segDictHandle, node []byte) (ast.Expr, error) {
 	if dict != nil {
-		return wire.DecodeNodeResolve(node, dict.resolve)
+		return wire.DecodeNodeResolveEnc(node, dict.resolve, c.sealer)
 	}
 	return c.decodeNode(node)
 }
@@ -138,7 +151,7 @@ func (c *Collection) decodeAdDict(dict *segDictHandle, stored []byte, codec Code
 	if err != nil {
 		return nil, err
 	}
-	a, err := wire.DecodeResolve(dec, dict.resolve)
+	a, err := wire.DecodeResolveEnc(dec, dict.resolve, c.sealer)
 	if err != nil {
 		return nil, err
 	}
@@ -153,9 +166,14 @@ func (c *Collection) wireToInline(dict *segDictHandle, w []byte) []byte {
 	if dict == nil {
 		return w
 	}
-	a, err := wire.DecodeResolve(w, dict.resolve)
+	a, err := c.decodeWireDict(dict, w) // sealer-aware: opens sealed values for an encrypted segment
 	if err != nil {
 		return w
+	}
+	if c.sealer != nil {
+		// Re-seal on the way to inline so the sample never carries plaintext values (which would
+		// leak into a retrained dict or a columnar block); matches the active segment's form.
+		return wire.EncodeInlineWithHotEnc(nil, a, nil, c.shouldEncrypt, c.sealer)
 	}
 	return wire.EncodeInline(nil, a)
 }
@@ -178,9 +196,13 @@ func (c *Collection) toSelfContained(dict *segDictHandle, ad []byte, codec Codec
 	if err != nil {
 		return ad
 	}
-	a, err := wire.DecodeResolve(dec, dict.resolve)
+	a, err := c.decodeWireDict(dict, dec) // sealer-aware: opens sealed values for an encrypted segment
 	if err != nil {
 		return ad
+	}
+	if c.sealer != nil {
+		// Re-seal so a deferred event's copied bytes stay sealed at rest, matching the source.
+		return codec.Compress(nil, wire.EncodeInlineWithHotEnc(nil, a, nil, c.shouldEncrypt, c.sealer))
 	}
 	return codec.Compress(nil, wire.EncodeInline(nil, a))
 }

--- a/collections/interning_encrypted_test.go
+++ b/collections/interning_encrypted_test.go
@@ -1,0 +1,357 @@
+package collections
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestEncryptedInterning is the phase-2 acceptance test: an encryption-at-rest collection now
+// INTERNS its segments at compaction (interned ids + a plaintext name dictionary + SEALED value
+// nodes). Reads decrypt correctly over the interned+encrypted segments (before and after a
+// reopen), and the secret value never appears in plaintext in any segment file.
+func TestEncryptedInterning(t *testing.T) {
+	if !mmapSupported {
+		t.Skip("persistence is unix-only")
+	}
+	dir := t.TempDir()
+	_, dataKey := deriveDataKey(t)
+	const secret = "ClaimId-super-secret-capability-9f83a2b7c1"
+	const n = 3000
+
+	open := func() *Collection {
+		c, err := Open(Options{
+			Shards: 2, Dir: dir, SegmentSize: 1 << 16,
+			DataKey:        dataKey,
+			EncryptedAttrs: []string{"Secret"},
+			ValueAttrs:     []string{"Val"}, // plaintext attr still indexes
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return c
+	}
+	c := open()
+	for i := 0; i < n; i++ {
+		if err := c.Put([]byte(fmt.Sprintf("k%05d", i)),
+			mustAd(t, fmt.Sprintf("[Id=%d; Val=%d; Secret=%q]", i, i%100, secret))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Force interning via compaction (encrypted collections are mutable).
+	for _, sh := range c.shards {
+		c.compactShard(sh, c.currentCodec())
+	}
+	c.reindexAfterCompaction()
+
+	assertInterned := func(tag string, col *Collection) {
+		sealed, interned := 0, 0
+		for _, sh := range col.shards {
+			sh.mu.RLock()
+			act := sh.act
+			for _, seg := range sh.segs {
+				if seg == nil || seg == act || seg.used == 0 {
+					continue
+				}
+				sealed++
+				if seg.dict.Load() != nil {
+					interned++
+				}
+			}
+			sh.mu.RUnlock()
+		}
+		if sealed == 0 || interned != sealed {
+			t.Fatalf("%s: %d/%d sealed interned (want all)", tag, interned, sealed)
+		}
+		t.Logf("%s: %d sealed segments, all interned+encrypted", tag, sealed)
+	}
+	verify := func(tag string, col *Collection) {
+		for i := 0; i < n; i++ {
+			a, ok := col.Get([]byte(fmt.Sprintf("k%05d", i)))
+			if !ok {
+				t.Fatalf("%s: Get k%05d missing", tag, i)
+			}
+			if v, _ := a.EvaluateAttrInt("Id"); int(v) != i {
+				t.Fatalf("%s: Id=%d want %d", tag, v, i)
+			}
+			if s, _ := a.EvaluateAttrString("Secret"); s != secret { // decrypted correctly
+				t.Fatalf("%s: Secret=%q not decrypted", tag, s)
+			}
+		}
+		cnt := 0
+		for range col.Query(mustQuery(t, "Val >= 50")) { // query on the plaintext attr
+			cnt++
+		}
+		if cnt != n/2 {
+			t.Fatalf("%s: Query(Val>=50)=%d want %d", tag, cnt, n/2)
+		}
+	}
+	// The secret value must not appear in plaintext in ANY segment file on disk.
+	assertSealedOnDisk := func(tag string) {
+		var files []string
+		filepath.WalkDir(dir, func(p string, d os.DirEntry, err error) error {
+			if err == nil && !d.IsDir() && filepath.Ext(p) == ".dat" {
+				files = append(files, p)
+			}
+			return nil
+		})
+		if len(files) == 0 {
+			t.Fatalf("%s: no segment files found", tag)
+		}
+		for _, p := range files {
+			b, err := os.ReadFile(p)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if bytes.Contains(b, []byte(secret)) {
+				t.Fatalf("%s: secret found in plaintext in %s (not sealed!)", tag, filepath.Base(p))
+			}
+		}
+	}
+
+	assertInterned("post-compact", c)
+	verify("post-compact", c)
+	assertSealedOnDisk("post-compact")
+
+	// The sample path (CollectSamples -> hot-set refresh / dict retrain) runs over the interned
+	// segments now. It must open+re-seal, never emitting the plaintext secret into a retrained
+	// zstd dictionary or leaving it in a sample. Retrain, then re-check disk + reads.
+	c.RefreshHotSet(2000, 8)
+	if _, err := c.RetrainDict(2000); err != nil {
+		t.Fatal(err)
+	}
+	verify("post-retrain", c)
+	assertSealedOnDisk("post-retrain")
+	if err := c.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	c2 := open()
+	assertInterned("post-reopen", c2)
+	verify("post-reopen", c2)
+	assertSealedOnDisk("post-reopen")
+	c2.Close()
+
+	// Wrong key over an interned+encrypted segment: the plaintext name dictionary still resolves
+	// ids, but every sealed value node fails to open -- decode must error cleanly (no panic) and
+	// the secret is never recovered.
+	_, wrongKey := deriveDataKey(t)
+	bad, err := Open(Options{
+		Shards: 2, Dir: dir, SegmentSize: 1 << 16,
+		DataKey: wrongKey, EncryptedAttrs: []string{"Secret"}, ValueAttrs: []string{"Val"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	recovered := 0
+	for i := 0; i < n; i++ {
+		if a, ok := bad.Get([]byte(fmt.Sprintf("k%05d", i))); ok {
+			if s, _ := a.EvaluateAttrString("Secret"); s == secret {
+				recovered++
+			}
+		}
+	}
+	if recovered != 0 {
+		t.Fatalf("wrong key recovered the secret in %d/%d records", recovered, n)
+	}
+	bad.Close()
+}
+
+// TestEncryptedInterningMixed exercises the per-segment dispatch that is the crux of the whole
+// design: a single encrypted collection holding BOTH inline+encrypted segments (recently filled,
+// not yet compacted) and interned+encrypted segments (compacted). Reads must decrypt across the
+// mix -- decodeAdDict routes each segment by seg.dict (nil -> DecodeInlineEnc, non-nil ->
+// DecodeResolveEnc) -- and recovery must restore that same mix (dict only for the interned ones).
+func TestEncryptedInterningMixed(t *testing.T) {
+	if !mmapSupported {
+		t.Skip("persistence is unix-only")
+	}
+	dir := t.TempDir()
+	_, dataKey := deriveDataKey(t)
+	const secret = "ClaimId-mixed-secret-77b3ce01"
+	const n1, n2 = 2000, 2000 // n1 compacted to interned; n2 written after -> inline
+
+	open := func() *Collection {
+		c, err := Open(Options{
+			Shards: 1, Dir: dir, SegmentSize: 1 << 16,
+			DataKey: dataKey, EncryptedAttrs: []string{"Secret"}, ValueAttrs: []string{"Val"},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return c
+	}
+	put := func(c *Collection, lo, hi int) {
+		for i := lo; i < hi; i++ {
+			if err := c.Put([]byte(fmt.Sprintf("k%05d", i)),
+				mustAd(t, fmt.Sprintf("[Id=%d; Val=%d; Secret=%q]", i, i%100, secret))); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	c := open()
+	put(c, 0, n1)
+	for _, sh := range c.shards { // compact the first tranche -> interned+encrypted
+		c.compactShard(sh, c.currentCodec())
+	}
+	c.reindexAfterCompaction()
+	put(c, n1, n1+n2) // write more AFTER compaction -> fresh inline+encrypted sealed segments
+
+	assertMix := func(tag string, col *Collection) {
+		interned, inlineSealed := 0, 0
+		for _, sh := range col.shards {
+			sh.mu.RLock()
+			act := sh.act
+			for _, seg := range sh.segs {
+				if seg == nil || seg == act || seg.used == 0 {
+					continue
+				}
+				if seg.dict.Load() != nil {
+					interned++
+				} else {
+					inlineSealed++
+				}
+			}
+			sh.mu.RUnlock()
+		}
+		if interned == 0 || inlineSealed == 0 {
+			t.Fatalf("%s: want BOTH kinds, got interned=%d inlineSealed=%d", tag, interned, inlineSealed)
+		}
+		t.Logf("%s: %d interned + %d inline sealed segments coexist", tag, interned, inlineSealed)
+	}
+	verify := func(tag string, col *Collection) {
+		for i := 0; i < n1+n2; i++ {
+			a, ok := col.Get([]byte(fmt.Sprintf("k%05d", i)))
+			if !ok {
+				t.Fatalf("%s: Get k%05d missing", tag, i)
+			}
+			if s, _ := a.EvaluateAttrString("Secret"); s != secret {
+				t.Fatalf("%s: Secret at k%05d not decrypted (%q)", tag, i, s)
+			}
+		}
+		cnt := 0
+		for range col.Query(mustQuery(t, "Val >= 50")) {
+			cnt++
+		}
+		if cnt != (n1+n2)/2 {
+			t.Fatalf("%s: Query(Val>=50)=%d want %d", tag, cnt, (n1+n2)/2)
+		}
+	}
+
+	assertMix("pre-reopen", c)
+	verify("pre-reopen", c)
+	if err := c.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	c2 := open() // recovery must restore the same mix: dict for interned segs, nil for inline
+	defer c2.Close()
+	assertMix("post-reopen", c2)
+	verify("post-reopen", c2)
+}
+
+// TestEncryptedInterningAppendOnly is the append-only (archive) analog: an encrypted append-only
+// collection interns its segments at reseal (RetrainDict), sealing values, and reads decrypt.
+func TestEncryptedInterningAppendOnly(t *testing.T) {
+	if !mmapSupported {
+		t.Skip("persistence is unix-only")
+	}
+	dir := t.TempDir()
+	_, dataKey := deriveDataKey(t)
+	const secret = "ClaimId-archive-secret-4a1c9e77"
+	const n = 4000
+
+	open := func() *Collection {
+		c, err := Open(Options{
+			AppendOnly: true, Dir: dir, SegmentSize: 1 << 16,
+			DataKey: dataKey, EncryptedAttrs: []string{"Secret"}, ValueAttrs: []string{"Ts"},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return c
+	}
+	c := open()
+	for i := 0; i < n; i++ {
+		if err := c.Put([]byte(fmt.Sprintf("k%05d", i)),
+			mustAd(t, fmt.Sprintf("[Id=%d; Ts=%d; Val=%d; Secret=%q]", i, i, i%100, secret))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := c.RetrainDict(n); err != nil { // reseal every segment -> interned + encrypted
+		t.Fatalf("RetrainDict: %v", err)
+	}
+
+	assertInterned := func(tag string, col *Collection) {
+		sealed, interned := 0, 0
+		for _, sh := range col.shards {
+			sh.mu.RLock()
+			act := sh.act
+			for _, seg := range sh.segs {
+				if seg == nil || seg == act || seg.used == 0 {
+					continue
+				}
+				sealed++
+				if seg.dict.Load() != nil {
+					interned++
+				}
+			}
+			sh.mu.RUnlock()
+		}
+		if sealed == 0 || interned != sealed {
+			t.Fatalf("%s: %d/%d sealed interned (want all)", tag, interned, sealed)
+		}
+		t.Logf("%s: %d sealed segments, all interned+encrypted", tag, sealed)
+	}
+	verify := func(tag string, col *Collection) {
+		total := 0
+		for a := range col.Scan() {
+			total++
+			if s, _ := a.EvaluateAttrString("Secret"); s != secret {
+				t.Fatalf("%s: Secret=%q not decrypted", tag, s)
+			}
+		}
+		if total != n {
+			t.Fatalf("%s: scan total=%d want %d", tag, total, n)
+		}
+		zc := 0
+		for range col.Query(mustQuery(t, "Ts >= 3000")) { // zone-pruned range on plaintext Ts
+			zc++
+		}
+		if zc != 1000 {
+			t.Fatalf("%s: Query(Ts>=3000)=%d want 1000", tag, zc)
+		}
+	}
+	assertSealedOnDisk := func(tag string) {
+		found := false
+		filepath.WalkDir(dir, func(p string, d os.DirEntry, err error) error {
+			if err != nil || d.IsDir() || filepath.Ext(p) != ".dat" {
+				return nil
+			}
+			found = true
+			b, _ := os.ReadFile(p)
+			if bytes.Contains(b, []byte(secret)) {
+				t.Fatalf("%s: secret found in plaintext in %s", tag, filepath.Base(p))
+			}
+			return nil
+		})
+		if !found {
+			t.Fatalf("%s: no segment files found", tag)
+		}
+	}
+
+	assertInterned("post-reseal", c)
+	verify("post-reseal", c)
+	assertSealedOnDisk("post-reseal")
+	if err := c.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	c2 := open()
+	defer c2.Close()
+	assertInterned("post-reopen", c2)
+	verify("post-reopen", c2)
+	assertSealedOnDisk("post-reopen")
+}

--- a/collections/interning_measure_test.go
+++ b/collections/interning_measure_test.go
@@ -141,6 +141,80 @@ func human(n int) string {
 	return fmt.Sprintf("%dB", n)
 }
 
+// TestInterningSizeTradeoffEncrypted answers whether per-segment interning still pays off for an
+// ENCRYPTION-AT-REST collection, where the designated attributes' values are sealed (AEAD nonce +
+// ciphertext, incompressible) instead of stored in the clear. It seals the realistic HTCondor
+// secrets (claim ids / glidein token / capability) -- a small fraction of value bytes -- and
+// compares inline+enc vs per-segment interned+enc, both zstd'd per segment. The plaintext
+// majority still interns, so the win should track (a bit below) the plaintext-only result.
+func TestInterningSizeTradeoffEncrypted(t *testing.T) {
+	ads, _ := loadOSPoolAds(t)
+	if len(ads) == 0 {
+		t.Skip("no ads")
+	}
+	asts := make([]*ast.ClassAd, len(ads))
+	for i, a := range ads {
+		asts[i] = a.AST()
+	}
+	N := len(asts)
+
+	secret := map[string]struct{}{
+		"PublicClaimId": {}, "ClaimId": {}, "ClaimIds": {}, "Capability": {},
+		"GLIDEIN_CONDOR_TOKEN": {}, "ChildClaimIds": {},
+	}
+	encrypt := func(name string) bool { _, ok := secret[name]; return ok }
+	_, dataKey := deriveDataKey(t)
+	seal := newDataKeySealer(dataKey)
+
+	// Measure how much of the value payload is sealed (context for the win).
+	sealedAds := 0
+	for _, a := range asts {
+		for _, at := range a.Attributes {
+			if encrypt(at.Name) {
+				sealedAds++
+				break
+			}
+		}
+	}
+
+	for _, K := range []int{512, N} {
+		inlRaw, psRaw := 0, 0
+		inlZ, psZ := 0, 0
+		psDictRaw, sealedNodes := 0, 0
+		for lo := 0; lo < N; lo += K {
+			hi := lo + K
+			if hi > N {
+				hi = N
+			}
+			var inlSeg, psRecs []byte
+			pt := wire.NewInternTable()
+			for _, a := range asts[lo:hi] {
+				inlSeg = wire.EncodeInlineWithHotEnc(inlSeg, a, nil, encrypt, seal)
+				psRecs = appendRec(psRecs, wire.EncodeWithHotEnc(nil, a, pt, nil, encrypt, seal))
+				for _, at := range a.Attributes {
+					if encrypt(at.Name) {
+						sealedNodes++
+					}
+				}
+			}
+			pnames := pt.Names()
+			psDictRaw += dictBytes(pnames)
+			psSeg := append(marshalDict(pnames), psRecs...)
+			inlRaw += len(inlSeg)
+			psRaw += len(psSeg)
+			inlZ += len(zstdAll(inlSeg))
+			psZ += len(zstdAll(psSeg))
+		}
+		fmt.Printf("\n===== ENCRYPTED segment size K=%d (%d segments) =====\n", K, (N+K-1)/K)
+		fmt.Printf("  ads with >=1 sealed attr=%d/%d, sealed nodes=%d, per-seg dict total=%s(raw)\n",
+			sealedAds, N, sealedNodes, human(psDictRaw))
+		fmt.Printf("  %-24s raw=%-10s zstd=%-10s\n", "INLINE+enc (names/rec)", human(inlRaw), human(inlZ))
+		fmt.Printf("  %-24s raw=%-10s zstd=%-10s\n", "PER-SEG interned+enc", human(psRaw), human(psZ))
+		fmt.Printf("  --> interning win vs inline+enc:  raw %.1f%% (mmap density / decode)   zstd %.1f%% (on-disk)\n",
+			100*(1-float64(psRaw)/float64(inlRaw)), 100*(1-float64(psZ)/float64(inlZ)))
+	}
+}
+
 // BenchmarkDecodeInlineVsInterned compares full-ad decode cost of an inline record vs an
 // interned one (global table), the read-side speed axis of the tradeoff.
 func BenchmarkDecodeEncodings(b *testing.B) {

--- a/collections/retrain_appendonly.go
+++ b/collections/retrain_appendonly.go
@@ -82,13 +82,14 @@ func (c *Collection) resealOneSegment(sh *shard, src *segment, targetCodec Codec
 	if src == nil || src.used == 0 {
 		return nil
 	}
-	// A persistent, plaintext collection reseals INTERNED: records carry segment-local ids
-	// against a per-segment table + a hot header, and the segment gets a dictionary appended at
-	// the end (see segdict.go / the interning design). In-memory (already global-interned) and
-	// encrypted (only inline has a sealing encoder) reseal via c.encodeAd as before. The two-pass
-	// build means the table is fully populated before the dict is sized, so the segment is sized
-	// EXACTLY -- no dict reserve/waste (unlike the streaming compaction transcode).
-	intern := c.inline && c.sealer == nil
+	// A persistent collection reseals INTERNED: records carry segment-local ids against a
+	// per-segment table + a hot header, and the segment gets a dictionary appended at the end
+	// (see segdict.go / the interning design). Encryption at rest composes -- encodeInterned seals
+	// the designated values while interning the rest. Only an in-memory collection (already
+	// global-interned, c.inline false) reseals via c.encodeAd. The two-pass build means the table
+	// is fully populated before the dict is sized, so the segment is sized EXACTLY -- no dict
+	// reserve/waste (unlike the streaming compaction transcode).
+	intern := c.inline
 	var table *wire.InternTable
 	hot := map[uint32]struct{}{}
 	lastLen := 0
@@ -137,7 +138,7 @@ func (c *Collection) resealOneSegment(sh *shard, src *segment, targetCodec Codec
 		}
 		var stored []byte
 		if intern {
-			wireBuf = wire.EncodeWithHot(wireBuf[:0], ad, table, hot)
+			wireBuf = c.encodeInterned(wireBuf[:0], ad, table, hot)
 			refreshHot()
 			stored = targetCodec.Compress(nil, wireBuf)
 		} else {

--- a/collections/wire/accessor.go
+++ b/collections/wire/accessor.go
@@ -489,7 +489,14 @@ func DecodeNode(node []byte, t *InternTable) (ast.Expr, error) {
 // resolving interned ids via `resolve` instead of an *InternTable -- e.g. backed by a sealed
 // segment's mmap dictionary. Counterpart to DecodeNode for the per-segment interned path.
 func DecodeNodeResolve(node []byte, resolve func(uint32) (string, bool)) (ast.Expr, error) {
-	d := &decoder{b: node, resolve: resolve}
+	return DecodeNodeResolveEnc(node, resolve, nil)
+}
+
+// DecodeNodeResolveEnc is DecodeNodeResolve that opens an nEncrypted node with open (the
+// per-segment interned analog of DecodeNodeInlineEnc). A nil open leaves an encrypted node an
+// error.
+func DecodeNodeResolveEnc(node []byte, resolve func(uint32) (string, bool), open Sealer) (ast.Expr, error) {
+	d := &decoder{b: node, resolve: resolve, open: open}
 	return d.node(0)
 }
 

--- a/collections/wire/decode.go
+++ b/collections/wire/decode.go
@@ -53,10 +53,18 @@ func Decode(b []byte, t *InternTable) (*ast.ClassAd, error) {
 // must be interned (not inline -- those are self-contained, use DecodeInline; not standalone).
 // The resolver is inherited by nested ad decoders, so it covers sub-ads too.
 func DecodeResolve(b []byte, resolve func(uint32) (string, bool)) (*ast.ClassAd, error) {
+	return DecodeResolveEnc(b, resolve, nil)
+}
+
+// DecodeResolveEnc is DecodeResolve for an interned ad that may contain nEncrypted attributes:
+// open supplies the segment's key so sealed values decrypt to their real (interned) nodes,
+// which then resolve their ids via resolve. A nil open leaves encrypted attributes opaque and
+// decode errors on them -- so pass the sealer only on the daemon read path that holds the key.
+func DecodeResolveEnc(b []byte, resolve func(uint32) (string, bool), open Sealer) (*ast.ClassAd, error) {
 	if resolve == nil {
 		return nil, fmt.Errorf("%w: interned ad requires a resolver", ErrMalformed)
 	}
-	d := &decoder{b: b, resolve: resolve}
+	d := &decoder{b: b, resolve: resolve, open: open}
 	flags, err := d.headerFlags()
 	if err != nil {
 		return nil, err

--- a/collections/wire/encode.go
+++ b/collections/wire/encode.go
@@ -96,6 +96,41 @@ func EncodeInline(dst []byte, ad *ast.ClassAd) []byte {
 // (case-folded) name is in hot are indexed by a (nameHash32, entries-relative
 // offset-to-entry) pair, so Ad.LookupByName finds them without scanning. hot keys
 // must be lower-cased. hot may be nil.
+// EncodeWithHotEnc is EncodeWithHot for at-rest encryption: any attribute for which
+// encrypt(name) is true is sealed with seal and stored as an nEncrypted node (its value's
+// interned node encoding, sealed), exactly as EncodeInlineWithHotEnc does for inline ads.
+// Encrypted attributes are never hot (never indexed), so they never enter the hot header.
+// encrypt and seal must both be non-nil to encrypt anything; with seal nil this is EncodeWithHot.
+func EncodeWithHotEnc(dst []byte, ad *ast.ClassAd, t *InternTable, hot map[uint32]struct{}, encrypt func(name string) bool, seal Sealer) []byte {
+	if ad == nil {
+		return Encode(dst, ad, t)
+	}
+	e := encoder{t: t, seal: seal}
+	var hots []hotPair
+	for _, attr := range ad.Attributes {
+		id := t.Intern(attr.Name)
+		e.buf = binary.AppendUvarint(e.buf, uint64(id))
+		nodeOff := len(e.buf)
+		if seal != nil && encrypt != nil && encrypt(attr.Name) {
+			e.encNode(attr.Value) // sealed; never hot
+			continue
+		}
+		e.node(attr.Value)
+		if _, ok := hot[id]; ok {
+			hots = append(hots, hotPair{id, uint32(nodeOff)})
+		}
+	}
+	out := append(dst, magicByte, formatVer, 0 /* flags */)
+	out = binary.AppendUvarint(out, uint64(len(hots)))
+	for _, h := range hots {
+		out = binary.AppendUvarint(out, uint64(h.id))
+		out = binary.AppendUvarint(out, uint64(h.off))
+	}
+	out = binary.AppendUvarint(out, uint64(len(ad.Attributes))) // attrCount
+	out = append(out, e.buf...)                                 // entries region
+	return out
+}
+
 func EncodeInlineWithHot(dst []byte, ad *ast.ClassAd, hot map[string]struct{}) []byte {
 	return EncodeInlineWithHotEnc(dst, ad, hot, nil, nil)
 }


### PR DESCRIPTION
Encryption-at-rest collections stayed inline before (interning was gated on sealer==nil). Add an interned+sealed encode/decode path so they intern at compaction and reseal like plaintext collections: segment-local ids with a plaintext name dictionary, attribute values sealed as nEncrypted nodes.

- wire: EncodeWithHotEnc (interned ids + sealed values), DecodeResolveEnc and DecodeNodeResolveEnc (resolve ids + open sealed); the non-Enc forms delegate.
- collections: sealer-aware decodeWireDict/decodeAdDict/decodeNodeDict plus an encodeInterned helper; flip the intern gate to allow sealer != nil in both the compaction and append-only reseal transcodes (decode opens, re-encode reseals).
- Deferred sample/event paths (wireToInline/toSelfContained) open then re-seal so a retrained dict or a copied event never carries plaintext.
- Disable the columnar (schema-scan) accelerator for encrypted collections: its block stores values in the clear, incompatible with encryption at rest.

Tests: mutable + append-only encrypted interning (reads decrypt, secret never plaintext on disk, survives reopen, sample path stays sealed); a mixed collection holding both inline+enc and interned+enc segments dispatches and recovers correctly; wrong-key reopen fails cleanly; a size measurement (interning halves raw mmap bytes on encrypted data; ~3% on-disk since zstd already dedupes names).