### PR TITLE
db: persist an archive's index set on AddIndex/DropIndex

### DIFF
--- a/db/archive.go
+++ b/db/archive.go
@@ -260,12 +260,39 @@ func (t *ArchiveTable) Rewrite() int { return t.a.Rewrite() }
 
 // AddIndex adds per-segment indexes on the named categorical and/or value attributes and
 // rebuilds them over existing segments. Returns false if the index set was unchanged.
+// A change is persisted (see saveIndexConfig).
 func (t *ArchiveTable) AddIndex(categorical, value []string) bool {
-	return t.a.AddIndex(categorical, value)
+	changed := t.a.AddIndex(categorical, value)
+	if changed {
+		t.saveIndexConfig()
+	}
+	return changed
 }
 
 // DropIndex removes the named per-segment indexes. Returns false if none matched.
-func (t *ArchiveTable) DropIndex(names ...string) bool { return t.a.DropIndex(names...) }
+// A change is persisted (see saveIndexConfig).
+func (t *ArchiveTable) DropIndex(names ...string) bool {
+	changed := t.a.DropIndex(names...)
+	if changed {
+		t.saveIndexConfig()
+	}
+	return changed
+}
+
+// saveIndexConfig folds the archive's live index set back into the saved config, so a
+// runtime AddIndex/DropIndex survives a restart. Without it the reopen path (which treats
+// archiveconfig.json as authoritative) would resurrect the creation-time index set, and the
+// rebuild AddIndex just paid for -- a full decompress of the archive -- would be discarded
+// and the sidecars rebuilt back down to the older, narrower spec.
+//
+// The live set is read back from the archive rather than merged from the caller's names,
+// because AddIndex normalizes them (a name given as both kinds, or already indexed as the
+// other kind, lands as categorical). Mirrors DB.saveIndexConfig, including its best-effort
+// contract: a write failure is ignored, leaving the change live for this run but unpersisted.
+func (t *ArchiveTable) saveIndexConfig() {
+	t.cfg.CategoricalAttrs, t.cfg.ValueAttrs = t.a.IndexedAttrs()
+	_ = t.saveConfig()
+}
 
 // Reindex rebuilds the per-segment indexes over all segments.
 func (t *ArchiveTable) Reindex() { t.a.Reindex() }

--- a/db/archive_indexpersist_test.go
+++ b/db/archive_indexpersist_test.go
@@ -1,0 +1,132 @@
+package db
+
+import (
+	"fmt"
+	"slices"
+	"testing"
+)
+
+// TestArchiveIndexConfigPersists covers the reopen half of a runtime index change on an
+// archive. archiveconfig.json is authoritative on reopen, so an AddIndex that does not
+// fold its result back into the saved config is silently undone by a restart -- and
+// because the on-disk sidecars were rebuilt under the wider spec, reopening under the
+// narrower creation-time spec discards the rebuild AddIndex just paid for (a full
+// decompress of the archive). Assert the index set survives, and that re-asserting the
+// same index after a restart is a no-op rather than a second backfill.
+func TestArchiveIndexConfigPersists(t *testing.T) {
+	dir := t.TempDir()
+	cat, err := OpenCatalog(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hist, err := cat.CreateArchiveTable("history", ArchiveConfig{
+		ValueAttrs: []string{"ClusterId"},
+		ZoneAttrs:  []string{"CompletionDate"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	const n = 200
+	for i := 0; i < n; i++ {
+		if err := hist.AppendOld(fmt.Sprintf(
+			"ClusterId = %d\nCompletionDate = %d\nOwner = %q", i, 1000+i, fmt.Sprintf("user%d", i%4),
+		)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Owner is not indexed at creation -- this is the state a deployed archive is in.
+	if cat0, _ := hist.IndexedAttrs(); slices.Contains(cat0, "Owner") {
+		t.Fatalf("Owner unexpectedly indexed at creation: %v", cat0)
+	}
+	if !hist.AddIndex([]string{"Owner"}, nil) {
+		t.Fatal("AddIndex(Owner) reported no change")
+	}
+	catAttrs, valAttrs := hist.IndexedAttrs()
+	if !slices.Contains(catAttrs, "Owner") {
+		t.Fatalf("after AddIndex, categorical = %v, want it to contain Owner", catAttrs)
+	}
+	if !slices.Contains(valAttrs, "ClusterId") {
+		t.Fatalf("after AddIndex, value = %v, want it to still contain ClusterId", valAttrs)
+	}
+	cat.Close()
+
+	cat2, err := OpenCatalog(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cat2.Close()
+	h2, ok := cat2.ArchiveTable("history")
+	if !ok {
+		t.Fatal("archive not recovered on reopen")
+	}
+
+	catAttrs2, valAttrs2 := h2.IndexedAttrs()
+	if !slices.Contains(catAttrs2, "Owner") {
+		t.Errorf("after reopen, categorical = %v, want it to contain Owner (index add was not persisted)", catAttrs2)
+	}
+	if !slices.Contains(valAttrs2, "ClusterId") {
+		t.Errorf("after reopen, value = %v, want it to still contain ClusterId", valAttrs2)
+	}
+
+	// Re-asserting the same index must be a no-op. If it reports a change, a daemon that
+	// reconciles its configured attributes at startup would re-run the full backfill on
+	// every restart.
+	if h2.AddIndex([]string{"Owner"}, nil) {
+		t.Error("re-adding an already-persisted index reported a change (would re-backfill every restart)")
+	}
+
+	// The data is still queryable through the recovered index.
+	rows, err := h2.Aggregate(`Owner == "user0"`, nil, []AggSpec{{Func: AggCount, Arg: "*"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 || rows[0].Values[0] != fmt.Sprint(n/4) {
+		t.Errorf("count for user0 = %v, want %d", rows, n/4)
+	}
+}
+
+// TestArchiveDropIndexPersists is the mirror: a runtime drop must not be resurrected by a
+// restart either.
+func TestArchiveDropIndexPersists(t *testing.T) {
+	dir := t.TempDir()
+	cat, err := OpenCatalog(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hist, err := cat.CreateArchiveTable("history", ArchiveConfig{
+		CategoricalAttrs: []string{"Owner", "AccountingGroup"},
+		ZoneAttrs:        []string{"CompletionDate"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 50; i++ {
+		if err := hist.AppendOld(fmt.Sprintf(
+			"CompletionDate = %d\nOwner = %q\nAccountingGroup = \"grp\"", 1000+i, fmt.Sprintf("user%d", i%4),
+		)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if !hist.DropIndex("AccountingGroup") {
+		t.Fatal("DropIndex(AccountingGroup) reported no change")
+	}
+	cat.Close()
+
+	cat2, err := OpenCatalog(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cat2.Close()
+	h2, ok := cat2.ArchiveTable("history")
+	if !ok {
+		t.Fatal("archive not recovered on reopen")
+	}
+	catAttrs, _ := h2.IndexedAttrs()
+	if slices.Contains(catAttrs, "AccountingGroup") {
+		t.Errorf("after reopen, categorical = %v, want AccountingGroup dropped (drop was not persisted)", catAttrs)
+	}
+	if !slices.Contains(catAttrs, "Owner") {
+		t.Errorf("after reopen, categorical = %v, want it to still contain Owner", catAttrs)
+	}
+}


### PR DESCRIPTION
`ArchiveTable.AddIndex` and `DropIndex` changed only the live index set, never `archiveconfig.json` — which `openArchiveTable` treats as authoritative on reopen (`cfg = saved`).

Two consequences:

- A runtime index change was silently undone by the next restart.
- Worse, the on-disk sidecars *had* been rebuilt under the wider spec. Reopening under the narrower creation-time spec discarded that rebuild — a full decompress of the archive — and rebuilt the sidecars back down.

`SetRetention` already does the right thing (updates `t.cfg`, calls `saveConfig`); this brings the index mutators in line.

The fix mirrors `DB.saveIndexConfig`: read the resulting set back from the store rather than merging the caller's names, since `AddIndex` normalizes them (a name given as both kinds, or already indexed as the other kind, lands as categorical). Same best-effort write contract — a failed write leaves the change live for this run but unpersisted.

## Why it matters beyond the obvious

This blocks reconciling a configured index set onto an existing archive at daemon startup: without persistence the reconciliation finds the attribute missing again on every restart and re-runs the full backfill, which grows from minutes on a young archive to hours on a mature one.

## Testing

Two regression tests, both verified failing before the fix:

- `TestArchiveIndexConfigPersists` — the index survives a reopen, and re-asserting it is a no-op rather than a second backfill.
- `TestArchiveDropIndexPersists` — a drop is not resurrected by a restart.

`go vet` and the full `db` suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
