### PR TITLE
collections/db/dbrpc: expose the columnar accelerator's state in diagnostics

### DIFF
--- a/collections/colscan.go
+++ b/collections/colscan.go
@@ -28,6 +28,49 @@ type schemaScanState struct {
 	cache  *blockCache
 }
 
+// SchemaScanInfo reports the state of the per-segment columnar (adschema) accelerator, for
+// diagnostics. Enabled means a numeric COUNT(*) WHERE can take the columnar fast path; HotFields
+// are the demand-hot numeric columns kept uncompressed for O(1) scan; SchemaFields is the schema's
+// field count; and CoveredSegments of SealedSegments carry a columnar block (the rest row-fall-back
+// until a rewrite/reindex reaches them).
+type SchemaScanInfo struct {
+	Enabled         bool     `json:"enabled"`
+	HotFields       []string `json:"hotFields,omitempty"`
+	SchemaFields    int      `json:"schemaFields,omitempty"`
+	SealedSegments  int      `json:"sealedSegments,omitempty"`
+	CoveredSegments int      `json:"coveredSegments,omitempty"`
+}
+
+// SchemaScanInfo returns the columnar accelerator's current state (see SchemaScanInfo).
+func (c *Collection) SchemaScanInfo() SchemaScanInfo {
+	var info SchemaScanInfo
+	if st := c.schemaScan.Load(); st != nil {
+		info.Enabled = true
+		info.SchemaFields = len(st.schema.fields)
+		for _, idx := range st.hot {
+			if idx >= 0 && idx < len(st.schema.fields) {
+				if name, ok := c.intern.Name(st.schema.fields[idx].id); ok {
+					info.HotFields = append(info.HotFields, name)
+				}
+			}
+		}
+	}
+	for _, sh := range c.shards {
+		sh.mu.RLock()
+		act := sh.act
+		for _, seg := range sh.segs {
+			if seg != nil && seg != act && seg.used > 0 {
+				info.SealedSegments++
+				if seg.colblk.Load() != nil {
+					info.CoveredSegments++
+				}
+			}
+		}
+		sh.mu.RUnlock()
+	}
+	return info
+}
+
 // EnableSchemaScan builds a columnar block over every currently-sealed segment (skipping the
 // active append target) for the given schema and hot field set, publishes it on each segment,
 // and records the state so CountQuery can auto-route matching queries. Additive and opt-in:

--- a/collections/schema_info_test.go
+++ b/collections/schema_info_test.go
@@ -1,0 +1,50 @@
+package collections
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/collections/vm"
+)
+
+// TestSchemaScanInfo checks the columnar accelerator's diagnostics: disabled before enable, and
+// after enable it reports the hot columns, a nonzero schema, and full segment coverage.
+func TestSchemaScanInfo(t *testing.T) {
+	store := New(Options{Shards: 1, SegmentSize: 1 << 12}) // small ⇒ sealed segments
+	for i := 0; i < 2000; i++ {
+		if err := store.Put([]byte(fmt.Sprintf("k%d", i)),
+			mustAdOld(t, fmt.Sprintf("Cpus=%d\nMemory=%d", 1+i%8, 1024+(i%64)*256))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if info := store.SchemaScanInfo(); info.Enabled || info.CoveredSegments != 0 {
+		t.Fatalf("before enable: %+v (want disabled, 0 covered)", info)
+	}
+	mc, _ := vm.Parse("Memory >= 0") // drive Memory demand -> hot
+	for i := 0; i < 30; i++ {
+		for range store.Query(mc) {
+		}
+	}
+	if !store.BuildAndEnableSchemaScan(2000, 4) {
+		t.Fatal("BuildAndEnableSchemaScan false")
+	}
+	info := store.SchemaScanInfo()
+	if !info.Enabled {
+		t.Fatal("not enabled after BuildAndEnableSchemaScan")
+	}
+	if info.SchemaFields == 0 || info.SealedSegments == 0 {
+		t.Fatalf("schema/segments empty: %+v", info)
+	}
+	if info.CoveredSegments != info.SealedSegments {
+		t.Fatalf("coverage %d/%d, want all sealed covered", info.CoveredSegments, info.SealedSegments)
+	}
+	found := false
+	for _, f := range info.HotFields {
+		if f == "Memory" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("Memory (queried) not in hot fields %v", info.HotFields)
+	}
+}

--- a/db/db.go
+++ b/db/db.go
@@ -333,6 +333,7 @@ type (
 	SidecarSizes    = collections.SidecarSizes
 	Retention       = collections.Retention
 	CodecStats      = collections.CodecStats
+	SchemaScanInfo  = collections.SchemaScanInfo
 	QueryExplain    = collections.QueryExplain
 	ProbeExplain    = collections.ProbeExplain
 	MatchExplain    = collections.MatchExplain
@@ -382,6 +383,10 @@ func (db *DB) OpStats() OpStats {
 // HotAttrs returns the current hot attributes (front-loaded in each ad's hot
 // header for cheap access).
 func (db *DB) HotAttrs() []string { return db.c.HotAttrNames() }
+
+// SchemaScanInfo reports the columnar (adschema) accelerator's state: whether it is enabled (so a
+// numeric COUNT(*) WHERE routes to the columnar fast path), its hot columns, and segment coverage.
+func (db *DB) SchemaScanInfo() SchemaScanInfo { return db.c.SchemaScanInfo() }
 
 // IndexedAttrs returns the currently-indexed attribute names, split into
 // categorical (string equality/membership) and value (numeric + range) indexes.

--- a/dbrpc/diag.go
+++ b/dbrpc/diag.go
@@ -31,6 +31,11 @@ type Diagnostics struct {
 	EncryptionEnabled bool     `json:"encryptionEnabled"`
 	EncryptedAttrs    []string `json:"encryptedAttrs,omitempty"`
 
+	// SchemaScan reports the per-segment columnar (adschema) accelerator's state: whether it is
+	// enabled (a numeric COUNT(*) WHERE takes the columnar fast path), its uncompressed hot
+	// columns, and how many sealed segments carry a block. Mutable tables only.
+	SchemaScan db.SchemaScanInfo `json:"schemaScan"`
+
 	// Archive marks an append-only history table (vs. a mutable one), and Retention carries
 	// its rotation bounds. Both are omitted for a mutable table. SidecarSizes reports the
 	// archive's sealed-segment sidecar index bytes.
@@ -72,6 +77,7 @@ func (s *Server) diagJSON(t *db.DB) ([]byte, error) {
 		DropSuggestions:    t.SuggestDrops(diagSampleMax),
 		EncryptionEnabled:  t.EncryptionEnabled(),
 		EncryptedAttrs:     t.EncryptedAttrNames(),
+		SchemaScan:         t.SchemaScanInfo(),
 	}
 	return json.Marshal(d)
 }

--- a/dbrpc/diag_schemascan_test.go
+++ b/dbrpc/diag_schemascan_test.go
@@ -1,0 +1,58 @@
+package dbrpc
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/classad"
+	"github.com/PelicanPlatform/classad/db"
+)
+
+// TestDiagnosticsSchemaScan verifies the columnar accelerator's state travels in Diagnostics: after
+// a Maintain pass enables schema-scan, a client's .stats surface reports it enabled, with its hot
+// columns and full segment coverage.
+func TestDiagnosticsSchemaScan(t *testing.T) {
+	d, err := db.OpenConfig(db.Config{Dir: t.TempDir(), SegmentSize: 1 << 9}) // tiny ⇒ segments seal
+	if err != nil {
+		t.Fatal(err)
+	}
+	tx := d.Begin()
+	for i := 0; i < 1200; i++ {
+		ad, _ := classad.ParseOld(fmt.Sprintf("Memory = %d\nCpus = %d\nName = \"n%05d\"", 1024+(i%64)*256, 1+i%8, i))
+		tx.NewClassAd(fmt.Sprintf("%d.0", i), ad)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 15; i++ { // Memory read demand -> hot
+		seq, err := d.QueryProject("true", []string{"Memory"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		for range seq {
+		}
+	}
+	d.Maintain(db.MaintainOptions{SchemaScanHotTopN: 4})
+
+	s := NewServer(d)
+	cconn, sconn := netPipe()
+	go func() { _ = s.ServeConnOpts(sconn, ServeOptions{Privileged: true}) }()
+	c := NewClient(cconn)
+	defer func() { c.Close(); s.Close(); d.Close() }()
+
+	diag, err := c.Diagnostics(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ss := diag.SchemaScan
+	if !ss.Enabled {
+		t.Fatalf("SchemaScan.Enabled false over the wire: %+v", ss)
+	}
+	if ss.SchemaFields == 0 || ss.SealedSegments == 0 || ss.CoveredSegments != ss.SealedSegments {
+		t.Fatalf("SchemaScan coverage wrong: %+v", ss)
+	}
+	if !contains(ss.HotFields, "Memory") {
+		t.Fatalf("Memory not in SchemaScan.HotFields %v", ss.HotFields)
+	}
+}


### PR DESCRIPTION
The per-segment columnar (adschema) accelerator — now on-by-default downstream — had **no observable state**. An operator couldn't tell whether a table's `COUNT(*) WHERE <numeric>` was taking the columnar fast path, which columns it accelerates, or how much of the table it covers. This surfaces it (the "schema info" that was planned in P4-full but never shipped).

## Change
- **collections**: `Collection.SchemaScanInfo()` → `SchemaScanInfo{Enabled, HotFields, SchemaFields, SealedSegments, CoveredSegments}` — enabled?, the uncompressed hot columns, the schema field count, and how many sealed segments carry a block (the rest row-fall-back until a rewrite/reindex reaches them).
- **db**: `type SchemaScanInfo = collections.SchemaScanInfo` + `DB.SchemaScanInfo()`, mirroring the other re-exported diagnostics.
- **dbrpc**: a `SchemaScan` field on `Diagnostics` (mutable tables), populated in `diagJSON`, so a client's `.stats` can render it.

## Tests
- collections: reports **disabled** before enable; **enabled** with the hot columns + **full segment coverage** after.
- dbrpc: the state **round-trips over the wire** — after a `Maintain` pass enables schema-scan, `Diagnostics.SchemaScan` reports enabled, the `Memory` hot column, and full coverage.

Follow-up (post-release): render `d.SchemaScan` in the htcondordb `.stats` output.
