### PR TITLE
collections: name-anchor the persisted columnar schema (adschema P3(2a))

### DIFF
--- a/collections/colpersist.go
+++ b/collections/colpersist.go
@@ -7,12 +7,17 @@ package collections
 // layoutColumnar -- the same helpers the encoder uses -- so a decoded block is identical to a
 // freshly built one. Only the payloads and offsets are stored.
 
-// marshalAdSchema writes a schema's fields as (id, kind, width, unsigned); the layout is
-// re-derived on read, not stored.
-func marshalAdSchema(dst []byte, s *adSchema) []byte {
+// marshalAdSchema writes a schema's fields as (name, kind, width, unsigned); the layout is
+// re-derived on read, not stored. Fields are keyed by NAME, not by their runtime intern id: a
+// persistent collection's global intern ids are assigned in first-seen order and differ across
+// reopen, so a stored id would resolve to the wrong attribute on the next Open. nameOf resolves a
+// field's current id to its name (c.intern.Name); readAdSchema re-resolves the name to whatever id
+// the reopened table assigns.
+func marshalAdSchema(dst []byte, s *adSchema, nameOf func(uint32) (string, bool)) []byte {
 	dst = appendU32(dst, uint32(len(s.fields)))
 	for _, f := range s.fields {
-		dst = appendU32(dst, f.id)
+		name, _ := nameOf(f.id) // "" only if the id is unknown, which cannot happen for a schema field
+		dst = appendBytes(dst, []byte(name))
 		dst = appendU16(dst, uint16(f.kind))
 		dst = appendU16(dst, uint16(f.width))
 		u := uint16(0)
@@ -24,31 +29,40 @@ func marshalAdSchema(dst []byte, s *adSchema) []byte {
 	return dst
 }
 
-func readAdSchema(c *cursor) *adSchema {
+// readAdSchema reads a name-keyed schema and re-binds each field to the current intern id via
+// internName (c.intern.Intern). Names are collected before any interning so a torn/corrupt read
+// (c.err) is rejected without polluting the intern table with junk names.
+func readAdSchema(c *cursor, internName func(string) uint32) *adSchema {
 	n := int(c.u32())
 	if n < 0 || n > 1<<20 || !c.need(0) {
 		return nil
 	}
-	fields := make([]adField, 0, n)
+	type raw struct {
+		name     string
+		kind     adKind
+		width    int
+		unsigned bool
+	}
+	raws := make([]raw, 0, n)
 	for i := 0; i < n; i++ {
-		fields = append(fields, adField{
-			id:       c.u32(),
-			kind:     adKind(c.u16()),
-			width:    int(c.u16()),
-			unsigned: c.u16() != 0,
-		})
+		name := string(c.bytes())
+		raws = append(raws, raw{name, adKind(c.u16()), int(c.u16()), c.u16() != 0})
 	}
 	if c.err != nil {
 		return nil
+	}
+	fields := make([]adField, n)
+	for i, r := range raws {
+		fields[i] = adField{id: internName(r.name), kind: r.kind, width: r.width, unsigned: r.unsigned}
 	}
 	return layoutSchema(fields)
 }
 
 // marshalColSegment serializes cs (its block's schema, hot set, record count, byte streams, and
 // per-record offsets, plus offs -- the block->arena map for MVCC visibility).
-func marshalColSegment(cs *colSegment) []byte {
+func marshalColSegment(cs *colSegment, nameOf func(uint32) (string, bool)) []byte {
 	b := cs.block
-	dst := marshalAdSchema(nil, b.schema)
+	dst := marshalAdSchema(nil, b.schema, nameOf)
 	dst = appendU32(dst, uint32(len(b.hotNum)))
 	for _, i := range b.hotNum {
 		dst = appendU32(dst, uint32(i))
@@ -75,9 +89,9 @@ func marshalColSegment(cs *colSegment) []byte {
 
 // unmarshalColSegment reconstructs a colSegment from marshalColSegment's output, attaching the
 // segment's codec (for later decompression). Returns nil on malformed data.
-func unmarshalColSegment(data []byte, codec Codec) *colSegment {
+func unmarshalColSegment(data []byte, codec Codec, internName func(string) uint32) *colSegment {
 	c := &cursor{b: data}
-	s := readAdSchema(c)
+	s := readAdSchema(c, internName)
 	if s == nil {
 		return nil
 	}

--- a/collections/colpersist_test.go
+++ b/collections/colpersist_test.go
@@ -30,7 +30,7 @@ func TestColSegmentMarshalRoundTrip(t *testing.T) {
 		}
 		orig := &colSegment{block: blk, offs: offs}
 
-		got := unmarshalColSegment(marshalColSegment(orig), codec)
+		got := unmarshalColSegment(marshalColSegment(orig, c.intern.Name), codec, c.intern.Intern)
 		if got == nil {
 			t.Fatalf("%s: unmarshal returned nil", codec.Name())
 		}
@@ -88,10 +88,75 @@ func TestUnmarshalColSegmentTruncated(t *testing.T) {
 	}
 	s := buildAdSchema(wires, adSchemaOpts{Presence: 0.5, Fit: 0.95})
 	blk := encodeColumnarBlock(s, encodeRows(s, wires), nil, identityCodec{})
-	full := marshalColSegment(&colSegment{block: blk, offs: make([]uint32, blk.n)})
+	full := marshalColSegment(&colSegment{block: blk, offs: make([]uint32, blk.n)}, c.intern.Name)
 	for _, cut := range []int{0, 1, len(full) / 2, len(full) - 1} {
-		if got := unmarshalColSegment(full[:cut], identityCodec{}); got != nil {
+		if got := unmarshalColSegment(full[:cut], identityCodec{}, c.intern.Intern); got != nil {
 			t.Errorf("truncated to %d bytes: expected nil, got a block", cut)
 		}
+	}
+}
+
+// TestColSegmentSchemaNameAnchored is the P3(2a) correctness proof: a persisted block's schema is
+// keyed by attribute NAME, not by the runtime intern id, so it survives a reopen that reassigns
+// ids. Marshal a block under one intern table, unmarshal under a fresh table that gives the SAME
+// names DIFFERENT ids, and confirm routing-by-name still lands on the right field and scans
+// correctly. With id-keyed serialization this test fails (byID holds stale ids).
+func TestColSegmentSchemaNameAnchored(t *testing.T) {
+	c := New(Options{Shards: 1})
+	var wires [][]byte
+	for i := 0; i < 80; i++ {
+		wires = append(wires, c.encodeAd(mustAdOld(t,
+			fmt.Sprintf("Cpus=%d\nMemory=%d\nDisk=%d", 1+i%8, 1024+i*64, i*4096)).AST()))
+	}
+	s := buildAdSchema(wires, adSchemaOpts{Presence: 0.8, Fit: 0.95})
+	blk := encodeColumnarBlock(s, encodeRows(s, wires), hotHalf(s), identityCodec{})
+	data := marshalColSegment(&colSegment{block: blk, offs: make([]uint32, blk.n)}, c.intern.Name)
+
+	// Simulate a reopen: a fresh intern table that assigns DIFFERENT ids to the same names
+	// (decoys shift first-seen order so Memory/Cpus/Disk do not land on their original ids).
+	reopened := wire.NewInternTable()
+	for _, d := range []string{"D0", "D1", "D2", "D3", "D4", "D5"} {
+		reopened.Intern(d)
+	}
+	for _, name := range []string{"Cpus", "Memory", "Disk"} {
+		aID, _ := c.intern.LookupID(name)
+		if bID := reopened.Intern(name); aID == bID {
+			t.Fatalf("setup: %s kept id %d across tables; decoys did not shift ids", name, aID)
+		}
+	}
+
+	got := unmarshalColSegment(data, identityCodec{}, reopened.Intern)
+	if got == nil {
+		t.Fatal("unmarshal returned nil")
+	}
+	// Every field re-bound to the REOPENED table's id, and byID indexes it under that id.
+	for _, f := range got.block.schema.fields {
+		name, ok := reopened.Name(f.id)
+		if !ok {
+			t.Fatalf("field id %d not resolvable in the reopened table", f.id)
+		}
+		if idx, ok := got.block.schema.byID[f.id]; !ok || got.block.schema.fields[idx].id != f.id {
+			t.Fatalf("byID does not index field %q (id %d)", name, f.id)
+		}
+	}
+	// Routing by name through the reopened table lands on the Memory int field...
+	memID := reopened.Intern("Memory")
+	idx, ok := got.block.schema.byID[memID]
+	if !ok || got.block.schema.fields[idx].kind != akInt {
+		t.Fatalf("Memory (reopened id %d) not resolvable as an int field", memID)
+	}
+	// ...and the block still scans that field's values correctly (records are positional, so the
+	// scan is independent of the intern id -- but the field is FOUND only because it is name-keyed).
+	origMemID, _ := c.intern.LookupID("Memory")
+	mismatch := 0
+	got.block.scanInt(idx, nil, func(k int, p bool, v int64) {
+		if node, ok := wire.Ad(wires[k]).Lookup(origMemID); ok {
+			if lit, _ := wire.LiteralValue(node); p && lit.Kind == wire.LitInt && v != lit.Int {
+				mismatch++
+			}
+		}
+	})
+	if mismatch != 0 {
+		t.Fatalf("%d Memory scan mismatches after reopen", mismatch)
 	}
 }


### PR DESCRIPTION
First step toward persisting the columnar (PAX) accelerator across reopen (adschema P3(2)).

## Problem
`marshalColSegment`/`marshalAdSchema` stored each schema field by its runtime **intern id**. A persistent collection's global intern ids are assigned in first-seen order and **differ across reopen**, so a persisted id would resolve to the *wrong attribute* on the next Open — silently corrupting a reloaded columnar block's schema. (The serialization exists but isn't wired into any seal/reload path yet, so nothing in production is affected today; this fixes it before it's wired.)

## Fix
Store field **names**:
- `marshalAdSchema(dst, s, nameOf)` writes names (`nameOf = c.intern.Name`).
- `readAdSchema(c, internName)` re-binds each name to whatever id the reopened table assigns (`internName = c.intern.Intern`), then `layoutSchema` rebuilds `byID`. Names are collected before any interning so a torn/corrupt read never pollutes the table.

The runtime id-keyed scan path is unchanged (ids stay consistent within a process). Because all blocks resolve against the same table, a name maps to the same id across segments — so the planned **per-segment-schema** reload can key each block by name independently (each segment keeps its own schema; a schema change never forces rewriting existing segments).

## Test
`TestColSegmentSchemaNameAnchored`: marshal a block under one intern table, unmarshal under a fresh table that assigns the same names **different** ids, and confirm routing-by-name still lands on the right field and scans correctly. Fails with the old id-keyed serialization.