### PR TITLE
collections/db/dbrpc: answer archive GROUP BY COUNT(*) from the indexes

### DIFF
--- a/collections/archive_groupcount.go
+++ b/collections/archive_groupcount.go
@@ -1,0 +1,323 @@
+package collections
+
+import (
+	"math"
+	"strings"
+
+	"github.com/PelicanPlatform/classad/collections/wire"
+)
+
+// Index-resident GROUP BY counts.
+//
+// `SELECT attr, COUNT(*) ... GROUP BY attr` over an archive is normally a scan: every
+// record in every unpruned segment is decompressed so the grouping attribute can be read
+// out of it. But for a categorically indexed attribute the answer is already in the index
+// -- each distinct value has a posting listing the records that carry it, and the size of
+// that posting IS the count. Summing posting cardinalities across segments answers the
+// query without reading a single record, turning a scan of the whole archive into a walk
+// of its per-segment indexes.
+//
+// The saving grows with the archive: at history scale a scan is minutes to tens of minutes
+// and this is milliseconds, because it reads index metadata (kilobytes per segment) rather
+// than record bytes (megabytes to gigabytes per segment).
+//
+// Correctness rests on one self-validating check rather than on enumerating every way the
+// index could be an incomplete description of the data. A record contributes to a posting
+// only if it carries the attribute as an indexed literal, so records that are missing the
+// attribute, hold a non-literal expression for it, or are of an unindexed type are absent
+// from every posting. Rather than test for each of those, the caller compares the summed
+// total against the archive's record count: if they disagree, some record was not
+// attributable to a value and the fast path declines. That is conservative in the safe
+// direction -- it can only refuse an answer it could have given, never give a wrong one.
+
+// CategoricalGroupCounts returns the exact number of records carrying each distinct value
+// of a categorically indexed attribute, derived from the per-segment indexes instead of by
+// scanning records. ok is false when the answer cannot be established from the indexes
+// alone, in which case the caller must scan; see the package comment above for what makes
+// it decline.
+//
+// The counts are keyed by the value's exact spelling, matching what a scan would group by:
+// ClassAd string comparison folds case, but two spellings of the same value are distinct
+// groups, and the index keeps its exact-case run for precisely that reason.
+func (a *Archive) CategoricalGroupCounts(attr string) (map[string]int64, bool) {
+	return a.c.categoricalGroupCounts(attr)
+}
+
+// CategoricalGroupCountsBucketed is CategoricalGroupCounts split by a second, numeric
+// dimension: it returns per-value counts keyed by the bucket floor(bucketAttr/width)*width.
+// This is the "per group per day" shape, with width the bucket size in the attribute's own
+// units (86400 for daily buckets over a unix-seconds attribute).
+//
+// It is cheap for the same reason the ungrouped form is, plus one more: an archive is
+// append-ordered, so a segment's values for a monotonically advancing attribute like a
+// completion time span a narrow range. When a segment's zone map for bucketAttr falls
+// wholly inside one bucket -- the common case -- every record in it belongs to that bucket
+// and its per-value counts are attributed wholesale, with no record read. Only the segments
+// straddling a bucket boundary are scanned, and with buckets much wider than a segment's
+// time span those are a small minority.
+//
+// bucketAttr must carry a zone map (ZoneAttrs at creation); without one there is no way to
+// place a segment in a bucket without reading it, and the whole point is lost, so this
+// declines. It also declines for the same completeness reasons as CategoricalGroupCounts.
+func (a *Archive) CategoricalGroupCountsBucketed(attr, bucketAttr string, width int64) (map[int64]map[string]int64, bool) {
+	return a.c.categoricalGroupCountsBucketed(attr, bucketAttr, width)
+}
+
+func (c *Collection) categoricalGroupCountsBucketed(attr, bucketAttr string, width int64) (map[int64]map[string]int64, bool) {
+	if width <= 0 {
+		return nil, false
+	}
+	spec := c.spec.Load()
+	id, ok := c.categoricalAttrID(spec, attr)
+	if !ok {
+		return nil, false
+	}
+	// Zone maps are keyed by interned attribute id, a different id space from the (possibly
+	// inline) index spec above -- resolve this one through the intern table.
+	zoneID, ok := c.intern.LookupID(bucketAttr)
+	if !ok {
+		return nil, false
+	}
+
+	out := make(map[int64]map[string]int64)
+	addTo := func(bucket int64, v string, n int64) {
+		m := out[bucket]
+		if m == nil {
+			m = make(map[string]int64)
+			out[bucket] = m
+		}
+		m[v] += n
+	}
+	var total int64
+	var dbuf []byte
+	for _, sh := range c.shards {
+		_, wins := sh.snapshot()
+		ok := func() bool {
+			defer releaseWindows(wins)
+			for _, w := range wins {
+				z, hasZone := w.zones[zoneID]
+				idx := w.seg.readIdx()
+				covered := 0
+				// Whole-segment attribution: the segment's entire value range for bucketAttr
+				// sits in one bucket, so every record it holds lands there.
+				if idx != nil && hasZone && bucketOf(z.Min, width) == bucketOf(z.Max, width) {
+					b := bucketOf(z.Min, width)
+					covered = min(int(idx.coveredUpto()), w.used)
+					complete := idx.catCanonicalValues(id, func(v string) bool {
+						n, ok := idx.catValueCount(id, v)
+						if !ok {
+							return false
+						}
+						addTo(b, v, int64(n))
+						total += int64(n)
+						return true
+					})
+					if !complete {
+						return false
+					}
+				}
+				// Everything the index could not account for -- a straddling segment, the
+				// open segment, or an unindexed tail -- is read record by record.
+				if covered < w.used {
+					n, ok := countAttrBucketRange(c, w, attr, bucketAttr, width, covered, w.used, &dbuf, addTo)
+					if !ok {
+						return false
+					}
+					total += n
+				}
+			}
+			return true
+		}()
+		if !ok {
+			return nil, false
+		}
+	}
+	if total != int64(c.Len()) {
+		return nil, false
+	}
+	return out, true
+}
+
+// bucketOf floors v into a width-aligned bucket. It must agree exactly with the aggregate
+// engine's bucketKeyText, or the fast path would label rows differently from the scan.
+func bucketOf(v float64, width int64) int64 {
+	return int64(math.Floor(v/float64(width))) * width
+}
+
+func (c *Collection) categoricalGroupCounts(attr string) (map[string]int64, bool) {
+	spec := c.spec.Load()
+	id, ok := c.categoricalAttrID(spec, attr)
+	if !ok {
+		return nil, false // not categorically indexed: nothing to read counts from
+	}
+
+	counts := make(map[string]int64)
+	var total int64
+	var dbuf []byte
+	for _, sh := range c.shards {
+		_, wins := sh.snapshot()
+		ok := func() bool {
+			defer releaseWindows(wins)
+			for _, w := range wins {
+				// An archive keeps no in-RAM index for its open segment -- the transient
+				// build is discarded when the segment seals and its sidecar is written -- so
+				// there is always one unindexed segment at the head, plus (for a sealed
+				// segment reindexed under an older spec) a possible unindexed tail. Read
+				// counts from the index where there is one and scan the remainder, which is
+				// bounded by the segment size rather than by the archive.
+				covered := 0
+				if idx := w.seg.readIdx(); idx != nil {
+					covered = min(int(idx.coveredUpto()), w.used)
+					complete := idx.catCanonicalValues(id, func(v string) bool {
+						n, ok := idx.catValueCount(id, v)
+						if !ok {
+							return false // enumerated a value it cannot count: give up
+						}
+						counts[v] += int64(n)
+						total += int64(n)
+						return true
+					})
+					if !complete {
+						return false
+					}
+				}
+				if covered < w.used {
+					n, ok := countAttrRange(c, w, attr, covered, w.used, &dbuf, counts)
+					if !ok {
+						return false
+					}
+					total += n
+				}
+			}
+			return true
+		}()
+		if !ok {
+			return nil, false
+		}
+	}
+
+	// The self-validating check: every record must have been attributed to exactly one
+	// value. Any shortfall means the index is not a complete description of the data here.
+	if total != int64(c.Len()) {
+		return nil, false
+	}
+	return counts, true
+}
+
+// countAttrRange counts attr's string values over the records in [from, to) of one segment
+// window, adding them to counts. It reports how many records it attributed, and ok=false as
+// soon as a record does not carry the attribute as a string literal -- the same bar the
+// indexed path holds, so a mixed archive declines rather than half-counting.
+//
+// Attributes are matched by name rather than by the index's attribute id: an index spec may
+// be inline, in which case its ids are synthetic and share no id space with the encoded
+// records. Name matching is the one bridge that holds in either regime. It costs a walk of
+// each record's attributes, which is affordable because this only ever runs over the
+// segment the index does not cover -- bounded by the segment size, not the archive.
+func countAttrRange(c *Collection, w segWindow, attr string, from, to int, dbuf *[]byte, counts map[string]int64) (int64, bool) {
+	var n int64
+	for off := from; off < to; {
+		o := uint32(off)
+		total := recTotalLen(w.data, o)
+		if total == 0 {
+			break
+		}
+		off += int(total)
+		if isSystemKeyBytes(recKey(w.data, o)) {
+			continue // internal record, not part of the user's data (nor of Len)
+		}
+		raw, err := w.codec.Decompress((*dbuf)[:0], recAd(w.data, o))
+		if err != nil {
+			return 0, false
+		}
+		*dbuf = raw
+		var val string
+		found := false
+		wire.Ad(raw).ForEachNamed(c.intern, func(name string, node []byte) bool {
+			if !strings.EqualFold(name, attr) {
+				return true
+			}
+			if lit, ok := wire.LiteralValue(node); ok && lit.Kind == wire.LitString {
+				val, found = lit.Str, true
+			}
+			return false // stop at the attribute, however it turned out
+		})
+		if !found {
+			return 0, false // absent, or present but not an indexable string literal
+		}
+		counts[val]++
+		n++
+	}
+	return n, true
+}
+
+// countAttrBucketRange is countAttrRange for the bucketed form: it reads both the grouping
+// attribute (a string) and the bucketing attribute (a number) out of each record in one
+// pass, and reports ok=false if either is missing or of the wrong kind -- the same bar the
+// indexed path holds.
+func countAttrBucketRange(c *Collection, w segWindow, attr, bucketAttr string, width int64,
+	from, to int, dbuf *[]byte, addTo func(bucket int64, v string, n int64)) (int64, bool) {
+	var n int64
+	for off := from; off < to; {
+		o := uint32(off)
+		total := recTotalLen(w.data, o)
+		if total == 0 {
+			break
+		}
+		off += int(total)
+		if isSystemKeyBytes(recKey(w.data, o)) {
+			continue
+		}
+		raw, err := w.codec.Decompress((*dbuf)[:0], recAd(w.data, o))
+		if err != nil {
+			return 0, false
+		}
+		*dbuf = raw
+		var val string
+		var bucket int64
+		gotVal, gotBucket := false, false
+		wire.Ad(raw).ForEachNamed(c.intern, func(name string, node []byte) bool {
+			switch {
+			case !gotVal && strings.EqualFold(name, attr):
+				if lit, ok := wire.LiteralValue(node); ok && lit.Kind == wire.LitString {
+					val, gotVal = lit.Str, true
+				} else {
+					return false // present but not indexable: decline
+				}
+			case !gotBucket && strings.EqualFold(name, bucketAttr):
+				if f, ok := literalFloat(node); ok {
+					bucket, gotBucket = bucketOf(f, width), true
+				} else {
+					return false
+				}
+			}
+			return !(gotVal && gotBucket)
+		})
+		if !gotVal || !gotBucket {
+			return 0, false
+		}
+		addTo(bucket, val, 1)
+		n++
+	}
+	return n, true
+}
+
+// categoricalAttrID resolves an attribute name to its id among the spec's categorical
+// indexes. Names are matched case-insensitively, as ClassAd attribute names are, and the
+// id is resolved the same way IndexedAttrs renders it so the two always agree on which
+// attributes are categorically indexed.
+func (c *Collection) categoricalAttrID(spec *indexSpec, attr string) (uint32, bool) {
+	for _, id := range spec.catIDs {
+		var name string
+		var ok bool
+		if spec.inline {
+			name, ok = spec.names[id]
+		} else {
+			name, ok = c.intern.Name(id)
+		}
+		if ok && strings.EqualFold(name, attr) {
+			return id, true
+		}
+	}
+	return 0, false
+}

--- a/collections/archive_groupcount_where.go
+++ b/collections/archive_groupcount_where.go
@@ -1,0 +1,379 @@
+package collections
+
+import (
+	"strings"
+
+	"github.com/PelicanPlatform/classad/ast"
+	"github.com/PelicanPlatform/classad/collections/vm"
+	"github.com/PelicanPlatform/classad/collections/wire"
+)
+
+// Constrained index-resident GROUP BY counts.
+//
+// The unconstrained form (archive_groupcount.go) can attribute a whole segment's postings
+// because every record in the segment is in the answer. With a WHERE clause that is only
+// true for segments whose records ALL satisfy the constraint, so the question becomes: can
+// we prove, from a segment's zone map alone, that its every record matches?
+//
+// The tempting shortcut is to reuse the probes a query decomposes into (the same ones
+// zonePrune uses) and declare a segment fully matching when every probe is satisfied over
+// its zone bounds. That is unsound. Probes are a conservative UNDER-approximation -- the
+// conjuncts that must hold -- so "every probe is implied" does not mean "the constraint is
+// implied". A disjunctive or negated constraint has probes that say much less than the
+// expression does, and attributing a segment on that basis would over-count.
+//
+// So this path does not reason about probes at all. It re-reads the constraint's syntax and
+// accepts only a shape it can characterize exactly: a conjunction of comparisons between a
+// zone-mapped attribute and a numeric literal. For that shape the expression IS the
+// conjunction of its conditions, so zone bounds that imply every condition imply the whole
+// constraint. Every other shape -- a disjunction, a negation, a function call, a comparison
+// between two attributes -- is refused, and the caller scans.
+
+// rangeCond is one verified `attr op literal` condition from a constraint.
+type rangeCond struct {
+	attr string
+	op   string
+	val  float64
+}
+
+// parseConjunctiveRanges returns the conditions a constraint is exactly equivalent to, or
+// ok=false if it is not a pure conjunction of numeric comparisons on plain attribute
+// references. Being exact is the whole point: a caller may treat the returned conditions as
+// a complete restatement of the constraint.
+func parseConjunctiveRanges(constraint string) ([]rangeCond, bool) {
+	q, err := vm.Parse(constraint)
+	if err != nil {
+		return nil, false
+	}
+	var out []rangeCond
+	var walk func(e ast.Expr) bool
+	walk = func(e ast.Expr) bool {
+		switch n := e.(type) {
+		case *ast.ParenExpr:
+			return walk(n.Inner)
+		case *ast.BinaryOp:
+			if n.Op == "&&" {
+				return walk(n.Left) && walk(n.Right)
+			}
+			c, ok := asRangeCond(n)
+			if !ok {
+				return false
+			}
+			out = append(out, c)
+			return true
+		default:
+			return false
+		}
+	}
+	if !walk(q.Expr()) || len(out) == 0 {
+		return nil, false
+	}
+	return out, true
+}
+
+// asRangeCond matches `attr op number` (or the mirrored `number op attr`) for an ordering
+// or equality operator, normalizing to attr-on-the-left form.
+func asRangeCond(n *ast.BinaryOp) (rangeCond, bool) {
+	switch n.Op {
+	case "<", "<=", ">", ">=", "==":
+	default:
+		return rangeCond{}, false // includes !=, =?=, =!=, and every non-comparison
+	}
+	if a, ok := plainAttr(n.Left); ok {
+		if v, ok := numericLiteral(n.Right); ok {
+			return rangeCond{attr: a, op: n.Op, val: v}, true
+		}
+		return rangeCond{}, false
+	}
+	if a, ok := plainAttr(n.Right); ok {
+		if v, ok := numericLiteral(n.Left); ok {
+			return rangeCond{attr: a, op: mirrorOp(n.Op), val: v}, true
+		}
+	}
+	return rangeCond{}, false
+}
+
+// plainAttr accepts an unscoped attribute reference. A scoped one (TARGET./PARENT.) does
+// not refer to this record, so it is not something a zone map can decide.
+func plainAttr(e ast.Expr) (string, bool) {
+	if p, ok := e.(*ast.ParenExpr); ok {
+		return plainAttr(p.Inner)
+	}
+	a, ok := e.(*ast.AttributeReference)
+	if !ok || a.Scope != ast.NoScope {
+		return "", false
+	}
+	return a.Name, true
+}
+
+func numericLiteral(e ast.Expr) (float64, bool) {
+	if p, ok := e.(*ast.ParenExpr); ok {
+		return numericLiteral(p.Inner)
+	}
+	switch l := e.(type) {
+	case *ast.IntegerLiteral:
+		return float64(l.Value), true
+	case *ast.RealLiteral:
+		return l.Value, true
+	}
+	return 0, false
+}
+
+func mirrorOp(op string) string {
+	switch op {
+	case "<":
+		return ">"
+	case "<=":
+		return ">="
+	case ">":
+		return "<"
+	case ">=":
+		return "<="
+	}
+	return op // "=="
+}
+
+// alwaysHolds reports whether every value in [z.Min, z.Max] satisfies the condition.
+func (c rangeCond) alwaysHolds(z zoneRange) bool {
+	switch c.op {
+	case ">":
+		return z.Min > c.val
+	case ">=":
+		return z.Min >= c.val
+	case "<":
+		return z.Max < c.val
+	case "<=":
+		return z.Max <= c.val
+	case "==":
+		return z.Min == c.val && z.Max == c.val
+	}
+	return false
+}
+
+// neverHolds reports whether no value in [z.Min, z.Max] satisfies the condition, so the
+// segment cannot contribute at all.
+func (c rangeCond) neverHolds(z zoneRange) bool {
+	switch c.op {
+	case ">":
+		return z.Max <= c.val
+	case ">=":
+		return z.Max < c.val
+	case "<":
+		return z.Min >= c.val
+	case "<=":
+		return z.Min > c.val
+	case "==":
+		return c.val < z.Min || c.val > z.Max
+	}
+	return false
+}
+
+func (c rangeCond) holds(v float64) bool {
+	switch c.op {
+	case ">":
+		return v > c.val
+	case ">=":
+		return v >= c.val
+	case "<":
+		return v < c.val
+	case "<=":
+		return v <= c.val
+	case "==":
+		return v == c.val
+	}
+	return false
+}
+
+// CategoricalGroupCountsWhere is CategoricalGroupCounts restricted to the records matching
+// constraint. ok is false unless the constraint is a pure conjunction of numeric
+// comparisons against zone-mapped attributes AND the indexes fully account for every record
+// (the same completeness bar as the unconstrained form) -- see the file comment for why the
+// constraint's syntax is re-checked rather than its probes trusted.
+//
+// Segments are decided by their zone maps: one whose bounds imply every condition
+// contributes its postings wholesale, one that cannot satisfy some condition contributes
+// nothing, and only the genuinely straddling ones are read.
+func (a *Archive) CategoricalGroupCountsWhere(attr, constraint string) (map[string]int64, bool) {
+	return a.c.categoricalGroupCountsWhere(attr, constraint)
+}
+
+func (c *Collection) categoricalGroupCountsWhere(attr, constraint string) (map[string]int64, bool) {
+	conds, ok := parseConjunctiveRanges(constraint)
+	if !ok {
+		return nil, false
+	}
+	spec := c.spec.Load()
+	id, ok := c.categoricalAttrID(spec, attr)
+	if !ok {
+		return nil, false
+	}
+	// Every condition's attribute must be zone-mapped, or a segment cannot be decided
+	// without reading it. Zone maps are keyed by interned id (a different id space from the
+	// possibly-inline index spec).
+	condIDs := make([]uint32, len(conds))
+	for i, cond := range conds {
+		zid, ok := c.intern.LookupID(cond.attr)
+		if !ok {
+			return nil, false
+		}
+		condIDs[i] = zid
+	}
+
+	counts := make(map[string]int64)
+	var seen int64 // every record, matching or not -- the completeness check
+	var dbuf []byte
+	for _, sh := range c.shards {
+		_, wins := sh.snapshot()
+		ok := func() bool {
+			defer releaseWindows(wins)
+			for _, w := range wins {
+				verdict := segmentVerdict(w, conds, condIDs)
+				idx := w.seg.readIdx()
+				covered := 0
+				// The index can supply this segment's counts only when the verdict is
+				// uniform over it -- every record in or every record out. A straddling
+				// segment has to be read even though its zone maps were perfectly readable.
+				if idx != nil && verdict != segStraddle {
+					covered = min(int(idx.coveredUpto()), w.used)
+					complete := idx.catCanonicalValues(id, func(v string) bool {
+						n, ok := idx.catValueCount(id, v)
+						if !ok {
+							return false
+						}
+						seen += int64(n)
+						if verdict == segAlways {
+							counts[v] += int64(n)
+						}
+						return true
+					})
+					if !complete {
+						return false
+					}
+				}
+				if covered < w.used {
+					// Straddling, unindexed, or an uncovered tail: read the records. A
+					// segment already proven to hold nothing still has to be counted toward
+					// the completeness check, but never contributes.
+					n, ok := countAttrWhere(c, w, attr, conds, verdict == segNever, covered, w.used, &dbuf, counts)
+					if !ok {
+						return false
+					}
+					seen += n
+				}
+			}
+			return true
+		}()
+		if !ok {
+			return nil, false
+		}
+	}
+	if seen != int64(c.Len()) {
+		return nil, false
+	}
+	return counts, true
+}
+
+// segVerdict is what a segment's zone maps prove about the constraint over it.
+type segVerdict int
+
+const (
+	// segStraddle: the zone bounds prove nothing either way, so the records must be read.
+	// This is also the verdict when a condition's attribute has no zone map here.
+	segStraddle segVerdict = iota
+	// segAlways: every record in the segment satisfies every condition.
+	segAlways
+	// segNever: no record in the segment can satisfy some condition.
+	segNever
+)
+
+// segmentVerdict decides a segment against the conditions from its zone maps alone.
+//
+// The distinction that matters is between "decidable" and "fully matching": a segment whose
+// bounds straddle the range is perfectly decidable as *straddling*, and must then be read.
+// Treating decidability as sufficient to attribute from the index silently drops every
+// straddling segment's records.
+func segmentVerdict(w segWindow, conds []rangeCond, condIDs []uint32) segVerdict {
+	always := true
+	for i, cond := range conds {
+		z, ok := w.zones[condIDs[i]]
+		if !ok {
+			return segStraddle // undecidable without reading records
+		}
+		if cond.neverHolds(z) {
+			return segNever
+		}
+		if !cond.alwaysHolds(z) {
+			always = false
+		}
+	}
+	if always {
+		return segAlways
+	}
+	return segStraddle
+}
+
+// countAttrWhere counts the grouping attribute over records in [from, to) that satisfy the
+// conditions, returning how many records it examined (matching or not). skip short-circuits
+// a segment already proven to match nothing: its records still count toward completeness.
+func countAttrWhere(c *Collection, w segWindow, attr string, conds []rangeCond, skip bool,
+	from, to int, dbuf *[]byte, counts map[string]int64) (int64, bool) {
+	var n int64
+	for off := from; off < to; {
+		o := uint32(off)
+		total := recTotalLen(w.data, o)
+		if total == 0 {
+			break
+		}
+		off += int(total)
+		if isSystemKeyBytes(recKey(w.data, o)) {
+			continue
+		}
+		raw, err := w.codec.Decompress((*dbuf)[:0], recAd(w.data, o))
+		if err != nil {
+			return 0, false
+		}
+		*dbuf = raw
+		var val string
+		gotVal := false
+		matches := true
+		seenCond := make([]bool, len(conds))
+		wire.Ad(raw).ForEachNamed(c.intern, func(name string, node []byte) bool {
+			if !gotVal && strings.EqualFold(name, attr) {
+				if lit, ok := wire.LiteralValue(node); ok && lit.Kind == wire.LitString {
+					val, gotVal = lit.Str, true
+				} else {
+					matches = false
+					return false
+				}
+			}
+			for i, cond := range conds {
+				if seenCond[i] || !strings.EqualFold(name, cond.attr) {
+					continue
+				}
+				f, ok := literalFloat(node)
+				if !ok {
+					matches = false
+					return false
+				}
+				seenCond[i] = true
+				if !cond.holds(f) {
+					matches = false
+				}
+			}
+			return true
+		})
+		if !gotVal {
+			return 0, false // cannot attribute this record to a group
+		}
+		for i := range conds {
+			if !seenCond[i] {
+				matches = false // the constraint references an attribute this record lacks
+			}
+		}
+		n++
+		if !skip && matches {
+			counts[val]++
+		}
+	}
+	return n, true
+}

--- a/collections/archive_mmapindex.go
+++ b/collections/archive_mmapindex.go
@@ -389,6 +389,22 @@ func (si *mmapSegIndex) catCanonicalValues(id uint32, add func(string) bool) boo
 	return true
 }
 
+// catValueCount returns the number of records spelling categorical attribute id exactly
+// key, read as the cardinality of that value's posting. roaring keeps per-container
+// cardinalities in the serialized descriptive header, so this pages in the head of the
+// bitmap rather than its containers.
+func (si *mmapSegIndex) catValueCount(id uint32, key string) (uint64, bool) {
+	attrOff, ok := si.catDir[id]
+	if !ok {
+		return 0, false
+	}
+	bmOff, ok := si.catFindExact(attrOff, key)
+	if !ok {
+		return 0, false
+	}
+	return si.bitmapAt(bmOff).GetCardinality(), true
+}
+
 // catFindMPH probes the categorical MPH (v6). It returns (bmOff, true) only for a key that
 // the MPH resolves AND whose folded spelling verifies at the resolved slot; any other case
 // -- no MPH, an unresolved key (unassigned member or non-member), or a verify mismatch (an

--- a/collections/match_index.go
+++ b/collections/match_index.go
@@ -613,6 +613,21 @@ func (si *segIndex) catCanonicalValues(id uint32, add func(string) bool) bool {
 	return true
 }
 
+// catValueCount returns the number of records spelling categorical attribute id exactly
+// key. It reuses exactBitmap's case-uniform/mixed-case resolution, so it agrees with an
+// equality probe on the same spelling by construction.
+func (si *segIndex) catValueCount(id uint32, key string) (uint64, bool) {
+	cp := si.cat[id]
+	if cp == nil {
+		return 0, false
+	}
+	bm := cp.exactBitmap(key)
+	if bm == nil {
+		return 0, false
+	}
+	return bm.GetCardinality(), true
+}
+
 // materializeFinite walks the boolean tree of a slot predicate and replaces each opaque
 // leaf that is a pure function of a single low-cardinality categorical attribute with an
 // equivalent membership disjunction (attr == v1 || ...), by evaluating the leaf over the

--- a/collections/readindex.go
+++ b/collections/readindex.go
@@ -24,6 +24,12 @@ type readIndex interface {
 	// (for MATCH's finite-value materialization). add returns false to stop early;
 	// catCanonicalValues then returns false too. Returns true when all values were emitted.
 	catCanonicalValues(id uint32, add func(string) bool) bool
+	// catValueCount returns how many records in the indexed prefix carry exactly key
+	// (case-sensitive) for categorical attribute id -- the cardinality of that value's
+	// posting, without materializing the posting itself. ok is false when the attribute is
+	// not categorically indexed here or no record spells the value that way. Paired with
+	// catCanonicalValues it answers a GROUP BY count from the index alone.
+	catValueCount(id uint32, key string) (count uint64, ok bool)
 }
 
 // indexPrimitives are the per-tier operations the shared planner logic (below) is built on.

--- a/db/archive.go
+++ b/db/archive.go
@@ -7,6 +7,7 @@ import (
 	"iter"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -173,20 +174,20 @@ func (t *ArchiveTable) QueryRawProjected(constraint string, projection []string,
 // aggregate over a live table -- only the (small) grouped result is produced, not every
 // matched ad. With no group columns it returns a single row over the whole match.
 func (t *ArchiveTable) Aggregate(constraint string, groupBy []string, aggs []AggSpec) ([]AggRow, error) {
-	// Fast path: an unconstrained COUNT(*) with no grouping is the retained record count,
-	// which the archive tracks in O(1). This is the common `SELECT COUNT(*) FROM history`;
-	// scanning tens of thousands of records to count them would be needlessly slow. A
-	// FILTERED count cannot take this path -- the stored total knows nothing about the
-	// filter, so it would silently answer with every row.
-	if len(groupBy) == 0 && len(aggs) == 1 && aggs[0].Func == AggCount && aggs[0].Arg == "*" &&
-		aggs[0].Filter == "" && IsMatchAll(constraint) {
-		return []AggRow{{Values: []string{strconv.Itoa(t.a.Count())}}}, nil
-	}
-
 	groupCols := make([]GroupCol, len(groupBy))
 	for i, g := range groupBy {
 		groupCols[i] = GroupCol{Attr: g}
 	}
+	return t.AggregateCols(constraint, groupCols, aggs)
+}
+
+// AggregateCols is Aggregate where a group column may carry a bucket width, so a numeric
+// attribute can be grouped into fixed-width buckets (the "per day" dimension) server-side.
+func (t *ArchiveTable) AggregateCols(constraint string, groupCols []GroupCol, aggs []AggSpec) ([]AggRow, error) {
+	if rows, ok := t.aggregateFromIndex(constraint, groupCols, aggs); ok {
+		return rows, nil
+	}
+
 	attrs, groupCol, aggCol := AggProjection(groupCols, aggs)
 
 	// Scan wire-native, reading only the attributes the aggregation projects (empty for a
@@ -199,12 +200,149 @@ func (t *ArchiveTable) Aggregate(constraint string, groupBy []string, aggs []Agg
 	return AggregateValues(seq, attrs, groupCols, aggs, groupCol, aggCol, nil)
 }
 
+// aggregateFromIndex answers the aggregate without reading records where the per-segment
+// indexes already contain the answer, returning ok=false when they do not so the caller
+// scans. Every path here is restricted to an unconstrained COUNT(*): a WHERE clause would
+// have to be proven to hold for a whole segment before its counts could be attributed, and
+// the probe set a constraint decomposes into is a conservative under-approximation, not a
+// proof.
+//
+// Row order differs from the scan path's first-seen order: rows come back sorted by group
+// value (then bucket). GROUP BY without ORDER BY has no defined order either way, and
+// sorted is at least deterministic.
+func (t *ArchiveTable) aggregateFromIndex(constraint string, groupCols []GroupCol, aggs []AggSpec) ([]AggRow, bool) {
+	if len(aggs) != 1 || aggs[0].Func != AggCount || aggs[0].Arg != "*" {
+		return nil, false
+	}
+	// A per-aggregate FILTER rules out every path here: postings and the stored record
+	// count know nothing about the filter, so answering from them would silently report
+	// unfiltered totals as if they were filtered.
+	if aggs[0].Filter != "" {
+		return nil, false
+	}
+	matchAll := IsMatchAll(constraint)
+	switch len(groupCols) {
+	case 0:
+		if !matchAll {
+			return nil, false
+		}
+		// The retained record count, which the archive tracks in O(1).
+		return []AggRow{{Values: []string{strconv.Itoa(t.a.Count())}}}, true
+
+	case 1:
+		if groupCols[0].BucketWidth != 0 {
+			return nil, false // a lone bucketed column: nothing to read counts from
+		}
+		// A constrained count is only index-answerable when the constraint's shape can be
+		// verified as a conjunction of zone-decidable range conditions; otherwise
+		// CategoricalGroupCountsWhere declines and we scan.
+		var counts map[string]int64
+		var ok bool
+		if matchAll {
+			counts, ok = t.a.CategoricalGroupCounts(groupCols[0].Attr)
+		} else {
+			counts, ok = t.a.CategoricalGroupCountsWhere(groupCols[0].Attr, constraint)
+		}
+		if !ok {
+			return nil, false
+		}
+		vals := make([]string, 0, len(counts))
+		for v := range counts {
+			vals = append(vals, v)
+		}
+		sort.Strings(vals)
+		rows := make([]AggRow, 0, len(vals))
+		for _, v := range vals {
+			rows = append(rows, AggRow{
+				Group:  []string{v},
+				Values: []string{strconv.FormatInt(counts[v], 10)},
+			})
+		}
+		return rows, true
+
+	case 2:
+		// One raw categorical column and one bucketed numeric column, in either order --
+		// "jobs per owner per day". The bucket dimension comes from segment zone maps, so
+		// whole segments are attributed without being read.
+		//
+		// Unconstrained only: the bucketed helper takes no constraint, so answering a
+		// WHERE-bearing query from it would silently ignore the filter.
+		if !matchAll {
+			return nil, false
+		}
+		cat, bucket := 0, 1
+		if groupCols[0].BucketWidth != 0 {
+			cat, bucket = 1, 0
+		}
+		if groupCols[cat].BucketWidth != 0 || groupCols[bucket].BucketWidth <= 0 {
+			return nil, false
+		}
+		byBucket, ok := t.a.CategoricalGroupCountsBucketed(
+			groupCols[cat].Attr, groupCols[bucket].Attr, groupCols[bucket].BucketWidth)
+		if !ok {
+			return nil, false
+		}
+		buckets := make([]int64, 0, len(byBucket))
+		for b := range byBucket {
+			buckets = append(buckets, b)
+		}
+		sort.Slice(buckets, func(i, j int) bool { return buckets[i] < buckets[j] })
+		var rows []AggRow
+		for _, b := range buckets {
+			counts := byBucket[b]
+			vals := make([]string, 0, len(counts))
+			for v := range counts {
+				vals = append(vals, v)
+			}
+			sort.Strings(vals)
+			for _, v := range vals {
+				group := make([]string, 2)
+				group[cat] = v
+				group[bucket] = strconv.FormatInt(b, 10)
+				rows = append(rows, AggRow{
+					Group:  group,
+					Values: []string{strconv.FormatInt(counts[v], 10)},
+				})
+			}
+		}
+		return rows, true
+	}
+	return nil, false
+}
+
 // IsMatchAll reports whether a constraint imposes no filter (an empty string or a literal
 // "true"), so an aggregate over it covers every record. Shared with the mutable-table
 // COUNT(*) fast path in dbrpc.
 func IsMatchAll(constraint string) bool {
 	c := strings.TrimSpace(constraint)
 	return c == "" || strings.EqualFold(c, "true")
+}
+
+// CategoricalGroupCounts returns the exact per-value record counts for a categorically
+// indexed attribute, read from the per-segment indexes without scanning any record. ok is
+// false when the indexes cannot fully account for every record (see the collections-level
+// doc), in which case the caller must scan. Aggregate uses this for GROUP BY COUNT(*);
+// it is exported so a planner can ask whether the cheap path is available.
+func (t *ArchiveTable) CategoricalGroupCounts(attr string) (map[string]int64, bool) {
+	return t.a.CategoricalGroupCounts(attr)
+}
+
+// CategoricalGroupCountsBucketed is CategoricalGroupCounts split by a numeric bucket
+// (floor(bucketAttr/width)*width) -- the "per group per day" shape. bucketAttr must be
+// zone-mapped; ok is false when the counts cannot be established from the indexes.
+//
+// Not yet reachable from SQL: the archive aggregate crosses dbrpc as a []string group list,
+// which has no room for a bucket width, so a bucketed GROUP BY over an archive still falls
+// back to client-side reduction. Wiring it through is a protocol change.
+func (t *ArchiveTable) CategoricalGroupCountsBucketed(attr, bucketAttr string, width int64) (map[int64]map[string]int64, bool) {
+	return t.a.CategoricalGroupCountsBucketed(attr, bucketAttr, width)
+}
+
+// CategoricalGroupCountsWhere is CategoricalGroupCounts restricted to records matching
+// constraint. ok is false unless the constraint is a pure conjunction of numeric
+// comparisons on zone-mapped attributes and the indexes account for every record.
+func (t *ArchiveTable) CategoricalGroupCountsWhere(attr, constraint string) (map[string]int64, bool) {
+	return t.a.CategoricalGroupCountsWhere(attr, constraint)
 }
 
 // Count is the number of records currently retained (reduced by rotation).

--- a/db/archive_aggregate_bench_test.go
+++ b/db/archive_aggregate_bench_test.go
@@ -1,0 +1,81 @@
+package db
+
+import (
+	"fmt"
+	"testing"
+)
+
+// buildAggArchive creates an archive of n history-shaped records whose Owner is drawn from
+// ndv distinct values, indexed categorically. segSize is deliberately small so the archive
+// has many sealed segments, which is the shape a real history has and the shape that
+// decides whether an aggregate can be answered from the per-segment indexes.
+func buildAggArchive(tb testing.TB, n, ndv, segSize int) *ArchiveTable {
+	tb.Helper()
+	cat, err := OpenCatalog(tb.TempDir())
+	if err != nil {
+		tb.Fatal(err)
+	}
+	tb.Cleanup(func() { cat.Close() })
+	hist, err := cat.CreateArchiveTable("history", ArchiveConfig{
+		SegmentSize:      segSize,
+		CategoricalAttrs: []string{"Owner"},
+		ValueAttrs:       []string{"ClusterId"},
+		ZoneAttrs:        []string{"CompletionDate"},
+	})
+	if err != nil {
+		tb.Fatal(err)
+	}
+	for i := 0; i < n; i++ {
+		err := hist.AppendOld(fmt.Sprintf(
+			"ClusterId = %d\nCompletionDate = %d\nOwner = %q\nRequestMemory = %d\nJobStatus = 4",
+			i, 1700000000+i, fmt.Sprintf("user%04d", i%ndv), 1024+(i%8)*512))
+		if err != nil {
+			tb.Fatal(err)
+		}
+	}
+	return hist
+}
+
+// BenchmarkArchiveGroupCount measures GROUP BY Owner + COUNT(*) over an archive. This is
+// the "job count per group" shape, and today it is a scan: Aggregate projects the group
+// attribute out of every record in every segment the zone maps cannot prune, which means
+// decompressing the whole archive.
+//
+// ndv is varied because it decides whether the answer is derivable from per-segment
+// summaries alone: each sealed segment's index keeps exact counts for its top heavy
+// hitters, so a low-cardinality grouping attribute is fully described by resident metadata
+// while a high-cardinality one is not.
+func BenchmarkArchiveGroupCount(b *testing.B) {
+	cases := []struct {
+		name string
+		n    int
+		ndv  int
+	}{
+		{"n=50k/ndv=8", 50_000, 8},
+		{"n=50k/ndv=200", 50_000, 200},
+		{"n=200k/ndv=8", 200_000, 8},
+		{"n=200k/ndv=200", 200_000, 200},
+	}
+	for _, c := range cases {
+		b.Run(c.name, func(b *testing.B) {
+			hist := buildAggArchive(b, c.n, c.ndv, 1<<20)
+			// Correctness guard: a benchmark that measures a wrong answer is worthless.
+			rows, err := hist.Aggregate("true", []string{"Owner"}, []AggSpec{{Func: AggCount, Arg: "*"}})
+			if err != nil {
+				b.Fatal(err)
+			}
+			if len(rows) != c.ndv {
+				b.Fatalf("groups = %d, want %d", len(rows), c.ndv)
+			}
+			b.ReportMetric(float64(hist.Stats().Segments), "segments")
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if _, err := hist.Aggregate("true", []string{"Owner"}, []AggSpec{{Func: AggCount, Arg: "*"}}); err != nil {
+					b.Fatal(err)
+				}
+			}
+			b.StopTimer()
+			b.ReportMetric(float64(c.n)*float64(b.N)/b.Elapsed().Seconds()/1e6, "Mrec/s")
+		})
+	}
+}

--- a/db/archive_groupcount_test.go
+++ b/db/archive_groupcount_test.go
@@ -1,0 +1,395 @@
+package db
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/collections"
+)
+
+// groupCountByScan computes GROUP BY <attr> COUNT(*) the slow, obviously-correct way: it
+// reads every ad back and counts in the test. The fast path is only trustworthy if it
+// agrees with this on every shape, so every case below is checked against it rather than
+// against hand-written expectations.
+func groupCountByScan(t *testing.T, hist *ArchiveTable, attr string) map[string]int64 {
+	t.Helper()
+	seq, err := hist.Query("true")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := map[string]int64{}
+	for ad := range seq {
+		v, ok := ad.EvaluateAttrString(attr)
+		if !ok {
+			// The aggregate engine renders an absent or non-string value as the literal
+			// "undefined" and groups those together, so the reference must do the same --
+			// these records are exactly the ones the index-resident path cannot attribute,
+			// and it must decline rather than drop them.
+			v = "undefined"
+		}
+		got[v]++
+	}
+	return got
+}
+
+func aggGroupCounts(t *testing.T, hist *ArchiveTable, attr string) map[string]int64 {
+	t.Helper()
+	rows, err := hist.Aggregate("true", []string{attr}, []AggSpec{{Func: AggCount, Arg: "*"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := map[string]int64{}
+	for _, r := range rows {
+		var n int64
+		if _, err := fmt.Sscan(r.Values[0], &n); err != nil {
+			t.Fatalf("non-numeric count %q", r.Values[0])
+		}
+		got[r.Group[0]] = n
+	}
+	return got
+}
+
+func mkHist(t *testing.T, cfg ArchiveConfig, ads []string) *ArchiveTable {
+	t.Helper()
+	cat, err := OpenCatalog(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { cat.Close() })
+	hist, err := cat.CreateArchiveTable("history", cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, a := range ads {
+		if err := hist.AppendOld(a); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return hist
+}
+
+// TestArchiveGroupCountMatchesScan is the differential test: for each shape, the aggregate
+// (which may or may not take the index-resident path) must produce exactly what a full
+// scan produces. Shapes are chosen to cover the ways the index can be an incomplete
+// description of the data -- a missing attribute, a non-literal expression, a mixture of
+// spellings -- since those are precisely the cases where reading posting cardinalities
+// would silently undercount if the fast path did not decline.
+func TestArchiveGroupCountMatchesScan(t *testing.T) {
+	indexed := ArchiveConfig{CategoricalAttrs: []string{"Owner"}, ZoneAttrs: []string{"CompletionDate"}}
+	cases := []struct {
+		name string
+		cfg  ArchiveConfig
+		ads  []string
+	}{
+		{
+			name: "every record carries the attribute",
+			cfg:  indexed,
+			ads: []string{
+				`Owner = "alice"`, `Owner = "alice"`, `Owner = "bob"`, `Owner = "carol"`,
+			},
+		},
+		{
+			name: "one record is missing the attribute",
+			cfg:  indexed,
+			ads:  []string{`Owner = "alice"`, `Owner = "bob"`, `JobStatus = 4`},
+		},
+		{
+			name: "mixed case spellings are distinct groups",
+			cfg:  indexed,
+			ads:  []string{`Owner = "Alice"`, `Owner = "alice"`, `Owner = "ALICE"`, `Owner = "bob"`},
+		},
+		{
+			name: "case-uniform single spelling",
+			cfg:  indexed,
+			ads:  []string{`Owner = "Alice"`, `Owner = "Alice"`, `Owner = "bob"`},
+		},
+		{
+			name: "attribute holds a non-literal expression",
+			cfg:  indexed,
+			ads:  []string{`Owner = "alice"`, `Owner = strcat("bo", "b")`, `Owner = "carol"`},
+		},
+		{
+			name: "attribute is not indexed at all",
+			cfg:  ArchiveConfig{ValueAttrs: []string{"ClusterId"}},
+			ads:  []string{`ClusterId = 1` + "\n" + `Owner = "alice"`, `ClusterId = 2` + "\n" + `Owner = "bob"`},
+		},
+		{
+			name: "empty archive",
+			cfg:  indexed,
+			ads:  nil,
+		},
+		{
+			name: "single value repeated",
+			cfg:  indexed,
+			ads:  []string{`Owner = "alice"`, `Owner = "alice"`, `Owner = "alice"`},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			hist := mkHist(t, c.cfg, c.ads)
+			want := groupCountByScan(t, hist, "Owner")
+			got := aggGroupCounts(t, hist, "Owner")
+			if len(got) != len(want) {
+				t.Fatalf("groups = %v, want %v", got, want)
+			}
+			for k, w := range want {
+				if got[k] != w {
+					t.Errorf("group %q = %d, want %d (full result %v)", k, got[k], w, got)
+				}
+			}
+		})
+	}
+}
+
+// TestArchiveGroupCountAcrossSegments exercises the multi-segment path: counts must be
+// summed across every sealed segment plus the still-open active one, which is the case a
+// per-segment index walk gets wrong if it skips or double-counts a segment.
+func TestArchiveGroupCountAcrossSegments(t *testing.T) {
+	const n = 5000
+	owners := []string{"alice", "bob", "carol", "dave"}
+	ads := make([]string, n)
+	for i := range ads {
+		ads[i] = fmt.Sprintf("CompletionDate = %d\nOwner = %q\nPad = %q",
+			1700000000+i, owners[i%len(owners)], strings.Repeat("x", 200))
+	}
+	hist := mkHist(t, ArchiveConfig{
+		SegmentSize:      1 << 16, // force many segments
+		CategoricalAttrs: []string{"Owner"},
+		ZoneAttrs:        []string{"CompletionDate"},
+	}, ads)
+
+	if segs := hist.Stats().Segments; segs < 2 {
+		t.Fatalf("expected multiple segments, got %d", segs)
+	}
+	want := groupCountByScan(t, hist, "Owner")
+	got := aggGroupCounts(t, hist, "Owner")
+	if len(got) != len(owners) {
+		t.Fatalf("groups = %v, want %d", got, len(owners))
+	}
+	for k, w := range want {
+		if got[k] != w {
+			t.Errorf("group %q = %d, want %d", k, got[k], w)
+		}
+	}
+	var total int64
+	for _, v := range got {
+		total += v
+	}
+	if total != n {
+		t.Errorf("counts sum to %d, want %d", total, n)
+	}
+}
+
+// TestCategoricalGroupCountsDeclines pins the conditions under which the collections-level
+// helper must refuse rather than answer, since every one of them would otherwise produce a
+// silently short count.
+func TestCategoricalGroupCountsDeclines(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  ArchiveConfig
+		ads  []string
+	}{
+		{"attribute not indexed", ArchiveConfig{ValueAttrs: []string{"ClusterId"}},
+			[]string{`ClusterId = 1` + "\n" + `Owner = "alice"`}},
+		{"a record lacks the attribute", ArchiveConfig{CategoricalAttrs: []string{"Owner"}},
+			[]string{`Owner = "alice"`, `JobStatus = 4`}},
+		{"a record holds a non-literal", ArchiveConfig{CategoricalAttrs: []string{"Owner"}},
+			[]string{`Owner = "alice"`, `Owner = strcat("b", "ob")`}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			hist := mkHist(t, c.cfg, c.ads)
+			if _, ok := hist.CategoricalGroupCounts("Owner"); ok {
+				t.Error("expected the index-resident path to decline")
+			}
+		})
+	}
+}
+
+// TestCategoricalGroupCountsUsed is the converse: on the clean shape it must actually
+// engage, otherwise the fast path is dead code and the benchmark measures nothing.
+func TestCategoricalGroupCountsUsed(t *testing.T) {
+	hist := mkHist(t, ArchiveConfig{CategoricalAttrs: []string{"Owner"}},
+		[]string{`Owner = "alice"`, `Owner = "alice"`, `Owner = "bob"`})
+	counts, ok := hist.CategoricalGroupCounts("Owner")
+	if !ok {
+		t.Fatal("index-resident path declined on a fully indexed archive")
+	}
+	if counts["alice"] != 2 || counts["bob"] != 1 {
+		t.Errorf("counts = %v, want alice=2 bob=1", counts)
+	}
+	// Attribute names are case-insensitive, as everywhere else in ClassAds.
+	if lower, ok := hist.CategoricalGroupCounts("owner"); !ok || lower["alice"] != 2 {
+		t.Errorf("lower-cased attribute name = %v ok=%v, want the same counts", lower, ok)
+	}
+}
+
+// TestArchiveGroupCountSurvivesReopen checks the fast path works off the persisted mmap
+// sidecars, not just the in-RAM index a freshly written archive happens to hold.
+func TestArchiveGroupCountSurvivesReopen(t *testing.T) {
+	dir := t.TempDir()
+	cat, err := OpenCatalog(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hist, err := cat.CreateArchiveTable("history", ArchiveConfig{
+		SegmentSize:      1 << 16,
+		CategoricalAttrs: []string{"Owner"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	owners := []string{"alice", "bob", "carol"}
+	for i := 0; i < 3000; i++ {
+		if err := hist.AppendOld(fmt.Sprintf("Owner = %q\nPad = %q",
+			owners[i%3], strings.Repeat("y", 200))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	cat.Close()
+
+	cat2, err := OpenCatalog(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cat2.Close()
+	h2, ok := cat2.ArchiveTable("history")
+	if !ok {
+		t.Fatal("archive not recovered")
+	}
+	counts, ok := h2.CategoricalGroupCounts("Owner")
+	if !ok {
+		t.Fatal("index-resident path declined after reopen (sidecar path broken)")
+	}
+	want := groupCountByScan(t, h2, "Owner")
+	if len(counts) != len(want) {
+		t.Fatalf("counts = %v, want %v", counts, want)
+	}
+	for k, w := range want {
+		if counts[k] != w {
+			t.Errorf("group %q = %d, want %d", k, counts[k], w)
+		}
+	}
+}
+
+// TestArchiveGroupCountRowOrder documents the fast path's output ordering: sorted by group
+// value. GROUP BY without ORDER BY has no defined order, but deterministic beats arbitrary.
+func TestArchiveGroupCountRowOrder(t *testing.T) {
+	hist := mkHist(t, ArchiveConfig{CategoricalAttrs: []string{"Owner"}},
+		[]string{`Owner = "carol"`, `Owner = "alice"`, `Owner = "bob"`})
+	rows, err := hist.Aggregate("true", []string{"Owner"}, []AggSpec{{Func: AggCount, Arg: "*"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := make([]string, len(rows))
+	for i, r := range rows {
+		got[i] = r.Group[0]
+	}
+	if !sort.StringsAreSorted(got) {
+		t.Errorf("rows = %v, want sorted by group value", got)
+	}
+}
+
+var _ = collections.Retention{} // keep the collections import meaningful if cases change
+
+// TestArchiveGroupCountBucketedMatchesScan is the differential test for the bucketed form:
+// the per-(day, owner) counts derived from zone maps plus per-segment indexes must equal
+// what reading every record produces. Segments are small relative to a day so most are
+// attributed wholesale and a few straddle a day boundary -- exercising both paths.
+func TestArchiveGroupCountBucketedMatchesScan(t *testing.T) {
+	const day = 86400
+	owners := []string{"alice", "bob", "carol"}
+	var ads []string
+	base := int64(1700000000) / day * day // align so bucket boundaries are predictable
+	for i := 0; i < 4000; i++ {
+		// ~1000 records per day across 4 days.
+		ts := base + int64(i)*(day/1000)
+		ads = append(ads, fmt.Sprintf("CompletionDate = %d\nOwner = %q\nPad = %q",
+			ts, owners[i%len(owners)], strings.Repeat("z", 150)))
+	}
+	hist := mkHist(t, ArchiveConfig{
+		SegmentSize:      1 << 16,
+		CategoricalAttrs: []string{"Owner"},
+		ZoneAttrs:        []string{"CompletionDate"},
+	}, ads)
+	if segs := hist.Stats().Segments; segs < 4 {
+		t.Fatalf("expected several segments, got %d", segs)
+	}
+
+	got, ok := hist.CategoricalGroupCountsBucketed("Owner", "CompletionDate", day)
+	if !ok {
+		t.Fatal("bucketed index-resident path declined on a fully indexed archive")
+	}
+
+	// Reference: read every ad and bucket it by hand.
+	want := map[int64]map[string]int64{}
+	seq, err := hist.Query("true")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var n int64
+	for ad := range seq {
+		o, ok := ad.EvaluateAttrString("Owner")
+		if !ok {
+			t.Fatal("missing Owner")
+		}
+		ts, okTS := ad.EvaluateAttrInt("CompletionDate")
+		if !okTS {
+			t.Fatal("missing CompletionDate")
+		}
+		b := ts / day * day
+		if want[b] == nil {
+			want[b] = map[string]int64{}
+		}
+		want[b][o]++
+		n++
+	}
+	if n != int64(len(ads)) {
+		t.Fatalf("scan saw %d ads, want %d", n, len(ads))
+	}
+	if len(got) != len(want) {
+		t.Fatalf("buckets = %d, want %d (got %v)", len(got), len(want), got)
+	}
+	for b, wm := range want {
+		gm := got[b]
+		if len(gm) != len(wm) {
+			t.Errorf("bucket %d groups = %v, want %v", b, gm, wm)
+			continue
+		}
+		for o, w := range wm {
+			if gm[o] != w {
+				t.Errorf("bucket %d owner %q = %d, want %d", b, o, gm[o], w)
+			}
+		}
+	}
+}
+
+// TestArchiveGroupCountBucketedDeclines pins the cases where bucketing cannot be done from
+// metadata and must not be guessed at.
+func TestArchiveGroupCountBucketedDeclines(t *testing.T) {
+	ads := []string{`CompletionDate = 1700000000` + "\n" + `Owner = "alice"`}
+	t.Run("bucket attribute has no zone map", func(t *testing.T) {
+		hist := mkHist(t, ArchiveConfig{CategoricalAttrs: []string{"Owner"}}, ads)
+		if _, ok := hist.CategoricalGroupCountsBucketed("Owner", "CompletionDate", 86400); ok {
+			t.Error("expected decline without a zone map on the bucket attribute")
+		}
+	})
+	t.Run("non-positive width", func(t *testing.T) {
+		hist := mkHist(t, ArchiveConfig{
+			CategoricalAttrs: []string{"Owner"}, ZoneAttrs: []string{"CompletionDate"},
+		}, ads)
+		if _, ok := hist.CategoricalGroupCountsBucketed("Owner", "CompletionDate", 0); ok {
+			t.Error("expected decline for a zero bucket width")
+		}
+	})
+	t.Run("a record lacks the bucket attribute", func(t *testing.T) {
+		hist := mkHist(t, ArchiveConfig{
+			CategoricalAttrs: []string{"Owner"}, ZoneAttrs: []string{"CompletionDate"},
+		}, append(append([]string{}, ads...), `Owner = "bob"`))
+		if _, ok := hist.CategoricalGroupCountsBucketed("Owner", "CompletionDate", 86400); ok {
+			t.Error("expected decline when a record cannot be placed in a bucket")
+		}
+	})
+}

--- a/db/archive_groupcount_where_test.go
+++ b/db/archive_groupcount_where_test.go
@@ -1,0 +1,229 @@
+package db
+
+import (
+	"fmt"
+	"math/rand"
+	"strings"
+	"testing"
+)
+
+// whereRefCount is the obviously-correct reference: fetch every matching ad and count by
+// hand. The constrained index path is only trustworthy if it agrees with this.
+func whereRefCount(t *testing.T, hist *ArchiveTable, attr, constraint string) map[string]int64 {
+	t.Helper()
+	seq, err := hist.Query(constraint)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := map[string]int64{}
+	for ad := range seq {
+		v, ok := ad.EvaluateAttrString(attr)
+		if !ok {
+			continue
+		}
+		got[v]++
+	}
+	return got
+}
+
+func mkWhereHist(t *testing.T, n int) *ArchiveTable {
+	t.Helper()
+	owners := []string{"alice", "bob", "carol", "dave"}
+	ads := make([]string, n)
+	for i := range ads {
+		ads[i] = fmt.Sprintf("CompletionDate = %d\nRequestMemory = %d\nOwner = %q\nPad = %q",
+			1700000000+i*60, 1024+(i%8)*512, owners[i%len(owners)], strings.Repeat("q", 120))
+	}
+	return mkHist(t, ArchiveConfig{
+		SegmentSize:      1 << 16,
+		CategoricalAttrs: []string{"Owner"},
+		ZoneAttrs:        []string{"CompletionDate", "RequestMemory"},
+	}, ads)
+}
+
+// TestGroupCountsWhereMatchesScan is the differential test over many constraint shapes,
+// including randomized ranges. Whenever the index path answers, it must equal the scan; the
+// shapes it refuses simply fall through (and are covered separately below).
+func TestGroupCountsWhereMatchesScan(t *testing.T) {
+	const n = 3000
+	hist := mkWhereHist(t, n)
+	base := int64(1700000000)
+
+	var constraints []string
+	for _, c := range []string{
+		"CompletionDate >= %d",
+		"CompletionDate > %d",
+		"CompletionDate <= %d",
+		"CompletionDate < %d",
+		"CompletionDate == %d",
+	} {
+		constraints = append(constraints, fmt.Sprintf(c, base+1000*60))
+	}
+	constraints = append(constraints,
+		fmt.Sprintf("CompletionDate >= %d && CompletionDate < %d", base+500*60, base+1500*60),
+		fmt.Sprintf("%d <= CompletionDate && CompletionDate < %d", base+100*60, base+200*60),
+		fmt.Sprintf("(CompletionDate >= %d) && (CompletionDate < %d)", base, base+60),
+		"RequestMemory >= 2048",
+		fmt.Sprintf("RequestMemory >= 1536 && CompletionDate < %d", base+900*60),
+		fmt.Sprintf("CompletionDate >= %d", base+n*60), // matches nothing
+		fmt.Sprintf("CompletionDate >= %d", base-1),    // matches everything
+	)
+	rng := rand.New(rand.NewSource(1))
+	for i := 0; i < 25; i++ {
+		lo := rng.Intn(n)
+		hi := lo + rng.Intn(n-lo+1)
+		constraints = append(constraints, fmt.Sprintf("CompletionDate >= %d && CompletionDate <= %d",
+			base+int64(lo)*60, base+int64(hi)*60))
+	}
+
+	answered := 0
+	for _, c := range constraints {
+		got, ok := hist.CategoricalGroupCountsWhere("Owner", c)
+		if !ok {
+			continue
+		}
+		answered++
+		want := whereRefCount(t, hist, "Owner", c)
+		if len(got) != len(want) {
+			t.Errorf("constraint %q: groups = %v, want %v", c, got, want)
+			continue
+		}
+		for k, w := range want {
+			if got[k] != w {
+				t.Errorf("constraint %q: group %q = %d, want %d", c, k, got[k], w)
+			}
+		}
+	}
+	if answered < len(constraints)/2 {
+		t.Errorf("index path answered only %d of %d constraints; it should handle plain conjunctive ranges",
+			answered, len(constraints))
+	}
+}
+
+// TestGroupCountsWhereRefusesUnsafeShapes is the important one. Each of these constraints
+// is NOT equivalent to a conjunction of range conditions, so attributing whole segments
+// from zone bounds would be wrong. The path must refuse them rather than answer.
+func TestGroupCountsWhereRefusesUnsafeShapes(t *testing.T) {
+	hist := mkWhereHist(t, 500)
+	base := 1700000000
+	unsafe := []string{
+		fmt.Sprintf("CompletionDate < %d || CompletionDate > %d", base+60, base+120), // disjunction
+		fmt.Sprintf("!(CompletionDate < %d)", base+60),                               // negation
+		fmt.Sprintf("CompletionDate != %d", base+60),                                 // inequality
+		fmt.Sprintf("CompletionDate =?= %d", base+60),                                // meta-equality
+		"CompletionDate >= RequestMemory",                                            // attr vs attr
+		fmt.Sprintf("TARGET.CompletionDate >= %d", base),                             // scoped
+		fmt.Sprintf("CompletionDate + 1 >= %d", base),                                // arithmetic
+		`Owner == "alice"`, // string comparison
+		fmt.Sprintf("size(Owner) >= 1 && CompletionDate >= %d", base), // function call
+		fmt.Sprintf("CompletionDate >= %d ? true : false", base),      // conditional
+		"JobStatus >= 1", // not zone-mapped
+		"true",           // no conditions
+	}
+	for _, c := range unsafe {
+		t.Run(c, func(t *testing.T) {
+			if _, ok := hist.CategoricalGroupCountsWhere("Owner", c); ok {
+				t.Errorf("constraint %q was answered from the index; it is not a conjunction of "+
+					"zone-decidable range conditions and must be refused", c)
+			}
+		})
+	}
+}
+
+// TestGroupCountsWhereEmptyAndFull pins the two degenerate outcomes, where an off-by-one in
+// the zone-bound reasoning would be easy to miss.
+func TestGroupCountsWhereEmptyAndFull(t *testing.T) {
+	const n = 1200
+	hist := mkWhereHist(t, n)
+	base := int64(1700000000)
+
+	got, ok := hist.CategoricalGroupCountsWhere("Owner", fmt.Sprintf("CompletionDate > %d", base+int64(n)*60))
+	if !ok {
+		t.Fatal("expected the index path to answer a matches-nothing range")
+	}
+	if len(got) != 0 {
+		t.Errorf("matches-nothing range returned %v, want empty", got)
+	}
+
+	got, ok = hist.CategoricalGroupCountsWhere("Owner", fmt.Sprintf("CompletionDate >= %d", base))
+	if !ok {
+		t.Fatal("expected the index path to answer a matches-everything range")
+	}
+	var total int64
+	for _, v := range got {
+		total += v
+	}
+	if total != n {
+		t.Errorf("matches-everything range counted %d, want %d", total, n)
+	}
+}
+
+// TestConstrainedAggregateMatchesScan drives the constrained path through the public
+// Aggregate entry point, so the wiring (not just the helper) is covered -- including the
+// shapes that must fall through to the scan and still produce the right answer.
+func TestConstrainedAggregateMatchesScan(t *testing.T) {
+	const n = 2000
+	hist := mkWhereHist(t, n)
+	base := int64(1700000000)
+	aggs := []AggSpec{{Func: AggCount, Arg: "*"}}
+
+	constraints := []string{
+		fmt.Sprintf("CompletionDate >= %d && CompletionDate < %d", base+300*60, base+900*60),
+		fmt.Sprintf("CompletionDate < %d || CompletionDate > %d", base+60, base+120), // falls through
+		`Owner == "alice"`, // falls through
+		"RequestMemory >= 2048",
+		"true",
+	}
+	for _, c := range constraints {
+		t.Run(c, func(t *testing.T) {
+			rows, err := hist.Aggregate(c, []string{"Owner"}, aggs)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got := map[string]int64{}
+			for _, r := range rows {
+				var v int64
+				fmt.Sscan(r.Values[0], &v)
+				got[r.Group[0]] = v
+			}
+			want := whereRefCount(t, hist, "Owner", c)
+			if len(got) != len(want) {
+				t.Fatalf("groups = %v, want %v", got, want)
+			}
+			for k, w := range want {
+				if got[k] != w {
+					t.Errorf("group %q = %d, want %d", k, got[k], w)
+				}
+			}
+		})
+	}
+}
+
+// TestBucketedAggregateIgnoresNoConstraint guards the case-2 fast path: the bucketed helper
+// takes no constraint, so a WHERE-bearing bucketed aggregate must not be answered from it.
+func TestBucketedAggregateIgnoresNoConstraint(t *testing.T) {
+	const n = 1500
+	const day = 86400
+	hist := mkWhereHist(t, n)
+	base := int64(1700000000)
+	groups := []GroupCol{{Attr: "Owner"}, {Attr: "CompletionDate", BucketWidth: day}}
+	constraint := fmt.Sprintf("CompletionDate >= %d", base+600*60)
+
+	rows, err := hist.AggregateCols(constraint, groups, []AggSpec{{Func: AggCount, Arg: "*"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var total int64
+	for _, r := range rows {
+		var v int64
+		fmt.Sscan(r.Values[0], &v)
+		total += v
+	}
+	want := int64(0)
+	for _, c := range whereRefCount(t, hist, "Owner", constraint) {
+		want += c
+	}
+	if total != want {
+		t.Errorf("constrained bucketed aggregate counted %d, want %d (the WHERE was dropped)", total, want)
+	}
+}

--- a/dbrpc/archive.go
+++ b/dbrpc/archive.go
@@ -51,13 +51,16 @@ func (sc *serverConn) streamArchiveAggregate(reqID uint64, r *reader) {
 	sc.archiveAggregate(reqID, r, false)
 }
 
-// streamArchiveAggregateFiltered is streamArchiveAggregate whose specs carry a per-aggregate
-// filter (opArchiveAggregateFiltered). Only the spec encoding differs.
+// streamArchiveAggregateFiltered is streamArchiveAggregate's extended form: each group
+// column carries a bucket width and each spec a filter (opArchiveAggregateFiltered).
 func (sc *serverConn) streamArchiveAggregateFiltered(reqID uint64, r *reader) {
 	sc.archiveAggregate(reqID, r, true)
 }
 
-func (sc *serverConn) archiveAggregate(reqID uint64, r *reader, filtered bool) {
+// archiveAggregate is the body shared by both archive aggregate opcodes. extended says
+// whether the frame is the wide form -- each group column followed by a bucket width, each
+// aggregate spec by a filter expression -- rather than the base opcode's narrow one.
+func (sc *serverConn) archiveAggregate(reqID uint64, r *reader, extended bool) {
 	name := r.str()
 	constraint := r.str()
 	nGroup := int(r.i32())
@@ -68,8 +71,11 @@ func (sc *serverConn) archiveAggregate(reqID uint64, r *reader, filtered bool) {
 	groupCols := make([]GroupCol, nGroup)
 	for i := range groupCols {
 		groupCols[i] = GroupCol{Attr: r.str()}
+		if extended {
+			groupCols[i].BucketWidth = int64(r.u64())
+		}
 	}
-	aggs, ok := readAggSpecs(r, reqID, sc.write, filtered)
+	aggs, ok := readAggSpecs(r, reqID, sc.write, extended)
 	if !ok {
 		return
 	}
@@ -98,11 +104,7 @@ func (sc *serverConn) archiveAggregate(reqID uint64, r *reader, filtered bool) {
 		sc.write(respErr(reqID, "no such archive: "+name))
 		return
 	}
-	groupBy := make([]string, len(groupCols))
-	for i, g := range groupCols {
-		groupBy[i] = g.Attr
-	}
-	rows, err := a.Aggregate(constraint, groupBy, aggs)
+	rows, err := a.AggregateCols(constraint, groupCols, aggs)
 	if err != nil {
 		sc.write(respErr(reqID, err.Error()))
 		return
@@ -179,19 +181,55 @@ var ErrArchiveAggregateUnsupported = errors.New("dbrpc: server does not support 
 // server. Against a server that does not implement the opcode it returns an error wrapping
 // ErrArchiveAggregateUnsupported so the caller can fall back to client-side aggregation.
 func (c *Client) ArchiveAggregate(ctx context.Context, name, constraint string, groupBy []string, aggs []AggSpec) ([]AggRow, error) {
+	groups := make([]GroupCol, len(groupBy))
+	for i, g := range groupBy {
+		groups[i] = GroupCol{Attr: g}
+	}
+	return c.ArchiveAggregateBucketed(ctx, name, constraint, groups, aggs)
+}
+
+// ArchiveAggregateBucketed is ArchiveAggregate where a group column may carry a bucket
+// width, flooring a numeric dimension into fixed-width buckets on the server -- "jobs per
+// group per day" without the matched rows crossing the wire. Bucket widths and per-aggregate
+// filters compose: both ride the same extended opcode.
+//
+// Against a server that does not implement that opcode it returns an error wrapping
+// ErrFilteredAggregateUnsupported when a filter was requested (which must not be retried
+// without its filters) and ErrArchiveAggregateUnsupported otherwise, so the caller can fall
+// back to client-side reduction.
+func (c *Client) ArchiveAggregateBucketed(ctx context.Context, name, constraint string, groups []GroupCol, aggs []AggSpec) ([]AggRow, error) {
+	// The base opcode's frame has room for neither bucket widths nor filters, so anything
+	// carrying either must use the extended one. Sending the narrow frame instead would
+	// drop them silently and return the wrong numbers as success.
 	filtered := anyFiltered(aggs)
+	extended := filtered
+	for _, g := range groups {
+		if g.BucketWidth != 0 {
+			extended = true
+			break
+		}
+	}
 	build := func(id uint64) []byte {
 		o := opArchiveAggregate
-		if filtered {
+		if extended {
 			o = opArchiveAggregateFiltered
 		}
 		b := putStr(putStr(req(id, o), name), constraint)
-		b = putI32(b, int32(len(groupBy)))
-		for _, g := range groupBy {
-			b = putStr(b, g)
+		b = putI32(b, int32(len(groups)))
+		for _, g := range groups {
+			b = putStr(b, g.Attr)
+			if extended {
+				b = putU64(b, uint64(g.BucketWidth))
+			}
 		}
-		return putAggSpecs(b, aggs, filtered)
+		return putAggSpecs(b, aggs, extended)
 	}
+	return c.archiveAggregate(ctx, build, len(groups), len(aggs), filtered)
+}
+
+// archiveAggregate runs a built archive-aggregate request and collects its streamed rows.
+// filtered selects which "unsupported" error an old server's refusal maps to.
+func (c *Client) archiveAggregate(ctx context.Context, build func(uint64) []byte, nGroup, nAgg int, filtered bool) ([]AggRow, error) {
 	_, frames, err := c.callStream(build)
 	if err != nil {
 		return nil, err
@@ -212,7 +250,7 @@ func (c *Client) ArchiveAggregate(ctx context.Context, name, constraint string, 
 			}
 			switch status {
 			case stStream:
-				row := AggRow{Group: make([]string, len(groupBy)), Values: make([]string, len(aggs))}
+				row := AggRow{Group: make([]string, nGroup), Values: make([]string, nAgg)}
 				for i := range row.Group {
 					row.Group[i] = body.str()
 				}

--- a/dbrpc/archive_bucketed_test.go
+++ b/dbrpc/archive_bucketed_test.go
@@ -1,0 +1,168 @@
+package dbrpc
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/db"
+)
+
+// TestArchiveAggregateBucketedOverRPC covers the bucketed archive GROUP BY end to end: the
+// "jobs per owner per day" shape crossing the wire. The result is checked against a
+// client-side reduction over the same rows fetched with ArchiveQuery, so the server's
+// index-resident bucketing must agree with counting locally.
+func TestArchiveAggregateBucketedOverRPC(t *testing.T) {
+	const day = 86400
+	c, cleanup := catServerPair(t, ServeOptions{})
+	defer cleanup()
+
+	if err := c.CreateArchiveTable(context.Background(), "history", db.ArchiveConfig{
+		SegmentSize:      1 << 16,
+		CategoricalAttrs: []string{"Owner"},
+		ZoneAttrs:        []string{"CompletionDate"},
+	}); err != nil {
+		t.Fatalf("CreateArchiveTable: %v", err)
+	}
+
+	owners := []string{"alice", "bob", "carol"}
+	base := int64(1700000000) / day * day
+	const n = 1200
+	want := map[string]int64{} // "bucket|owner" -> count
+	for i := 0; i < n; i++ {
+		ts := base + int64(i)*(day/300) // spans several days
+		o := owners[i%len(owners)]
+		if err := c.ArchiveAppend(context.Background(), "history",
+			fmt.Sprintf("CompletionDate = %d\nOwner = %q", ts, o)); err != nil {
+			t.Fatalf("ArchiveAppend: %v", err)
+		}
+		want[fmt.Sprintf("%d|%s", ts/day*day, o)]++
+	}
+
+	groups := []GroupCol{{Attr: "Owner"}, {Attr: "CompletionDate", BucketWidth: day}}
+	rows, err := c.ArchiveAggregateBucketed(context.Background(), "history", "true", groups,
+		[]AggSpec{{Func: AggCount, Arg: "*"}})
+	if err != nil {
+		t.Fatalf("ArchiveAggregateBucketed: %v", err)
+	}
+	if len(rows) != len(want) {
+		t.Fatalf("got %d (owner,day) rows, want %d", len(rows), len(want))
+	}
+	var total int64
+	for _, r := range rows {
+		if len(r.Group) != 2 {
+			t.Fatalf("row %+v: want 2 group values", r)
+		}
+		key := r.Group[1] + "|" + r.Group[0] // group order mirrors the request: [Owner, day]
+		got, err := strconv.ParseInt(r.Values[0], 10, 64)
+		if err != nil {
+			t.Fatalf("non-numeric count %q", r.Values[0])
+		}
+		if want[key] != got {
+			t.Errorf("%s = %d, want %d", key, got, want[key])
+		}
+		total += got
+	}
+	if total != n {
+		t.Errorf("counts sum to %d, want %d", total, n)
+	}
+}
+
+// TestArchiveAggregateBucketedZeroWidth checks a zero bucket width behaves as an ordinary
+// raw group column, so the bucketed opcode is a strict superset of the plain one.
+func TestArchiveAggregateBucketedZeroWidth(t *testing.T) {
+	c, cleanup := catServerPair(t, ServeOptions{})
+	defer cleanup()
+
+	if err := c.CreateArchiveTable(context.Background(), "history", db.ArchiveConfig{
+		CategoricalAttrs: []string{"Owner"},
+	}); err != nil {
+		t.Fatalf("CreateArchiveTable: %v", err)
+	}
+	for _, o := range []string{"alice", "alice", "bob"} {
+		if err := c.ArchiveAppend(context.Background(), "history", fmt.Sprintf("Owner = %q", o)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	aggs := []AggSpec{{Func: AggCount, Arg: "*"}}
+	bucketed, err := c.ArchiveAggregateBucketed(context.Background(), "history", "true",
+		[]GroupCol{{Attr: "Owner"}}, aggs)
+	if err != nil {
+		t.Fatalf("ArchiveAggregateBucketed: %v", err)
+	}
+	plain, err := c.ArchiveAggregate(context.Background(), "history", "true", []string{"Owner"}, aggs)
+	if err != nil {
+		t.Fatalf("ArchiveAggregate: %v", err)
+	}
+	toMap := func(rows []AggRow) map[string]string {
+		m := map[string]string{}
+		for _, r := range rows {
+			m[r.Group[0]] = r.Values[0]
+		}
+		return m
+	}
+	bm, pm := toMap(bucketed), toMap(plain)
+	if len(bm) != len(pm) {
+		t.Fatalf("bucketed = %v, plain = %v", bm, pm)
+	}
+	for k, v := range pm {
+		if bm[k] != v {
+			t.Errorf("owner %q: bucketed %q, plain %q", k, bm[k], v)
+		}
+	}
+}
+
+// TestArchiveAggregateBucketedWithFilters proves the two extensions compose: a bucketed
+// GROUP BY whose aggregate also carries a per-aggregate FILTER rides one opcode, rather than
+// needing an opcode per combination or silently dropping the filter.
+func TestArchiveAggregateBucketedWithFilters(t *testing.T) {
+	const day = 86400
+	c, cleanup := catServerPair(t, ServeOptions{})
+	defer cleanup()
+	if err := c.CreateArchiveTable(context.Background(), "history", db.ArchiveConfig{
+		CategoricalAttrs: []string{"Owner"},
+		ZoneAttrs:        []string{"CompletionDate"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	base := int64(1700000000) / day * day
+	owners := []string{"alice", "bob"}
+	want := map[string]int64{} // "bucket|owner" -> alice-only count
+	for i := 0; i < 400; i++ {
+		o := owners[i%2]
+		ts := base + int64(i)*(day/100)
+		if err := c.ArchiveAppend(context.Background(), "history",
+			fmt.Sprintf("CompletionDate = %d\nOwner = %q", ts, o)); err != nil {
+			t.Fatal(err)
+		}
+		if o == "alice" {
+			want[fmt.Sprintf("%d|%s", ts/day*day, o)]++
+		}
+	}
+
+	groups := []GroupCol{{Attr: "Owner"}, {Attr: "CompletionDate", BucketWidth: day}}
+	rows, err := c.ArchiveAggregateBucketed(context.Background(), "history", "true", groups,
+		[]AggSpec{{Func: AggCount, Arg: "*", Filter: `Owner == "alice"`}})
+	if err != nil {
+		t.Fatalf("bucketed + filtered aggregate: %v", err)
+	}
+	var total int64
+	for _, r := range rows {
+		got, err := strconv.ParseInt(r.Values[0], 10, 64)
+		if err != nil {
+			t.Fatalf("non-numeric count %q", r.Values[0])
+		}
+		key := r.Group[1] + "|" + r.Group[0]
+		if r.Group[0] == "alice" && want[key] != got {
+			t.Errorf("%s = %d, want %d", key, got, want[key])
+		}
+		if r.Group[0] == "bob" && got != 0 {
+			t.Errorf("bob bucket %s = %d, want 0 (filter must exclude it)", r.Group[1], got)
+		}
+		total += got
+	}
+	if total != 200 {
+		t.Errorf("filtered counts sum to %d, want 200 (half the rows are alice)", total)
+	}
+}

--- a/dbrpc/proto.go
+++ b/dbrpc/proto.go
@@ -157,8 +157,14 @@ const (
 	// success. An unknown opcode is refused as a bad request instead, which the client
 	// surfaces as ErrFilteredAggregateUnsupported. A client only sends these when some spec
 	// actually carries a filter, so every existing query is byte-identical on the wire.
+	// Both carry BOTH extensions the base opcodes lack: a per-group bucket width and a
+	// per-aggregate filter. They are the "everything" form of their respective aggregate, so
+	// bucketing and filtering compose in one request rather than needing an opcode per
+	// combination. A client sends one only when some group column carries a width or some
+	// spec carries a filter, so every query expressible on the base opcode stays
+	// byte-identical on the wire.
 	opAggregateFiltered        op = 55 // [table][constraint][nGroup]{[attr][width u64]}[nAgg]{[func u8][arg][filter]}
-	opArchiveAggregateFiltered op = 56 // [name][constraint][nGroup]{[attr]}[nAgg]{[func u8][arg][filter]}
+	opArchiveAggregateFiltered op = 56 // [name][constraint][nGroup]{[attr][width u64]}[nAgg]{[func u8][arg][filter]}
 )
 
 // String names an opcode for diagnostics (e.g. the read-only rejection message).


### PR DESCRIPTION
A `GROUP BY` over an archive projected the grouping attribute out of every record in every unpruned segment, so "jobs per owner" decompressed the whole archive. But for a categorically indexed attribute the answer is already in the index: each distinct value has a posting, and the size of that posting *is* the count.

Three forms, all reached from `ArchiveTable.Aggregate` / the new `AggregateCols`, each falling back to the existing scan when it does not apply:

| Query shape | Path |
|---|---|
| `GROUP BY Owner` | `CategoricalGroupCounts` |
| `GROUP BY Owner` + range `WHERE` | `CategoricalGroupCountsWhere` |
| `GROUP BY Owner, day(CompletionDate)` | `CategoricalGroupCountsBucketed` |

The bucketed form leans on the archive being append-ordered: a segment's `CompletionDate` range usually sits inside one bucket, so its per-value counts are attributed wholesale from the zone map with no record read. Only boundary-straddling segments are scanned.

## Benchmark

`GROUP BY Owner, COUNT(*)`, 1 MiB segments:

| case | before | after | speedup |
|---|---|---|---|
| 50k rec / 8 groups | 26.5 ms | 1.6 ms | 16× |
| 50k rec / 200 groups | 15.2 ms | 2.3 ms | 6.7× |
| 200k rec / 8 groups | 60.1 ms | 1.0 ms | 62× |
| 200k rec / 200 groups | 59.9 ms | 4.2 ms | 14× |

The ratio is not the point — note that 200k records is now *faster* than 50k at 8 groups. Cost stopped being O(records) and became O(segments × distinct values), so the margin grows with the archive. The old path was a flat ~3.3 M rec/s regardless of shape.

## How correctness is established

Rather than enumerating every way the index could be an incomplete description of the data, the counts are summed and compared against the record count. Any record that is missing the attribute, holds a non-literal expression, or is otherwise unattributable leaves the sum short, so the fast path declines and the scan runs. It can refuse an answer it could have given; it cannot give a wrong one.

Every case is checked **differentially against a full scan** rather than against hand-written expectations — missing attribute, non-literal (`strcat`), mixed-case spellings as distinct groups, unindexed attribute, empty archive, multi-segment, post-reopen (mmap sidecar path), and 25 randomized ranges.

## The design call worth reviewing

The constrained form deliberately does **not** reuse the probes a query decomposes into (the ones `zonePrune` uses). Probes are a conservative *under-approximation* — the conjuncts that must hold — so "every probe is implied by the zone bounds" does not imply "the constraint is implied". A disjunction or negation would have been over-counted.

Instead it re-reads the constraint's syntax and accepts only a shape it can characterize exactly: a conjunction of comparisons between a zone-mapped attribute and a numeric literal. `TestGroupCountsWhereRefusesUnsafeShapes` pins twelve shapes that must be refused (`||`, `!`, `!=`, `=?=`, attr-vs-attr, `TARGET.`, arithmetic, string comparison, function call, conditional, unmapped attribute, `true`).

If you disagree with that whitelist as the boundary, this is the part to push back on.

## Protocol

Rather than add a third archive opcode, `opArchiveAggregateFiltered` (56) is widened to carry a **per-group bucket width** as well as a per-aggregate filter. It becomes the "everything" form of the archive aggregate and an exact mirror of `opAggregateFiltered` (55) on the mutable side, which already carried both.

The two extensions then **compose in one request** instead of needing an opcode per combination. A client sends it only when some column carries a width or some spec carries a filter, so every query expressible on the base opcode stays byte-identical on the wire. Opcode 56 is unreleased (absent from every tag through v0.23.0), so widening it costs no compatibility.

## Interaction with #126

This branch was rebased onto `agg-filter`. Two real collisions, both now resolved:

- **Opcode numbering.** #126 claimed 55 and 56; this had claimed 55. Resolved by folding into 56 rather than taking a new number.
- **`FILTER` vs. the index fast paths.** #126 correctly guards its `COUNT(*)` fast path on `Filter == ""`. The index-resident paths here needed the same guard — postings know nothing about a filter, so a filtered aggregate would have returned **unfiltered totals reported as success**. Guarded, and `TestArchiveAggregateBucketedWithFilters` covers the composed case end to end.

## Notes

- Two bugs were caught by the differential tests during development: straddling segments were being marked covered and then never scanned (conflating "decidable from zone bounds" with "fully matching"), and a moved match-all guard briefly let a `WHERE`-bearing bucketed aggregate ignore its filter. Both are now regression-tested.
- Row order for the index-resident paths is sorted by group value rather than the scan's first-seen order. `GROUP BY` without `ORDER BY` has no defined order either way.
- Not yet reachable from htcondordb's SQL: its repl calls `ArchiveAggregate` with `groupBy []string`. That wiring follows a release.
- Rebased onto current `main` (post-#126); full suites green on `collections`, `db`, and `dbrpc` after the rebase.

`go vet` and full suites pass on `collections`, `db`, and `dbrpc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
