### PR TITLE
db,dbrpc: COUNT(DISTINCT col)

### DIFF
--- a/db/aggdistinct_test.go
+++ b/db/aggdistinct_test.go
@@ -1,0 +1,184 @@
+package db
+
+import (
+	"fmt"
+	"testing"
+)
+
+// distinctArchive seeds an archive where each owner repeats values, so a distinct count and
+// a plain count differ.
+//
+//	alice: hosts a,a,b      statuses 4,4,2
+//	bob:   hosts c,c        statuses 2,2
+//	carol: host  a          status   4      (shares a host with alice)
+func distinctArchive(t *testing.T) *ArchiveTable {
+	t.Helper()
+	cat, err := OpenCatalog(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { cat.Close() })
+	a, err := cat.CreateArchiveTable("history", ArchiveConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rows := []struct {
+		owner, host string
+		status      int
+	}{
+		{"alice", "a", 4}, {"alice", "a", 4}, {"alice", "b", 2},
+		{"bob", "c", 2}, {"bob", "c", 2},
+		{"carol", "a", 4},
+	}
+	for i, r := range rows {
+		if err := a.AppendOld(fmt.Sprintf(
+			"Owner = \"%s\"\nHost = \"%s\"\nJobStatus = %d\nID = %d\n",
+			r.owner, r.host, r.status, i)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return a
+}
+
+// TestCountDistinct is the core: distinct counts differ from row counts, per group and over
+// the whole table.
+func TestCountDistinct(t *testing.T) {
+	a := distinctArchive(t)
+
+	rows, err := a.Aggregate("true", []string{"Owner"}, []AggSpec{
+		{Func: AggCount, Arg: "*"},
+		{Func: AggCountDistinct, Arg: "Host"},
+		{Func: AggCountDistinct, Arg: "JobStatus"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := map[string][]string{}
+	for _, r := range rows {
+		got[r.Group[0]] = r.Values
+	}
+	want := map[string][]string{
+		"alice": {"3", "2", "2"}, // 3 rows, hosts {a,b}, statuses {4,2}
+		"bob":   {"2", "1", "1"},
+		"carol": {"1", "1", "1"},
+	}
+	for owner, w := range want {
+		g := got[owner]
+		if len(g) != len(w) {
+			t.Errorf("%s = %v, want %v", owner, g, w)
+			continue
+		}
+		for i := range w {
+			if g[i] != w[i] {
+				t.Errorf("%s = %v, want %v", owner, g, w)
+				break
+			}
+		}
+	}
+
+	// Ungrouped: distinct is over the whole table, so a host shared between owners counts
+	// once -- not the sum of the per-owner distincts.
+	rows, err = a.Aggregate("true", nil, []AggSpec{
+		{Func: AggCount, Arg: "*"},
+		{Func: AggCountDistinct, Arg: "Host"},
+		{Func: AggCountDistinct, Arg: "Owner"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v := rows[0].Values; v[0] != "6" || v[1] != "3" || v[2] != "3" {
+		t.Errorf("ungrouped = %v, want [6 3 3] (hosts a,b,c and three owners)", v)
+	}
+}
+
+// TestCountDistinctIgnoresUndefined checks that a row missing the attribute contributes no
+// value, matching COUNT(col), rather than counting "undefined" as a distinct value.
+func TestCountDistinctIgnoresUndefined(t *testing.T) {
+	cat, err := OpenCatalog(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cat.Close()
+	a, err := cat.CreateArchiveTable("h", ArchiveConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, text := range []string{
+		"Owner = \"alice\"\nHost = \"a\"\n",
+		"Owner = \"alice\"\nHost = \"b\"\n",
+		"Owner = \"alice\"\n", // no Host at all
+	} {
+		if err := a.AppendOld(text); err != nil {
+			t.Fatal(err)
+		}
+	}
+	rows, err := a.Aggregate("true", nil, []AggSpec{
+		{Func: AggCount, Arg: "*"},
+		{Func: AggCount, Arg: "Host"},
+		{Func: AggCountDistinct, Arg: "Host"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v := rows[0].Values; v[0] != "3" || v[1] != "2" || v[2] != "2" {
+		t.Errorf("values = %v, want [3 2 2]: undefined is not a distinct value", v)
+	}
+}
+
+// TestCountDistinctWithFilter checks that DISTINCT and FILTER compose -- the distinct set is
+// built only from the rows the filter admits.
+func TestCountDistinctWithFilter(t *testing.T) {
+	a := distinctArchive(t)
+	rows, err := a.Aggregate("true", nil, []AggSpec{
+		{Func: AggCountDistinct, Arg: "Host"},
+		{Func: AggCountDistinct, Arg: "Host", Filter: "JobStatus == 4"},
+		{Func: AggCountDistinct, Arg: "Host", Filter: "JobStatus == 2"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// All hosts {a,b,c}; completed rows are on {a}; running rows on {b,c}.
+	if v := rows[0].Values; v[0] != "3" || v[1] != "1" || v[2] != "2" {
+		t.Errorf("values = %v, want [3 1 2]", v)
+	}
+}
+
+// TestCountDistinctStar is refused: there is no such thing as a distinct row.
+func TestCountDistinctStar(t *testing.T) {
+	a := distinctArchive(t)
+	if _, err := a.Aggregate("true", nil, []AggSpec{{Func: AggCountDistinct, Arg: "*"}}); err == nil {
+		t.Error("COUNT(DISTINCT *) should be refused")
+	}
+}
+
+// TestCountDistinctNumericIdentity checks that values are keyed the way the group tuple keys
+// them, so a distinct count and a GROUP BY over the same attribute agree on what "the same
+// value" means.
+func TestCountDistinctNumericIdentity(t *testing.T) {
+	cat, err := OpenCatalog(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cat.Close()
+	a, err := cat.CreateArchiveTable("h", ArchiveConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, text := range []string{"N = 1\n", "N = 1\n", "N = 2\n", "N = 2.0\n"} {
+		if err := a.AppendOld(text); err != nil {
+			t.Fatal(err)
+		}
+	}
+	distinct, err := a.Aggregate("true", nil, []AggSpec{{Func: AggCountDistinct, Arg: "N"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	grouped, err := a.Aggregate("true", []string{"N"}, []AggSpec{{Func: AggCount, Arg: "*"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := distinct[0].Values[0], fmt.Sprint(len(grouped)); got != want {
+		t.Errorf("COUNT(DISTINCT N) = %s but GROUP BY N produced %s groups; the two must agree",
+			got, want)
+	}
+}

--- a/db/aggregate.go
+++ b/db/aggregate.go
@@ -28,10 +28,18 @@ const (
 	AggAvg
 	AggMin
 	AggMax
+	// AggCountDistinct is COUNT(DISTINCT col): the number of distinct defined values of
+	// the argument in the group. It is EXACT, and therefore keeps one entry per distinct
+	// value per group while the scan runs -- fine for the attributes people group and
+	// count by (Owner, JobStatus, a host name), but not something to point at a
+	// unique-per-row attribute over a large history. There is deliberately no silent
+	// switch to a sketch: a query written COUNT(DISTINCT ...) gets a true count, and an
+	// approximate one would have to be asked for by name.
+	AggCountDistinct
 )
 
 // AggSpec is one aggregate in a query: a function over an argument attribute.
-// Arg "*" (only meaningful for COUNT) counts every row in the group; otherwise
+// Arg "*" (only meaningful for plain COUNT) counts every row in the group; otherwise
 // Arg is an attribute name evaluated per ad.
 //
 // Filter, when non-empty, is a ClassAd expression restricting this aggregate -- and only
@@ -228,6 +236,11 @@ func bindValue(ad *classad.ClassAd, name string, v classad.Value) {
 // scan whose client has gone away.
 func AggregateValues(seq iter.Seq[[]classad.Value], attrs []string, groupCols []GroupCol, aggs []AggSpec, groupCol, aggCol []int, stop func() bool) ([]AggRow, error) {
 	nGroup := len(groupCols)
+	for _, a := range aggs {
+		if a.Func == AggCountDistinct && a.Arg == "*" {
+			return nil, fmt.Errorf("COUNT(DISTINCT *) is not meaningful; name an attribute")
+		}
+	}
 	filters, anyFilter, err := compileFilters(attrs, aggs)
 	if err != nil {
 		return nil, err
@@ -319,9 +332,10 @@ type groupState struct {
 // propagation, numeric-only min/max) matches HTCondor's sum()/avg()/min()/max()
 // exactly rather than a re-implementation.
 type aggAcc struct {
-	rows int             // all rows in the group (COUNT(*))
-	defN int             // rows where the argument is defined (COUNT(col))
-	vals []classad.Value // argument values for SUM/AVG/MIN/MAX
+	rows int                 // all rows in the group (COUNT(*))
+	defN int                 // rows where the argument is defined (COUNT(col))
+	vals []classad.Value     // argument values for SUM/AVG/MIN/MAX
+	seen map[string]struct{} // distinct defined argument values (COUNT DISTINCT)
 }
 
 // update folds one row's already-resolved argument value v into the accumulator.
@@ -331,10 +345,22 @@ func (a *aggAcc) update(spec AggSpec, v classad.Value) {
 	if spec.Arg == "*" {
 		return
 	}
-	if !v.IsUndefined() && !v.IsError() {
+	defined := !v.IsUndefined() && !v.IsError()
+	if defined {
 		a.defN++
 	}
-	if spec.Func != AggCount {
+	switch spec.Func {
+	case AggCount:
+	case AggCountDistinct:
+		// Keyed on the same rendering the group tuple uses, so two rows count as one
+		// value exactly when they would group together.
+		if defined {
+			if a.seen == nil {
+				a.seen = map[string]struct{}{}
+			}
+			a.seen[ValueText(v)] = struct{}{}
+		}
+	default:
 		a.vals = append(a.vals, v) // the library aggregates skip undefined / coerce
 	}
 }
@@ -347,6 +373,8 @@ func (a *aggAcc) result(spec AggSpec) string {
 			return strconv.Itoa(a.rows)
 		}
 		return strconv.Itoa(a.defN)
+	case AggCountDistinct:
+		return strconv.Itoa(len(a.seen))
 	case AggSum:
 		return ValueText(classad.Sum(a.vals))
 	case AggAvg:

--- a/dbrpc/aggfilter_test.go
+++ b/dbrpc/aggfilter_test.go
@@ -217,3 +217,53 @@ func TestAggregateFilterPrivateAttr(t *testing.T) {
 		t.Error("a filter over a private attribute should be refused")
 	}
 }
+
+// TestCountDistinctOverRPC checks the distinct count end to end, including that it composes
+// with a filter.
+func TestCountDistinctOverRPC(t *testing.T) {
+	c, cleanup := testPair(t)
+	defer cleanup()
+	seedStatusMix(t, c) // alice 4 rows / statuses {4,2,5}; bob 3 rows / statuses {4,2}
+
+	rows, err := c.Aggregate(context.Background(), "true", []string{"Owner"}, []AggSpec{
+		{Func: AggCount, Arg: "*"},
+		{Func: AggCountDistinct, Arg: "JobStatus"},
+		{Func: AggCountDistinct, Arg: "JobStatus", Filter: "Cpus > 1"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := map[string][]string{}
+	for _, r := range rows {
+		got[r.Group[0]] = r.Values
+	}
+	// alice: 4 rows, statuses {4,2,5}; with Cpus>1 her rows are cpus 2(st 4),4(st 2),8(st 5).
+	if g := got["alice"]; len(g) != 3 || g[0] != "4" || g[1] != "3" || g[2] != "3" {
+		t.Errorf("alice = %v, want [4 3 3]", g)
+	}
+	// bob: 3 rows, statuses {4,2}; with Cpus>1 his rows are cpus 2(st 2),16(st 2) -> {2}.
+	if g := got["bob"]; len(g) != 3 || g[0] != "3" || g[1] != "2" || g[2] != "1" {
+		t.Errorf("bob = %v, want [3 2 1]", g)
+	}
+}
+
+// TestCountDistinctUnsupportedServer checks that COUNT DISTINCT is gated like a filter: an
+// older server would decode the frame and return "undefined" for the column, so the client
+// refuses the opcode instead.
+func TestCountDistinctUnsupportedServer(t *testing.T) {
+	c, cleanup := testPairOps(t, func(o op) bool {
+		return o != opAggregateFiltered && o != opArchiveAggregateFiltered
+	})
+	defer cleanup()
+	seedStatusMix(t, c)
+
+	_, err := c.Aggregate(context.Background(), "true", nil,
+		[]AggSpec{{Func: AggCountDistinct, Arg: "JobStatus"}})
+	if !errors.Is(err, ErrExtendedAggregateUnsupported) {
+		t.Errorf("err = %v, want ErrExtendedAggregateUnsupported", err)
+	}
+	// The former name is the same value, so existing callers keep matching.
+	if !errors.Is(err, ErrFilteredAggregateUnsupported) {
+		t.Errorf("the deprecated alias should still match")
+	}
+}

--- a/dbrpc/aggregate.go
+++ b/dbrpc/aggregate.go
@@ -26,6 +26,9 @@ const (
 	AggAvg   = db.AggAvg
 	AggMin   = db.AggMin
 	AggMax   = db.AggMax
+	// AggCountDistinct is COUNT(DISTINCT col). It rides the extended opcodes (see
+	// anyFiltered), since an older server would not recognize the function.
+	AggCountDistinct = db.AggCountDistinct
 )
 
 // Aggregate runs a server-side GROUP BY: the server buckets the constraint match
@@ -94,7 +97,7 @@ func (c *Client) AggregateTable(ctx context.Context, table, constraint string, g
 				// fallback -- retrying without the filters would answer a different
 				// question and report it as success.
 				if filtered {
-					return nil, ErrFilteredAggregateUnsupported
+					return nil, ErrExtendedAggregateUnsupported
 				}
 				return out, fmt.Errorf("dbrpc: aggregate rejected as a bad request")
 			}
@@ -165,7 +168,7 @@ func (c *Client) AggregateBucketedTable(ctx context.Context, table, constraint s
 				// caller can fall back to client-side bucketing -- but NOT for a filtered
 				// request, where dropping the filters would change the answer.
 				if filtered {
-					return nil, ErrFilteredAggregateUnsupported
+					return nil, ErrExtendedAggregateUnsupported
 				}
 				return nil, ErrBucketedUnsupported
 			default:
@@ -252,12 +255,17 @@ func readAggSpecs(r *reader, reqID uint64, write func([]byte), filtered bool) ([
 	return aggs, true
 }
 
-// anyFiltered reports whether some spec carries a per-aggregate filter, which is what makes
-// a client reach for the newer opcode. Without one the request goes out on the original
-// opcode, so an older server keeps serving it.
+// anyFiltered reports whether some spec needs the extended opcodes: a per-aggregate filter,
+// or a function an older server would not recognize. Without one the request goes out on the
+// original opcode, so an older server keeps serving it.
+//
+// COUNT DISTINCT is gated for the same reason a filter is. The function selector is a u8, so
+// an old server would decode the frame happily, fail to match the unknown function, and
+// return "undefined" for that column -- visibly odd rather than plausibly wrong, but still
+// not an error. Refusing the opcode says what actually happened.
 func anyFiltered(aggs []AggSpec) bool {
 	for _, a := range aggs {
-		if a.Filter != "" {
+		if a.Filter != "" || a.Func > AggMax {
 			return true
 		}
 	}
@@ -276,11 +284,17 @@ func putAggSpecs(b []byte, aggs []AggSpec, filtered bool) []byte {
 	return b
 }
 
-// ErrFilteredAggregateUnsupported is returned when the server is too old to know the
-// filtered-aggregate opcodes. The caller must NOT retry without the filters: the answer
-// would be an unfiltered aggregate, which is wrong rather than merely slower.
-var ErrFilteredAggregateUnsupported = errors.New(
-	"dbrpc: server does not support per-aggregate FILTER")
+// ErrExtendedAggregateUnsupported is returned when the server is too old to know the
+// extended-aggregate opcodes -- the ones carrying a per-aggregate FILTER or a function it
+// would not recognize, such as COUNT DISTINCT. The caller must NOT retry without them: the
+// answer would be a different aggregate, which is wrong rather than merely slower.
+var ErrExtendedAggregateUnsupported = errors.New(
+	"dbrpc: server does not support per-aggregate FILTER or COUNT DISTINCT")
+
+// ErrFilteredAggregateUnsupported is the former name of ErrExtendedAggregateUnsupported,
+// from when a filter was the only thing the extended opcodes carried. It is the same error
+// value, so errors.Is against either still matches.
+var ErrFilteredAggregateUnsupported = ErrExtendedAggregateUnsupported
 
 // aggregate is the shared GROUP BY core for both aggregate opcodes: it refuses
 // private attributes for an unprivileged connection, projects only the attributes

--- a/dbrpc/archive.go
+++ b/dbrpc/archive.go
@@ -265,7 +265,7 @@ func (c *Client) archiveAggregate(ctx context.Context, build func(uint64) []byte
 				// archive aggregate can fall back to a client-side scan; a FILTERED one
 				// must not be retried without its filters.
 				if filtered {
-					return nil, ErrFilteredAggregateUnsupported
+					return nil, ErrExtendedAggregateUnsupported
 				}
 				return nil, ErrArchiveAggregateUnsupported
 			default:


### PR DESCRIPTION
The aggregate engine could count rows but not distinct values, so "how many owners" or "how many machines did this user land on" had no server-side answer.

`AggCountDistinct` keeps the distinct **defined** values of its argument per group. It composes with the per-aggregate `FILTER` from #126, so the distinct set is built only from the rows a filter admits:

```go
{Func: AggCountDistinct, Arg: "Host"}                              // all hosts
{Func: AggCountDistinct, Arg: "Host", Filter: "JobStatus == 4"}    // hosts of completed jobs
```

## Two semantics worth checking

**Distinct agrees with GROUP BY.** Values are keyed on the same rendering the group tuple uses, so `COUNT(DISTINCT N)` and the number of groups `GROUP BY N` produces are always the same number. A test asserts exactly that rather than trusting it — including the `2` vs `2.0` case, where the two must agree whichever way they resolve it.

**Undefined is not a value.** A row missing the attribute contributes nothing, matching `COUNT(col)`'s existing behaviour rather than counting "undefined" as a distinct value.

`COUNT(DISTINCT *)` is refused — there is no such thing as a distinct row.

## Why not the HyperLogLog sketches

I suggested earlier that this could ride the per-segment `segStats.hll` sketches and answer without touching rows. On closer inspection that is wrong for this function, twice over:

- the sketches are per segment per indexed attribute and cover the whole segment, so they can only answer an **unconstrained, ungrouped** count — not one with a WHERE or a GROUP BY, which is most of them;
- more importantly, returning an approximation for a query written `COUNT(DISTINCT ...)` would be wrong rather than fast.

So this is exact. An approximate count is a good idea, but it has to be asked for by name — a separate `APPROX_COUNT_DISTINCT` accumulating an HLL per group during the scan, which would then work with filters and grouping too. Worth doing; not this.

**The cost of exactness** is one entry per distinct value per group for the duration of the scan. That is the right trade for the attributes people count by — owners, hosts, statuses — and the wrong one for a unique-per-row attribute over a large history. The doc comment says so plainly rather than leaving it to be discovered.

## Wire

The function selector is a `u8`, so an older server would decode the frame happily, fail to match the unknown function, and return `"undefined"` for that column — visibly odd rather than plausibly wrong, but still not an error. So COUNT DISTINCT rides the extended opcodes added for FILTER, and the client refuses rather than sending something an old server would half-answer.

`ErrFilteredAggregateUnsupported` is renamed `ErrExtendedAggregateUnsupported` now that it covers both, with the old name kept as an alias of **the same error value**, so `errors.Is` against either still matches and v0.23.1 callers are unaffected.

## Testing

`db/aggdistinct_test.go` — per-group and whole-table counts (with a host shared across owners, so the ungrouped count is not the sum of the per-group ones), undefined handling, composition with FILTER, the `DISTINCT *` refusal, and the GROUP BY identity property.

`dbrpc/aggfilter_test.go` — end to end with a filter, and the old-server refusal (including that the deprecated alias still matches).

All four modules green; `db` and `dbrpc` green under `-race`.

The `repl` syntax (`SELECT COUNT(DISTINCT Owner) FROM jobs`) follows after a tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
