### PR TITLE
collections: intern append-only segments eagerly at seal

### DIFF
--- a/collections/archive.go
+++ b/collections/archive.go
@@ -88,6 +88,11 @@ type ArchiveOptions struct {
 	ZoneAttrs []string
 	// Retention bounds what rotation keeps. Zero ⇒ keep everything.
 	Retention Retention
+	// InternAtSeal interns each segment as soon as it seals (see Options.InternAtSeal), so an
+	// archive gets the interning density/decode win immediately instead of only after a later
+	// RetrainDict/Rewrite. Optional; default off. Trades a per-seal transcode (off the write
+	// lock) for the win landing eagerly.
+	InternAtSeal bool
 }
 
 const defaultArchiveSegmentSize = 8 << 20 // 8 MiB
@@ -119,7 +124,8 @@ func archiveCollectionOptions(opts ArchiveOptions) Options {
 		ValueAttrs:       opts.ValueAttrs, // numeric ValueAttrs are auto-added to the zone maps
 		ZoneAttrs:        opts.ZoneAttrs,
 		Retention:        opts.Retention,
-		WatchHistory:     archiveWatchCap, // enable the append-stream watch
+		InternAtSeal:     opts.InternAtSeal, // intern each segment eagerly at seal
+		WatchHistory:     archiveWatchCap,   // enable the append-stream watch
 	}
 }
 
@@ -174,15 +180,22 @@ func (a *Archive) Append(ad *classad.ClassAd) error {
 	if err := a.c.Put(nil, ad); err != nil {
 		return err
 	}
-	// If this append sealed a segment, build its sidecar index now (off the write lock),
-	// so categorical/value queries on just-appended history are accelerated immediately
-	// instead of scanning until the next periodic reindex. Reindex builds only the missing
-	// sidecar (all older segments are already sealed) and is serialized against the periodic
-	// reindex. Skipped when no per-segment indexes are configured (nothing to build).
-	if a.c.hasSegmentIndexes() {
+	// If this append sealed a segment, do the eager per-seal work now (off the write lock):
+	// intern the just-sealed segment (Options.InternAtSeal) so its density/decode win lands
+	// immediately, then build its sidecar index so categorical/value queries on just-appended
+	// history are accelerated instead of scanning until the next periodic reindex. Interning
+	// runs first so the sidecar is built over the interned segment. Both are idempotent, build
+	// only what is missing (all older segments are already sealed/interned), and are serialized
+	// against the periodic passes. Skipped when neither is configured (nothing to do).
+	if a.c.internAtSeal || a.c.hasSegmentIndexes() {
 		if seal := a.c.appendSealSeq(); seal != a.lastSeal {
 			a.lastSeal = seal
-			a.c.Reindex()
+			if a.c.internAtSeal {
+				a.c.InternSealed()
+			}
+			if a.c.hasSegmentIndexes() {
+				a.c.Reindex()
+			}
 		}
 	}
 	return nil

--- a/collections/interning_atseal_test.go
+++ b/collections/interning_atseal_test.go
@@ -1,0 +1,201 @@
+package collections
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// countSealedSegs returns (sealed, interned): sealed = non-active segments with data; interned =
+// those carrying a per-segment dictionary. Used to assert interning-at-seal progress.
+func countSealedSegs(c *Collection) (sealed, interned int) {
+	for _, sh := range c.shards {
+		sh.mu.RLock()
+		act := sh.act
+		for _, seg := range sh.segs {
+			if seg == nil || seg == act || seg.used == 0 {
+				continue
+			}
+			sealed++
+			if seg.dict.Load() != nil {
+				interned++
+			}
+		}
+		sh.mu.RUnlock()
+	}
+	return
+}
+
+// TestArchiveInternAtSeal exercises Options.InternAtSeal: an append-only archive interns each
+// segment as it seals (via the Archive.Append eager-seal hook -> InternSealed), with NO
+// RetrainDict. The eager hook interns during appends; a final InternSealed flushes the last
+// straggler (the segment sealed by the final append, whose interning would otherwise wait for the
+// next append) and is idempotent. Reads/queries are correct, and recovery restores the interned
+// segments across a reopen.
+func TestArchiveInternAtSeal(t *testing.T) {
+	if !mmapSupported {
+		t.Skip("persistence is unix-only")
+	}
+	dir := t.TempDir()
+	const n = 4000
+
+	a, err := CreateArchive(ArchiveOptions{
+		Dir: dir, SegmentSize: 1 << 16, InternAtSeal: true, ValueAttrs: []string{"Ts"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < n; i++ {
+		if err := a.Append(mustAd(t,
+			fmt.Sprintf("[Id=%d; Ts=%d; Val=%d; Host=\"h%d.example.org\"]", i, i, i%100, i))); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// The eager seal hook must have interned segments DURING appends -- no RetrainDict was called.
+	if _, internedEager := countSealedSegs(a.c); internedEager == 0 {
+		t.Fatal("InternAtSeal: no segments interned during appends (eager hook did not fire)")
+	}
+	// Flush the final straggler and confirm every sealed segment is interned; idempotent re-call.
+	a.c.InternSealed()
+	a.c.InternSealed()
+	sealed, interned := countSealedSegs(a.c)
+	if sealed == 0 || interned != sealed {
+		t.Fatalf("post-InternSealed: %d/%d sealed interned (want all)", interned, sealed)
+	}
+	t.Logf("interned %d/%d sealed segments at seal (no RetrainDict)", interned, sealed)
+
+	verify := func(tag string, ar *Archive) {
+		total := 0
+		for a := range ar.c.Scan() {
+			total++
+			_ = a
+		}
+		if total != n {
+			t.Fatalf("%s: scan total=%d want %d", tag, total, n)
+		}
+		vc := 0
+		for range ar.c.Query(mustQuery(t, "Val >= 50")) {
+			vc++
+		}
+		if vc != n/2 {
+			t.Fatalf("%s: Query(Val>=50)=%d want %d", tag, vc, n/2)
+		}
+		zc := 0
+		for range ar.c.Query(mustQuery(t, "Ts >= 3000")) { // zone-pruned range on the monotonic Ts
+			zc++
+		}
+		if zc != 1000 {
+			t.Fatalf("%s: Query(Ts>=3000)=%d want 1000", tag, zc)
+		}
+	}
+	verify("pre-reopen", a)
+	if err := a.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	a2, err := OpenArchive(ArchiveOptions{
+		Dir: dir, SegmentSize: 1 << 16, InternAtSeal: true, ValueAttrs: []string{"Ts"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer a2.Close()
+	// Recovery must restore every segment interned before close. The formerly-ACTIVE segment
+	// (never sealed pre-close, so never interned at seal) is now a sealed inline segment, so the
+	// interned count can be one short until a fresh InternSealed transcodes it.
+	if s, in := countSealedSegs(a2.c); in < interned {
+		t.Fatalf("post-reopen: %d interned, recovery lost some (had %d before close, %d sealed now)", in, interned, s)
+	}
+	verify("post-reopen", a2) // reads correct over the recovered interned + inline mix
+	a2.c.InternSealed()       // intern the recovered formerly-active segment too
+	if s, in := countSealedSegs(a2.c); s == 0 || in != s {
+		t.Fatalf("post-reopen after InternSealed: %d/%d interned (want all)", in, s)
+	}
+	verify("post-reopen-interned", a2)
+}
+
+// TestArchiveInternAtSealOptOut confirms the default (off): without InternAtSeal, an archive's
+// sealed segments stay INLINE at seal (interning only happens on an explicit RetrainDict/Rewrite
+// or InternSealed), so today's behavior is unchanged.
+func TestArchiveInternAtSealOptOut(t *testing.T) {
+	if !mmapSupported {
+		t.Skip("persistence is unix-only")
+	}
+	dir := t.TempDir()
+	const n = 4000
+	a, err := CreateArchive(ArchiveOptions{Dir: dir, SegmentSize: 1 << 16}) // InternAtSeal: false
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer a.Close()
+	for i := 0; i < n; i++ {
+		if err := a.Append(mustAd(t, fmt.Sprintf("[Id=%d; Val=%d]", i, i%100))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if sealed, interned := countSealedSegs(a.c); sealed == 0 || interned != 0 {
+		t.Fatalf("opt-out: %d/%d sealed interned (want 0 interned)", interned, sealed)
+	}
+	// The manual maintenance pass still interns on demand (it is gated on append-only, not the
+	// InternAtSeal option).
+	a.c.InternSealed()
+	if sealed, interned := countSealedSegs(a.c); sealed == 0 || interned != sealed {
+		t.Fatalf("after manual InternSealed: %d/%d interned (want all)", interned, sealed)
+	}
+}
+
+// TestInternSealedEncrypted checks InternSealed composes with encryption at rest: an encrypted
+// append-only collection (raw Options -- the Archive wrapper does not expose encryption) interns
+// its sealed segments on the manual pass, sealing the designated values. (The eager Append
+// trigger is Archive-only; encrypted archives drive InternSealed directly.)
+func TestInternSealedEncrypted(t *testing.T) {
+	if !mmapSupported {
+		t.Skip("persistence is unix-only")
+	}
+	dir := t.TempDir()
+	_, dataKey := deriveDataKey(t)
+	const secret = "ClaimId-atseal-secret-b19f4c"
+	const n = 3000
+	c, err := Open(Options{
+		AppendOnly: true, Dir: dir, SegmentSize: 1 << 16,
+		DataKey: dataKey, EncryptedAttrs: []string{"Secret"}, ValueAttrs: []string{"Ts"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+	for i := 0; i < n; i++ {
+		if err := c.Put([]byte(fmt.Sprintf("k%05d", i)),
+			mustAd(t, fmt.Sprintf("[Id=%d; Ts=%d; Secret=%q]", i, i, secret))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	c.InternSealed()
+	sealed, interned := countSealedSegs(c)
+	if sealed == 0 || interned != sealed {
+		t.Fatalf("%d/%d sealed interned (want all)", interned, sealed)
+	}
+	// Reads decrypt over the interned+encrypted segments.
+	total := 0
+	for a := range c.Scan() {
+		total++
+		if s, _ := a.EvaluateAttrString("Secret"); s != secret {
+			t.Fatalf("Secret not decrypted: %q", s)
+		}
+	}
+	if total != n {
+		t.Fatalf("scan total=%d want %d", total, n)
+	}
+	// The secret is sealed on disk (never plaintext in a segment file).
+	filepath.WalkDir(dir, func(p string, d os.DirEntry, err error) error {
+		if err == nil && !d.IsDir() && filepath.Ext(p) == ".dat" {
+			if b, _ := os.ReadFile(p); bytes.Contains(b, []byte(secret)) {
+				t.Fatalf("secret in plaintext in %s", filepath.Base(p))
+			}
+		}
+		return nil
+	})
+}

--- a/collections/retrain_appendonly.go
+++ b/collections/retrain_appendonly.go
@@ -64,6 +64,66 @@ func (c *Collection) resealAppendOnly(targetCodec Codec) {
 	c.pruneDicts()
 }
 
+// InternSealed transcodes every sealed, still-inline segment of a persistent append-only
+// collection to interned form under the current codec, swapping each in and rebuilding its
+// indexes. It is the eager complement to interning-at-compaction (resealAppendOnly): an archive
+// that never retrains still gets the density/decode win as soon as segments seal. Idempotent --
+// already-interned segments and the active write target are skipped, so re-calling is cheap and
+// it composes with a later RetrainDict. Append-only only: a mutable segment's records can be
+// superseded in place after seal, which this off-lock transcode would race (there interning rides
+// compaction, which reconciles supersedes in a final critical section). Holds maintMu, so it
+// serializes against Compact/RetrainDict/Rotate/Rewrite. Called opt-in from the Archive.Append
+// eager-seal hook (Options.InternAtSeal) and available as a manual maintenance pass.
+func (c *Collection) InternSealed() {
+	if !c.inline || !c.appendOnly() {
+		return // interning-at-seal is an append-only, persistent-collection operation
+	}
+	c.maintMu.Lock()
+	defer c.maintMu.Unlock()
+	codec := c.currentCodec()
+	swapped := false
+	for _, sh := range c.shards {
+		sh.mu.Lock()
+		act := sh.act
+		var srcs []*segment
+		for _, s := range sh.segs {
+			if s != nil && s != act && s.used > 0 && s.dict.Load() == nil {
+				srcs = append(srcs, s) // sealed + still inline: a transcode candidate
+			}
+		}
+		sh.mu.Unlock()
+
+		var toReap []*segment
+		for _, src := range srcs {
+			newseg := c.resealOneSegment(sh, src, codec) // interns (c.inline); reads src off-lock
+			if newseg == nil {
+				continue // transcode failed: leave the inline original in place (best-effort)
+			}
+			sh.mu.Lock()
+			// Swap only if the source still occupies its slot and is not the (new) active
+			// target -- defensive against a concurrent reseal/rotate.
+			if int(src.id) < len(sh.segs) && sh.segs[src.id] == src && sh.act != src {
+				sh.segs[src.id] = newseg
+				swapped = true
+				if src.retire() {
+					toReap = append(toReap, src)
+				}
+			} else {
+				newseg.retire()
+				newseg.reapAndHook() // slot moved under us: drop the fresh file, don't leak it
+			}
+			sh.mu.Unlock()
+		}
+		for _, seg := range toReap {
+			seg.reapAndHook() // munmap + unlink the old inline file, off-lock
+		}
+	}
+	if swapped {
+		c.reindexAfterCompaction() // rebuild sidecars over the interned segments (takes reindexMu)
+		c.pruneDicts()
+	}
+}
+
 // resealEntry is one record staged for reseal: a data record (its re-encoded, recompressed
 // stored bytes and key) or a time-checkpoint marker (marker=true, millis set).
 type resealEntry struct {

--- a/collections/store.go
+++ b/collections/store.go
@@ -46,6 +46,16 @@ type Options struct {
 	// history archive's aging-out). The zero value keeps everything (Rotate is
 	// then inert). Only meaningful with AppendOnly. See Rotate.
 	Retention Retention
+	// InternAtSeal makes an AppendOnly collection intern each segment as soon as it
+	// seals (when the active segment fills), rather than only when RetrainDict/Rewrite
+	// later reseal it. Interning stores segment-local ids + a per-segment name dictionary
+	// instead of inline names, halving raw mmap bytes and speeding decode (see the
+	// interning design). This trades a per-seal transcode (off the write lock) for the
+	// density/decode win landing immediately on an archive that never retrains. Only
+	// meaningful with AppendOnly (a mutable segment's records can be superseded in place,
+	// which an off-lock transcode would race -- there interning rides compaction instead).
+	// Optional; default off preserves exactly today's behavior. See InternSealed.
+	InternAtSeal bool
 	// ZoneAttrs names numeric attributes to keep a per-segment [min,max] zone map on,
 	// so a range/equality query on one (e.g. CompletionDate > T) skips whole sealed
 	// segments whose span cannot match, and age-based Retention (MaxAgeAttr) can drop
@@ -246,6 +256,10 @@ type Collection struct {
 	queryPar         int
 	qsem             chan struct{}
 	parallelMinBytes int
+
+	// internAtSeal interns each append-only segment as soon as it seals (see
+	// Options.InternAtSeal), via InternSealed from the Archive.Append eager-seal hook.
+	internAtSeal bool
 
 	// reverseScan yields records newest-first (see Options.ReverseScan). Forces
 	// serial scans (no fan-out), since fan-out has no cross-segment order.
@@ -556,6 +570,9 @@ func New(opts Options) *Collection {
 	}
 	c.parallelMinBytes = defaultParallelMinBytes
 	c.reverseScan = opts.ReverseScan
+	// Persistent (Dir set) append-only only: c.inline (set later in persist setup) is exactly
+	// Dir != "", and InternSealed is a no-op otherwise, so gate on the option's preconditions here.
+	c.internAtSeal = opts.InternAtSeal && opts.AppendOnly && opts.Dir != ""
 	c.ret = opts.Retention
 	c.queryPar = resolveQueryParallelism(opts.QueryParallelism)
 	if c.queryPar >= 2 {


### PR DESCRIPTION
An append-only collection interned its segments only when `RetrainDict`/`Rewrite` resealed them, so an archive that never retrains kept inline (name-per-record) segments indefinitely. This adds eager interning at seal.

## Changes
- **`InternSealed()`** — an idempotent maintenance pass that transcodes every sealed, still-inline segment to interned form under the current codec (reusing `resealOneSegment` off the write lock, swapping under `maintMu`), then rebuilds indexes.
- **`Options.InternAtSeal`** (+ `ArchiveOptions.InternAtSeal`) — drives `InternSealed` from the `Archive.Append` eager-seal hook, so each segment interns as soon as it fills. Default off preserves today's behavior exactly.

## Why append-only only
A mutable segment's records can be superseded *in place* after seal (the sup field is written into the sealed segment bytes at `commit.go`), which an off-lock transcode would race. There, interning correctly rides compaction, which reconciles supersedes in a final critical section. Append-only never supersedes, so `resealOneSegment` is safe off-lock.

## Composition
- Encryption at rest: values stay sealed through the transcode (verified: secret never hits disk plaintext).
- Per-seal sidecar reindex: interning runs first, so the sidecar is built over the interned form.

## Tests
- Eager at-seal interns during appends with no `RetrainDict`; recovery restores the interned segments; a final `InternSealed` flushes the last straggler and is idempotent.
- Opt-out (default) keeps segments inline until an explicit pass.
- `InternSealed` composes with encryption (interned+sealed, secret sealed on disk).
- Reads/queries/zone-pruning correct across the interned + inline mix.

Follows #117 (encrypted interning).