### PR TITLE
collections: persist the columnar accelerator across reopen (adschema P3(2))

### DIFF
--- a/collections/colpersist.go
+++ b/collections/colpersist.go
@@ -1,11 +1,54 @@
 package collections
 
+import (
+	"encoding/binary"
+	"hash/crc32"
+)
+
 // Serialization of a sealed segment's columnar accelerator (schema + block streams + the
 // arena-offset map), so it can be persisted beside the segment's index sidecar and rebuilt on
 // reopen instead of re-transcoding the whole segment. The layout (field offsets, hot/cold
 // partition) is recomputed from the persisted (schema, hot set, n) via layoutSchema /
 // layoutColumnar -- the same helpers the encoder uses -- so a decoded block is identical to a
 // freshly built one. Only the payloads and offsets are stored.
+//
+// The marshaled block is framed with a magic/version/upto/CRC header before it goes into the
+// sidecar's columnar section, so a reload rejects a truncated, bit-rotted, or stale section (one
+// built from a different segment byte length) and rebuilds instead of trusting corrupt bytes --
+// the same "derived state, any doubt rebuilds" contract the attribute-index sidecar follows.
+const (
+	colSectionMagic   = 0x434f4c58 // "COLX"
+	colSectionVersion = 1
+	colSectionHdr     = 4 + 2 + 4 + 4 // magic u32 | version u16 | upto u32 | crc u32
+)
+
+// wrapColSection frames a marshaled columnar block for the sidecar. upto is the segment byte
+// length the block was built from.
+func wrapColSection(body []byte, upto int) []byte {
+	b := make([]byte, 0, colSectionHdr+len(body))
+	b = appendU32(b, colSectionMagic)
+	b = appendU16(b, colSectionVersion)
+	b = appendU32(b, uint32(upto))
+	b = appendU32(b, crc32.ChecksumIEEE(body))
+	return append(b, body...)
+}
+
+// readColSection validates a framed columnar section against the segment's current byte length and
+// the body CRC, returning the inner marshaled block bytes, or nil if the section is
+// absent/short/wrong-version/stale/corrupt (the caller then row-scans and rebuilds).
+func readColSection(data []byte, upto int) []byte {
+	if len(data) < colSectionHdr ||
+		binary.LittleEndian.Uint32(data[0:]) != colSectionMagic ||
+		binary.LittleEndian.Uint16(data[4:]) != colSectionVersion ||
+		int(binary.LittleEndian.Uint32(data[6:])) != upto {
+		return nil
+	}
+	body := data[colSectionHdr:]
+	if binary.LittleEndian.Uint32(data[10:]) != crc32.ChecksumIEEE(body) {
+		return nil
+	}
+	return body
+}
 
 // marshalAdSchema writes a schema's fields as (name, kind, width, unsigned); the layout is
 // re-derived on read, not stored. Fields are keyed by NAME, not by their runtime intern id: a

--- a/collections/colpersist.go
+++ b/collections/colpersist.go
@@ -132,6 +132,14 @@ func marshalColSegment(cs *colSegment, nameOf func(uint32) (string, bool)) []byt
 
 // unmarshalColSegment reconstructs a colSegment from marshalColSegment's output, attaching the
 // segment's codec (for later decompression). Returns nil on malformed data.
+//
+// ZERO-COPY: the block's byte streams (hot + the three compressed cold streams) ALIAS data rather
+// than being copied -- the hot column is then scanned strided directly over the mmap, and the cold
+// streams decompress lazily into the bounded block cache only when touched, so a reloaded block
+// adds no per-segment stream heap. This is the same lifetime contract as the mmap'd attribute
+// index (mmapSegIndex): both alias the segment's <seg>.idx mapping, which is released together on
+// reap and re-published together when reindex swaps the sidecar. Callers must therefore keep data
+// (the mapping, or a heap buffer in tests) alive for the block's lifetime.
 func unmarshalColSegment(data []byte, codec Codec, internName func(string) uint32) *colSegment {
 	c := &cursor{b: data}
 	s := readAdSchema(c, internName)
@@ -148,10 +156,10 @@ func unmarshalColSegment(data []byte, codec Codec, internName func(string) uint3
 	}
 	n := int(c.u32())
 	b := &columnarBlock{id: colBlockSeq.Add(1), schema: s, codec: codec, n: n}
-	b.hot = append([]byte(nil), c.bytes()...)
-	b.coldNumComp = append([]byte(nil), c.bytes()...)
-	b.strComp = append([]byte(nil), c.bytes()...)
-	b.coldComp = append([]byte(nil), c.bytes()...)
+	b.hot = c.bytes() // aliases data (the mmap); read-only, scanned in place
+	b.coldNumComp = c.bytes()
+	b.strComp = c.bytes()
+	b.coldComp = c.bytes()
 	b.strOff = readInts(c)
 	b.coldOff = readInts(c)
 	offs := readU32s(c)

--- a/collections/colscan.go
+++ b/collections/colscan.go
@@ -98,6 +98,19 @@ func (c *Collection) colBlobForSeg(seg *segment) []byte {
 	return wrapColSection(marshalColSegment(cs, c.intern.Name), seg.used)
 }
 
+// colBlobPreserve returns the sidecar columnar section for seg on a REINDEX (sidecar rewrite),
+// preserving the segment's existing block by re-marshaling it -- a reindex changes the attribute
+// index spec, not the schema the block was built under, so there is no need to re-transcode the
+// records. Falls back to building the block when the segment has none yet but schema-scan is
+// enabled (an index added just after enabling schema-scan). nil when there is nothing to persist.
+func (c *Collection) colBlobPreserve(seg *segment) []byte {
+	cs := seg.colblk.Load()
+	if cs == nil {
+		return c.colBlobForSeg(seg)
+	}
+	return wrapColSection(marshalColSegment(cs, c.intern.Name), seg.used)
+}
+
 // adoptPersistedSchemaScan enables schema-scan on reopen from persisted columnar blocks: if any
 // sealed segment recovered a block (publishSidecar unmarshaled it from the sidecar's col section),
 // the collection adopts one block's schema + hot tier as the current schema-scan state, so

--- a/collections/colscan.go
+++ b/collections/colscan.go
@@ -95,7 +95,7 @@ func (c *Collection) colBlobForSeg(seg *segment) []byte {
 	if cs == nil {
 		return nil
 	}
-	return marshalColSegment(cs, c.intern.Name)
+	return wrapColSection(marshalColSegment(cs, c.intern.Name), seg.used)
 }
 
 // adoptPersistedSchemaScan enables schema-scan on reopen from persisted columnar blocks: if any

--- a/collections/colscan.go
+++ b/collections/colscan.go
@@ -3,10 +3,16 @@ package collections
 import (
 	"sort"
 	"strings"
+	"sync/atomic"
 
 	"github.com/PelicanPlatform/classad/collections/vm"
 	"github.com/PelicanPlatform/classad/collections/wire"
 )
+
+// colSegmentBuilds counts columnar-block builds from segment records (buildColSegment). A reopen
+// that reloads persisted blocks does NOT build any, so a test asserts this stays flat across an
+// Open -- proving the accelerator came off disk rather than being re-transcoded.
+var colSegmentBuilds atomic.Int64
 
 // colSegment is a sealed segment's columnar accelerator: the PAX block plus offs, mapping each
 // block record k to its arena offset so a scan can read the record's live MVCC seq/sup.
@@ -54,12 +60,75 @@ func (c *Collection) EnableSchemaScan(s *adSchema, hot []int) {
 		}
 		sh.mu.RUnlock()
 		for _, seg := range segs {
-			d := seg.dict.Load() // interned segment -> resolve its local ids during transcode
-			blk, offs := buildColumnarFromSegment(seg.data, seg.used, seg.codec, s, hot,
-				func(dst, w []byte) ([]byte, bool) { return c.recordToInternedDict(d, dst, w) })
-			seg.colblk.Store(&colSegment{block: blk, offs: offs})
+			if cs := c.buildColSegment(seg, s, hot); cs != nil {
+				seg.colblk.Store(cs)
+			}
 		}
 	}
+}
+
+// buildColSegment transcodes a sealed segment into its columnar accelerator block under schema s
+// and hot tier hot (resolving an interned segment's local ids on the way). Returns nil if the
+// block cannot be built. Off the write lock (reads immutable sealed bytes).
+func (c *Collection) buildColSegment(seg *segment, s *adSchema, hot []int) *colSegment {
+	colSegmentBuilds.Add(1)
+	d := seg.dict.Load() // interned segment -> resolve its local ids during transcode
+	blk, offs := buildColumnarFromSegment(seg.data, seg.used, seg.codec, s, hot,
+		func(dst, w []byte) ([]byte, bool) { return c.recordToInternedDict(d, dst, w) })
+	if blk == nil {
+		return nil
+	}
+	return &colSegment{block: blk, offs: offs}
+}
+
+// colBlobForSeg builds and marshals seg's columnar block under the collection's CURRENT schema-scan
+// schema, for embedding in the segment's sidecar container so the block persists. Returns nil when
+// schema-scan is not enabled (nothing to persist) -- and never runs for an encryption-at-rest
+// collection, since EnableSchemaScan refuses those (a columnar block would store values in the
+// clear). Written at seal (sealSegmentIndex) and rebuilt on reindex (reindexSealedFile).
+func (c *Collection) colBlobForSeg(seg *segment) []byte {
+	st := c.schemaScan.Load()
+	if st == nil {
+		return nil
+	}
+	cs := c.buildColSegment(seg, st.schema, st.hot)
+	if cs == nil {
+		return nil
+	}
+	return marshalColSegment(cs, c.intern.Name)
+}
+
+// adoptPersistedSchemaScan enables schema-scan on reopen from persisted columnar blocks: if any
+// sealed segment recovered a block (publishSidecar unmarshaled it from the sidecar's col section),
+// the collection adopts one block's schema + hot tier as the current schema-scan state, so
+// CountQuery routes and future seals build under it. Existing segments keep their OWN per-segment
+// schemas -- the scan resolves the field per block -- so this only seeds the "current" schema; it
+// never rewrites anything. A no-op when schema-scan is already enabled or no block was persisted
+// (so an encryption-at-rest collection, which never persists a block, never enables it here).
+func (c *Collection) adoptPersistedSchemaScan() {
+	if c.schemaScan.Load() != nil {
+		return
+	}
+	var adopt *colSegment
+	for _, sh := range c.shards {
+		sh.mu.RLock()
+		for _, seg := range sh.segs {
+			if seg != nil {
+				if cs := seg.colblk.Load(); cs != nil {
+					adopt = cs // last recovered block wins; any block's schema is a valid seed
+				}
+			}
+		}
+		sh.mu.RUnlock()
+	}
+	if adopt == nil {
+		return
+	}
+	bc, err := newBlockCache(256 << 20)
+	if err != nil {
+		return
+	}
+	c.schemaScan.Store(&schemaScanState{schema: adopt.block.schema, hot: adopt.block.hotNum, cache: bc})
 }
 
 // BuildAndEnableSchemaScan samples the collection, builds an adschema, chooses the hot numeric
@@ -197,7 +266,9 @@ func (c *Collection) CountQuery(q *vm.Query) (int, bool) {
 		}
 		return true
 	}
-	return c.schemaScanCount(s, fieldIdx, fieldID, st.cache, eval), true
+	// fieldIdx above is only the routing decision (the attr is an int field in the current
+	// schema); the scan resolves the field per block against each block's own schema.
+	return c.schemaScanCount(fieldID, st.cache, eval), true
 }
 
 func numCmp(op string, t float64) (func(float64) bool, bool) {
@@ -218,14 +289,17 @@ func numCmp(op string, t float64) (func(float64) bool, bool) {
 	return nil, false
 }
 
-// schemaScanCount counts records whose numeric field (s.fields[fieldIdx]) is present, live, and
-// satisfies eval -- using each sealed segment's columnar block (hot column: no decode; cold
-// column: one cached decode) and each window's live MVCC visibility. A window with no block
-// (active segment) falls back to the row scan; an escaped value is read from the cold tail.
-func (c *Collection) schemaScanCount(s *adSchema, fieldIdx int, fieldID uint32, bc *blockCache, eval func(float64) bool) int {
-	// The brute fallback (segments without a matching columnar block -- e.g. the active
-	// segment) reads records straight from the arena, so it must honor the collection's wire
-	// mode: look the field up by inline name on a persistent store, by interned id in memory.
+// schemaScanCount counts records whose numeric attribute fieldID is present, live, and satisfies
+// eval -- using each sealed segment's columnar block (hot column: no decode; cold column: one
+// cached decode) and each window's live MVCC visibility. The field is resolved PER BLOCK against
+// that block's OWN schema (byID over the shared intern id): a segment sealed under a schema that
+// includes fieldID as an int is columnar-scanned; one whose schema lacks it (or types it
+// differently) -- including the active segment, which has no block -- row-scans instead. This is
+// what lets a heterogeneous set of per-segment schemas coexist: a schema change never forces
+// rewriting existing segments; they simply row-fall-back for attributes absent from their schema.
+func (c *Collection) schemaScanCount(fieldID uint32, bc *blockCache, eval func(float64) bool) int {
+	// The brute fallback reads records straight from the arena, so it must honor the collection's
+	// wire mode: look the field up by inline name on a persistent store, by interned id in memory.
 	lookup := func(a wire.Ad) ([]byte, bool) { return a.Lookup(fieldID) }
 	if c.inline {
 		if name, ok := c.intern.Name(fieldID); ok {
@@ -237,27 +311,34 @@ func (c *Collection) schemaScanCount(s *adSchema, fieldIdx int, fieldID uint32, 
 		s0, wins := sh.snapshot()
 		for _, w := range wins {
 			cs := w.seg.colblk.Load()
-			if cs != nil && cs.block.schema == s {
-				cs.block.scanInt(fieldIdx, bc, func(k int, present bool, v int64) {
-					o := cs.offs[k]
-					if !(recSeq(w.data, o) <= s0 && recSuperseded(w.data, o) > s0) {
-						return // not visible at this snapshot
-					}
-					if present {
-						if eval(float64(v)) {
-							count++
-						}
-						return
-					}
-					if rec, err := cs.block.reconstruct(k, bc); err == nil { // escaped: cold tail
-						if f, ok := numFieldOf(s, rec, fieldID); ok && eval(f) {
-							count++
-						}
-					}
-				})
+			bs := (*adSchema)(nil)
+			bidx := -1
+			if cs != nil {
+				if idx, ok := cs.block.schema.byID[fieldID]; ok && cs.block.schema.fields[idx].kind == akInt {
+					bs, bidx = cs.block.schema, idx
+				}
+			}
+			if bidx < 0 {
+				count += bruteNumCount(w, s0, lookup, eval) // no block, or field absent/non-int in this segment's schema
 				continue
 			}
-			count += bruteNumCount(w, s0, lookup, eval)
+			cs.block.scanInt(bidx, bc, func(k int, present bool, v int64) {
+				o := cs.offs[k]
+				if !(recSeq(w.data, o) <= s0 && recSuperseded(w.data, o) > s0) {
+					return // not visible at this snapshot
+				}
+				if present {
+					if eval(float64(v)) {
+						count++
+					}
+					return
+				}
+				if rec, err := cs.block.reconstruct(k, bc); err == nil { // escaped: cold tail
+					if f, ok := numFieldOf(bs, rec, fieldID); ok && eval(f) {
+						count++
+					}
+				}
+			})
 		}
 		releaseWindows(wins)
 	}
@@ -270,7 +351,7 @@ func (c *Collection) schemaScanIntCount(s *adSchema, fieldIdx int, match func(in
 	if st := c.schemaScan.Load(); st != nil {
 		bc = st.cache
 	}
-	return c.schemaScanCount(s, fieldIdx, s.fields[fieldIdx].id, bc, func(f float64) bool { return match(int64(f)) })
+	return c.schemaScanCount(s.fields[fieldIdx].id, bc, func(f float64) bool { return match(int64(f)) })
 }
 
 // bruteNumCount is the row-scan fallback: walk a window's visible records, read the numeric

--- a/collections/colscan_persist_bench_test.go
+++ b/collections/colscan_persist_bench_test.go
@@ -1,0 +1,92 @@
+package collections
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/collections/vm"
+)
+
+// BenchmarkSchemaScanPersistedReopen measures the REAL persisted path: a store whose columnar
+// blocks were written at seal and RELOADED (mmap-backed, zero-copy) on reopen -- the accelerator
+// nobody rebuilt. Two accelerated scans bracket the cost model:
+//
+//   - Cpus > 4: Cpus fits a byte, so no value escapes the fitted int width -- this is the pure
+//     hot-column strided read over the mmap (fast, few allocs), the zero-heap best case.
+//   - Memory > 4096: ~5% of Memory values fall outside the fitted int width and ESCAPE to the cold
+//     tail, where the current scan reconstructs the whole record to read one field -- the dominant
+//     cost when a numeric attribute has a heavy tail. (Optimization: read just the escaped field.)
+//
+// Both are compared to the row QueryProject count. Also asserts the reopen did ZERO block rebuilds.
+func BenchmarkSchemaScanPersistedReopen(b *testing.B) {
+	if !mmapSupported {
+		b.Skip("persistence is unix-only")
+	}
+	ads, _ := loadOSPoolAds(b)
+	if len(ads) == 0 {
+		b.Skip("no corpus")
+	}
+	dir := b.TempDir()
+	open := func() *Collection {
+		c, err := Open(Options{Dir: dir, Shards: 1, SegmentSize: 512 << 10})
+		if err != nil {
+			b.Fatal(err)
+		}
+		return c
+	}
+	c := open()
+	// Enable schema-scan early (after a small sample) so every segment that seals afterward
+	// persists its block -- the steady state a long-running daemon reaches.
+	for i := 0; i < 20 && i < len(ads); i++ {
+		c.Put([]byte(fmt.Sprintf("k%d", i)), ads[i])
+	}
+	mq, _ := vm.Parse("true")
+	for i := 0; i < 20; i++ {
+		for range c.QueryProject(mq, []string{"Memory"}) {
+		}
+	}
+	if !c.BuildAndEnableSchemaScan(2000, 4) {
+		b.Skip("schema-scan not enabled (Memory not stable int?)")
+	}
+	for i := 20; i < len(ads); i++ {
+		c.Put([]byte(fmt.Sprintf("k%d", i)), ads[i])
+	}
+	c.Close()
+
+	before := colSegmentBuilds.Load()
+	c2 := open()
+	defer c2.Close()
+	if built := colSegmentBuilds.Load() - before; built != 0 {
+		b.Fatalf("reopen rebuilt %d columnar blocks (want 0 -- must reload from disk)", built)
+	}
+
+	mem, _ := vm.Parse("Memory > 4096")
+	cpus, _ := vm.Parse("Cpus > 4")
+
+	b.Run("RowQueryProject_Memory", func(b *testing.B) {
+		b.ReportAllocs()
+		for n := 0; n < b.N; n++ {
+			cnt := 0
+			for range c2.QueryProject(mem, []string{"Memory"}) {
+				cnt++
+			}
+			_ = cnt
+		}
+	})
+	b.Run("Columnar_Memory_withEscapes", func(b *testing.B) {
+		b.ReportAllocs()
+		for n := 0; n < b.N; n++ {
+			if _, ok := c2.CountQuery(mem); !ok {
+				b.Fatal("CountQuery declined")
+			}
+		}
+	})
+	b.Run("Columnar_Cpus_noEscapes", func(b *testing.B) {
+		b.ReportAllocs()
+		for n := 0; n < b.N; n++ {
+			if _, ok := c2.CountQuery(cpus); !ok {
+				b.Fatal("CountQuery declined")
+			}
+		}
+	})
+}

--- a/collections/colscan_persist_test.go
+++ b/collections/colscan_persist_test.go
@@ -1,7 +1,10 @@
 package collections
 
 import (
+	"encoding/binary"
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/PelicanPlatform/classad/collections/vm"
@@ -107,6 +110,104 @@ func TestSchemaScanReloadZeroRebuild(t *testing.T) {
 		}
 		if got != want[e] || got != truth(c2, e) {
 			t.Fatalf("post-reopen %q: got=%d want=%d truth=%d", e, got, want[e], truth(c2, e))
+		}
+	}
+}
+
+// TestSchemaScanReloadCorruptSection verifies the reload's "any doubt rebuilds" contract: a
+// bit-flipped columnar section fails its CRC and is ignored, so that segment row-scans while the
+// rest stay columnar -- and CountConstraint still returns the correct answer.
+func TestSchemaScanReloadCorruptSection(t *testing.T) {
+	if !mmapSupported {
+		t.Skip("persistence is unix-only")
+	}
+	dir := t.TempDir()
+	exprs := []string{"Memory > 4096", "Memory <= 4096"}
+
+	open := func() *Collection {
+		c, err := Open(Options{Dir: dir, Shards: 1, SegmentSize: 1 << 12})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return c
+	}
+	c := open()
+	for i := 0; i < 600; i++ {
+		if err := c.Put([]byte(fmt.Sprintf("k%d", i)),
+			mustAdOld(t, fmt.Sprintf("Cpus=%d\nMemory=%d\nDisk=%d", 1+i%8, 1024+(i%64)*256, i*4096))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mq, _ := vm.Parse("true")
+	for i := 0; i < 20; i++ {
+		for range c.QueryProject(mq, []string{"Memory"}) {
+		}
+	}
+	if !c.BuildAndEnableSchemaScan(2000, 4) {
+		t.Fatal("BuildAndEnableSchemaScan false")
+	}
+	for i := 600; i < 2400; i++ {
+		if err := c.Put([]byte(fmt.Sprintf("k%d", i)),
+			mustAdOld(t, fmt.Sprintf("Cpus=%d\nMemory=%d\nDisk=%d", 1+i%8, 1024+(i%64)*256, i*4096))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	want := map[string]int{}
+	for _, e := range exprs {
+		want[e], _ = c.CountConstraint(e)
+	}
+	c.Close()
+
+	// Corrupt the columnar body of exactly one v2 sidecar (flip a byte just before the 16-byte
+	// container trailer, inside the col section; the trailer stays intact so the container still
+	// parses and yields the section, but its CRC now fails).
+	corrupted := ""
+	filepath.WalkDir(dir, func(p string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() || filepath.Ext(p) != ".idx" || corrupted != "" {
+			return nil
+		}
+		b, e := os.ReadFile(p)
+		if e != nil || len(b) < sidecarTrailerLenV2+colSectionHdr+1 {
+			return nil
+		}
+		if binary.LittleEndian.Uint32(b[len(b)-4:]) != sidecarContainerMagicV2 {
+			return nil // v1 (no columnar section)
+		}
+		b[len(b)-sidecarTrailerLenV2-1] ^= 0xFF // last byte of the col body
+		if e := os.WriteFile(p, b, 0o644); e != nil {
+			t.Fatal(e)
+		}
+		corrupted = p
+		return nil
+	})
+	if corrupted == "" {
+		t.Fatal("no v2 (columnar) sidecar found to corrupt")
+	}
+
+	before := colSegmentBuilds.Load()
+	c2 := open()
+	defer c2.Close()
+	if built := colSegmentBuilds.Load() - before; built != 0 {
+		t.Fatalf("reopen rebuilt %d blocks (want 0; a corrupt section should just row-scan)", built)
+	}
+	// Exactly one sealed segment should now lack a block (the corrupted one), and reads are correct.
+	missing := 0
+	for _, sh := range c2.shards {
+		sh.mu.RLock()
+		for _, seg := range sh.segs {
+			if seg != nil && seg != sh.act && seg.used > 0 && seg.colblk.Load() == nil {
+				missing++
+			}
+		}
+		sh.mu.RUnlock()
+	}
+	if missing == 0 {
+		t.Fatal("corrupt section was not rejected (segment still has a block)")
+	}
+	for _, e := range exprs {
+		got, ok := c2.CountConstraint(e)
+		if !ok || got != want[e] {
+			t.Fatalf("%q after corruption: ok=%v got=%d want=%d", e, ok, got, want[e])
 		}
 	}
 }

--- a/collections/colscan_persist_test.go
+++ b/collections/colscan_persist_test.go
@@ -211,3 +211,69 @@ func TestSchemaScanReloadCorruptSection(t *testing.T) {
 		}
 	}
 }
+
+// TestSchemaScanReindexKeepsBlock exercises the zero-copy block's mapping-swap path: a reindex
+// (AddIndex) rewrites and remaps each sealed segment's sidecar. The columnar block aliases that
+// mapping, so it must be re-published from the new mapping on the swap (like msidx) -- otherwise it
+// would read a released mapping. Query correctness must survive the reindex, and it must NOT
+// re-transcode the block from records (colBlobPreserve re-marshals the existing one).
+func TestSchemaScanReindexKeepsBlock(t *testing.T) {
+	if !mmapSupported {
+		t.Skip("persistence is unix-only")
+	}
+	dir := t.TempDir()
+	c, err := Open(Options{Dir: dir, Shards: 1, SegmentSize: 1 << 12})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+	for i := 0; i < 300; i++ {
+		if err := c.Put([]byte(fmt.Sprintf("k%d", i)),
+			mustAdOld(t, fmt.Sprintf("Cpus=%d\nMemory=%d\nOwner=\"u%d\"", 1+i%8, 1024+(i%64)*256, i%5))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mq, _ := vm.Parse("true")
+	for i := 0; i < 20; i++ {
+		for range c.QueryProject(mq, []string{"Memory"}) {
+		}
+	}
+	if !c.BuildAndEnableSchemaScan(2000, 4) {
+		t.Fatal("BuildAndEnableSchemaScan false")
+	}
+	for i := 300; i < 1500; i++ {
+		if err := c.Put([]byte(fmt.Sprintf("k%d", i)),
+			mustAdOld(t, fmt.Sprintf("Cpus=%d\nMemory=%d\nOwner=\"u%d\"", 1+i%8, 1024+(i%64)*256, i%5))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	expr := "Memory > 4096"
+	want, ok := c.CountConstraint(expr)
+	if !ok {
+		t.Fatal("CountConstraint declined pre-reindex")
+	}
+
+	// Reindex every sealed segment by adding a categorical index -> reindexSealedFile rewrites and
+	// remaps each sidecar, re-publishing the aliased block from the new mapping.
+	before := colSegmentBuilds.Load()
+	if !c.AddIndex([]string{"Owner"}, nil) {
+		t.Fatal("AddIndex returned false")
+	}
+	if built := colSegmentBuilds.Load() - before; built != 0 {
+		t.Fatalf("reindex re-transcoded %d blocks (want 0; colBlobPreserve should re-marshal)", built)
+	}
+	// The block still answers correctly after the mapping swap (a use-after-free would corrupt this).
+	got, ok := c.CountConstraint(expr)
+	if !ok || got != want {
+		t.Fatalf("post-reindex %q: ok=%v got=%d want=%d", expr, ok, got, want)
+	}
+	// And the categorical query the reindex enabled also works (the reindex genuinely happened).
+	q, _ := vm.Parse(`Owner == "u3"`)
+	n := 0
+	for range c.Query(q) {
+		n++
+	}
+	if n == 0 {
+		t.Fatal("Owner index query returned nothing after AddIndex")
+	}
+}

--- a/collections/colscan_persist_test.go
+++ b/collections/colscan_persist_test.go
@@ -1,0 +1,112 @@
+package collections
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/collections/vm"
+)
+
+// TestSchemaScanReloadZeroRebuild is the P3(2) payoff: with schema-scan enabled, segments that
+// seal persist their columnar block into the sidecar. On reopen the accelerator comes back LIVE
+// straight off disk -- schema-scan re-enabled by adopt-from-sidecar, every persisted block
+// reloaded, CountConstraint auto-routing to the same answers -- with ZERO block rebuilds (no
+// re-sample, no re-transcode).
+func TestSchemaScanReloadZeroRebuild(t *testing.T) {
+	if !mmapSupported {
+		t.Skip("persistence is unix-only")
+	}
+	dir := t.TempDir()
+	exprs := []string{"Memory > 4096", "Memory <= 4096", "Memory >= 2000 && Memory < 9000"}
+
+	open := func() *Collection {
+		c, err := Open(Options{Dir: dir, Shards: 1, SegmentSize: 1 << 12}) // small ⇒ many sealed segments
+		if err != nil {
+			t.Fatal(err)
+		}
+		return c
+	}
+	put := func(c *Collection, lo, hi int) {
+		for i := lo; i < hi; i++ {
+			ad := mustAdOld(t, fmt.Sprintf("Cpus=%d\nMemory=%d\nDisk=%d\nMachine=\"m%05d\"",
+				1+i%8, 1024+(i%64)*256, i*4096, i))
+			if err := c.Put([]byte(fmt.Sprintf("k%d", i)), ad); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	truth := func(c *Collection, expr string) int {
+		q, _ := vm.Parse(expr)
+		n := 0
+		for range c.Query(q) {
+			n++
+		}
+		return n
+	}
+	countPersistedBlocks := func(c *Collection) int {
+		n := 0
+		for _, sh := range c.shards {
+			sh.mu.RLock()
+			for _, seg := range sh.segs {
+				if seg != nil && seg != sh.act && seg.colblk.Load() != nil {
+					n++
+				}
+			}
+			sh.mu.RUnlock()
+		}
+		return n
+	}
+
+	// Build a first tranche, sample it, and enable schema-scan. Then write MORE so fresh segments
+	// seal WHILE schema-scan is enabled -- those persist their block at seal.
+	c := open()
+	put(c, 0, 600)
+	mq, _ := vm.Parse("true")
+	for i := 0; i < 20; i++ {
+		for range c.QueryProject(mq, []string{"Memory"}) { // drive Memory read demand -> hot tier
+		}
+	}
+	if !c.BuildAndEnableSchemaScan(2000, 4) {
+		t.Fatal("BuildAndEnableSchemaScan returned false")
+	}
+	put(c, 600, 2400) // these segments seal with a persisted columnar block
+
+	persisted := countPersistedBlocks(c)
+	if persisted == 0 {
+		t.Fatal("no segment persisted a columnar block after enabling schema-scan")
+	}
+	want := map[string]int{}
+	for _, e := range exprs {
+		got, ok := c.CountConstraint(e)
+		if !ok || got != truth(c, e) {
+			t.Fatalf("pre-reopen %q: ok=%v got=%d want=%d", e, ok, got, truth(c, e))
+		}
+		want[e] = got
+	}
+	if err := c.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Reopen: the accelerator must come back off disk with NO block builds.
+	before := colSegmentBuilds.Load()
+	c2 := open()
+	defer c2.Close()
+	if built := colSegmentBuilds.Load() - before; built != 0 {
+		t.Fatalf("reopen rebuilt %d columnar blocks (want 0 -- should reload from disk)", built)
+	}
+	if c2.schemaScan.Load() == nil {
+		t.Fatal("reopen did not re-enable schema-scan from the persisted blocks (adopt-from-sidecar)")
+	}
+	if got := countPersistedBlocks(c2); got < persisted {
+		t.Fatalf("reopen recovered %d columnar blocks, had %d before close", got, persisted)
+	}
+	for _, e := range exprs {
+		got, ok := c2.CountConstraint(e)
+		if !ok {
+			t.Fatalf("post-reopen %q: CountConstraint declined", e)
+		}
+		if got != want[e] || got != truth(c2, e) {
+			t.Fatalf("post-reopen %q: got=%d want=%d truth=%d", e, got, want[e], truth(c2, e))
+		}
+	}
+}

--- a/collections/persist.go
+++ b/collections/persist.go
@@ -271,6 +271,9 @@ func Open(opts Options) (*Collection, error) {
 	// The maintained ordered indexes are likewise derived: rebuild them from the
 	// recovered ads so a reopened collection's Ordered() is immediately correct.
 	c.rebuildOrdered()
+	// If sealed segments recovered persisted columnar blocks, re-enable schema-scan from them
+	// (adopt-from-sidecar) so the accelerator is live immediately -- no re-sample, no rebuild.
+	c.adoptPersistedSchemaScan()
 	return c, nil
 }
 

--- a/collections/sealed_index.go
+++ b/collections/sealed_index.go
@@ -54,8 +54,8 @@ func (c *Collection) publishSidecar(seg *segment, path string, spec *indexSpec) 
 	// row-scans until the block is rebuilt. The unmarshal COPIES its streams, so the block is
 	// independent of this mapping.
 	var cs *colSegment
-	if len(col) > 0 {
-		cs = unmarshalColSegment(col, seg.codec, c.intern.Intern) // nil on malformed -> row-scan
+	if body := readColSection(col, seg.used); body != nil { // rejects truncated/corrupt/stale -> row-scan
+		cs = unmarshalColSegment(body, seg.codec, c.intern.Intern)
 	}
 	// keyIdx is set exactly once per seal and is the "sealed" marker; CAS so a
 	// concurrent seal cannot leak a mapping.

--- a/collections/sealed_index.go
+++ b/collections/sealed_index.go
@@ -33,7 +33,7 @@ func (c *Collection) publishSidecar(seg *segment, path string, spec *indexSpec) 
 	if err != nil {
 		return false
 	}
-	attr, key, _, ok := splitSegmentSidecar(data)
+	attr, key, col, ok := splitSegmentSidecar(data)
 	if !ok {
 		_ = closer()
 		return false
@@ -49,11 +49,22 @@ func (c *Collection) publishSidecar(seg *segment, path string, spec *indexSpec) 
 			mm = m
 		}
 	}
+	// Columnar accelerator block (v2 container). Derived like the attribute index: any
+	// doubt (unparseable / wrong record count) leaves it unpublished, so the segment simply
+	// row-scans until the block is rebuilt. The unmarshal COPIES its streams, so the block is
+	// independent of this mapping.
+	var cs *colSegment
+	if len(col) > 0 {
+		cs = unmarshalColSegment(col, seg.codec, c.intern.Intern) // nil on malformed -> row-scan
+	}
 	// keyIdx is set exactly once per seal and is the "sealed" marker; CAS so a
 	// concurrent seal cannot leak a mapping.
 	if !seg.keyIdx.CompareAndSwap(nil, ki) {
 		_ = closer()
 		return false
+	}
+	if cs != nil {
+		seg.colblk.Store(cs)
 	}
 	// Phase 2: a resident key Bloom over the segment's key-hashes, built from the key
 	// index, gates the sealed-segment probe. Published after keyIdx so a probe that
@@ -94,7 +105,7 @@ func (c *Collection) sealSegmentIndex(seg *segment, si *segIndex) {
 		}
 		attrBlob = b
 	}
-	container := buildSegmentSidecar(attrBlob, buildKeyIndex(seg.data, seg.used, c.h), nil)
+	container := buildSegmentSidecar(attrBlob, buildKeyIndex(seg.data, seg.used, c.h), c.colBlobForSeg(seg))
 	if err := writeFileAtomic(path, container); err != nil {
 		return
 	}
@@ -163,7 +174,7 @@ func (c *Collection) reindexSealedFile(sh *shard, seg *segment, si *segIndex) bo
 	}
 	// Rename over the live file: the existing mapping is unaffected (it holds the old
 	// inode), so readers keep working until they are swapped over below.
-	if err := writeFileAtomic(path, buildSegmentSidecar(attrBlob, buildKeyIndex(seg.data, seg.used, c.h), nil)); err != nil {
+	if err := writeFileAtomic(path, buildSegmentSidecar(attrBlob, buildKeyIndex(seg.data, seg.used, c.h), c.colBlobForSeg(seg))); err != nil {
 		return false
 	}
 	data, closer, err := mapFile(path)

--- a/collections/sealed_index.go
+++ b/collections/sealed_index.go
@@ -174,14 +174,14 @@ func (c *Collection) reindexSealedFile(sh *shard, seg *segment, si *segIndex) bo
 	}
 	// Rename over the live file: the existing mapping is unaffected (it holds the old
 	// inode), so readers keep working until they are swapped over below.
-	if err := writeFileAtomic(path, buildSegmentSidecar(attrBlob, buildKeyIndex(seg.data, seg.used, c.h), c.colBlobForSeg(seg))); err != nil {
+	if err := writeFileAtomic(path, buildSegmentSidecar(attrBlob, buildKeyIndex(seg.data, seg.used, c.h), c.colBlobPreserve(seg))); err != nil {
 		return false
 	}
 	data, closer, err := mapFile(path)
 	if err != nil {
 		return false
 	}
-	attr, key, _, ok := splitSegmentSidecar(data)
+	attr, key, col, ok := splitSegmentSidecar(data)
 	if !ok {
 		_ = closer()
 		return false
@@ -203,11 +203,21 @@ func (c *Collection) reindexSealedFile(sh *shard, seg *segment, si *segIndex) bo
 	// Publish under the shard write lock: the readers that touch a sidecar without a scan
 	// pin (SidecarSizes, IndexSizes) hold the read lock while they do, so the lock is what
 	// bounds them. Pinned scan readers are handled by the pin drain instead.
+	// The columnar block, if present, ALIASES this new mapping (zero-copy) just like msidx, so it
+	// is re-published on the same swap: the displaced mapping (which backed the old block) is
+	// reaped together by swapSidecarHook + releaseStale once scan pins drain.
+	var cs *colSegment
+	if body := readColSection(col, seg.used); body != nil {
+		cs = unmarshalColSegment(body, seg.codec, c.intern.Intern)
+	}
 	sh.mu.Lock()
 	seg.msidx.Store(mm)
 	seg.keyIdx.Store(ki)
 	seg.keyBloom.Store(bloomFromKeyIndex(ki))
 	seg.idx.Store(nil) // the heap copy stays dropped; msidx serves queries
+	if cs != nil {
+		seg.colblk.Store(cs)
+	}
 	seg.swapSidecarHook(func() { _ = closer() }, true)
 	sh.mu.Unlock()
 	seg.releaseStale() // free the displaced mapping now if no scan is reading it


### PR DESCRIPTION
Persist the columnar (PAX) accelerator across reopen — adschema P3(2), the payoff of the interning work. Builds on #119 (name-anchored schema) and #120 (sidecar columnar section), both merged.

Before this, the columnar accelerator was rebuilt in RAM on every Open/Maintain (`buildColumnarFromSegment` re-transcoding each sealed segment). Now each sealed segment's block is written into its sidecar at seal and **reloaded on reopen** — a restarted store gets the accelerator live off disk with zero rebuilds.

## What's here (3 commits)

**1. Persist + reload** (`27bb578`)
- `colBlobForSeg` builds + marshals the block under the current schema-scan schema; `sealSegmentIndex`/`reindexSealedFile` embed it in the sidecar container.
- `publishSidecar` unmarshals a recovered section into `seg.colblk` (name-anchored schema re-resolved to the reopened intern ids).
- `adoptPersistedSchemaScan` re-enables schema-scan on Open from any recovered block.
- **Per-segment schema**: the scan resolves the field *per block* against each block's own schema (`byID` over the shared intern id) rather than by pointer identity with one collection schema. So heterogeneous per-segment schemas coexist — **a schema change never rewrites existing segments**; they row-fall-back for attributes absent from their own schema. This is what makes the feature safe on a large (e.g. 10 TB) store: schema evolution is free.

**2. Version + CRC framing** (`fa29125`)
- The marshaled block is wrapped with a magic/version/`upto`/CRC header; reload validates it before trusting the bytes. Any mismatch (truncated, bit-rotted, stale length) leaves the block unpublished and the segment row-scans — the same "derived state, any doubt rebuilds" contract the attribute-index sidecar follows.

**3. Zero-heap mmap read** (`fe0679a`)
- A reloaded block's byte streams **alias the `.idx` mapping** instead of being copied to the heap: the hot numeric column is scanned strided directly over the mmap; cold streams decompress lazily into the bounded block cache only when touched. Same lifetime contract as the mmap'd attribute index — both alias the one mapping, reaped together and re-published together when reindex swaps the sidecar (`reindexSealedFile` re-publishes the block; `colBlobPreserve` re-marshals rather than re-transcodes). This removes the per-segment stream heap the whole interning/columnar effort is chasing.

## Tests
- **Zero-rebuild payoff**: enable schema-scan, seal segments, close, reopen → schema-scan re-enabled, every block reloaded, `CountConstraint` == row truth, **0 block rebuilds** (a build counter asserts nothing was re-transcoded on the reopen path).
- **Corruption**: bit-flip one persisted section on disk → reopen ignores it (that segment row-scans, the rest stay columnar), counts still correct, no rebuild.
- **Reindex-after-persist**: `AddIndex` swaps every sidecar mapping → query correct after the swap (a use-after-free would corrupt it), no re-transcode.
- Full suite + a targeted pin/reindex/reload race pass under `-race`.

Encryption at rest never persists a block (schema-scan is disabled for encrypted collections), so it is unaffected.
