### PR TITLE
db,dbrpc: per-aggregate FILTER

### DIFF
--- a/db/aggfilter_test.go
+++ b/db/aggfilter_test.go
@@ -1,0 +1,191 @@
+package db
+
+import (
+	"fmt"
+	"testing"
+)
+
+// aggFilterArchive seeds a history table with a status mix, so one pass can answer several
+// differently-conditioned questions -- the case per-aggregate filters exist for.
+//
+//	alice: 2 completed (status 4), 1 running (2), 1 held (5)
+//	bob:   1 completed,             2 running
+func aggFilterArchive(t *testing.T) *ArchiveTable {
+	t.Helper()
+	cat, err := OpenCatalog(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { cat.Close() })
+	a, err := cat.CreateArchiveTable("history", ArchiveConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rows := []struct {
+		owner  string
+		status int
+		cpus   int
+	}{
+		{"alice", 4, 1}, {"alice", 4, 2}, {"alice", 2, 4}, {"alice", 5, 8},
+		{"bob", 4, 1}, {"bob", 2, 2}, {"bob", 2, 16},
+	}
+	for i, r := range rows {
+		if err := a.AppendOld(fmt.Sprintf(
+			"Owner = \"%s\"\nJobStatus = %d\nCpus = %d\nID = %d\n", r.owner, r.status, r.cpus, i)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return a
+}
+
+// TestAggregateFilterPivot is the shape the feature is for: total plus per-status counts in
+// ONE aggregation, where each filtered count sees only its own rows.
+func TestAggregateFilterPivot(t *testing.T) {
+	a := aggFilterArchive(t)
+	rows, err := a.Aggregate("true", []string{"Owner"}, []AggSpec{
+		{Func: AggCount, Arg: "*"},
+		{Func: AggCount, Arg: "*", Filter: "JobStatus == 4"},
+		{Func: AggCount, Arg: "*", Filter: "JobStatus == 2"},
+		{Func: AggSum, Arg: "Cpus", Filter: "JobStatus == 2"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := map[string][]string{}
+	for _, r := range rows {
+		got[r.Group[0]] = r.Values
+	}
+	// alice: 4 rows, 2 completed, 1 running (4 cpus); bob: 3 rows, 1 completed, 2 running (18).
+	want := map[string][]string{
+		"alice": {"4", "2", "1", "4"},
+		"bob":   {"3", "1", "2", "18"},
+	}
+	for owner, w := range want {
+		g := got[owner]
+		if len(g) != len(w) {
+			t.Errorf("%s: %v, want %v", owner, g, w)
+			continue
+		}
+		for i := range w {
+			if g[i] != w[i] {
+				t.Errorf("%s: %v, want %v", owner, g, w)
+				break
+			}
+		}
+	}
+}
+
+// TestAggregateFilterNarrowsAggregateNotGroup pins the distinction from WHERE: a group whose
+// rows all fail the filter still appears, with COUNT 0 -- it is not removed from the result.
+func TestAggregateFilterNarrowsAggregateNotGroup(t *testing.T) {
+	a := aggFilterArchive(t)
+	rows, err := a.Aggregate("true", []string{"Owner"}, []AggSpec{
+		{Func: AggCount, Arg: "*", Filter: "JobStatus == 5"}, // only alice has one
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := map[string]string{}
+	for _, r := range rows {
+		got[r.Group[0]] = r.Values[0]
+	}
+	if len(got) != 2 {
+		t.Fatalf("groups = %v, want both owners to survive", got)
+	}
+	if got["alice"] != "1" || got["bob"] != "0" {
+		t.Errorf("counts = %v, want alice 1 and bob 0", got)
+	}
+}
+
+// TestAggregateFilterWithoutGrouping covers the single implicit group.
+func TestAggregateFilterWithoutGrouping(t *testing.T) {
+	a := aggFilterArchive(t)
+	rows, err := a.Aggregate("true", nil, []AggSpec{
+		{Func: AggCount, Arg: "*"},
+		{Func: AggCount, Arg: "*", Filter: "JobStatus == 2"},
+		{Func: AggCount, Arg: "*", Filter: "JobStatus == 99"}, // matches nothing
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("rows = %v, want one", rows)
+	}
+	if v := rows[0].Values; v[0] != "7" || v[1] != "3" || v[2] != "0" {
+		t.Errorf("values = %v, want [7 3 0]", v)
+	}
+}
+
+// TestAggregateFilterCombinesWithConstraint checks that the query constraint and the
+// per-aggregate filter compose: the constraint picks the rows, the filter narrows one
+// aggregate within them.
+func TestAggregateFilterCombinesWithConstraint(t *testing.T) {
+	a := aggFilterArchive(t)
+	rows, err := a.Aggregate(`Owner == "alice"`, nil, []AggSpec{
+		{Func: AggCount, Arg: "*"},
+		{Func: AggCount, Arg: "*", Filter: "JobStatus == 4"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v := rows[0].Values; v[0] != "4" || v[1] != "2" {
+		t.Errorf("values = %v, want [4 2] (alice's rows, then her completed ones)", v)
+	}
+}
+
+// TestAggregateFilterExpressions checks that a filter is a full ClassAd expression, not a
+// restricted comparison grammar.
+func TestAggregateFilterExpressions(t *testing.T) {
+	a := aggFilterArchive(t)
+	rows, err := a.Aggregate("true", nil, []AggSpec{
+		{Func: AggCount, Arg: "*", Filter: "JobStatus == 4 || JobStatus == 5"},
+		{Func: AggCount, Arg: "*", Filter: "Cpus >= 4 && JobStatus != 5"},
+		{Func: AggCount, Arg: "*", Filter: `Owner == "bob"`},
+		{Func: AggMax, Arg: "Cpus", Filter: `Owner == "bob"`},
+		{Func: AggCount, Arg: "*", Filter: "Missing is undefined"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// completed+held: 3+1 = 4; cpus>=4 and not held: alice's 4, bob's 16 = 2; bob: 3;
+	// bob's max cpus: 16; a filter on an absent attribute holds for every row: 7.
+	if v := rows[0].Values; v[0] != "4" || v[1] != "2" || v[2] != "3" || v[3] != "16" || v[4] != "7" {
+		t.Errorf("values = %v, want [4 2 3 16 7]", v)
+	}
+}
+
+// TestAggregateFilterBadExpression checks that an unparseable filter is reported rather than
+// silently ignored -- ignoring it would return an unfiltered count that looks plausible.
+func TestAggregateFilterBadExpression(t *testing.T) {
+	a := aggFilterArchive(t)
+	_, err := a.Aggregate("true", nil, []AggSpec{
+		{Func: AggCount, Arg: "*", Filter: "JobStatus =="},
+	})
+	if err == nil {
+		t.Fatal("expected an error for a malformed filter")
+	}
+}
+
+// TestAggregateUnfilteredUnchanged is the regression guard: specs with no filter must behave
+// exactly as before.
+func TestAggregateUnfilteredUnchanged(t *testing.T) {
+	a := aggFilterArchive(t)
+	rows, err := a.Aggregate("true", []string{"Owner"}, []AggSpec{
+		{Func: AggCount, Arg: "*"},
+		{Func: AggSum, Arg: "Cpus"},
+		{Func: AggMax, Arg: "Cpus"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := map[string][]string{}
+	for _, r := range rows {
+		got[r.Group[0]] = r.Values
+	}
+	if g := got["alice"]; g[0] != "4" || g[1] != "15" || g[2] != "8" {
+		t.Errorf("alice = %v, want [4 15 8]", g)
+	}
+	if g := got["bob"]; g[0] != "3" || g[1] != "19" || g[2] != "16" {
+		t.Errorf("bob = %v, want [3 19 16]", g)
+	}
+}

--- a/db/aggregate.go
+++ b/db/aggregate.go
@@ -1,12 +1,15 @@
 package db
 
 import (
+	"fmt"
 	"iter"
 	"math"
 	"strconv"
 	"strings"
 
+	"github.com/PelicanPlatform/classad/ast"
 	"github.com/PelicanPlatform/classad/classad"
+	"github.com/PelicanPlatform/classad/collections/vm"
 )
 
 // This file holds the shared server-side GROUP BY / reduce engine. Both the mutable-table
@@ -30,9 +33,21 @@ const (
 // AggSpec is one aggregate in a query: a function over an argument attribute.
 // Arg "*" (only meaningful for COUNT) counts every row in the group; otherwise
 // Arg is an attribute name evaluated per ad.
+//
+// Filter, when non-empty, is a ClassAd expression restricting this aggregate -- and only
+// this one -- to the rows of its group where the expression is true (SQL's
+// `COUNT(*) FILTER (WHERE ...)`). It is what lets one pass over the data answer several
+// differently-conditioned questions at once:
+//
+//	SELECT Owner, COUNT(*), COUNT(*) FILTER (WHERE JobStatus == 2) FROM jobs GROUP BY Owner
+//
+// Without it that is one scan per condition. The filter narrows an aggregate, never the
+// group: a group whose rows all fail every filter still appears, with COUNT 0 and the other
+// functions undefined, exactly as SQL has it.
 type AggSpec struct {
-	Func AggFunc
-	Arg  string
+	Func   AggFunc
+	Arg    string
+	Filter string
 }
 
 // AggRow is one group's result: the group-by column values followed by the
@@ -78,11 +93,127 @@ func AggProjection(groupCols []GroupCol, aggs []AggSpec) (attrs []string, groupC
 	for i, a := range aggs {
 		if a.Arg == "*" {
 			aggCol[i] = -1
-			continue
+		} else {
+			aggCol[i] = intern(a.Arg)
 		}
-		aggCol[i] = intern(a.Arg)
+		// A filtered aggregate also reads whatever its filter tests, so those attributes
+		// have to be projected too or the filter would see them all undefined.
+		for _, ref := range filterAttrs(a.Filter) {
+			intern(ref)
+		}
 	}
 	return attrs, groupCol, aggCol
+}
+
+// AggFilterAttrs returns the attributes a per-aggregate filter reads. Callers use it to hold
+// a filter to the same rules as the rest of the request -- notably the RPC layer's refusal to
+// let an unprivileged reader touch a private attribute, which a filter could otherwise turn
+// into an oracle (`COUNT(*) FILTER (WHERE Secret == "guess")` leaks by its count).
+func AggFilterAttrs(filter string) []string { return filterAttrs(filter) }
+
+// filterAttrs returns the attributes a per-aggregate filter reads, or nil for no filter (or
+// one that does not compile -- compileFilters reports that as an error later, where it can
+// be returned rather than silently dropped).
+func filterAttrs(filter string) []string {
+	if filter == "" {
+		return nil
+	}
+	q, err := vm.Parse(filter)
+	if err != nil {
+		return nil
+	}
+	return q.ReadAttrs()
+}
+
+// aggFilter is one compiled per-aggregate filter, bound to the projected value row: expr is
+// evaluated against a scope holding just the attributes it reads, at the positions the
+// projection put them.
+type aggFilter struct {
+	expr  *classad.Expr
+	names []string // attribute names the filter reads
+	cols  []int    // their indices in the projected value row, aligned with names
+}
+
+// compileFilters compiles each spec's filter against the projected attribute list. It
+// returns one entry per spec (nil where the spec is unfiltered) and whether any spec has
+// one, so the reduction can skip the whole mechanism for the common unfiltered query.
+func compileFilters(attrs []string, aggs []AggSpec) ([]*aggFilter, bool, error) {
+	out := make([]*aggFilter, len(aggs))
+	col := make(map[string]int, len(attrs))
+	for i, a := range attrs {
+		col[strings.ToLower(a)] = i
+	}
+	any := false
+	for i, a := range aggs {
+		if a.Filter == "" {
+			continue
+		}
+		q, err := vm.Parse(a.Filter)
+		if err != nil {
+			return nil, false, fmt.Errorf("aggregate filter %q: %w", a.Filter, err)
+		}
+		ex, err := classad.ParseExpr(a.Filter)
+		if err != nil {
+			return nil, false, fmt.Errorf("aggregate filter %q: %w", a.Filter, err)
+		}
+		f := &aggFilter{expr: ex}
+		for _, ref := range q.ReadAttrs() {
+			if c, ok := col[strings.ToLower(ref)]; ok {
+				f.names = append(f.names, ref)
+				f.cols = append(f.cols, c)
+			}
+		}
+		out[i] = f
+		any = true
+	}
+	return out, any, nil
+}
+
+// keeps reports whether a row passes this filter. The scope ad is reused across rows and
+// filters, so a filtered aggregate costs one rebind plus one evaluation per row rather than
+// an allocation. A filter that does not evaluate to true excludes the row, so undefined and
+// error behave as they do everywhere else in ClassAd.
+func (f *aggFilter) keeps(scope *classad.ClassAd, vals []classad.Value) bool {
+	for k, c := range f.cols {
+		bindValue(scope, f.names[k], vals[c])
+	}
+	b, err := f.expr.Eval(scope).BoolValue()
+	return err == nil && b
+}
+
+// bindValue binds one projected value into the reused filter scope. Every attribute the
+// filter reads is rebound on every row -- including as undefined -- so nothing carries over
+// from the previous row.
+//
+// Scalars bind natively. A list or nested ad binds as undefined: the projected scan hands
+// back evaluated values, and there is no exported way to turn one back into an expression,
+// so a filter over a list-valued attribute cannot be answered on this path. Filters in
+// practice test scalars (JobStatus, ExitCode, Owner), and undefined excludes the row rather
+// than miscounting it.
+func bindValue(ad *classad.ClassAd, name string, v classad.Value) {
+	switch {
+	case v.IsInteger():
+		if i, err := v.IntValue(); err == nil {
+			ad.InsertAttr(name, i)
+			return
+		}
+	case v.IsReal():
+		if f, err := v.RealValue(); err == nil {
+			ad.InsertAttrFloat(name, f)
+			return
+		}
+	case v.IsBool():
+		if b, err := v.BoolValue(); err == nil {
+			ad.InsertAttrBool(name, b)
+			return
+		}
+	case v.IsString():
+		if s, err := v.StringValue(); err == nil {
+			ad.InsertAttrString(name, s)
+			return
+		}
+	}
+	ad.Insert(name, &ast.UndefinedLiteral{})
 }
 
 // AggregateValues is the shared GROUP BY core: it buckets a sequence of projected
@@ -95,8 +226,18 @@ func AggProjection(groupCols []GroupCol, aggs []AggSpec) (attrs []string, groupC
 // undefined). If stop is non-nil it is polled per row and, when it returns true,
 // the scan halts early with the groups accumulated so far -- used to abandon a
 // scan whose client has gone away.
-func AggregateValues(seq iter.Seq[[]classad.Value], groupCols []GroupCol, aggs []AggSpec, groupCol, aggCol []int, stop func() bool) []AggRow {
+func AggregateValues(seq iter.Seq[[]classad.Value], attrs []string, groupCols []GroupCol, aggs []AggSpec, groupCol, aggCol []int, stop func() bool) ([]AggRow, error) {
 	nGroup := len(groupCols)
+	filters, anyFilter, err := compileFilters(attrs, aggs)
+	if err != nil {
+		return nil, err
+	}
+	// One reused scope for every filter on every row; only touched when a filter exists, so
+	// an unfiltered aggregate keeps its allocation-free reduction.
+	var scope *classad.ClassAd
+	if anyFilter {
+		scope = classad.New()
+	}
 
 	// Hash-map aggregation: bucket by the joined group-value tuple, preserving
 	// first-seen order for stable output. scratch builds each row's key without
@@ -132,6 +273,9 @@ func AggregateValues(seq iter.Seq[[]classad.Value], groupCols []GroupCol, aggs [
 			order = append(order, key)
 		}
 		for i, a := range aggs {
+			if filters[i] != nil && !filters[i].keeps(scope, vals) {
+				continue // this row is outside THIS aggregate's filter, not the group
+			}
 			var v classad.Value
 			if aggCol[i] >= 0 {
 				v = vals[aggCol[i]]
@@ -147,7 +291,7 @@ func AggregateValues(seq iter.Seq[[]classad.Value], groupCols []GroupCol, aggs [
 		for i, a := range aggs {
 			row.Values[i] = gs.accs[i].result(a)
 		}
-		return []AggRow{row}
+		return []AggRow{row}, nil
 	}
 
 	out := make([]AggRow, 0, len(order))
@@ -159,7 +303,7 @@ func AggregateValues(seq iter.Seq[[]classad.Value], groupCols []GroupCol, aggs [
 		}
 		out = append(out, row)
 	}
-	return out
+	return out, nil
 }
 
 // groupState holds one group's key values and per-aggregate accumulators.

--- a/db/archive.go
+++ b/db/archive.go
@@ -175,9 +175,11 @@ func (t *ArchiveTable) QueryRawProjected(constraint string, projection []string,
 func (t *ArchiveTable) Aggregate(constraint string, groupBy []string, aggs []AggSpec) ([]AggRow, error) {
 	// Fast path: an unconstrained COUNT(*) with no grouping is the retained record count,
 	// which the archive tracks in O(1). This is the common `SELECT COUNT(*) FROM history`;
-	// scanning tens of thousands of records to count them would be needlessly slow.
+	// scanning tens of thousands of records to count them would be needlessly slow. A
+	// FILTERED count cannot take this path -- the stored total knows nothing about the
+	// filter, so it would silently answer with every row.
 	if len(groupBy) == 0 && len(aggs) == 1 && aggs[0].Func == AggCount && aggs[0].Arg == "*" &&
-		IsMatchAll(constraint) {
+		aggs[0].Filter == "" && IsMatchAll(constraint) {
 		return []AggRow{{Values: []string{strconv.Itoa(t.a.Count())}}}, nil
 	}
 
@@ -194,7 +196,7 @@ func (t *ArchiveTable) Aggregate(constraint string, groupBy []string, aggs []Agg
 	if err != nil {
 		return nil, err
 	}
-	return AggregateValues(seq, groupCols, aggs, groupCol, aggCol, nil), nil
+	return AggregateValues(seq, attrs, groupCols, aggs, groupCol, aggCol, nil)
 }
 
 // IsMatchAll reports whether a constraint imposes no filter (an empty string or a literal

--- a/dbrpc/aggfilter_test.go
+++ b/dbrpc/aggfilter_test.go
@@ -1,0 +1,219 @@
+package dbrpc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/db"
+)
+
+// oldServerConn is a server-side transport that refuses the opcodes an older build would
+// not recognize: it answers them with respBad exactly as the dispatcher's default does, and
+// forwards everything else. That makes the back-compat path testable for real rather than
+// by inspection -- the client must see the refusal, never an unfiltered answer.
+type oldServerConn struct {
+	MsgConn
+	knows func(op) bool
+}
+
+func (c *oldServerConn) ReadMsg() ([]byte, error) {
+	for {
+		frame, err := c.MsgConn.ReadMsg()
+		if err != nil {
+			return nil, err
+		}
+		o, ok := frameOp(frame)
+		if !ok || c.knows(o) {
+			return frame, nil
+		}
+		reqID, _ := frameReqID(frame)
+		if err := c.MsgConn.WriteMsg(respBad(reqID)); err != nil {
+			return nil, err
+		}
+	}
+}
+
+// testPairOps is testPair against a server that only knows the opcodes knows() accepts.
+func testPairOps(t *testing.T, knows func(op) bool) (*Client, func()) {
+	t.Helper()
+	d, err := db.Open("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := NewServer(d)
+	cconn, sconn := netPipe()
+	go func() { _ = s.ServeConn(&oldServerConn{MsgConn: sconn, knows: knows}) }()
+	c := NewClient(cconn)
+	return c, func() { c.Close(); s.Close(); d.Close() }
+}
+
+// seedStatusMix inserts jobs with a status/owner mix, the shape a per-status dashboard
+// pivot runs over.
+//
+//	alice: 2 completed (4), 1 running (2), 1 held (5)
+//	bob:   1 completed,     2 running
+func seedStatusMix(t *testing.T, c *Client) {
+	t.Helper()
+	rows := []struct {
+		owner  string
+		status int
+		cpus   int
+	}{
+		{"alice", 4, 1}, {"alice", 4, 2}, {"alice", 2, 4}, {"alice", 5, 8},
+		{"bob", 4, 1}, {"bob", 2, 2}, {"bob", 2, 16},
+	}
+	ctx := context.Background()
+	tx, err := c.Begin(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i, r := range rows {
+		if err := tx.NewClassAd(ctx, fmt.Sprintf("k%d", i), fmt.Sprintf(
+			"Owner = \"%s\"\nJobStatus = %d\nCpus = %d\n", r.owner, r.status, r.cpus)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestAggregateFilterOverRPC is the end-to-end pivot: total plus per-status counts for every
+// owner, from one aggregation over the wire.
+func TestAggregateFilterOverRPC(t *testing.T) {
+	c, cleanup := testPair(t)
+	defer cleanup()
+	seedStatusMix(t, c)
+
+	rows, err := c.Aggregate(context.Background(), "true", []string{"Owner"}, []AggSpec{
+		{Func: AggCount, Arg: "*"},
+		{Func: AggCount, Arg: "*", Filter: "JobStatus == 4"},
+		{Func: AggCount, Arg: "*", Filter: "JobStatus == 2"},
+		{Func: AggSum, Arg: "Cpus", Filter: "JobStatus == 2"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := map[string][]string{}
+	for _, r := range rows {
+		got[r.Group[0]] = r.Values
+	}
+	want := map[string][]string{
+		"alice": {"4", "2", "1", "4"},
+		"bob":   {"3", "1", "2", "18"},
+	}
+	for owner, w := range want {
+		g := got[owner]
+		if len(g) != len(w) {
+			t.Errorf("%s = %v, want %v", owner, g, w)
+			continue
+		}
+		for i := range w {
+			if g[i] != w[i] {
+				t.Errorf("%s = %v, want %v", owner, g, w)
+				break
+			}
+		}
+	}
+}
+
+// TestAggregateFilterCountFastPath is the regression for the bug the db tests caught: an
+// ungrouped COUNT(*) over a match-all constraint has a fast path that answers from the
+// tracked row count. A FILTERED count must not take it, or it would silently report the
+// total.
+func TestAggregateFilterCountFastPath(t *testing.T) {
+	c, cleanup := testPair(t)
+	defer cleanup()
+	seedStatusMix(t, c)
+	ctx := context.Background()
+
+	all, err := c.Aggregate(ctx, "true", nil, []AggSpec{{Func: AggCount, Arg: "*"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if all[0].Values[0] != "7" {
+		t.Fatalf("unfiltered count = %s, want 7", all[0].Values[0])
+	}
+	filtered, err := c.Aggregate(ctx, "true", nil, []AggSpec{
+		{Func: AggCount, Arg: "*", Filter: "JobStatus == 2"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if filtered[0].Values[0] != "3" {
+		t.Errorf("filtered count = %s, want 3 (the fast path must not answer this)",
+			filtered[0].Values[0])
+	}
+}
+
+// TestAggregateFilterBucketed covers the bucketed opcode's filtered form.
+func TestAggregateFilterBucketed(t *testing.T) {
+	c, cleanup := testPair(t)
+	defer cleanup()
+	seedStatusMix(t, c)
+
+	rows, err := c.AggregateBucketed(context.Background(), "true",
+		[]GroupCol{{Attr: "Owner"}}, []AggSpec{
+			{Func: AggCount, Arg: "*"},
+			{Func: AggCount, Arg: "*", Filter: "JobStatus == 2"},
+		})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := map[string][]string{}
+	for _, r := range rows {
+		got[r.Group[0]] = r.Values
+	}
+	if g := got["alice"]; len(g) != 2 || g[0] != "4" || g[1] != "1" {
+		t.Errorf("alice = %v, want [4 1]", g)
+	}
+	if g := got["bob"]; len(g) != 2 || g[0] != "3" || g[1] != "2" {
+		t.Errorf("bob = %v, want [3 2]", g)
+	}
+}
+
+// TestAggregateFilterUnsupportedServer is the back-compat guarantee. A server that does not
+// know the filtered opcodes must produce an ERROR, never an unfiltered answer -- the whole
+// reason these are separate opcodes rather than an extra field.
+func TestAggregateFilterUnsupportedServer(t *testing.T) {
+	c, cleanup := testPairOps(t, func(o op) bool {
+		return o != opAggregateFiltered && o != opArchiveAggregateFiltered
+	})
+	defer cleanup()
+	seedStatusMix(t, c)
+	ctx := context.Background()
+
+	// An unfiltered aggregate is unaffected: it never reaches for the new opcode.
+	if _, err := c.Aggregate(ctx, "true", []string{"Owner"},
+		[]AggSpec{{Func: AggCount, Arg: "*"}}); err != nil {
+		t.Fatalf("unfiltered aggregate should still work against an old server: %v", err)
+	}
+	// A filtered one is refused, distinctly, so a caller cannot mistake it for an answer.
+	_, err := c.Aggregate(ctx, "true", []string{"Owner"},
+		[]AggSpec{{Func: AggCount, Arg: "*", Filter: "JobStatus == 2"}})
+	if !errors.Is(err, ErrFilteredAggregateUnsupported) {
+		t.Errorf("filtered aggregate against an old server: err = %v, want ErrFilteredAggregateUnsupported", err)
+	}
+	_, err = c.AggregateBucketed(ctx, "true", []GroupCol{{Attr: "Owner"}},
+		[]AggSpec{{Func: AggCount, Arg: "*", Filter: "JobStatus == 2"}})
+	if !errors.Is(err, ErrFilteredAggregateUnsupported) {
+		t.Errorf("filtered bucketed aggregate: err = %v, want ErrFilteredAggregateUnsupported", err)
+	}
+}
+
+// TestAggregateFilterPrivateAttr checks that a filter cannot be used to read a private
+// attribute an unprivileged connection may not aggregate.
+func TestAggregateFilterPrivateAttr(t *testing.T) {
+	c, cleanup := testPair(t)
+	defer cleanup()
+	seedStatusMix(t, c)
+
+	_, err := c.Aggregate(context.Background(), "true", nil, []AggSpec{
+		{Func: AggCount, Arg: "*", Filter: `_condor_privSecret == "x"`},
+	})
+	if err == nil {
+		t.Error("a filter over a private attribute should be refused")
+	}
+}

--- a/dbrpc/aggregate.go
+++ b/dbrpc/aggregate.go
@@ -39,17 +39,24 @@ func (c *Client) Aggregate(ctx context.Context, constraint string, groupBy []str
 
 // AggregateTable is Aggregate on the named table.
 func (c *Client) AggregateTable(ctx context.Context, table, constraint string, groupBy []string, aggs []AggSpec) ([]AggRow, error) {
+	filtered := anyFiltered(aggs)
 	build := func(id uint64) []byte {
+		// A filtered request goes out on the newer opcode, whose group tuple carries a
+		// bucket width; an unfiltered one keeps the original frame byte for byte.
+		if filtered {
+			b := putStr(putStr(req(id, opAggregateFiltered), table), constraint)
+			b = putI32(b, int32(len(groupBy)))
+			for _, g := range groupBy {
+				b = putU64(putStr(b, g), 0)
+			}
+			return putAggSpecs(b, aggs, true)
+		}
 		b := putStr(putStr(req(id, opAggregate), table), constraint)
 		b = putI32(b, int32(len(groupBy)))
 		for _, g := range groupBy {
 			b = putStr(b, g)
 		}
-		b = putI32(b, int32(len(aggs)))
-		for _, a := range aggs {
-			b = putStr(putU8(b, byte(a.Func)), a.Arg)
-		}
-		return b
+		return putAggSpecs(b, aggs, false)
 	}
 	_, frames, err := c.callStream(build)
 	if err != nil {
@@ -81,6 +88,15 @@ func (c *Client) AggregateTable(ctx context.Context, table, constraint string, g
 				out = append(out, row)
 			case stErr:
 				return out, statusErr(status, body)
+			case stBadReq:
+				// Only reachable for a filtered request: a server too old to know
+				// opAggregateFiltered refuses the opcode. There is deliberately no
+				// fallback -- retrying without the filters would answer a different
+				// question and report it as success.
+				if filtered {
+					return nil, ErrFilteredAggregateUnsupported
+				}
+				return out, fmt.Errorf("dbrpc: aggregate rejected as a bad request")
 			}
 		}
 	}
@@ -101,17 +117,18 @@ func (c *Client) AggregateBucketed(ctx context.Context, constraint string, group
 
 // AggregateBucketedTable is AggregateBucketed on the named table.
 func (c *Client) AggregateBucketedTable(ctx context.Context, table, constraint string, groups []GroupCol, aggs []AggSpec) ([]AggRow, error) {
+	filtered := anyFiltered(aggs)
 	build := func(id uint64) []byte {
-		b := putStr(putStr(req(id, opAggregateBucketed), table), constraint)
+		o := opAggregateBucketed
+		if filtered {
+			o = opAggregateFiltered // same request shape, specs carry a filter
+		}
+		b := putStr(putStr(req(id, o), table), constraint)
 		b = putI32(b, int32(len(groups)))
 		for _, g := range groups {
 			b = putU64(putStr(b, g.Attr), uint64(g.BucketWidth))
 		}
-		b = putI32(b, int32(len(aggs)))
-		for _, a := range aggs {
-			b = putStr(putU8(b, byte(a.Func)), a.Arg)
-		}
-		return b
+		return putAggSpecs(b, aggs, filtered)
 	}
 	_, frames, err := c.callStream(build)
 	if err != nil {
@@ -144,8 +161,12 @@ func (c *Client) AggregateBucketedTable(ctx context.Context, table, constraint s
 			case stErr:
 				return out, statusErr(status, body)
 			case stBadReq:
-				// A server too old to know opAggregateBucketed rejects it as a bad
-				// request; signal the caller to fall back to client-side bucketing.
+				// A server too old to know the opcode rejects it as a bad request. The
+				// caller can fall back to client-side bucketing -- but NOT for a filtered
+				// request, where dropping the filters would change the answer.
+				if filtered {
+					return nil, ErrFilteredAggregateUnsupported
+				}
 				return nil, ErrBucketedUnsupported
 			default:
 				return out, fmt.Errorf("dbrpc: unexpected aggregate status %d", status)
@@ -168,7 +189,7 @@ func (s *Server) streamAggregate(ctx context.Context, reqID uint64, r *reader, i
 	for i := range groups {
 		groups[i] = GroupCol{Attr: r.str()}
 	}
-	aggs, ok := readAggSpecs(r, reqID, write)
+	aggs, ok := readAggSpecs(r, reqID, write, false)
 	if !ok {
 		return
 	}
@@ -178,6 +199,17 @@ func (s *Server) streamAggregate(ctx context.Context, reqID uint64, r *reader, i
 // streamAggregateBucketed is streamAggregate where each group column may carry a
 // bucket width (opAggregateBucketed).
 func (s *Server) streamAggregateBucketed(ctx context.Context, reqID uint64, r *reader, includePrivate bool, write func([]byte)) {
+	s.streamAggregateWidths(ctx, reqID, r, includePrivate, false, write)
+}
+
+// streamAggregateFiltered is streamAggregateBucketed whose specs carry a per-aggregate
+// filter (opAggregateFiltered). The request shape is otherwise identical, so a filtered
+// plain aggregate rides the bucketed frame with every width zero.
+func (s *Server) streamAggregateFiltered(ctx context.Context, reqID uint64, r *reader, includePrivate bool, write func([]byte)) {
+	s.streamAggregateWidths(ctx, reqID, r, includePrivate, true, write)
+}
+
+func (s *Server) streamAggregateWidths(ctx context.Context, reqID uint64, r *reader, includePrivate, filtered bool, write func([]byte)) {
 	table := r.str()
 	constraint := r.str()
 	nGroup := int(r.i32())
@@ -190,16 +222,17 @@ func (s *Server) streamAggregateBucketed(ctx context.Context, reqID uint64, r *r
 		attr := r.str()
 		groups[i] = GroupCol{Attr: attr, BucketWidth: int64(r.u64())}
 	}
-	aggs, ok := readAggSpecs(r, reqID, write)
+	aggs, ok := readAggSpecs(r, reqID, write, filtered)
 	if !ok {
 		return
 	}
 	s.aggregate(ctx, reqID, table, constraint, groups, aggs, includePrivate, write)
 }
 
-// readAggSpecs reads the [nAgg]{[func u8][arg]} tail shared by both aggregate
-// opcodes, writing respBad and returning ok=false on a malformed frame.
-func readAggSpecs(r *reader, reqID uint64, write func([]byte)) ([]AggSpec, bool) {
+// readAggSpecs reads the [nAgg]{[func u8][arg]} tail shared by the aggregate opcodes,
+// writing respBad and returning ok=false on a malformed frame. filtered selects the
+// [func u8][arg][filter] form the *Filtered opcodes carry.
+func readAggSpecs(r *reader, reqID uint64, write func([]byte), filtered bool) ([]AggSpec, bool) {
 	nAgg := int(r.i32())
 	if nAgg < 0 || nAgg > 1024 {
 		write(respBad(reqID))
@@ -208,6 +241,9 @@ func readAggSpecs(r *reader, reqID uint64, write func([]byte)) ([]AggSpec, bool)
 	aggs := make([]AggSpec, nAgg)
 	for i := range aggs {
 		aggs[i] = AggSpec{Func: AggFunc(r.u8()), Arg: r.str()}
+		if filtered {
+			aggs[i].Filter = r.str()
+		}
 	}
 	if r.err != nil {
 		write(respBad(reqID))
@@ -215,6 +251,36 @@ func readAggSpecs(r *reader, reqID uint64, write func([]byte)) ([]AggSpec, bool)
 	}
 	return aggs, true
 }
+
+// anyFiltered reports whether some spec carries a per-aggregate filter, which is what makes
+// a client reach for the newer opcode. Without one the request goes out on the original
+// opcode, so an older server keeps serving it.
+func anyFiltered(aggs []AggSpec) bool {
+	for _, a := range aggs {
+		if a.Filter != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// putAggSpecs writes the [nAgg]{[func u8][arg]([filter])} tail.
+func putAggSpecs(b []byte, aggs []AggSpec, filtered bool) []byte {
+	b = putI32(b, int32(len(aggs)))
+	for _, a := range aggs {
+		b = putStr(putU8(b, byte(a.Func)), a.Arg)
+		if filtered {
+			b = putStr(b, a.Filter)
+		}
+	}
+	return b
+}
+
+// ErrFilteredAggregateUnsupported is returned when the server is too old to know the
+// filtered-aggregate opcodes. The caller must NOT retry without the filters: the answer
+// would be an unfiltered aggregate, which is wrong rather than merely slower.
+var ErrFilteredAggregateUnsupported = errors.New(
+	"dbrpc: server does not support per-aggregate FILTER")
 
 // aggregate is the shared GROUP BY core for both aggregate opcodes: it refuses
 // private attributes for an unprivileged connection, projects only the attributes
@@ -232,6 +298,13 @@ func (s *Server) aggregate(ctx context.Context, reqID uint64, table, constraint 
 			if a.Arg != "*" && classad.IsPrivateAttribute(a.Arg) {
 				write(respErr(reqID, "cannot aggregate private attribute "+a.Arg))
 				return
+			}
+			// A filter reads attributes too, and its count would leak them.
+			for _, ref := range db.AggFilterAttrs(a.Filter) {
+				if classad.IsPrivateAttribute(ref) {
+					write(respErr(reqID, "cannot filter on private attribute "+ref))
+					return
+				}
 			}
 		}
 	}
@@ -251,7 +324,7 @@ func (s *Server) aggregate(ctx context.Context, reqID uint64, table, constraint 
 	// (parent-only) ads, which a match-all scan excludes but Len() counts (a chained job_queue
 	// has them; a flat table like Startd does not). Mirrors ArchiveTable.Aggregate.
 	if len(groupCols) == 0 && len(aggs) == 1 && aggs[0].Func == AggCount && aggs[0].Arg == "*" &&
-		db.IsMatchAll(constraint) && !d.Chained() {
+		aggs[0].Filter == "" && db.IsMatchAll(constraint) && !d.Chained() {
 		frame := respHead(reqID, stStream)
 		frame = putStr(frame, strconv.Itoa(d.Len()))
 		write(frame)
@@ -264,7 +337,7 @@ func (s *Server) aggregate(ctx context.Context, reqID uint64, table, constraint 
 	// eligible. CountConstraint returns ok=false otherwise (schema-scan off, or a predicate the
 	// columnar path can't handle), and we fall through to the projected scan.
 	if len(groupCols) == 0 && len(aggs) == 1 && aggs[0].Func == AggCount && aggs[0].Arg == "*" &&
-		!db.IsMatchAll(constraint) {
+		aggs[0].Filter == "" && !db.IsMatchAll(constraint) {
 		if n, ok := d.CountConstraint(constraint); ok {
 			frame := respHead(reqID, stStream)
 			frame = putStr(frame, strconv.Itoa(n))
@@ -279,7 +352,11 @@ func (s *Server) aggregate(ctx context.Context, reqID uint64, table, constraint 
 		write(respErr(reqID, err.Error()))
 		return
 	}
-	rows := db.AggregateValues(seq, groupCols, aggs, groupCol, aggCol, func() bool { return cancelled(ctx) })
+	rows, err := db.AggregateValues(seq, attrs, groupCols, aggs, groupCol, aggCol, func() bool { return cancelled(ctx) })
+	if err != nil {
+		write(respErr(reqID, err.Error()))
+		return
+	}
 	if cancelled(ctx) {
 		return // client gone mid-scan: nothing left to stream
 	}

--- a/dbrpc/archive.go
+++ b/dbrpc/archive.go
@@ -48,6 +48,16 @@ func (sc *serverConn) streamArchiveQuery(reqID uint64, r *reader) {
 // engine so the result is identical to the same aggregate over a mutable table. Private
 // attributes are refused for an unprivileged reader, as with the mutable aggregate.
 func (sc *serverConn) streamArchiveAggregate(reqID uint64, r *reader) {
+	sc.archiveAggregate(reqID, r, false)
+}
+
+// streamArchiveAggregateFiltered is streamArchiveAggregate whose specs carry a per-aggregate
+// filter (opArchiveAggregateFiltered). Only the spec encoding differs.
+func (sc *serverConn) streamArchiveAggregateFiltered(reqID uint64, r *reader) {
+	sc.archiveAggregate(reqID, r, true)
+}
+
+func (sc *serverConn) archiveAggregate(reqID uint64, r *reader, filtered bool) {
 	name := r.str()
 	constraint := r.str()
 	nGroup := int(r.i32())
@@ -59,7 +69,7 @@ func (sc *serverConn) streamArchiveAggregate(reqID uint64, r *reader) {
 	for i := range groupCols {
 		groupCols[i] = GroupCol{Attr: r.str()}
 	}
-	aggs, ok := readAggSpecs(r, reqID, sc.write)
+	aggs, ok := readAggSpecs(r, reqID, sc.write, filtered)
 	if !ok {
 		return
 	}
@@ -74,6 +84,12 @@ func (sc *serverConn) streamArchiveAggregate(reqID uint64, r *reader) {
 			if a.Arg != "*" && classad.IsPrivateAttribute(a.Arg) {
 				sc.write(respErr(reqID, "cannot aggregate private attribute "+a.Arg))
 				return
+			}
+			for _, ref := range db.AggFilterAttrs(a.Filter) {
+				if classad.IsPrivateAttribute(ref) {
+					sc.write(respErr(reqID, "cannot filter on private attribute "+ref))
+					return
+				}
 			}
 		}
 	}
@@ -163,17 +179,18 @@ var ErrArchiveAggregateUnsupported = errors.New("dbrpc: server does not support 
 // server. Against a server that does not implement the opcode it returns an error wrapping
 // ErrArchiveAggregateUnsupported so the caller can fall back to client-side aggregation.
 func (c *Client) ArchiveAggregate(ctx context.Context, name, constraint string, groupBy []string, aggs []AggSpec) ([]AggRow, error) {
+	filtered := anyFiltered(aggs)
 	build := func(id uint64) []byte {
-		b := putStr(putStr(req(id, opArchiveAggregate), name), constraint)
+		o := opArchiveAggregate
+		if filtered {
+			o = opArchiveAggregateFiltered
+		}
+		b := putStr(putStr(req(id, o), name), constraint)
 		b = putI32(b, int32(len(groupBy)))
 		for _, g := range groupBy {
 			b = putStr(b, g)
 		}
-		b = putI32(b, int32(len(aggs)))
-		for _, a := range aggs {
-			b = putStr(putU8(b, byte(a.Func)), a.Arg)
-		}
-		return b
+		return putAggSpecs(b, aggs, filtered)
 	}
 	_, frames, err := c.callStream(build)
 	if err != nil {
@@ -206,8 +223,12 @@ func (c *Client) ArchiveAggregate(ctx context.Context, name, constraint string, 
 			case stErr:
 				return out, statusErr(status, body)
 			case stBadReq:
-				// A server too old to know opArchiveAggregate rejects it as a bad
-				// request; signal the caller to fall back to client-side aggregation.
+				// A server too old to know the opcode rejects it as a bad request. A plain
+				// archive aggregate can fall back to a client-side scan; a FILTERED one
+				// must not be retried without its filters.
+				if filtered {
+					return nil, ErrFilteredAggregateUnsupported
+				}
 				return nil, ErrArchiveAggregateUnsupported
 			default:
 				return out, fmt.Errorf("dbrpc: unexpected archive aggregate status %d", status)

--- a/dbrpc/proto.go
+++ b/dbrpc/proto.go
@@ -146,6 +146,19 @@ const (
 	// caller can address matched rows for UPDATE/DELETE by their real db key regardless of whether
 	// the ad carries a self-reported key attribute. Read-only.
 	opQueryKeys op = 54 // [table][constraint] -> stream of [key]
+
+	// opAggregateFiltered and opArchiveAggregateFiltered are opAggregateBucketed and
+	// opArchiveAggregate with a per-aggregate FILTER expression appended to each spec
+	// (SQL's `COUNT(*) FILTER (WHERE ...)`; see db.AggSpec.Filter).
+	//
+	// They are separate opcodes rather than an extra field on the existing ones because a
+	// server too old to know about filters would read the existing frame, ignore the
+	// trailing filter strings, and answer with UNFILTERED counts -- wrong data reported as
+	// success. An unknown opcode is refused as a bad request instead, which the client
+	// surfaces as ErrFilteredAggregateUnsupported. A client only sends these when some spec
+	// actually carries a filter, so every existing query is byte-identical on the wire.
+	opAggregateFiltered        op = 55 // [table][constraint][nGroup]{[attr][width u64]}[nAgg]{[func u8][arg][filter]}
+	opArchiveAggregateFiltered op = 56 // [name][constraint][nGroup]{[attr]}[nAgg]{[func u8][arg][filter]}
 )
 
 // String names an opcode for diagnostics (e.g. the read-only rejection message).

--- a/dbrpc/server.go
+++ b/dbrpc/server.go
@@ -429,6 +429,8 @@ func (sc *serverConn) dispatch(frame []byte) {
 		sc.s.streamOrdered(sc.ctx, reqID, body, priv, sc.write)
 	case opAggregate:
 		sc.s.streamAggregate(sc.ctx, reqID, body, priv, sc.write)
+	case opAggregateFiltered:
+		sc.s.streamAggregateFiltered(sc.ctx, reqID, body, priv, sc.write)
 	case opAggregateBucketed:
 		sc.s.streamAggregateBucketed(sc.ctx, reqID, body, priv, sc.write)
 	case opMatchTables:
@@ -441,6 +443,8 @@ func (sc *serverConn) dispatch(frame []byte) {
 		sc.streamArchiveQuery(reqID, body)
 	case opArchiveAggregate:
 		sc.streamArchiveAggregate(reqID, body)
+	case opArchiveAggregateFiltered:
+		sc.streamArchiveAggregateFiltered(reqID, body)
 	case opQueryKeys:
 		sc.s.streamQueryKeys(sc.ctx, reqID, body, sc.write)
 	case opWatchStop:


### PR DESCRIPTION
The server side of conditional aggregation. An aggregate could only see every row of its group, so the per-status pivot every dashboard wants took one scan per condition:

```sql
SELECT Owner,
       COUNT(*)                                  AS total,
       COUNT(*) FILTER (WHERE JobStatus == 2)    AS running,
       COUNT(*) FILTER (WHERE JobStatus == 1)    AS idle
FROM jobs GROUP BY Owner
```

`AggSpec` gains a `Filter` — a ClassAd expression narrowing **that** aggregate to the rows of its group where it holds. The filter narrows the aggregate, never the group: a group whose rows all fail it still appears with `COUNT` 0, as SQL has it.

htcondordb's `repl` will lower both `COUNT(*) FILTER (WHERE …)` and the portable `SUM(CASE WHEN … THEN 1 ELSE 0 END)` onto this, in a follow-up after a tag.

## Keeping the scan wire-native

The aggregate path deliberately projects only the attributes it reads and never materializes an ad. Filters preserve that: they are compiled once per query, their attributes join the projection, and each row is tested against a **reused** scope holding just the attributes that filter reads. So a filtered aggregate costs one rebind plus one evaluation per row, and an unfiltered one keeps its existing allocation-free path.

One limit worth knowing: a list- or ad-valued attribute binds as `undefined`, because the projected scan yields evaluated values and there is no exported way back to an expression. Filters in practice test scalars (`JobStatus`, `ExitCode`, `Owner`), and `undefined` excludes the row rather than miscounting it.

## Two bugs the tests found, both silent-wrong-answer shaped

**Count fast paths.** Every ungrouped `COUNT(*)` has a path that answers *without scanning* — the archive's stored count, the collection's `Len()`, and the adschema columnar count. A filtered count would have taken them and returned the **unfiltered total**. All three now require an unfiltered spec. This is the one I'd most want a second pair of eyes on: the failure is a plausible-looking number, not an error.

**Private attributes.** The RPC refused private attributes as group columns and aggregate arguments, but not inside a filter — so an unprivileged reader could use one as an oracle, since the count of `FILTER (WHERE _condor_privSecret == "guess")` leaks the value. Filters are now held to the same rule, on both the table and archive paths.

## Why two new opcodes instead of a new field

A server too old to know about filters would read the existing frame, ignore the trailing filter strings, and answer with unfiltered counts — **reported as success**. That is the worst possible failure for this feature, so filters ride new opcodes: an unknown opcode is refused as a bad request, and the client maps that to `ErrFilteredAggregateUnsupported`.

There is deliberately **no fallback**. `ErrBucketedUnsupported` and `ErrArchiveAggregateUnsupported` both invite the caller to retry client-side; retrying a filtered aggregate without its filters would answer a different question, so this error says so instead.

A client only reaches for the new opcodes when a spec actually carries a filter, so every existing query is byte-identical on the wire. The filtered table opcode reuses the bucketed request shape, so one opcode covers both the plain and bucketed table aggregates (widths are zero for the plain case).

## Testing

`db/aggfilter_test.go` — the pivot, filter-narrows-aggregate-not-group, no grouping, composition with the query constraint, full expression filters (`||`, `&&`, `is undefined`, a filtered `MAX`), a malformed filter reported rather than ignored, and an unfiltered-behaviour regression guard.

`dbrpc/aggfilter_test.go` — the same end to end, the count fast path, the bucketed opcode, private-attribute refusal, and the back-compat guarantee tested against a server transport that refuses the new opcodes exactly as an older dispatcher would, rather than by inspection.

All four modules green; `db` and `dbrpc` green under `-race`.

## Note on API

`AggregateValues` takes the projected attribute list and returns an error (a filter can fail to compile). `AggProjection` is unchanged in signature but now also interns filter attributes. Both callers are in-repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
