### PR TITLE
collections: persist a segment's columnar block at EnableSchemaScan time

### DIFF
--- a/collections/colscan.go
+++ b/collections/colscan.go
@@ -62,9 +62,43 @@ func (c *Collection) EnableSchemaScan(s *adSchema, hot []int) {
 		for _, seg := range segs {
 			if cs := c.buildColSegment(seg, s, hot); cs != nil {
 				seg.colblk.Store(cs)
+				c.persistColSeg(sh, seg) // write it to the sidecar so a reopen reloads it (no-op for RAM)
 			}
 		}
 	}
+}
+
+// persistColSeg writes seg's freshly-built columnar block into its sidecar container (preserving
+// the existing attribute + key sections) and remaps it, so a block built at EnableSchemaScan time
+// over an ALREADY-sealed segment survives a reopen instead of being re-transcoded. Without it a
+// segment sealed BEFORE schema-scan was enabled would keep an in-RAM-only block and row-fall-back
+// after reopen until a reindex touched it. No-op for an in-memory (RAM) segment or one whose
+// sidecar cannot be read. Holds reindexMu to serialize the sidecar rewrite against a concurrent
+// Reindex, which rewrites the same container.
+func (c *Collection) persistColSeg(sh *shard, seg *segment) {
+	path := snapshotPath(seg)
+	if path == "" {
+		return // in-memory segment: the block stays in RAM, nothing to persist
+	}
+	colBlob := c.colBlobPreserve(seg)
+	if colBlob == nil {
+		return
+	}
+	c.reindexMu.Lock()
+	defer c.reindexMu.Unlock()
+	// Copy the current attribute + key sections out of the live mapping before the rewrite.
+	data, closer, err := mapFile(path)
+	if err != nil {
+		return
+	}
+	attr, key, _, ok := splitSegmentSidecar(data)
+	if !ok {
+		_ = closer()
+		return
+	}
+	container := buildSegmentSidecar(append([]byte(nil), attr...), append([]byte(nil), key...), colBlob)
+	_ = closer()
+	c.installSidecar(sh, seg, path, container)
 }
 
 // buildColSegment transcodes a sealed segment into its columnar accelerator block under schema s

--- a/collections/colscan_persist_enable_test.go
+++ b/collections/colscan_persist_enable_test.go
@@ -1,0 +1,105 @@
+package collections
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/collections/vm"
+)
+
+// TestSchemaScanPersistAtEnable covers the persist-at-enable path: segments sealed BEFORE
+// schema-scan is enabled must have their columnar block written to the sidecar at enable time (not
+// just kept in RAM), so a reopen reloads them off disk with ZERO rebuilds instead of row-falling-
+// back. (Before this, only segments sealed AFTER enable persisted.)
+func TestSchemaScanPersistAtEnable(t *testing.T) {
+	if !mmapSupported {
+		t.Skip("persistence is unix-only")
+	}
+	dir := t.TempDir()
+	exprs := []string{"Memory > 4096", "Memory <= 4096", "Memory >= 2000 && Memory < 9000"}
+	open := func() *Collection {
+		c, err := Open(Options{Dir: dir, Shards: 1, SegmentSize: 1 << 12})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return c
+	}
+	truth := func(c *Collection, e string) int {
+		q, _ := vm.Parse(e)
+		n := 0
+		for range c.Query(q) {
+			n++
+		}
+		return n
+	}
+	sealedWithBlock := func(c *Collection) (sealed, withBlk int) {
+		for _, sh := range c.shards {
+			sh.mu.RLock()
+			for _, seg := range sh.segs {
+				if seg != nil && seg != sh.act && seg.used > 0 {
+					sealed++
+					if seg.colblk.Load() != nil {
+						withBlk++
+					}
+				}
+			}
+			sh.mu.RUnlock()
+		}
+		return
+	}
+
+	// Write ALL the data first -> segments seal as inline (schema-scan not yet enabled).
+	c := open()
+	const n = 2400
+	for i := 0; i < n; i++ {
+		if err := c.Put([]byte(fmt.Sprintf("k%d", i)),
+			mustAdOld(t, fmt.Sprintf("Cpus=%d\nMemory=%d\nDisk=%d", 1+i%8, 1024+(i%64)*256, i*4096))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mq, _ := vm.Parse("true")
+	for i := 0; i < 20; i++ {
+		for range c.QueryProject(mq, []string{"Memory"}) {
+		}
+	}
+	// Enable NOW, over already-sealed segments -> they must persist at enable time.
+	if !c.BuildAndEnableSchemaScan(2000, 4) {
+		t.Fatal("BuildAndEnableSchemaScan false")
+	}
+	sealed, withBlk := sealedWithBlock(c)
+	if sealed == 0 || withBlk != sealed {
+		t.Fatalf("pre-reopen: %d/%d sealed segments have a block (want all)", withBlk, sealed)
+	}
+	want := map[string]int{}
+	for _, e := range exprs {
+		got, ok := c.CountConstraint(e)
+		if !ok || got != truth(c, e) {
+			t.Fatalf("pre-reopen %q: ok=%v got=%d", e, ok, got)
+		}
+		want[e] = got
+	}
+	if err := c.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Reopen: the pre-enable segments' blocks must reload off disk, no rebuild.
+	before := colSegmentBuilds.Load()
+	c2 := open()
+	defer c2.Close()
+	if built := colSegmentBuilds.Load() - before; built != 0 {
+		t.Fatalf("reopen rebuilt %d blocks (want 0 -- persist-at-enable should reload from disk)", built)
+	}
+	if c2.schemaScan.Load() == nil {
+		t.Fatal("reopen did not re-enable schema-scan (blocks not persisted at enable?)")
+	}
+	s2, w2 := sealedWithBlock(c2)
+	if s2 == 0 || w2 != s2 {
+		t.Fatalf("post-reopen: %d/%d sealed segments reloaded a block (want all)", w2, s2)
+	}
+	for _, e := range exprs {
+		got, ok := c2.CountConstraint(e)
+		if !ok || got != want[e] || got != truth(c2, e) {
+			t.Fatalf("post-reopen %q: ok=%v got=%d want=%d", e, ok, got, want[e])
+		}
+	}
+}

--- a/collections/sealed_index.go
+++ b/collections/sealed_index.go
@@ -172,9 +172,22 @@ func (c *Collection) reindexSealedFile(sh *shard, seg *segment, si *segIndex) bo
 	if err != nil {
 		return false
 	}
-	// Rename over the live file: the existing mapping is unaffected (it holds the old
-	// inode), so readers keep working until they are swapped over below.
-	if err := writeFileAtomic(path, buildSegmentSidecar(attrBlob, buildKeyIndex(seg.data, seg.used, c.h), c.colBlobPreserve(seg))); err != nil {
+	container := buildSegmentSidecar(attrBlob, buildKeyIndex(seg.data, seg.used, c.h), c.colBlobPreserve(seg))
+	return c.installSidecar(sh, seg, path, container)
+}
+
+// installSidecar atomically rewrites seg's sidecar to container, remaps it, and publishes the key
+// index (always), the attribute index (when the container carries a valid one), and the columnar
+// block (when present) -- all aliasing the ONE new mapping, swapped in under the shard lock and
+// reaped together with the displaced mapping once scan pins drain. Shared by the reindex rewrite
+// and the enable-time columnar persist. Best-effort: on any malformed remap it drops the new
+// mapping and leaves the old sidecar in place. It never reaps the old mapping while leaving the
+// segment's live attribute index dangling: if the segment has an msidx but the new container has
+// no valid one, it aborts.
+func (c *Collection) installSidecar(sh *shard, seg *segment, path string, container []byte) bool {
+	// Rename over the live file: the existing mapping is unaffected (it holds the old inode), so
+	// readers keep working until they are swapped over below.
+	if err := writeFileAtomic(path, container); err != nil {
 		return false
 	}
 	data, closer, err := mapFile(path)
@@ -191,30 +204,33 @@ func (c *Collection) reindexSealedFile(sh *shard, seg *segment, si *segIndex) bo
 		_ = closer()
 		return false
 	}
-	if !sidecarCRCValid(attr) {
-		_ = closer()
+	var mm *mmapSegIndex
+	if len(attr) > 0 && sidecarCRCValid(attr) {
+		if m, e := parseMmapSidecar(attr); e == nil && m != nil && int(m.upto) == seg.used {
+			mm = m
+		}
+	}
+	if mm == nil && seg.msidx.Load() != nil {
+		_ = closer() // would drop the segment's live attribute index: abort, keep the old sidecar
 		return false
 	}
-	mm, err := parseMmapSidecar(attr)
-	if err != nil || mm == nil || int(mm.upto) != seg.used {
-		_ = closer()
-		return false
-	}
-	// Publish under the shard write lock: the readers that touch a sidecar without a scan
-	// pin (SidecarSizes, IndexSizes) hold the read lock while they do, so the lock is what
-	// bounds them. Pinned scan readers are handled by the pin drain instead.
-	// The columnar block, if present, ALIASES this new mapping (zero-copy) just like msidx, so it
-	// is re-published on the same swap: the displaced mapping (which backed the old block) is
-	// reaped together by swapSidecarHook + releaseStale once scan pins drain.
+	// The columnar block, if present, ALIASES this new mapping (zero-copy) like msidx, so it is
+	// published on the same swap; the displaced mapping (which backed the old block) is reaped
+	// together by swapSidecarHook + releaseStale once scan pins drain.
 	var cs *colSegment
 	if body := readColSection(col, seg.used); body != nil {
 		cs = unmarshalColSegment(body, seg.codec, c.intern.Intern)
 	}
+	// Publish under the shard write lock: the readers that touch a sidecar without a scan pin
+	// (SidecarSizes, IndexSizes) hold the read lock while they do; pinned scan readers are handled
+	// by the pin drain instead.
 	sh.mu.Lock()
-	seg.msidx.Store(mm)
 	seg.keyIdx.Store(ki)
 	seg.keyBloom.Store(bloomFromKeyIndex(ki))
-	seg.idx.Store(nil) // the heap copy stays dropped; msidx serves queries
+	if mm != nil {
+		seg.msidx.Store(mm)
+		seg.idx.Store(nil) // the heap copy stays dropped; msidx serves queries
+	}
 	if cs != nil {
 		seg.colblk.Store(cs)
 	}


### PR DESCRIPTION
Closes the last gap from the columnar-persistence work. A block built over an **already-sealed** segment when schema-scan is enabled was kept only in RAM, so a store that turns schema-scan on *after* accumulating data lost those blocks on reopen — the pre-enable segments row-fell-back and were re-transcoded on every restart (the cost #121 was meant to remove). Only segments sealed *after* enable persisted.

## Change
- `EnableSchemaScan` now calls `persistColSeg` after building each block: it preserves the segment`s existing attribute + key sidecar sections, adds the columnar section, rewrites atomically, and remaps so the block is mmap-backed like a reopened one.
- Factored the rewrite/remap/publish tail of `reindexSealedFile` into a shared **`installSidecar`** (both use it). It never reaps the old mapping while leaving the segment`s live attribute index dangling — it aborts if the new container has no valid one.
- `persistColSeg` holds `reindexMu` to serialize against a concurrent `Reindex` (which rewrites the same container).

## Test
`TestSchemaScanPersistAtEnable`: write all data, **then** enable schema-scan → every already-sealed segment persists its block; reopen reloads all of them with **zero rebuilds** and correct `CountConstraint` counts (previously the pre-enable segments row-fell-back). Full suite + a targeted sidecar/reindex/persist race pass under `-race`.

No-op for in-memory (RAM) segments and for encryption-at-rest collections (which never build a columnar block).