### PR TITLE
Transaction-scoped reads: a query inside a transaction sees its own writes

### DIFF
--- a/changefeed/go.mod
+++ b/changefeed/go.mod
@@ -11,6 +11,9 @@ require (
 require (
 	github.com/RoaringBitmap/roaring/v2 v2.19.0 // indirect
 	github.com/bits-and-blooms/bitset v1.24.4 // indirect
+	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/dgraph-io/ristretto/v2 v2.4.2 // indirect
+	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/klauspost/compress v1.19.0 // indirect
 	github.com/mschoch/smat v0.2.0 // indirect
 	github.com/tidwall/btree v1.8.1 // indirect

--- a/changefeed/go.sum
+++ b/changefeed/go.sum
@@ -2,8 +2,16 @@ github.com/RoaringBitmap/roaring/v2 v2.19.0 h1:zsWtVE+biht4eVl0YDLvykUqGkftR3Qc5
 github.com/RoaringBitmap/roaring/v2 v2.19.0/go.mod h1:SfT3of9nYh3vis1dIbCj4Yw6KQGujTN+f345nrN/0JA=
 github.com/bits-and-blooms/bitset v1.24.4 h1:95H15Og1clikBrKr/DuzMXkQzECs1M6hhoGXLwLQOZE=
 github.com/bits-and-blooms/bitset v1.24.4/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
+github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
+github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgraph-io/ristretto/v2 v2.4.2 h1:x0cvjmUKxt764Yxdk2nr94we1AvPPAMh1rh5TQ+Jo80=
+github.com/dgraph-io/ristretto/v2 v2.4.2/go.mod h1:0KsrXtXvnv0EqnzyowllbVJB8yBonswa2lTCK2gGo9E=
+github.com/dgryski/go-farm v0.0.0-20240924180020-3414d57e47da h1:aIftn67I1fkbMa512G+w+Pxci9hJPB8oMnkcP3iZF38=
+github.com/dgryski/go-farm v0.0.0-20240924180020-3414d57e47da/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
+github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
+github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/klauspost/compress v1.19.0 h1:sXLILfc9jV2QYWkzFOPWStmcUVH2RHEB1JCdY2oVvCQ=
 github.com/klauspost/compress v1.19.0/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/mschoch/smat v0.2.0 h1:8imxQsjDm8yFEAVBe7azKmKSgzSkZXDuKkSq9374khM=

--- a/collections/txnquery.go
+++ b/collections/txnquery.go
@@ -1,0 +1,108 @@
+package collections
+
+import (
+	"iter"
+	"sort"
+
+	"github.com/PelicanPlatform/classad/classad"
+	"github.com/PelicanPlatform/classad/collections/vm"
+)
+
+// Query returns the ads matching q as the transaction sees them: the committed rows,
+// with the transaction's own buffered writes overlaid (read-your-writes). A row the
+// transaction deleted is absent, a row it rewrote is matched and yielded in its
+// rewritten form, and a row it created is included if it matches -- so a query inside a
+// transaction observes the transaction's own work, which Collection.Query cannot.
+//
+// Consistency: the committed half is read live, not at the transaction's snapshot, so
+// this is read-committed plus read-your-writes rather than full snapshot isolation. Get
+// does read at the snapshot, so a point lookup and a scan in the same transaction can
+// disagree about a row a *different* transaction committed in between. Making the scan
+// snapshot-consistent needs a scan-at-sequence path the store does not have; the
+// transaction's own writes -- the thing callers actually reach for a transactional query
+// to see -- are exact either way.
+//
+// Cost: with no buffered writes this is exactly Collection.Query, index pushdown and
+// all. Once the transaction has staged a write the committed half becomes a full scan,
+// because the overlay has to know each row's key to tell whether the transaction
+// superseded it, and the indexed query path yields ads without keys. Transactions exist
+// to batch writes, so that trade -- pay only after you have written -- keeps the common
+// BEGIN/SELECT/COMMIT shape at full speed.
+func (tx *Txn) Query(q *vm.Query) iter.Seq[*classad.ClassAd] {
+	if len(tx.writes) == 0 {
+		return tx.c.Query(q)
+	}
+	return func(yield func(*classad.ClassAd) bool) {
+		if !tx.scanCommitted(q, func(_ string, ad *classad.ClassAd) bool { return yield(ad) }) {
+			return
+		}
+		tx.forEachBufferedMatch(q, func(_ string, ad *classad.ClassAd) bool { return yield(ad) })
+	}
+}
+
+// KeysWhere returns the storage keys of the rows matching q as the transaction sees
+// them, with the same overlay and the same caveats as Query. It is what lets an UPDATE
+// or DELETE inside a transaction address rows the transaction itself created.
+func (tx *Txn) KeysWhere(q *vm.Query) iter.Seq[string] {
+	return func(yield func(string) bool) {
+		if !tx.scanCommitted(q, func(key string, _ *classad.ClassAd) bool { return yield(key) }) {
+			return
+		}
+		tx.forEachBufferedMatch(q, func(key string, _ *classad.ClassAd) bool { return yield(key) })
+	}
+}
+
+// scanCommitted visits every committed row matching q whose key the transaction has NOT
+// buffered -- those are represented by the buffered version, which forEachBufferedMatch
+// yields instead. Returns false if the caller stopped early.
+func (tx *Txn) scanCommitted(q *vm.Query, visit func(key string, ad *classad.ClassAd) bool) bool {
+	ok := true
+	tx.c.ForEachAd(func(key string, ad *classad.ClassAd) bool {
+		if _, superseded := tx.writes[key]; superseded {
+			return true
+		}
+		if !q.Matches(ad) {
+			return true
+		}
+		ok = visit(key, ad)
+		return ok
+	})
+	return ok
+}
+
+// forEachBufferedMatch visits the transaction's own buffered rows that match q, in key
+// order. Deletes are skipped: the row is gone as far as this transaction is concerned,
+// and scanCommitted already excluded its committed version.
+//
+// Key order rather than map order so a query's results are reproducible across runs --
+// SQL callers order explicitly, but a non-deterministic iteration makes tests flaky and
+// diffs noisy for no benefit.
+func (tx *Txn) forEachBufferedMatch(q *vm.Query, visit func(key string, ad *classad.ClassAd) bool) {
+	keys := make([]string, 0, len(tx.writes))
+	for key, buf := range tx.writes {
+		if buf.del || buf.ad == nil {
+			continue
+		}
+		if IsSystemKey(key) {
+			continue // internal system record: hidden from client iteration, as in ForEachAd
+		}
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		// Through Get, so a buffered row is yielded exactly as a point lookup in this
+		// transaction would return it -- including the parent merge on a chained
+		// collection, which reading tx.writes directly would skip.
+		ad, ok := tx.Get([]byte(key))
+		if !ok {
+			continue
+		}
+		if !q.Matches(ad) {
+			continue
+		}
+		if !visit(key, ad) {
+			return
+		}
+	}
+}

--- a/collections/txnquery_test.go
+++ b/collections/txnquery_test.go
@@ -1,0 +1,241 @@
+package collections
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/classad"
+)
+
+// txnAd builds an ad with an Owner and a numeric Cpus, the shape these tests query on.
+func txnAd(owner string, cpus int64) *classad.ClassAd {
+	ad := classad.New()
+	ad.InsertAttrString("Owner", owner)
+	ad.InsertAttr("Cpus", cpus)
+	return ad
+}
+
+// owners collects the Owner attribute of each yielded ad, sorted for comparison.
+func owners(seq func(func(*classad.ClassAd) bool)) []string {
+	var out []string
+	for ad := range seq {
+		s, _ := ad.EvaluateAttr("Owner").StringValue()
+		out = append(out, s)
+	}
+	slices.Sort(out)
+	return out
+}
+
+func newTxnColl(t *testing.T) *Collection {
+	t.Helper()
+	return New(Options{Shards: 4})
+}
+
+// commit writes ads under the given keys and commits, so later tests query committed state.
+func txnCommit(t *testing.T, c *Collection, ads map[string]*classad.ClassAd) {
+	t.Helper()
+	tx := c.Begin()
+	for k, ad := range ads {
+		tx.Put([]byte(k), ad)
+	}
+	if res := tx.Commit(); res.Conflicted() {
+		t.Fatalf("unexpected conflicts: %v", res.Conflicts)
+	}
+}
+
+// With nothing buffered the transaction sees exactly the committed state -- and takes the
+// fast path straight to Collection.Query.
+func TestTxnQueryWithoutWritesMatchesCollectionQuery(t *testing.T) {
+	c := newTxnColl(t)
+	txnCommit(t, c, map[string]*classad.ClassAd{
+		"a": txnAd("alice", 4),
+		"b": txnAd("bob", 8),
+	})
+
+	tx := c.Begin()
+	q := mustQuery(t, "Cpus >= 4")
+	if got, want := owners(tx.Query(q)), []string{"alice", "bob"}; !slices.Equal(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+// The point of the whole change: a row the transaction created is visible to its own query.
+func TestTxnQuerySeesOwnInsert(t *testing.T) {
+	c := newTxnColl(t)
+	txnCommit(t, c, map[string]*classad.ClassAd{"a": txnAd("alice", 4)})
+
+	tx := c.Begin()
+	tx.Put([]byte("b"), txnAd("bob", 8))
+
+	q := mustQuery(t, "Cpus >= 4")
+	if got, want := owners(tx.Query(q)), []string{"alice", "bob"}; !slices.Equal(got, want) {
+		t.Errorf("got %v, want %v (the transaction's own insert is missing)", got, want)
+	}
+	// ... and is still invisible to a committed-state query until commit.
+	if got, want := owners(c.Query(q)), []string{"alice"}; !slices.Equal(got, want) {
+		t.Errorf("committed query got %v, want %v", got, want)
+	}
+}
+
+// A row the transaction deleted is gone from its own query, even though it is still
+// committed.
+func TestTxnQueryHidesOwnDelete(t *testing.T) {
+	c := newTxnColl(t)
+	txnCommit(t, c, map[string]*classad.ClassAd{
+		"a": txnAd("alice", 4),
+		"b": txnAd("bob", 8),
+	})
+
+	tx := c.Begin()
+	tx.Delete([]byte("b"))
+
+	q := mustQuery(t, "Cpus >= 4")
+	if got, want := owners(tx.Query(q)), []string{"alice"}; !slices.Equal(got, want) {
+		t.Errorf("got %v, want %v (the deleted row is still visible)", got, want)
+	}
+}
+
+// A rewritten row is matched and yielded in its rewritten form -- not once per version,
+// and not by its committed values.
+func TestTxnQueryUsesRewrittenValues(t *testing.T) {
+	c := newTxnColl(t)
+	txnCommit(t, c, map[string]*classad.ClassAd{"a": txnAd("alice", 4)})
+
+	tx := c.Begin()
+	tx.Put([]byte("a"), txnAd("alice-renamed", 16))
+
+	if got, want := owners(tx.Query(mustQuery(t, "Cpus >= 4"))), []string{"alice-renamed"}; !slices.Equal(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+	// The rewrite moved the row out of this constraint's match set.
+	if got := owners(tx.Query(mustQuery(t, "Cpus == 4"))); len(got) != 0 {
+		t.Errorf("got %v, want no rows (the committed version should not match)", got)
+	}
+	// ... and into this one, which the committed version never matched.
+	if got, want := owners(tx.Query(mustQuery(t, "Cpus == 16"))), []string{"alice-renamed"}; !slices.Equal(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+// A buffered row that does not match is not yielded just because it is buffered.
+func TestTxnQueryFiltersBufferedRows(t *testing.T) {
+	c := newTxnColl(t)
+	tx := c.Begin()
+	tx.Put([]byte("a"), txnAd("alice", 2))
+	tx.Put([]byte("b"), txnAd("bob", 8))
+
+	if got, want := owners(tx.Query(mustQuery(t, "Cpus >= 4"))), []string{"bob"}; !slices.Equal(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+// Stopping early must stop the scan in both halves of the overlay, not just the first.
+func TestTxnQueryStopsEarly(t *testing.T) {
+	c := newTxnColl(t)
+	txnCommit(t, c, map[string]*classad.ClassAd{"a": txnAd("alice", 4), "b": txnAd("bob", 4)})
+
+	tx := c.Begin()
+	tx.Put([]byte("c"), txnAd("carol", 4))
+	tx.Put([]byte("d"), txnAd("dave", 4))
+
+	n := 0
+	for range tx.Query(mustQuery(t, "Cpus >= 4")) {
+		n++
+		break
+	}
+	if n != 1 {
+		t.Errorf("yielded %d rows after break, want 1", n)
+	}
+
+	// Break inside the buffered half (after the two committed rows are consumed).
+	n = 0
+	for range tx.Query(mustQuery(t, "Cpus >= 4")) {
+		n++
+		if n == 3 {
+			break
+		}
+	}
+	if n != 3 {
+		t.Errorf("yielded %d rows, want 3", n)
+	}
+}
+
+// Committing makes the transaction's view the committed view -- the overlay was not a
+// separate universe.
+func TestTxnQueryMatchesCommittedStateAfterCommit(t *testing.T) {
+	c := newTxnColl(t)
+	txnCommit(t, c, map[string]*classad.ClassAd{"a": txnAd("alice", 4)})
+
+	tx := c.Begin()
+	tx.Put([]byte("b"), txnAd("bob", 8))
+	tx.Delete([]byte("a"))
+	want := owners(tx.Query(mustQuery(t, "Cpus >= 1")))
+	if res := tx.Commit(); res.Conflicted() {
+		t.Fatalf("unexpected conflicts: %v", res.Conflicts)
+	}
+
+	if got := owners(c.Query(mustQuery(t, "Cpus >= 1"))); !slices.Equal(got, want) {
+		t.Errorf("after commit the committed state is %v, but the transaction saw %v", got, want)
+	}
+}
+
+func TestTxnKeysWhereOverlay(t *testing.T) {
+	c := newTxnColl(t)
+	txnCommit(t, c, map[string]*classad.ClassAd{
+		"a": txnAd("alice", 4),
+		"b": txnAd("bob", 8),
+	})
+
+	tx := c.Begin()
+	tx.Put([]byte("c"), txnAd("carol", 16)) // new
+	tx.Delete([]byte("b"))                  // removed
+	tx.Put([]byte("a"), txnAd("alice", 1))  // moved out of the match set
+
+	var keys []string
+	for k := range tx.KeysWhere(mustQuery(t, "Cpus >= 4")) {
+		keys = append(keys, k)
+	}
+	slices.Sort(keys)
+	if want := []string{"c"}; !slices.Equal(keys, want) {
+		t.Errorf("got %v, want %v", keys, want)
+	}
+}
+
+// System keys stay hidden from a transactional scan, matching ForEachAd and Query.
+func TestTxnQuerySkipsSystemKeys(t *testing.T) {
+	c := newTxnColl(t)
+	tx := c.Begin()
+	tx.Put([]byte(SystemKey("internal")), txnAd("system", 8))
+	tx.Put([]byte("visible"), txnAd("alice", 8))
+
+	if got, want := owners(tx.Query(mustQuery(t, "Cpus >= 4"))), []string{"alice"}; !slices.Equal(got, want) {
+		t.Errorf("got %v, want %v (a system key leaked into the result)", got, want)
+	}
+}
+
+// Buffered rows are yielded in key order, so a result set is reproducible run to run.
+func TestTxnQueryBufferedRowsAreOrdered(t *testing.T) {
+	c := newTxnColl(t)
+	tx := c.Begin()
+	for _, k := range []string{"z", "m", "a", "q", "b"} {
+		tx.Put([]byte(k), txnAd(k, 8))
+	}
+
+	var first []string
+	for range 5 { // repeat: map iteration order varies per range, sorting must mask it
+		var got []string
+		for k := range tx.KeysWhere(mustQuery(t, "Cpus >= 4")) {
+			got = append(got, k)
+		}
+		if first == nil {
+			first = got
+			continue
+		}
+		if !slices.Equal(got, first) {
+			t.Fatalf("iteration order varies: %v then %v", first, got)
+		}
+	}
+	if want := []string{"a", "b", "m", "q", "z"}; !slices.Equal(first, want) {
+		t.Errorf("got %v, want %v", first, want)
+	}
+}

--- a/db/db.go
+++ b/db/db.go
@@ -744,6 +744,37 @@ func (t *Txn) LookupClassAd(key string) (*classad.ClassAd, bool) {
 	return t.tx.Get([]byte(key))
 }
 
+// Query returns the ads matching the constraint as the transaction sees them: the
+// committed rows with the transaction's own buffered writes overlaid, so a query inside
+// a transaction observes work the transaction has not committed yet. DB.Query cannot --
+// it reads the committed store -- which is why a caller that has staged writes and then
+// wants to read them back must go through the transaction.
+//
+// See collections.Txn.Query for the two properties worth knowing: the committed half is
+// read live rather than at the transaction's snapshot (read-committed plus
+// read-your-writes, not full snapshot isolation), and it degrades from an indexed query
+// to a full scan once the transaction has buffered a write. Errors only on a malformed
+// constraint.
+func (t *Txn) Query(constraint string) (iter.Seq[*classad.ClassAd], error) {
+	q, err := vm.Parse(constraint)
+	if err != nil {
+		return nil, fmt.Errorf("classad-db: bad constraint %q: %w", constraint, err)
+	}
+	return t.tx.Query(q), nil
+}
+
+// KeysWhere returns the storage keys of the rows matching the constraint as the
+// transaction sees them (DB.KeysWhere with the transaction's writes overlaid). It is
+// what lets an UPDATE or DELETE inside a transaction address a row the transaction
+// itself created. Errors only on a malformed constraint.
+func (t *Txn) KeysWhere(constraint string) (iter.Seq[string], error) {
+	q, err := vm.Parse(constraint)
+	if err != nil {
+		return nil, fmt.Errorf("classad-db: bad constraint %q: %w", constraint, err)
+	}
+	return t.tx.KeysWhere(q), nil
+}
+
 // LookupAttr returns the unparsed expression of one attribute as the transaction
 // sees it (classad_log.h LookupInTransaction), or ("", false).
 func (t *Txn) LookupAttr(key, name string) (string, bool) {

--- a/db/txnquery_test.go
+++ b/db/txnquery_test.go
@@ -1,0 +1,146 @@
+package db
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/classad"
+)
+
+func txnOwnerAd(owner string, cpus int64) *classad.ClassAd {
+	ad := classad.New()
+	ad.InsertAttrString("Owner", owner)
+	ad.InsertAttr("Cpus", cpus)
+	return ad
+}
+
+func txnOwners(t *testing.T, seq func(func(*classad.ClassAd) bool)) []string {
+	t.Helper()
+	var out []string
+	for ad := range seq {
+		s, _ := ad.EvaluateAttr("Owner").StringValue()
+		out = append(out, s)
+	}
+	slices.Sort(out)
+	return out
+}
+
+func openTxnDB(t *testing.T) *DB {
+	t.Helper()
+	d, err := Open("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { d.Close() })
+	return d
+}
+
+// Txn.Query sees the transaction's own uncommitted writes; DB.Query does not. This is the
+// distinction the whole transaction-scoped read path exists to provide.
+func TestTxnQueryReadYourWrites(t *testing.T) {
+	d := openTxnDB(t)
+
+	seed := d.Begin()
+	seed.NewClassAd("a", txnOwnerAd("alice", 8))
+	if err := seed.Commit(); err != nil {
+		t.Fatal(err)
+	}
+
+	tx := d.Begin()
+	defer tx.Abort()
+	tx.NewClassAd("b", txnOwnerAd("bob", 8))
+
+	seq, err := tx.Query("Cpus >= 4")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := txnOwners(t, seq), []string{"alice", "bob"}; !slices.Equal(got, want) {
+		t.Errorf("Txn.Query got %v, want %v", got, want)
+	}
+
+	committed, err := d.Query("Cpus >= 4")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := txnOwners(t, committed), []string{"alice"}; !slices.Equal(got, want) {
+		t.Errorf("DB.Query got %v, want %v", got, want)
+	}
+}
+
+// SetAttribute composes with the transaction's own earlier writes, and the query sees the
+// composed result -- the read-modify-write an in-transaction UPDATE performs.
+func TestTxnQueryAfterSetAttribute(t *testing.T) {
+	d := openTxnDB(t)
+
+	tx := d.Begin()
+	defer tx.Abort()
+	tx.NewClassAd("a", txnOwnerAd("alice", 8))
+	if err := tx.SetAttribute("a", "JobStatus", "2"); err != nil {
+		t.Fatal(err)
+	}
+
+	seq, err := tx.Query("JobStatus == 2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := txnOwners(t, seq), []string{"alice"}; !slices.Equal(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestTxnKeysWhere(t *testing.T) {
+	d := openTxnDB(t)
+
+	seed := d.Begin()
+	seed.NewClassAd("committed", txnOwnerAd("alice", 8))
+	if err := seed.Commit(); err != nil {
+		t.Fatal(err)
+	}
+
+	tx := d.Begin()
+	defer tx.Abort()
+	tx.NewClassAd("staged", txnOwnerAd("bob", 8))
+	tx.DestroyClassAd("committed")
+
+	seq, err := tx.KeysWhere("Cpus >= 4")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var keys []string
+	for k := range seq {
+		keys = append(keys, k)
+	}
+	if want := []string{"staged"}; !slices.Equal(keys, want) {
+		t.Errorf("got %v, want %v", keys, want)
+	}
+}
+
+func TestTxnQueryBadConstraint(t *testing.T) {
+	d := openTxnDB(t)
+	tx := d.Begin()
+	defer tx.Abort()
+
+	if _, err := tx.Query("not ( a constraint"); err == nil {
+		t.Error("Txn.Query accepted a malformed constraint")
+	}
+	if _, err := tx.KeysWhere("not ( a constraint"); err == nil {
+		t.Error("Txn.KeysWhere accepted a malformed constraint")
+	}
+}
+
+// An aborted transaction leaves nothing behind for a later reader.
+func TestTxnQueryAbortDiscards(t *testing.T) {
+	d := openTxnDB(t)
+
+	tx := d.Begin()
+	tx.NewClassAd("a", txnOwnerAd("alice", 8))
+	tx.Abort()
+
+	seq, err := d.Query("Cpus >= 4")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := txnOwners(t, seq); len(got) != 0 {
+		t.Errorf("got %v after abort, want no rows", got)
+	}
+}

--- a/dbrpc/client.go
+++ b/dbrpc/client.go
@@ -2,6 +2,7 @@ package dbrpc
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -234,9 +235,17 @@ func (c *Client) sendIDTimed(id uint64, build func(reqID uint64) []byte, stream 
 	return ch, st, nil
 }
 
+// ErrBadRequest is the server's stBadReq: the request was malformed -- which is also how
+// it answers an opcode it does not implement, so a newer client can tell "this server is
+// too old for this op" from a genuine failure without matching on message text.
+var ErrBadRequest = errors.New("dbrpc: bad request")
+
 func statusErr(status int32, body *reader) error {
-	if status == stErr {
+	switch status {
+	case stErr:
 		return &ServerError{Msg: body.str()}
+	case stBadReq:
+		return ErrBadRequest
 	}
 	return fmt.Errorf("dbrpc: status %d", status)
 }

--- a/dbrpc/proto.go
+++ b/dbrpc/proto.go
@@ -165,6 +165,17 @@ const (
 	// byte-identical on the wire.
 	opAggregateFiltered        op = 55 // [table][constraint][nGroup]{[attr][width u64]}[nAgg]{[func u8][arg][filter]}
 	opArchiveAggregateFiltered op = 56 // [name][constraint][nGroup]{[attr][width u64]}[nAgg]{[func u8][arg][filter]}
+
+	// Transaction-scoped reads. Unlike opQuery and opQueryKeys -- which carry no
+	// transaction id and read the committed store -- these run through an open
+	// transaction, so they see its uncommitted writes (read-your-writes). Neither
+	// carries a [table]: the transaction is already bound to one by opBegin.
+	//
+	// Separate opcodes rather than an extra field on the existing ops, so a client
+	// that speaks them fails cleanly (stBadReq -> ErrTxnReadUnsupported) against a
+	// server that does not, instead of the server misparsing a longer frame.
+	opTxnQuery     op = 57 // [txnID u64][limit i32][constraint] -> stream of [adText]
+	opTxnQueryKeys op = 58 // [txnID u64][constraint] -> stream of [key]
 )
 
 // String names an opcode for diagnostics (e.g. the read-only rejection message).
@@ -256,6 +267,10 @@ func (o op) String() string {
 		return "ArchiveAggregate"
 	case opQueryKeys:
 		return "QueryKeys"
+	case opTxnQuery:
+		return "TxnQuery"
+	case opTxnQueryKeys:
+		return "TxnQueryKeys"
 	}
 	return "op(unknown)"
 }

--- a/dbrpc/server.go
+++ b/dbrpc/server.go
@@ -447,6 +447,10 @@ func (sc *serverConn) dispatch(frame []byte) {
 		sc.streamArchiveAggregateFiltered(reqID, body)
 	case opQueryKeys:
 		sc.s.streamQueryKeys(sc.ctx, reqID, body, sc.write)
+	case opTxnQuery:
+		sc.s.streamTxnQuery(sc.ctx, reqID, body, priv, sc.write)
+	case opTxnQueryKeys:
+		sc.s.streamTxnQueryKeys(sc.ctx, reqID, body, sc.write)
 	case opWatchStop:
 		sc.stopWatch(body.u64())
 		sc.write(resp(reqID, stOK))

--- a/dbrpc/txnquery.go
+++ b/dbrpc/txnquery.go
@@ -1,0 +1,132 @@
+package dbrpc
+
+import (
+	"context"
+	"errors"
+)
+
+// ErrTxnReadUnsupported is returned by the Tx read methods against a server too old to
+// implement the transaction-scoped read opcodes (it rejects the request). A caller falls
+// back to the connection-level Query/QueryKeys, which read the committed store and so do
+// not see the transaction's own uncommitted writes.
+var ErrTxnReadUnsupported = errors.New("dbrpc: server does not support transaction-scoped reads")
+
+// Query returns the ads matching the constraint as this transaction sees them: the
+// committed rows with the transaction's own uncommitted writes overlaid. Client.Query
+// reads the committed store and cannot see them, which is the whole reason this exists --
+// a caller that has staged writes and wants to read them back must come through here.
+//
+// The transaction's table is implied (opBegin bound it), so unlike QueryTable there is no
+// table argument. A limit <= 0 returns every match. Against a server without the opcode it
+// returns ErrTxnReadUnsupported.
+func (t *Tx) Query(ctx context.Context, constraint string, limit int) ([]string, error) {
+	rows, err := t.c.streamCtx(ctx, func(id uint64) []byte {
+		return putStr(putI32(putU64(req(id, opTxnQuery), t.id), int32(limit)), constraint)
+	})
+	return rows, txnReadErr(err)
+}
+
+// QueryStream is Query delivering each ad's text to yield as it arrives, rather than
+// collecting the whole result. yield returns false to stop early.
+func (t *Tx) QueryStream(ctx context.Context, constraint string, limit int, yield func(row string) bool) error {
+	return txnReadErr(t.c.streamEach(ctx, func(id uint64) []byte {
+		return putStr(putI32(putU64(req(id, opTxnQuery), t.id), int32(limit)), constraint)
+	}, yield))
+}
+
+// KeysWhere returns the storage keys of the rows matching the constraint as this
+// transaction sees them. It is what lets a caller address rows -- for a subsequent
+// SetAttribute or DestroyClassAd in the same transaction -- including rows the
+// transaction itself created, which Client.QueryKeysTable cannot see.
+//
+// Against a server without the opcode it returns ErrTxnReadUnsupported.
+func (t *Tx) KeysWhere(ctx context.Context, constraint string) ([]string, error) {
+	keys, err := t.c.streamCtx(ctx, func(id uint64) []byte {
+		return putStr(putU64(req(id, opTxnQueryKeys), t.id), constraint)
+	})
+	return keys, txnReadErr(err)
+}
+
+// txnReadErr maps the server's rejection of an unknown opcode to ErrTxnReadUnsupported,
+// so a caller can tell "this server is too old" from "this query was wrong" without
+// matching on message text.
+func txnReadErr(err error) error {
+	if errors.Is(err, ErrBadRequest) {
+		return ErrTxnReadUnsupported
+	}
+	return err
+}
+
+// streamTxnQuery is the server side of opTxnQuery: the transaction's own view of a
+// constraint query, streamed like opQuery.
+func (s *Server) streamTxnQuery(ctx context.Context, reqID uint64, r *reader, includePrivate bool, write func([]byte)) {
+	id := r.u64()
+	limit := int(r.i32())
+	constraint := r.str()
+	if r.err != nil {
+		write(respBad(reqID))
+		return
+	}
+	s.withTxnStream(reqID, id, write, func(st *serverTxn) {
+		seq, err := st.tx.Query(constraint)
+		if err != nil {
+			write(respErr(reqID, err.Error()))
+			return
+		}
+		n := 0
+		for ad := range seq {
+			if cancelled(ctx) {
+				return // client gone: stop the scan
+			}
+			write(putStr(respHead(reqID, stStream), adString(ad, includePrivate)))
+			n++
+			if limit > 0 && n >= limit {
+				break
+			}
+		}
+		write(respHead(reqID, stStreamEnd))
+	})
+}
+
+// streamTxnQueryKeys is the server side of opTxnQueryKeys.
+func (s *Server) streamTxnQueryKeys(ctx context.Context, reqID uint64, r *reader, write func([]byte)) {
+	id := r.u64()
+	constraint := r.str()
+	if r.err != nil {
+		write(respBad(reqID))
+		return
+	}
+	s.withTxnStream(reqID, id, write, func(st *serverTxn) {
+		seq, err := st.tx.KeysWhere(constraint)
+		if err != nil {
+			write(respErr(reqID, err.Error()))
+			return
+		}
+		for key := range seq {
+			if cancelled(ctx) {
+				return
+			}
+			write(putStr(respHead(reqID, stStream), key))
+		}
+		write(respHead(reqID, stStreamEnd))
+	})
+}
+
+// withTxnStream resolves a transaction id and runs a streaming read under its lock.
+//
+// It is withTxn's shape for a streamer: withTxn returns one response frame, while these
+// ops write many. The lock is held for the whole stream because db.Txn is not safe for
+// concurrent use -- a write op pipelined onto the same transaction mid-scan would race
+// the scan's read of the write buffer.
+func (s *Server) withTxnStream(reqID, id uint64, write func([]byte), fn func(*serverTxn)) {
+	v, ok := s.txns.Load(id)
+	if !ok {
+		write(respErr(reqID, "no such transaction"))
+		return
+	}
+	st := v.(*serverTxn)
+	st.lastTouch.Store(nowNano())
+	st.mu.Lock()
+	defer st.mu.Unlock()
+	fn(st)
+}

--- a/dbrpc/txnquery_test.go
+++ b/dbrpc/txnquery_test.go
@@ -1,0 +1,267 @@
+package dbrpc
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// adText builds the old-ClassAd text one row, so tests can write through Tx.NewClassAd.
+func adText(owner string, cpus int) string {
+	return "Owner = \"" + owner + "\"\nCpus = " + itoa(cpus) + "\n"
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b []byte
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	return string(b)
+}
+
+// ownersOf pulls the Owner value out of each returned ad's text, sorted. The server
+// renders a query result in new-ClassAd form -- one bracketed line, attributes separated
+// by ';' -- so split on both that and newlines rather than assuming either.
+func ownersOf(rows []string) []string {
+	var out []string
+	for _, row := range rows {
+		body := strings.Trim(strings.TrimSpace(row), "[]")
+		for _, field := range strings.FieldsFunc(body, func(r rune) bool { return r == ';' || r == '\n' }) {
+			if name, value, ok := strings.Cut(field, "="); ok && strings.TrimSpace(name) == "Owner" {
+				out = append(out, strings.Trim(strings.TrimSpace(value), "\""))
+			}
+		}
+	}
+	slices.Sort(out)
+	return out
+}
+
+// A transaction's own uncommitted writes are visible to Tx.Query and invisible to
+// Client.Query -- the whole point of the transaction-scoped read opcodes.
+func TestTxQuerySeesUncommittedWrites(t *testing.T) {
+	c, cleanup := testPair(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	tx, err := c.Begin(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.NewClassAd(ctx, "a", adText("alice", 8)); err != nil {
+		t.Fatal(err)
+	}
+
+	rows, err := tx.Query(ctx, "Cpus >= 4", 0)
+	if err != nil {
+		t.Fatalf("Tx.Query: %v", err)
+	}
+	if got, want := ownersOf(rows), []string{"alice"}; !slices.Equal(got, want) {
+		t.Errorf("Tx.Query got %v, want %v", got, want)
+	}
+
+	// The committed store still knows nothing about it.
+	committed, err := c.Query(ctx, "Cpus >= 4")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := ownersOf(committed); len(got) != 0 {
+		t.Errorf("Client.Query got %v, want no rows before commit", got)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatal(err)
+	}
+	committed, err = c.Query(ctx, "Cpus >= 4")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := ownersOf(committed), []string{"alice"}; !slices.Equal(got, want) {
+		t.Errorf("after commit got %v, want %v", got, want)
+	}
+}
+
+func TestTxQueryOverlaysDeletesAndRewrites(t *testing.T) {
+	c, cleanup := testPair(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	seed, err := c.Begin(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for key, ad := range map[string]string{"a": adText("alice", 8), "b": adText("bob", 8)} {
+		if err := seed.NewClassAd(ctx, key, ad); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := seed.Commit(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	tx, err := c.Begin(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tx.Abort(ctx)
+	if err := tx.DestroyClassAd(ctx, "b"); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.NewClassAd(ctx, "c", adText("carol", 8)); err != nil {
+		t.Fatal(err)
+	}
+
+	rows, err := tx.Query(ctx, "Cpus >= 4", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := ownersOf(rows), []string{"alice", "carol"}; !slices.Equal(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestTxQueryLimit(t *testing.T) {
+	c, cleanup := testPair(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	tx, err := c.Begin(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tx.Abort(ctx)
+	for _, key := range []string{"a", "b", "c", "d"} {
+		if err := tx.NewClassAd(ctx, key, adText(key, 8)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	rows, err := tx.Query(ctx, "Cpus >= 4", 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 2 {
+		t.Errorf("got %d rows, want 2 (LIMIT was not applied)", len(rows))
+	}
+}
+
+// KeysWhere is what lets an UPDATE or DELETE inside a transaction address a row the
+// transaction itself created, which the committed-state QueryKeys cannot see.
+func TestTxKeysWhereSeesUncommittedWrites(t *testing.T) {
+	c, cleanup := testPair(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	tx, err := c.Begin(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tx.Abort(ctx)
+	if err := tx.NewClassAd(ctx, "staged", adText("alice", 8)); err != nil {
+		t.Fatal(err)
+	}
+
+	keys, err := tx.KeysWhere(ctx, "Cpus >= 4")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := []string{"staged"}; !slices.Equal(keys, want) {
+		t.Errorf("got %v, want %v", keys, want)
+	}
+
+	// The key is addressable within the same transaction: set an attribute on the row
+	// the transaction just created and read it back through the transaction.
+	if err := tx.SetAttribute(ctx, keys[0], "JobStatus", "2"); err != nil {
+		t.Fatal(err)
+	}
+	rows, err := tx.Query(ctx, "JobStatus == 2", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 {
+		t.Errorf("got %d rows, want 1 (the in-transaction update is not visible)", len(rows))
+	}
+}
+
+func TestTxQueryBadConstraint(t *testing.T) {
+	c, cleanup := testPair(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	tx, err := c.Begin(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tx.Abort(ctx)
+
+	if _, err := tx.Query(ctx, "this is not ( a constraint", 0); err == nil {
+		t.Error("a malformed constraint was accepted")
+	} else if errors.Is(err, ErrTxnReadUnsupported) {
+		t.Errorf("a malformed constraint reported as unsupported: %v", err)
+	}
+}
+
+// A transaction id the server does not know is an error, not a silent empty result --
+// otherwise a client whose transaction was reaped would read an empty table as truth.
+func TestTxQueryUnknownTransaction(t *testing.T) {
+	c, cleanup := testPair(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	stale := &Tx{c: c, id: 999999}
+	if _, err := stale.Query(ctx, "true", 0); err == nil {
+		t.Error("querying an unknown transaction succeeded")
+	}
+	if _, err := stale.KeysWhere(ctx, "true"); err == nil {
+		t.Error("KeysWhere on an unknown transaction succeeded")
+	}
+}
+
+// An aborted transaction's writes are visible to nobody, including a later reader.
+func TestTxQueryAfterAbort(t *testing.T) {
+	c, cleanup := testPair(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	tx, err := c.Begin(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.NewClassAd(ctx, "a", adText("alice", 8)); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Abort(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	rows, err := c.Query(ctx, "Cpus >= 4")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := ownersOf(rows); len(got) != 0 {
+		t.Errorf("got %v after abort, want no rows", got)
+	}
+}
+
+// stBadReq maps to ErrBadRequest so a client can distinguish "the server does not
+// implement this opcode" from a genuine failure without matching message text. This is
+// what makes the ErrTxnReadUnsupported fallback possible.
+func TestBadRequestIsASentinel(t *testing.T) {
+	if !errors.Is(statusErr(stBadReq, &reader{}), ErrBadRequest) {
+		t.Error("stBadReq did not map to ErrBadRequest")
+	}
+	if errors.Is(statusErr(stErr, &reader{b: putStr(nil, "boom")}), ErrBadRequest) {
+		t.Error("stErr wrongly mapped to ErrBadRequest")
+	}
+	if got := txnReadErr(ErrBadRequest); !errors.Is(got, ErrTxnReadUnsupported) {
+		t.Errorf("txnReadErr(ErrBadRequest) = %v, want ErrTxnReadUnsupported", got)
+	}
+	if got := txnReadErr(nil); got != nil {
+		t.Errorf("txnReadErr(nil) = %v, want nil", got)
+	}
+}


### PR DESCRIPTION
A query never saw the transaction it ran in. `opQuery` and `opQueryKeys` carry no transaction id and read the committed store, so a caller that staged writes and then read them back got the state from before its own work. A SQL client on top feels this as `INSERT` followed by `SELECT` returning nothing -- which is what prompted this.

## What changed

`collections.Txn.Query` and `Txn.KeysWhere` overlay the transaction's buffered writes on the committed rows:

- a row the transaction deleted is absent
- a row it rewrote is matched and yielded in its rewritten form (so a rewrite can move a row into or out of the constraint's match set)
- a row it created appears if it matches

`db.Txn.Query` and `db.Txn.KeysWhere` expose both by constraint, and `dbrpc.Tx.Query` / `Tx.QueryStream` / `Tx.KeysWhere` carry them over the wire.

`KeysWhere` matters as much as `Query`: it is what lets an UPDATE or DELETE inside a transaction address a row the transaction itself created.

## Two properties worth reviewing

Both are documented at the call site, not just here.

**Read-committed plus read-your-writes, not full snapshot isolation.** The committed half is read live rather than at the transaction's snapshot, so a point lookup (`Get`, which does read at the snapshot) and a scan in the same transaction can disagree about a row a *different* transaction committed in between. Making the scan snapshot-consistent needs a scan-at-sequence path the store does not have. The transaction's own writes -- the thing callers actually reach for a transactional query to see -- are exact either way.

**A buffered write costs the index pushdown.** The overlay has to know each row's key to tell whether the transaction superseded it, and the indexed query path yields ads without keys, so once the transaction has staged a write the committed half becomes a full scan. An empty write buffer delegates to `Collection.Query` untouched, so the common BEGIN/SELECT/COMMIT shape keeps its pushdown and pays nothing.

## Wire compatibility

`opTxnQuery` (57) and `opTxnQueryKeys` (58) are new opcodes rather than an extra field on the existing ops. A client that speaks them degrades cleanly against a server that does not -- the server answers `stBadReq`, which the client surfaces as `ErrTxnReadUnsupported` so a caller can fall back to the committed-state read -- instead of having a longer frame misparsed by an older server.

To make that detectable without matching on message text, `stBadReq` now maps to a new `ErrBadRequest` sentinel in `statusErr` (it previously fell through to `fmt.Errorf("dbrpc: status %d")`).

Neither op carries a `[table]`: the transaction is already bound to one by `opBegin`.

## Testing

New tests at all three layers, covering the overlay (insert, delete, rewrite in and out of a match set, non-matching buffered rows), early termination in both halves of the iteration, system-key hiding, deterministic key ordering, LIMIT, unknown/aborted transactions, malformed constraints, and the `ErrBadRequest` to `ErrTxnReadUnsupported` mapping.

`go vet` and `go test` are clean in all five modules.

## Separate first commit

`changefeed/go.mod` was already stale on `main` -- `collections` gained ristretto, xxhash and go-humanize, and changefeed resolves collections through a local replace, so a plain `go vet ./...` in changefeed fails on a clean checkout. Tidied in its own commit so this PR's CI reflects this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
