### PR TITLE
collections: add a columnar section to the segment sidecar container (adschema P3(2b))

### DIFF
--- a/collections/keyindex.go
+++ b/collections/keyindex.go
@@ -134,49 +134,79 @@ func (m *mmapKeyIndex) lookup(hash uint64) []uint32 {
 	return offs
 }
 
-// A segment sidecar container packs the (optional) attribute-index blob and the
-// key-index blob into ONE file (<seg>.idx), so a persistent segment carries a single
-// sidecar rather than two. The attribute blob is written first so it keeps offset 0 --
-// its roaring bitmaps stay aligned and the existing ARCX writer/parser (shared with
-// the archive table type) handle it unchanged; the offset-insensitive key blob
-// follows; a fixed trailer records the two lengths:
+// A segment sidecar container packs the (optional) attribute-index blob, the key-index blob, and
+// the (optional) columnar-accelerator blob into ONE file (<seg>.idx), so a persistent segment
+// carries a single sidecar rather than three. The attribute blob is written first so it keeps
+// offset 0 -- its roaring bitmaps stay aligned and the existing ARCX writer/parser (shared with
+// the archive table type) handle it unchanged; the offset-insensitive key blob follows; the
+// columnar blob (if any) follows that. A fixed trailer records the section lengths. Two versions:
 //
-//	[attr blob (attrLen bytes; ARCX; empty when no attr index)]
-//	[key  blob (keyLen bytes; KIDX)]
-//	[attrLen u32 | keyLen u32 | containerMagic u32]   (12-byte trailer)
+//	v1 (no columnar block): [attr][key][attrLen u32 | keyLen u32 | magic("SCNT") u32]   (12-byte)
+//	v2 (with columnar):     [attr][key][col][attrLen u32 | keyLen u32 | colLen u32 | magic("SCN2") u32]  (16-byte)
+//
+// An empty columnar blob writes v1 byte-for-byte as before, so a collection without the columnar
+// accelerator produces identical sidecars. The container magic is always the last 4 bytes, and the
+// two magics differ, so the reader distinguishes the versions unambiguously; a v1 sidecar (or a
+// pre-columnar file) reads with col == nil.
 const (
-	sidecarContainerMagic = 0x53434e54 // "SCNT"
-	sidecarTrailerLen     = 12
+	sidecarContainerMagic   = 0x53434e54 // "SCNT" (v1, 2-section)
+	sidecarContainerMagicV2 = 0x53434e32 // "SCN2" (v2, 3-section, adds the columnar blob)
+	sidecarTrailerLen       = 12
+	sidecarTrailerLenV2     = 16
 )
 
-// buildSegmentSidecar packs an attribute-index blob (may be empty) and a key-index
-// blob into the container byte layout.
-func buildSegmentSidecar(attrBlob, keyBlob []byte) []byte {
-	b := make([]byte, 0, len(attrBlob)+len(keyBlob)+sidecarTrailerLen)
+// buildSegmentSidecar packs the attribute-index blob (may be empty), the key-index blob, and the
+// columnar blob (may be empty) into the container byte layout. An empty colBlob yields the v1
+// (2-section) layout, identical to a pre-columnar sidecar.
+func buildSegmentSidecar(attrBlob, keyBlob, colBlob []byte) []byte {
+	if len(colBlob) == 0 {
+		b := make([]byte, 0, len(attrBlob)+len(keyBlob)+sidecarTrailerLen)
+		b = append(b, attrBlob...)
+		b = append(b, keyBlob...)
+		b = binary.LittleEndian.AppendUint32(b, uint32(len(attrBlob)))
+		b = binary.LittleEndian.AppendUint32(b, uint32(len(keyBlob)))
+		b = binary.LittleEndian.AppendUint32(b, sidecarContainerMagic)
+		return b
+	}
+	b := make([]byte, 0, len(attrBlob)+len(keyBlob)+len(colBlob)+sidecarTrailerLenV2)
 	b = append(b, attrBlob...)
 	b = append(b, keyBlob...)
+	b = append(b, colBlob...)
 	b = binary.LittleEndian.AppendUint32(b, uint32(len(attrBlob)))
 	b = binary.LittleEndian.AppendUint32(b, uint32(len(keyBlob)))
-	b = binary.LittleEndian.AppendUint32(b, sidecarContainerMagic)
+	b = binary.LittleEndian.AppendUint32(b, uint32(len(colBlob)))
+	b = binary.LittleEndian.AppendUint32(b, sidecarContainerMagicV2)
 	return b
 }
 
-// splitSegmentSidecar returns the attribute and key sub-slices of a container, or
-// ok=false if data is not a well-formed container (bare/old sidecar, or corruption).
-func splitSegmentSidecar(data []byte) (attr, key []byte, ok bool) {
-	if len(data) < sidecarTrailerLen {
-		return nil, nil, false
+// splitSegmentSidecar returns the attribute, key, and columnar sub-slices of a container. col is
+// nil for a v1 (2-section) container -- a pre-columnar sidecar, read unchanged. ok=false if data
+// is not a well-formed container (bare/old sidecar, or corruption).
+func splitSegmentSidecar(data []byte) (attr, key, col []byte, ok bool) {
+	if len(data) >= sidecarTrailerLenV2 {
+		t := data[len(data)-sidecarTrailerLenV2:]
+		if binary.LittleEndian.Uint32(t[12:]) == sidecarContainerMagicV2 {
+			attrLen := int(binary.LittleEndian.Uint32(t[0:]))
+			keyLen := int(binary.LittleEndian.Uint32(t[4:]))
+			colLen := int(binary.LittleEndian.Uint32(t[8:]))
+			if attrLen < 0 || keyLen < 0 || colLen < 0 || attrLen+keyLen+colLen+sidecarTrailerLenV2 != len(data) {
+				return nil, nil, nil, false
+			}
+			return data[:attrLen], data[attrLen : attrLen+keyLen], data[attrLen+keyLen : attrLen+keyLen+colLen], true
+		}
 	}
-	t := data[len(data)-sidecarTrailerLen:]
-	if binary.LittleEndian.Uint32(t[8:]) != sidecarContainerMagic {
-		return nil, nil, false
+	if len(data) >= sidecarTrailerLen {
+		t := data[len(data)-sidecarTrailerLen:]
+		if binary.LittleEndian.Uint32(t[8:]) == sidecarContainerMagic {
+			attrLen := int(binary.LittleEndian.Uint32(t[0:]))
+			keyLen := int(binary.LittleEndian.Uint32(t[4:]))
+			if attrLen < 0 || keyLen < 0 || attrLen+keyLen+sidecarTrailerLen != len(data) {
+				return nil, nil, nil, false
+			}
+			return data[:attrLen], data[attrLen : attrLen+keyLen], nil, true
+		}
 	}
-	attrLen := int(binary.LittleEndian.Uint32(t[0:]))
-	keyLen := int(binary.LittleEndian.Uint32(t[4:]))
-	if attrLen < 0 || keyLen < 0 || attrLen+keyLen+sidecarTrailerLen != len(data) {
-		return nil, nil, false
-	}
-	return data[:attrLen], data[attrLen : attrLen+keyLen], true
+	return nil, nil, nil, false
 }
 
 // writeFileAtomic writes b to path via a temp file + fsync + rename, so a crash never

--- a/collections/sealed_index.go
+++ b/collections/sealed_index.go
@@ -33,7 +33,7 @@ func (c *Collection) publishSidecar(seg *segment, path string, spec *indexSpec) 
 	if err != nil {
 		return false
 	}
-	attr, key, ok := splitSegmentSidecar(data)
+	attr, key, _, ok := splitSegmentSidecar(data)
 	if !ok {
 		_ = closer()
 		return false
@@ -94,7 +94,7 @@ func (c *Collection) sealSegmentIndex(seg *segment, si *segIndex) {
 		}
 		attrBlob = b
 	}
-	container := buildSegmentSidecar(attrBlob, buildKeyIndex(seg.data, seg.used, c.h))
+	container := buildSegmentSidecar(attrBlob, buildKeyIndex(seg.data, seg.used, c.h), nil)
 	if err := writeFileAtomic(path, container); err != nil {
 		return
 	}
@@ -163,14 +163,14 @@ func (c *Collection) reindexSealedFile(sh *shard, seg *segment, si *segIndex) bo
 	}
 	// Rename over the live file: the existing mapping is unaffected (it holds the old
 	// inode), so readers keep working until they are swapped over below.
-	if err := writeFileAtomic(path, buildSegmentSidecar(attrBlob, buildKeyIndex(seg.data, seg.used, c.h))); err != nil {
+	if err := writeFileAtomic(path, buildSegmentSidecar(attrBlob, buildKeyIndex(seg.data, seg.used, c.h), nil)); err != nil {
 		return false
 	}
 	data, closer, err := mapFile(path)
 	if err != nil {
 		return false
 	}
-	attr, key, ok := splitSegmentSidecar(data)
+	attr, key, _, ok := splitSegmentSidecar(data)
 	if !ok {
 		_ = closer()
 		return false

--- a/collections/sidecar_container_test.go
+++ b/collections/sidecar_container_test.go
@@ -1,0 +1,64 @@
+package collections
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+)
+
+// TestSegmentSidecarContainer covers the sidecar container framing, including the v2 (3-section)
+// layout that carries the columnar-accelerator blob and the backward-compatible parse of a v1
+// (2-section, pre-columnar) container.
+func TestSegmentSidecarContainer(t *testing.T) {
+	attr := []byte("ARCX-attribute-index-blob")
+	key := []byte("KIDX-key-index-blob-payload")
+	col := []byte("COLX-columnar-block-payload-bytes")
+
+	// v2: all three sections round-trip.
+	c2 := buildSegmentSidecar(attr, key, col)
+	if binary.LittleEndian.Uint32(c2[len(c2)-4:]) != sidecarContainerMagicV2 {
+		t.Fatal("v2 container: wrong trailing magic")
+	}
+	a, k, cc, ok := splitSegmentSidecar(c2)
+	if !ok || !bytes.Equal(a, attr) || !bytes.Equal(k, key) || !bytes.Equal(cc, col) {
+		t.Fatalf("v2 split: ok=%v attr=%q key=%q col=%q", ok, a, k, cc)
+	}
+
+	// Empty col writes the v1 layout byte-for-byte (identical to a pre-columnar sidecar): trailing
+	// magic is SCNT, length is attr+key+12, and split returns col == nil.
+	c1 := buildSegmentSidecar(attr, key, nil)
+	if binary.LittleEndian.Uint32(c1[len(c1)-4:]) != sidecarContainerMagic {
+		t.Fatal("empty col should write the v1 magic")
+	}
+	if len(c1) != len(attr)+len(key)+sidecarTrailerLen {
+		t.Fatalf("v1 length = %d, want %d", len(c1), len(attr)+len(key)+sidecarTrailerLen)
+	}
+	a, k, cc, ok = splitSegmentSidecar(c1)
+	if !ok || !bytes.Equal(a, attr) || !bytes.Equal(k, key) || cc != nil {
+		t.Fatalf("v1 split: ok=%v attr=%q key=%q col=%v (want col nil)", ok, a, k, cc)
+	}
+
+	// Empty attr (no attribute index) still frames correctly alongside a columnar block.
+	c3 := buildSegmentSidecar(nil, key, col)
+	a, k, cc, ok = splitSegmentSidecar(c3)
+	if !ok || len(a) != 0 || !bytes.Equal(k, key) || !bytes.Equal(cc, col) {
+		t.Fatalf("empty-attr split: ok=%v attr=%q key=%q col=%q", ok, a, k, cc)
+	}
+
+	// Malformed: too short, wrong magic, and inconsistent lengths all fail cleanly (no panic).
+	for _, bad := range [][]byte{
+		nil,
+		[]byte("short"),
+		append(append([]byte{}, c2...), 0x00), // trailing byte breaks the length invariant
+		func() []byte { b := append([]byte{}, c2...); b[len(b)-1] ^= 0xFF; return b }(), // magic corrupted
+		func() []byte { // v2 with an over-large colLen
+			b := append([]byte{}, c2...)
+			binary.LittleEndian.PutUint32(b[len(b)-8:], 1<<30)
+			return b
+		}(),
+	} {
+		if _, _, _, ok := splitSegmentSidecar(bad); ok {
+			t.Errorf("malformed container parsed as ok: %q", bad)
+		}
+	}
+}


### PR DESCRIPTION
Second step toward persisting the columnar (PAX) accelerator across reopen (adschema P3(2)). Independent of #119 — different files.

## Change
The `<seg>.idx` sidecar is already a multi-section container (attribute-index blob + key-index blob). Add an optional **third section** for the columnar block, so a persisted block rides the segment's existing single sidecar file — no new file/handle per segment (file handles are at a premium).

- `buildSegmentSidecar(attr, key, col)`: an empty `col` writes the **v1** (2-section) layout byte-for-byte, so a collection without the columnar accelerator produces identical sidecars; a non-empty `col` writes a **v2** (3-section) layout — 16-byte trailer adding `colLen`, magic `"SCN2"`.
- `splitSegmentSidecar` now returns `(attr, key, col, ok)`. The container magic is always the last 4 bytes and the two magics differ, so v1/v2 are distinguished unambiguously; a v1 / pre-columnar sidecar reads with `col == nil`. No migration — an old file just parses without a columnar section.

Callers pass `nil` col for now; the seal/reload wiring that fills it (2c/2d) lands next.

## Test
`TestSegmentSidecarContainer`: v2 round-trips all three sections; empty col writes v1 byte-identically and splits with `col == nil`; empty-attr framing; malformed/truncated/wrong-magic/over-large-length all fail cleanly (no panic). The existing `TestKeyIndexSidecar` (real sealed segments through the changed callers) still passes.
