### PR TITLE
collections: widen hot int columns to (near-)zero escapes

### DIFF
--- a/collections/colscan.go
+++ b/collections/colscan.go
@@ -213,8 +213,66 @@ func (c *Collection) BuildAndEnableSchemaScan(sampleMax, hotTopN int) bool {
 	for i := 0; i < len(nums) && i < hotTopN; i++ {
 		hot = append(hot, nums[i].idx)
 	}
+	// Re-fit the hot int columns to (near-)zero escapes: an escaped value on a queried column
+	// forces the block's cold-stream decompression + a cold-tail walk, so a hot field wants a
+	// width that covers essentially all its values. Cold fields keep the tight base width. See
+	// refitHotIntWidths.
+	s, hot = refitHotIntWidths(s, samples, hot, hotIntFit)
 	c.EnableSchemaScan(s, hot)
 	return true
+}
+
+// hotIntFit is the width fit percentile for HOT (demand-queried) int columns: high enough to
+// eliminate escapes on real data, but below 1.0 so a single sampled outlier does not widen the
+// column for every record (0.999 and 1.0 pick identical widths on the OSPool corpus, but 0.999
+// caps an outlier's blast radius at 0.1%). Cold columns keep the base Fit (0.95).
+const hotIntFit = 0.999
+
+// refitHotIntWidths widens each hot INT field to cover ~all its sampled values (hotFit), so a
+// queried column rarely escapes to the cold path. It re-collects the hot fields' sampled int
+// values (buildAdSchema discards them), re-chooses their widths at hotFit, and re-lays-out the
+// schema; cold fields and non-int hot fields are untouched. Returns the re-fitted schema and the
+// hot field indices remapped into its (re-sorted) layout. A no-op when no hot int field exists.
+func refitHotIntWidths(s *adSchema, samples [][]byte, hot []int, hotFit float64) (*adSchema, []int) {
+	hotByID := make(map[uint32]bool, len(hot)) // all hot fields (int+real), for index remap
+	hotIntIDs := map[uint32]bool{}             // hot int fields, for width re-fit
+	for _, i := range hot {
+		hotByID[s.fields[i].id] = true
+		if s.fields[i].kind == akInt {
+			hotIntIDs[s.fields[i].id] = true
+		}
+	}
+	if len(hotIntIDs) == 0 {
+		return s, hot
+	}
+	vals := map[uint32][]int64{}
+	for _, w := range samples {
+		wire.Ad(w).ForEach(func(id uint32, node []byte) bool {
+			if hotIntIDs[id] {
+				if k, lit := nodeKind(node); k == akInt {
+					vals[id] = append(vals[id], lit.Int)
+				}
+			}
+			return true
+		})
+	}
+	fs := make([]adField, len(s.fields))
+	copy(fs, s.fields)
+	for i := range fs {
+		if hotIntIDs[fs[i].id] {
+			if vs := vals[fs[i].id]; len(vs) > 0 {
+				fs[i].width, fs[i].unsigned = chooseIntWidth(vs, hotFit)
+			}
+		}
+	}
+	s2 := layoutSchema(fs)
+	var hot2 []int
+	for i := range s2.fields {
+		if hotByID[s2.fields[i].id] {
+			hot2 = append(hot2, i)
+		}
+	}
+	return s2, hot2
 }
 
 // CountConstraint parses a constraint string and, if it is columnar-eligible, counts via the

--- a/collections/colscan_hotrefit_test.go
+++ b/collections/colscan_hotrefit_test.go
@@ -1,0 +1,103 @@
+package collections
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/collections/vm"
+)
+
+// TestRefitHotIntWidths unit-tests the re-fit helper: two fields share a distribution (mostly
+// small, a ~2% tail that overflows 2 bytes), but only one is in the hot set. The hot field must be
+// widened to cover its tail (no escape); the cold field must keep the tight base width.
+func TestRefitHotIntWidths(t *testing.T) {
+	c := New(Options{Shards: 1})
+	var wires [][]byte
+	for i := 0; i < 3000; i++ {
+		v := 1024 + (i%64)*256 // fits 2 bytes
+		if i%50 == 0 {
+			v = 5_000_000 + i // ~2% tail, overflows 2 bytes
+		}
+		wires = append(wires, c.encodeAd(mustAdOld(t,
+			fmt.Sprintf("Cpus=%d\nMem=%d\nCold=%d", 1+i%8, v, v)).AST()))
+	}
+	s := buildAdSchema(wires, adSchemaOpts{Presence: 0.9, Fit: 0.95, Strings: true})
+	memID, _ := c.intern.LookupID("Mem")
+	coldID, _ := c.intern.LookupID("Cold")
+	// Precondition: at the base Fit both land at the narrow (escaping) width.
+	if w := s.fields[s.byID[memID]].width; w != 2 {
+		t.Fatalf("precondition: Mem base width %d, want 2", w)
+	}
+	// Re-fit with only Mem hot.
+	s2, hot2 := refitHotIntWidths(s, wires, []int{s.byID[memID]}, hotIntFit)
+	memF := s2.fields[s2.byID[memID]]
+	coldF := s2.fields[s2.byID[coldID]]
+	if !intFits(5_000_000+3000, memF.width, memF.unsigned) {
+		t.Fatalf("hot Mem width=%d still escapes its tail", memF.width)
+	}
+	if intFits(5_000_000, coldF.width, coldF.unsigned) {
+		t.Fatalf("cold width=%d widened (should stay narrow)", coldF.width)
+	}
+	if memF.width <= coldF.width {
+		t.Fatalf("hot Mem width %d not wider than cold %d", memF.width, coldF.width)
+	}
+	// hot2 must point at Mem in the re-laid-out schema.
+	if len(hot2) != 1 || s2.fields[hot2[0]].id != memID {
+		t.Fatalf("hot2 does not map to Mem after re-layout: %v", hot2)
+	}
+	t.Logf("hot Mem=%dB (covers tail), cold=%dB (escapes)", memF.width, coldF.width)
+}
+
+// TestHotTierRefitEndToEnd drives query demand on Mem (a constraint that evaluates it), so
+// BuildAndEnableSchemaScan makes Mem hot and re-fits it; the columnar count stays correct across
+// the tail.
+func TestHotTierRefitEndToEnd(t *testing.T) {
+	store := New(Options{Shards: 1, SegmentSize: 1 << 12})
+	const n = 3000
+	for i := 0; i < n; i++ {
+		v := 1024 + (i%64)*256
+		if i%50 == 0 {
+			v = 5_000_000 + i
+		}
+		if err := store.Put([]byte(fmt.Sprintf("k%d", i)),
+			mustAdOld(t, fmt.Sprintf("Cpus=%d\nMem=%d\nCold=%d", 1+i%8, v, v))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Evaluate Mem (recordReads bumps its demand) -> Mem becomes the hot field.
+	mc, _ := vm.Parse("Mem >= 0")
+	for i := 0; i < 30; i++ {
+		for range store.Query(mc) {
+		}
+	}
+	if !store.BuildAndEnableSchemaScan(2000, 1) {
+		t.Fatal("BuildAndEnableSchemaScan false")
+	}
+	st := store.schemaScan.Load()
+	memID, _ := store.intern.LookupID("Mem")
+	if len(st.hot) == 0 || st.schema.fields[st.hot[0]].id != memID {
+		got := "?"
+		if len(st.hot) > 0 {
+			got, _ = store.intern.Name(st.schema.fields[st.hot[0]].id)
+		}
+		t.Fatalf("Mem is not the hot field (got %q) -- demand not driven", got)
+	}
+	memF := st.schema.fields[st.schema.byID[memID]]
+	if !intFits(5_000_000+n, memF.width, memF.unsigned) {
+		t.Fatalf("hot Mem width=%d not widened to cover its tail", memF.width)
+	}
+	for _, expr := range []string{"Mem > 4096", "Mem > 1000000", "Mem >= 5000000"} {
+		got, ok := store.CountConstraint(expr)
+		if !ok {
+			t.Fatalf("%q declined", expr)
+		}
+		q, _ := vm.Parse(expr)
+		want := 0
+		for range store.Query(q) {
+			want++
+		}
+		if got != want {
+			t.Fatalf("%q: columnar %d != row %d", expr, got, want)
+		}
+	}
+}


### PR DESCRIPTION
An escaped value on a *queried* columnar field forces the block`s cold-stream decompression plus a cold-tail walk, so even a 0.5%-tail attribute like `Memory` scanned ~4x slower than a field that fit its width (measured). This sizes the demand-hot int columns to essentially never escape, while cold columns stay tight.

## Change
After `BuildAndEnableSchemaScan` picks the demand-hot tier, `refitHotIntWidths` re-collects those fields` sampled int values, re-chooses their widths at a high percentile, and re-lays-out the schema. Cold columns and non-int hot fields are untouched.

## Why `Fit=0.999`, not `1.0`
On the OSPool corpus both pick **identical** widths (0 escapes, `totIntBytes` equal, 0 fields differ) — so 0.999 loses nothing on real data. But `1.0` sets the width from the *sample maximum*, so one freak sampled value would widen a column for every record; `0.999` caps that blast radius at 0.1%. (`0.99` was too weak — it left `Memory` at the slow 2B.)

## Cost
Only the handful of tailed, queried fields widen. With the 6-byte width (#122) a widened field lands at 6B rather than 8B where it fits, so the extra sidecar disk is **~1%** — for the ~4x scan speedup on those fields.

## Tests
- `TestRefitHotIntWidths`: a hot field is widened to cover its tail while an identically-distributed **cold** field stays narrow (asymmetry proves it is hot-only).
- `TestHotTierRefitEndToEnd`: a demand-hot field is re-fit and the columnar count stays correct across the tail.

Composes with #122 (6-byte width). Independent of it at the file level.