### PR TITLE
collections: read an escaped numeric field without reconstructing the record

### DIFF
--- a/collections/colblock.go
+++ b/collections/colblock.go
@@ -1,6 +1,7 @@
 package collections
 
 import (
+	"encoding/binary"
 	"errors"
 	"sync/atomic"
 
@@ -215,4 +216,37 @@ func (b *columnarBlock) reconstruct(k int, bc *blockCache) ([]byte, error) {
 	rec = append(rec, strRaw[b.strOff[k]:b.strOff[k+1]]...)
 	rec = append(rec, tailRaw[b.coldOff[k]:b.coldOff[k+1]]...)
 	return rec, nil
+}
+
+// escapedNumField reads the numeric value of an ESCAPED schema field (fieldID) for record k
+// straight from its cold-tail slice, skipping the whole-record reconstruct. A field is escaped
+// when it is missing or exceptional (out of the fitted width, or a type exception); an exceptional
+// value lives in the cold tail as a uvarint(id)+node entry alongside the record's non-schema
+// attributes. Returns (value, true) if fieldID has a numeric value here, or (0, false) if it is
+// missing or non-numeric. bc caches the decompressed cold stream, so a scan's many escaped reads
+// on one block share a single decompression. Callers use this only for records the scan has
+// already found escaped for fieldID; a hot/cold-column value never reaches here.
+func (b *columnarBlock) escapedNumField(k int, fieldID uint32, bc *blockCache) (float64, bool, error) {
+	ds, err := bc.streams(b)
+	if err != nil {
+		return 0, false, err
+	}
+	cold := ds.cold[b.coldOff[k]:b.coldOff[k+1]]
+	for len(cold) > 0 {
+		id, m := binary.Uvarint(cold)
+		if m <= 0 {
+			return 0, false, nil // malformed tail: treat fieldID as absent
+		}
+		cold = cold[m:]
+		nl, ok := wire.NodeLen(cold)
+		if !ok || nl > len(cold) {
+			return 0, false, nil
+		}
+		if uint32(id) == fieldID {
+			f, found := literalFloat(cold[:nl])
+			return f, found, nil
+		}
+		cold = cold[nl:]
+	}
+	return 0, false, nil
 }

--- a/collections/colscan.go
+++ b/collections/colscan.go
@@ -324,11 +324,10 @@ func (c *Collection) schemaScanCount(fieldID uint32, bc *blockCache, eval func(f
 		s0, wins := sh.snapshot()
 		for _, w := range wins {
 			cs := w.seg.colblk.Load()
-			bs := (*adSchema)(nil)
 			bidx := -1
 			if cs != nil {
 				if idx, ok := cs.block.schema.byID[fieldID]; ok && cs.block.schema.fields[idx].kind == akInt {
-					bs, bidx = cs.block.schema, idx
+					bidx = idx
 				}
 			}
 			if bidx < 0 {
@@ -346,10 +345,10 @@ func (c *Collection) schemaScanCount(fieldID uint32, bc *blockCache, eval func(f
 					}
 					return
 				}
-				if rec, err := cs.block.reconstruct(k, bc); err == nil { // escaped: cold tail
-					if f, ok := numFieldOf(bs, rec, fieldID); ok && eval(f) {
-						count++
-					}
+				// Escaped: read only fieldID from the cold tail, not the whole record. (numFieldOf
+				// via a full reconstruct dominated the scan when a numeric attr has a value tail.)
+				if f, ok, err := cs.block.escapedNumField(k, fieldID, bc); err == nil && ok && eval(f) {
+					count++
 				}
 			})
 		}
@@ -391,19 +390,4 @@ func bruteNumCount(w segWindow, s0 uint64, lookup func(wire.Ad) ([]byte, bool), 
 		off += int(total)
 	}
 	return count
-}
-
-// numFieldOf returns the numeric value (int or real) of fieldID in a reconstructed schema
-// record, if present as a number (missing or non-numeric ⇒ false).
-func numFieldOf(s *adSchema, rec []byte, fieldID uint32) (float64, bool) {
-	var out float64
-	var found bool
-	s.forEach(rec, func(id uint32, node []byte) bool {
-		if id != fieldID {
-			return true
-		}
-		out, found = literalFloat(node)
-		return false
-	})
-	return out, found
 }

--- a/collections/colscan_escaped_test.go
+++ b/collections/colscan_escaped_test.go
@@ -1,0 +1,56 @@
+package collections
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/collections/vm"
+)
+
+// TestSchemaScanEscapedField drives the escaped-value scan path (escapedNumField): most Memory
+// values fit a small int width, but a heavy tail of huge values ESCAPE it and live in the cold
+// tail. A threshold placed among the escaped values forces the scan to read those escaped values
+// (not just the hot column) -- the columnar count must equal the row truth across the boundary.
+func TestSchemaScanEscapedField(t *testing.T) {
+	store := New(Options{Shards: 1, SegmentSize: 1 << 12}) // small -> sealed segments
+	const n = 2000
+	for i := 0; i < n; i++ {
+		mem := 1024 + (i%32)*128 // mostly small (fits a narrow width)
+		if i%10 == 0 {
+			mem = 5_000_000 + i // 10% huge -> escape the fitted width to the cold tail
+		}
+		ad := mustAdOld(t, fmt.Sprintf("Cpus=%d\nMemory=%d\nDisk=%d", 1+i%8, mem, i))
+		if err := store.Put([]byte(fmt.Sprintf("k%d", i)), ad); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for i := 0; i < 20; i++ {
+		mq, _ := vm.Parse("true")
+		for range store.QueryProject(mq, []string{"Memory"}) {
+		}
+	}
+	if !store.BuildAndEnableSchemaScan(2000, 4) {
+		t.Fatal("BuildAndEnableSchemaScan false")
+	}
+	// Thresholds: below all escaped (counts them), between, and above all.
+	for _, expr := range []string{
+		"Memory > 4096",      // small + all escaped
+		"Memory > 1000000",   // only the escaped huge ones
+		"Memory >= 5000000",  // escaped ones at/above the tail base
+		"Memory > 100000000", // above every value -> zero
+		"Memory == 5000000",  // exact escaped value (i==0)
+	} {
+		got, ok := store.CountConstraint(expr)
+		if !ok {
+			t.Fatalf("%q: CountConstraint declined", expr)
+		}
+		q, _ := vm.Parse(expr)
+		want := 0
+		for range store.Query(q) {
+			want++
+		}
+		if got != want {
+			t.Fatalf("%q: columnar %d != row truth %d (escaped-field path)", expr, got, want)
+		}
+	}
+}


### PR DESCRIPTION
The columnar count`s escaped-value path — a numeric attribute whose value fell outside its fitted int width and moved to the cold tail — reconstructed the **whole record** and walked every field to read one value. For an attribute with a heavy value tail that dominated the scan.

## Change
Add `columnarBlock.escapedNumField`, which reads only the requested field straight from record k`s cold-tail slice (the `uvarint(id)+node` run), sharing one cached cold-stream decompression across the scan. `schemaScanCount` uses it in place of `reconstruct` + `numFieldOf` (now removed).

## Impact (OSPool, `Memory>4096`)
| | before | after |
|---|---|---|
| persisted / mmap-reopened | 214µs, 218 allocs | **167µs, 30 allocs** |
| in-memory | 88µs, 142 allocs | **50µs, 4 allocs** |

The full-record reconstruction and its per-scan garbage are gone (in-memory is now essentially alloc-free).

## Correctness
Unchanged — the columnar count still equals the row truth across escape boundaries. `TestSchemaScanEscapedField` forces a tail of out-of-width values and queries thresholds right through it (including exact escaped values).

Follows #121 (columnar persistence).