### PR TITLE
Scan at a snapshot sequence, so transactional reads are isolated

### DIFF
--- a/collections/truncate.go
+++ b/collections/truncate.go
@@ -83,6 +83,42 @@ func (c *Collection) ForEachAd(fn func(key string, ad *classad.ClassAd) bool) {
 	}
 }
 
+// ForEachAdAt is ForEachAd over the versions visible at a caller-chosen snapshot
+// sequence per shard, instead of each shard's current commit sequence.
+//
+// snapOf is called once per shard, with the shard's index, and returns the sequence to
+// read that shard at. It is a callback rather than a map so a transaction can capture a
+// shard's sequence lazily on first touch -- and, having captured it, stay pinned to it
+// for every later read of that shard.
+//
+// This is what lets a transaction scan the committed store at its own snapshot: the same
+// versions its point lookups see, rather than whatever has committed since.
+func (c *Collection) ForEachAdAt(snapOf func(shardIdx int) uint64, fn func(key string, ad *classad.ClassAd) bool) {
+	for i, sh := range c.shards {
+		s0 := snapOf(i)
+		wins := sh.snapshotAt(s0)
+		stop := false
+		forEachVisibleKeyed(s0, wins, func(key, ad []byte, codec Codec, dict *segDictHandle) bool {
+			if isSystemKeyBytes(key) {
+				return true // internal system record: hidden from client iteration
+			}
+			decoded, err := c.decodeAdDict(dict, ad, codec)
+			if err != nil {
+				return true // skip an undecodable record, as ForEachAd does
+			}
+			if !fn(string(key), decoded) {
+				stop = true
+				return false
+			}
+			return true
+		})
+		releaseWindows(wins)
+		if stop {
+			return
+		}
+	}
+}
+
 // ForEachSystemAd calls fn with every internal system-keyed ad and its key -- the mirror
 // image of ForEachAd, which hides them. It is the enumeration path a TTL reaper uses to
 // find and expire durable bookkeeping records. Each ad is fully decoded; iteration stops

--- a/collections/txnquery.go
+++ b/collections/txnquery.go
@@ -14,24 +14,19 @@ import (
 // rewritten form, and a row it created is included if it matches -- so a query inside a
 // transaction observes the transaction's own work, which Collection.Query cannot.
 //
-// Consistency: the committed half is read live, not at the transaction's snapshot, so
-// this is read-committed plus read-your-writes rather than full snapshot isolation. Get
-// does read at the snapshot, so a point lookup and a scan in the same transaction can
-// disagree about a row a *different* transaction committed in between. Making the scan
-// snapshot-consistent needs a scan-at-sequence path the store does not have; the
-// transaction's own writes -- the thing callers actually reach for a transactional query
-// to see -- are exact either way.
+// Consistency: snapshot isolation plus read-your-writes. The committed half is read at
+// the transaction's own snapshot sequence per shard -- the same sequence Get reads at --
+// so a scan and a point lookup in one transaction agree, and a row another transaction
+// commits mid-scan is invisible to both. Scanning a shard captures its snapshot if the
+// transaction has not touched it yet, which pins every later read of that shard too.
 //
-// Cost: with no buffered writes this is exactly Collection.Query, index pushdown and
-// all. Once the transaction has staged a write the committed half becomes a full scan,
-// because the overlay has to know each row's key to tell whether the transaction
-// superseded it, and the indexed query path yields ads without keys. Transactions exist
-// to batch writes, so that trade -- pay only after you have written -- keeps the common
-// BEGIN/SELECT/COMMIT shape at full speed.
+// Cost: a full scan of the committed half, because reading at a past sequence and
+// overlaying by key both need the per-record walk that the indexed query path (which
+// yields ads without keys, at the current sequence) does not do. A transaction that has
+// bought nothing from either -- no buffered writes, and content to read the live store --
+// is better served by Collection.Query, which is what Txn with an untouched write buffer
+// used to fall back to; that fast path is gone now that the snapshot is the point.
 func (tx *Txn) Query(q *vm.Query) iter.Seq[*classad.ClassAd] {
-	if len(tx.writes) == 0 {
-		return tx.c.Query(q)
-	}
 	return func(yield func(*classad.ClassAd) bool) {
 		if !tx.scanCommitted(q, func(_ string, ad *classad.ClassAd) bool { return yield(ad) }) {
 			return
@@ -52,12 +47,13 @@ func (tx *Txn) KeysWhere(q *vm.Query) iter.Seq[string] {
 	}
 }
 
-// scanCommitted visits every committed row matching q whose key the transaction has NOT
-// buffered -- those are represented by the buffered version, which forEachBufferedMatch
-// yields instead. Returns false if the caller stopped early.
+// scanCommitted visits every row matching q that was committed as of the transaction's
+// snapshot and whose key the transaction has NOT buffered -- those are represented by the
+// buffered version, which forEachBufferedMatch yields instead. Returns false if the
+// caller stopped early.
 func (tx *Txn) scanCommitted(q *vm.Query, visit func(key string, ad *classad.ClassAd) bool) bool {
 	ok := true
-	tx.c.ForEachAd(func(key string, ad *classad.ClassAd) bool {
+	tx.c.ForEachAdAt(tx.snapOf, func(key string, ad *classad.ClassAd) bool {
 		if _, superseded := tx.writes[key]; superseded {
 			return true
 		}

--- a/collections/txnquery_test.go
+++ b/collections/txnquery_test.go
@@ -239,3 +239,101 @@ func TestTxnQueryBufferedRowsAreOrdered(t *testing.T) {
 		t.Errorf("got %v, want %v", first, want)
 	}
 }
+
+// A row another transaction commits after this one captured its snapshot is invisible to
+// this transaction's scan -- the property that makes a scan and a point lookup agree.
+// Before ForEachAdAt the scan read the live store and would have seen it.
+func TestTxnQueryIsSnapshotIsolated(t *testing.T) {
+	c := newTxnColl(t)
+	txnCommit(t, c, map[string]*classad.ClassAd{"a": txnAd("alice", 8)})
+
+	tx := c.Begin()
+	// Capture the snapshot: a buffered write touches (and pins) its shard, and the first
+	// scan pins the rest.
+	tx.Put([]byte("staged"), txnAd("staged", 8))
+	if got, want := owners(tx.Query(mustQuery(t, "Cpus >= 4"))), []string{"alice", "staged"}; !slices.Equal(got, want) {
+		t.Fatalf("before the concurrent commit: got %v, want %v", got, want)
+	}
+
+	// Another writer lands a row after this transaction's snapshot.
+	txnCommit(t, c, map[string]*classad.ClassAd{"b": txnAd("bob", 8)})
+
+	if got, want := owners(tx.Query(mustQuery(t, "Cpus >= 4"))), []string{"alice", "staged"}; !slices.Equal(got, want) {
+		t.Errorf("after the concurrent commit: got %v, want %v (bob leaked into the snapshot)", got, want)
+	}
+	// A fresh transaction does see it, so the row really did commit.
+	fresh := c.Begin()
+	if got, want := owners(fresh.Query(mustQuery(t, "Cpus >= 4"))), []string{"alice", "bob"}; !slices.Equal(got, want) {
+		t.Errorf("fresh transaction got %v, want %v", got, want)
+	}
+}
+
+// The scan and a point lookup in one transaction must agree about a row a concurrent
+// writer changed: both read at the transaction's snapshot.
+func TestTxnQueryAgreesWithGet(t *testing.T) {
+	c := newTxnColl(t)
+	txnCommit(t, c, map[string]*classad.ClassAd{"a": txnAd("alice", 8)})
+
+	tx := c.Begin()
+	tx.Put([]byte("staged"), txnAd("staged", 8)) // force the overlay path
+	// Read "a" first, so its shard's snapshot is captured BEFORE the concurrent write.
+	// Without that the transaction would capture the snapshot after the fact and the two
+	// reads would agree trivially, proving nothing.
+	if _, ok := tx.Get([]byte("a")); !ok {
+		t.Fatal("seed row missing")
+	}
+
+	// A concurrent writer moves "a" out of the match set.
+	txnCommit(t, c, map[string]*classad.ClassAd{"a": txnAd("alice", 1)})
+
+	scanned := owners(tx.Query(mustQuery(t, "Cpus >= 4")))
+	ad, ok := tx.Get([]byte("a"))
+	if !ok {
+		t.Fatal("Get lost the row entirely")
+	}
+	cpus, _ := ad.EvaluateAttr("Cpus").IntValue()
+	inScan := slices.Contains(scanned, "alice")
+	if inScan != (cpus >= 4) {
+		t.Errorf("scan says alice matches=%v but Get reports Cpus=%d: the two disagree", inScan, cpus)
+	}
+}
+
+// A transaction that never writes still reads at its snapshot, so repeated scans are
+// stable even while other writers commit.
+func TestTxnQueryRepeatableWithoutWrites(t *testing.T) {
+	c := newTxnColl(t)
+	txnCommit(t, c, map[string]*classad.ClassAd{"a": txnAd("alice", 8)})
+
+	tx := c.Begin()
+	first := owners(tx.Query(mustQuery(t, "Cpus >= 4")))
+
+	txnCommit(t, c, map[string]*classad.ClassAd{"b": txnAd("bob", 8)})
+
+	if second := owners(tx.Query(mustQuery(t, "Cpus >= 4"))); !slices.Equal(first, second) {
+		t.Errorf("repeated scan changed under a concurrent commit: %v then %v", first, second)
+	}
+}
+
+// KeysWhere reads at the snapshot too -- an UPDATE or DELETE inside a transaction must
+// not pick up rows that appeared after it started.
+func TestTxnKeysWhereIsSnapshotIsolated(t *testing.T) {
+	c := newTxnColl(t)
+	txnCommit(t, c, map[string]*classad.ClassAd{"a": txnAd("alice", 8)})
+
+	tx := c.Begin()
+	var before []string
+	for k := range tx.KeysWhere(mustQuery(t, "Cpus >= 4")) {
+		before = append(before, k)
+	}
+	txnCommit(t, c, map[string]*classad.ClassAd{"b": txnAd("bob", 8)})
+
+	var after []string
+	for k := range tx.KeysWhere(mustQuery(t, "Cpus >= 4")) {
+		after = append(after, k)
+	}
+	slices.Sort(before)
+	slices.Sort(after)
+	if !slices.Equal(before, after) {
+		t.Errorf("key set changed under a concurrent commit: %v then %v", before, after)
+	}
+}

--- a/db/db.go
+++ b/db/db.go
@@ -750,11 +750,12 @@ func (t *Txn) LookupClassAd(key string) (*classad.ClassAd, bool) {
 // it reads the committed store -- which is why a caller that has staged writes and then
 // wants to read them back must go through the transaction.
 //
-// See collections.Txn.Query for the two properties worth knowing: the committed half is
-// read live rather than at the transaction's snapshot (read-committed plus
-// read-your-writes, not full snapshot isolation), and it degrades from an indexed query
-// to a full scan once the transaction has buffered a write. Errors only on a malformed
-// constraint.
+// Isolation is snapshot plus read-your-writes: the committed half is read at the
+// transaction's own snapshot sequence, the same one Get reads at, so a scan and a point
+// lookup in one transaction agree and a concurrent commit is invisible to both. The cost
+// is a full scan -- reading at a past sequence and overlaying by key both need the
+// per-record walk the indexed query path skips. See collections.Txn.Query. Errors only on
+// a malformed constraint.
 func (t *Txn) Query(constraint string) (iter.Seq[*classad.ClassAd], error) {
 	q, err := vm.Parse(constraint)
 	if err != nil {

--- a/dbrpc/txnquery.go
+++ b/dbrpc/txnquery.go
@@ -16,6 +16,9 @@ var ErrTxnReadUnsupported = errors.New("dbrpc: server does not support transacti
 // reads the committed store and cannot see them, which is the whole reason this exists --
 // a caller that has staged writes and wants to read them back must come through here.
 //
+// Reads are snapshot-isolated: the committed rows are read at the transaction's own
+// snapshot, so a concurrent commit is invisible for the transaction's lifetime.
+//
 // The transaction's table is implied (opBegin bound it), so unlike QueryTable there is no
 // table argument. A limit <= 0 returns every match. Against a server without the opcode it
 // returns ErrTxnReadUnsupported.


### PR DESCRIPTION
Follow-up to #131, which landed transaction-scoped reads with a documented caveat: the committed half was read live rather than at the transaction's snapshot, so it offered read-committed plus read-your-writes rather than snapshot isolation. This closes that gap.

## The problem

`Txn.Query` and `Txn.KeysWhere` scanned the live store, while `Get` reads at the transaction's snapshot. Two consequences:

- A scan and a point lookup in one transaction could disagree about a row a concurrent writer changed.
- Two scans in one transaction could return different row sets.

## The fix

`Collection.ForEachAdAt(snapOf, fn)` is `ForEachAd` at a caller-chosen sequence per shard. The shard layer already had the pieces — `snapshotAt(s0)` exists for AS OF queries, and `forEachVisibleKeyed` already takes an arbitrary `s0` — so this is the keyed iteration wired to them.

`snapOf` is a callback rather than a map so a transaction captures a shard's sequence lazily on first touch, and having captured it stays pinned for every later read of that shard. Scanning therefore pins the shards it visits, which is what makes a later `Get` agree with the scan.

## What this costs

The no-buffered-writes fast path that delegated to `Collection.Query` is gone. It read the live store, which is precisely the bug. A transaction's scan now always pays the full per-record walk — reading at a past sequence and overlaying by key both need it, and the indexed query path yields ads without keys at the current sequence.

Callers that want the indexed path and do not need transactional semantics should use `Collection.Query` directly, unchanged.

## Testing

Four new tests:

- a row committed by another transaction after the snapshot stays invisible (and a fresh transaction does see it, proving it really committed)
- a scan and a `Get` in one transaction agree about a row a concurrent writer changed
- repeated scans in one transaction are stable under concurrent commits
- `KeysWhere` is isolated too, so an in-transaction UPDATE/DELETE cannot pick up rows that appeared after it started

Each one fails without the change — verified by reverting the single call site and re-running, rather than trusting that they exercise it. The third test in particular started out passing vacuously and was rewritten to capture the snapshot before the concurrent write.

`go vet` and `go test` are clean in all five modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
