### PR TITLE
A projection that chases its expressions' references

### DIFF
--- a/db/archive.go
+++ b/db/archive.go
@@ -166,6 +166,17 @@ func (t *ArchiveTable) QueryRawProjected(constraint string, projection []string,
 	return t.a.QueryRawProjected(q, projection, false, redact), nil
 }
 
+// QueryRawProjectedRefs is QueryRawProjected with the projected expressions' attribute
+// references resolved too, so each yielded ad evaluates self-contained. See
+// db.DB.QueryRawProjectedRefs for why that is a separate call rather than the default.
+func (t *ArchiveTable) QueryRawProjectedRefs(constraint string, projection []string, redact bool) (iter.Seq[collections.RawAd], error) {
+	q, err := vm.Parse(constraint)
+	if err != nil {
+		return nil, fmt.Errorf("archive: parsing constraint: %w", err)
+	}
+	return t.a.QueryRawProjected(q, projection, true, redact), nil
+}
+
 // Aggregate runs a server-side GROUP BY over the archive's matches: it applies the
 // constraint (using the archive's zone-map pruning, so segments no matching record can
 // fall in are never scanned), groups by the raw group columns, and reduces each group

--- a/db/rawwire.go
+++ b/db/rawwire.go
@@ -115,6 +115,30 @@ func (db *DB) QueryRawProjected(constraint string, projection []string, redact b
 	return db.c.QueryRawProjected(q, projection, false, redact), nil
 }
 
+// QueryRawProjectedRefs is QueryRawProjected that also carries the attributes the
+// projected expressions reference, transitively, so each yielded ad EVALUATES
+// self-contained (collections chaseRefs).
+//
+// The distinction matters whenever a projected attribute holds an expression rather than
+// a literal, which is the norm for HTCondor data -- Requirements, Rank and friends are
+// expressions over sibling attributes. Projecting to exactly the requested names drops
+// those siblings, so the expression evaluates to undefined at the far end: asking for
+// Requirements alone answers undefined where asking for the whole ad answers true.
+//
+// QueryRawProjected remains the right call for a relay that must reproduce HTCondor's
+// query protocol, which specifies exactly the requested attributes and nothing more. Use
+// this one when the recipient is going to EVALUATE what it receives.
+func (db *DB) QueryRawProjectedRefs(constraint string, projection []string, redact bool) (iter.Seq[collections.RawAd], error) {
+	if s := strings.TrimSpace(constraint); s == "" || strings.EqualFold(s, "true") {
+		return db.c.ScanRawProjected(projection, true, redact), nil
+	}
+	q, err := vm.Parse(constraint)
+	if err != nil {
+		return nil, fmt.Errorf("classad-db: bad constraint %q: %w", constraint, err)
+	}
+	return db.c.QueryRawProjected(q, projection, true, redact), nil
+}
+
 // QueryRawWire yields each matching ad as a self-contained WIRE-FORM ROW (an
 // inline-names subset ad assembled by slice copies -- see
 // collections.ScanRawWire): the relay form for shipping ads to a remote

--- a/dbrpc/projectrefs_test.go
+++ b/dbrpc/projectrefs_test.go
@@ -1,0 +1,207 @@
+package dbrpc
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/classad"
+)
+
+// seedExprRow stores an ad whose Req attribute is an expression over a sibling, the shape
+// HTCondor data takes (Requirements, Rank, WithinResourceLimits, ...).
+func seedExprRow(t *testing.T, c *Client, key string, memory int64) {
+	t.Helper()
+	ctx := context.Background()
+	tx, err := c.Begin(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ad := "Memory = " + itoaTest(memory) + "\nReq = Memory > 1024\n"
+	if err := tx.NewClassAd(ctx, key, ad); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func itoaTest(n int64) string {
+	if n == 0 {
+		return "0"
+	}
+	var b []byte
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	return string(b)
+}
+
+// evalReq parses a returned ad and evaluates its Req attribute, the way any client that
+// projects and then reads a value must.
+func evalReq(t *testing.T, adText string) classad.Value {
+	t.Helper()
+	ad, err := classad.ParseOld(adText)
+	if err != nil {
+		t.Fatalf("parsing %q: %v", adText, err)
+	}
+	return ad.EvaluateAttr("Req")
+}
+
+// Projecting to exactly the requested attributes drops the sibling an expression
+// attribute reads, so it evaluates to undefined at the far end. This is the existing
+// contract -- correct for a relay reproducing HTCondor's query protocol -- and it is
+// pinned so the new op's behaviour reads as a deliberate difference rather than a change.
+func TestQueryRawProjectDropsExpressionDependencies(t *testing.T) {
+	c, cleanup := testPair(t)
+	defer cleanup()
+	seedExprRow(t, c, "a", 2048)
+
+	rows, err := c.QueryRawProject(context.Background(), DefaultTable, "true", []string{"Req"}, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("got %d rows, want 1", len(rows))
+	}
+	// Not a substring check: the expression TEXT mentions Memory. What must be absent is
+	// a Memory attribute of its own, which is what evaluation would need.
+	ad, err := classad.ParseOld(rows[0])
+	if err != nil {
+		t.Fatalf("parsing %q: %v", rows[0], err)
+	}
+	if _, ok := ad.Lookup("Memory"); ok {
+		t.Errorf("plain projection carried a Memory attribute; it should send exactly what was asked for: %q", rows[0])
+	}
+	if v := evalReq(t, rows[0]); !v.IsUndefined() {
+		t.Errorf("Req evaluated to %v, want undefined (the sibling was projected away)", v)
+	}
+}
+
+// The refs-chasing op carries the referenced sibling, so the same projection evaluates to
+// the answer SELECT * would give.
+func TestQueryRawProjectRefsKeepsExpressionDependencies(t *testing.T) {
+	c, cleanup := testPair(t)
+	defer cleanup()
+	seedExprRow(t, c, "a", 2048)
+
+	rows, err := c.QueryRawProjectRefs(context.Background(), DefaultTable, "true", []string{"Req"}, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("got %d rows, want 1", len(rows))
+	}
+	v := evalReq(t, rows[0])
+	b, err := v.BoolValue()
+	if err != nil || !b {
+		t.Errorf("Req evaluated to %v, want true (the referenced sibling should have come along)", v)
+	}
+}
+
+// The chased result must track the data, not a constant: a row whose sibling fails the
+// test evaluates false.
+func TestQueryRawProjectRefsEvaluatesPerRow(t *testing.T) {
+	c, cleanup := testPair(t)
+	defer cleanup()
+	seedExprRow(t, c, "big", 2048)
+	seedExprRow(t, c, "small", 512)
+
+	rows, err := c.QueryRawProjectRefs(context.Background(), DefaultTable, "true", []string{"Req"}, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("got %d rows, want 2", len(rows))
+	}
+	var sawTrue, sawFalse bool
+	for _, row := range rows {
+		b, err := evalReq(t, row).BoolValue()
+		if err != nil {
+			t.Fatalf("Req did not evaluate to a bool in %q", row)
+		}
+		sawTrue = sawTrue || b
+		sawFalse = sawFalse || !b
+	}
+	if !sawTrue || !sawFalse {
+		t.Errorf("expected one true and one false row; sawTrue=%v sawFalse=%v", sawTrue, sawFalse)
+	}
+}
+
+// A projection of plain literal attributes behaves identically under both ops -- chasing
+// references costs nothing when there are none to chase.
+func TestQueryRawProjectRefsMatchesPlainForLiterals(t *testing.T) {
+	c, cleanup := testPair(t)
+	defer cleanup()
+	ctx := context.Background()
+	tx, err := c.Begin(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.NewClassAd(ctx, "a", "Owner = \"alice\"\nMemory = 2048\n"); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	plain, err := c.QueryRawProject(ctx, DefaultTable, "true", []string{"Owner"}, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	chased, err := c.QueryRawProjectRefs(ctx, DefaultTable, "true", []string{"Owner"}, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plain) != 1 || len(chased) != 1 {
+		t.Fatalf("got %d/%d rows, want 1/1", len(plain), len(chased))
+	}
+	if plain[0] != chased[0] {
+		t.Errorf("literal projection differs:\n plain  = %q\n chased = %q", plain[0], chased[0])
+	}
+}
+
+func TestQueryRawProjectRefsLimitAndStream(t *testing.T) {
+	c, cleanup := testPair(t)
+	defer cleanup()
+	ctx := context.Background()
+	for _, k := range []string{"a", "b", "c"} {
+		seedExprRow(t, c, k, 2048)
+	}
+
+	rows, err := c.QueryRawProjectRefs(ctx, DefaultTable, "true", []string{"Req"}, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 2 {
+		t.Errorf("got %d rows, want 2 (LIMIT was not applied)", len(rows))
+	}
+
+	n := 0
+	err = c.QueryRawProjectRefsStream(ctx, DefaultTable, "true", []string{"Req"}, 0, func(string) bool {
+		n++
+		return true
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 3 {
+		t.Errorf("streamed %d rows, want 3", n)
+	}
+}
+
+// A server that does not implement the opcode is reported as such, so a caller can fall
+// back to the plain projection rather than treating it as a query failure.
+func TestProjectRefsUnsupportedSentinel(t *testing.T) {
+	if got := projectRefsErr(ErrBadRequest); !errors.Is(got, ErrProjectRefsUnsupported) {
+		t.Errorf("projectRefsErr(ErrBadRequest) = %v, want ErrProjectRefsUnsupported", got)
+	}
+	if got := projectRefsErr(nil); got != nil {
+		t.Errorf("projectRefsErr(nil) = %v, want nil", got)
+	}
+	other := errors.New("some other failure")
+	if got := projectRefsErr(other); !errors.Is(got, other) {
+		t.Errorf("projectRefsErr passed through the wrong error: %v", got)
+	}
+}

--- a/dbrpc/proto.go
+++ b/dbrpc/proto.go
@@ -176,6 +176,15 @@ const (
 	// server that does not, instead of the server misparsing a longer frame.
 	opTxnQuery     op = 57 // [txnID u64][limit i32][constraint] -> stream of [adText]
 	opTxnQueryKeys op = 58 // [txnID u64][constraint] -> stream of [key]
+
+	// opQueryRawProjRefs is opQueryRawProj whose projection also carries the attributes
+	// the projected expressions reference, so each returned ad EVALUATES self-contained.
+	// Same request shape; a separate opcode because the two have genuinely different
+	// contracts -- opQueryRawProj reproduces HTCondor's projection protocol (exactly the
+	// requested attributes), which a relay depends on, while a client that evaluates what
+	// it receives needs the references. Separate rather than a flag so an older server
+	// rejects it cleanly instead of misparsing a longer frame.
+	opQueryRawProjRefs op = 59 // [table][limit i32][constraint][nattrs i32]{[attr]} -> stream of [oldClassAdText]
 )
 
 // String names an opcode for diagnostics (e.g. the read-only rejection message).
@@ -271,6 +280,8 @@ func (o op) String() string {
 		return "TxnQuery"
 	case opTxnQueryKeys:
 		return "TxnQueryKeys"
+	case opQueryRawProjRefs:
+		return "QueryRawProjectRefs"
 	}
 	return "op(unknown)"
 }

--- a/dbrpc/queryraw.go
+++ b/dbrpc/queryraw.go
@@ -3,6 +3,7 @@ package dbrpc
 import (
 	"context"
 	"encoding/binary"
+	"errors"
 	"iter"
 	"strings"
 	"time"
@@ -40,6 +41,56 @@ func (c *Client) QueryRawProject(ctx context.Context, table, constraint string, 
 		}
 		return b
 	})
+}
+
+// ErrProjectRefsUnsupported is returned by the refs-chasing projection calls against a
+// server too old to implement the opcode. A caller falls back to QueryRawProject, whose
+// results are correct for literal-valued attributes and undefined for expression-valued
+// ones whose references were projected away.
+var ErrProjectRefsUnsupported = errors.New("dbrpc: server does not support reference-chasing projection")
+
+// QueryRawProjectRefs is QueryRawProject whose projection also carries the attributes the
+// projected expressions reference, transitively, so each returned ad EVALUATES
+// self-contained.
+//
+// Use this whenever the caller is going to evaluate what it receives. QueryRawProject
+// returns exactly the requested attributes -- correct for a relay reproducing HTCondor's
+// query protocol, and wrong for an evaluator, because an attribute holding an expression
+// over its siblings (Requirements, Rank, ...) loses those siblings and evaluates to
+// undefined.
+//
+// Against a server without the opcode it returns ErrProjectRefsUnsupported.
+func (c *Client) QueryRawProjectRefs(ctx context.Context, table, constraint string, attrs []string, limit int) ([]string, error) {
+	rows, err := c.streamCtx(ctx, projectRefsFrame(table, constraint, attrs, limit))
+	return rows, projectRefsErr(err)
+}
+
+// QueryRawProjectRefsStream is QueryRawProjectRefs with the streaming delivery of
+// QueryRawTableStream.
+func (c *Client) QueryRawProjectRefsStream(ctx context.Context, table, constraint string, attrs []string, limit int, yield func(row string) bool) error {
+	return projectRefsErr(c.streamEach(ctx, projectRefsFrame(table, constraint, attrs, limit), yield))
+}
+
+// projectRefsFrame builds the opQueryRawProjRefs request frame (same shape as
+// opQueryRawProj).
+func projectRefsFrame(table, constraint string, attrs []string, limit int) func(uint64) []byte {
+	return func(id uint64) []byte {
+		b := putStr(putI32(putStr(req(id, opQueryRawProjRefs), table), int32(limit)), constraint)
+		b = putI32(b, int32(len(attrs)))
+		for _, a := range attrs {
+			b = putStr(b, a)
+		}
+		return b
+	}
+}
+
+// projectRefsErr maps the server's rejection of an unknown opcode to a sentinel the
+// caller can fall back on, without matching message text.
+func projectRefsErr(err error) error {
+	if errors.Is(err, ErrBadRequest) {
+		return ErrProjectRefsUnsupported
+	}
+	return err
 }
 
 // QueryRawTableStream is QueryRawTable that hands each matching ad's old-ClassAd wire
@@ -171,6 +222,19 @@ func rawAdText(ra collections.RawAd) string {
 // every ad across the wire. The projection is applied server-side; matching is
 // case-insensitive (ClassAd attribute names are).
 func (s *Server) streamQueryRawProject(ctx context.Context, reqID uint64, r *reader, includePrivate bool, write func([]byte), qlog func(QueryLog)) {
+	s.streamQueryRawProjectOpt(ctx, reqID, r, includePrivate, write, qlog, false)
+}
+
+// streamQueryRawProjectRefs is streamQueryRawProject whose projection also carries the
+// attributes the projected expressions reference, so each streamed ad evaluates
+// self-contained at the far end. See db.DB.QueryRawProjectedRefs.
+func (s *Server) streamQueryRawProjectRefs(ctx context.Context, reqID uint64, r *reader, includePrivate bool, write func([]byte), qlog func(QueryLog)) {
+	s.streamQueryRawProjectOpt(ctx, reqID, r, includePrivate, write, qlog, true)
+}
+
+// streamQueryRawProjectOpt is the shared body of the two projection ops; chaseRefs picks
+// which db projection they use.
+func (s *Server) streamQueryRawProjectOpt(ctx context.Context, reqID uint64, r *reader, includePrivate bool, write func([]byte), qlog func(QueryLog), chaseRefs bool) {
 	start := time.Now()
 	table := r.str()
 	limit := int(r.i32())
@@ -183,7 +247,7 @@ func (s *Server) streamQueryRawProject(ctx context.Context, reqID uint64, r *rea
 	n := 0
 	if qlog != nil {
 		defer func() {
-			qlog(QueryLog{Op: "QueryRawProject", Table: table, Constraint: constraint, Limit: limit, Rows: n, Duration: time.Since(start)})
+			qlog(QueryLog{Op: projectOpName(chaseRefs), Table: table, Constraint: constraint, Limit: limit, Rows: n, Duration: time.Since(start)})
 		}()
 	}
 	if r.err != nil {
@@ -198,12 +262,25 @@ func (s *Server) streamQueryRawProject(ctx context.Context, reqID uint64, r *rea
 	// (an archive streams newest-first, like its plain query).
 	var seq iter.Seq[collections.RawAd]
 	var err error
+	redact := !includePrivate
 	if d, ok := s.cat.Table(table); ok {
-		seq, err = d.QueryRawProjected(constraint, attrs, !includePrivate)
+		if chaseRefs {
+			seq, err = d.QueryRawProjectedRefs(constraint, attrs, redact)
+		} else {
+			seq, err = d.QueryRawProjected(constraint, attrs, redact)
+		}
 	} else if d, ok := s.cat.ViewBacking(table); ok {
-		seq, err = d.QueryRawProjected(constraint, attrs, !includePrivate)
+		if chaseRefs {
+			seq, err = d.QueryRawProjectedRefs(constraint, attrs, redact)
+		} else {
+			seq, err = d.QueryRawProjected(constraint, attrs, redact)
+		}
 	} else if a, ok := s.cat.ArchiveTable(table); ok {
-		seq, err = a.QueryRawProjected(constraint, attrs, !includePrivate)
+		if chaseRefs {
+			seq, err = a.QueryRawProjectedRefs(constraint, attrs, redact)
+		} else {
+			seq, err = a.QueryRawProjected(constraint, attrs, redact)
+		}
 	} else {
 		write(respErr(reqID, "no such table: "+table))
 		return
@@ -373,4 +450,12 @@ func (s *Server) streamQueryRawWire(ctx context.Context, reqID uint64, r *reader
 	}
 	flush()
 	write(respHead(reqID, stStreamEnd))
+}
+
+// projectOpName labels a projection query in the query log by which contract it ran under.
+func projectOpName(chaseRefs bool) string {
+	if chaseRefs {
+		return "QueryRawProjectRefs"
+	}
+	return "QueryRawProject"
 }

--- a/dbrpc/server.go
+++ b/dbrpc/server.go
@@ -421,6 +421,8 @@ func (sc *serverConn) dispatch(frame []byte) {
 		sc.s.streamQueryRaw(sc.ctx, reqID, body, priv, sc.write, sc.opts.QueryLog)
 	case opQueryRawProj:
 		sc.s.streamQueryRawProject(sc.ctx, reqID, body, priv, sc.write, sc.opts.QueryLog)
+	case opQueryRawProjRefs:
+		sc.s.streamQueryRawProjectRefs(sc.ctx, reqID, body, priv, sc.write, sc.opts.QueryLog)
 	case opQueryRawWire:
 		sc.s.streamQueryRawWire(sc.ctx, reqID, body, priv, sc.write, sc.opts.QueryLog)
 	case opMatchSorted:


### PR DESCRIPTION
Fixes a silent wrong-data path found while testing SQL SELECT over HTCondor data.

## The problem

Projecting an ad to exactly the requested attributes drops the siblings a projected *expression* reads, so the expression evaluates to undefined at the far end:

```
whole ad                      -->  Req = true
projection {Memory, Req}      -->  Req = true
projection {Req}              -->  Req = undefined   <-- silently wrong
```

This matters because HTCondor data is mostly this shape — `Requirements`, `Rank`, `WithinResourceLimits` and friends are expressions over sibling attributes. Through htcondordb's SQL layer it surfaces as `SELECT Requirements FROM machines` reporting undefined for rows that `SELECT *` reports true for, with no error.

## Why this adds a contract instead of changing one

Returning exactly the requested attributes is *correct* for a relay reproducing HTCondor's query protocol, which specifies exactly that — the collector depends on it. It is wrong only for a client that evaluates what it receives.

So there are now two calls with two contracts:

- `QueryRawProjected` / `opQueryRawProj` — exactly the requested attributes. Unchanged.
- `QueryRawProjectedRefs` / `opQueryRawProjRefs` — plus the attributes the projected expressions reference, transitively, so each ad evaluates self-contained.

`collections` already implemented the hard part: `QueryRawProjected` takes a `chaseRefs` flag that resolves each emitted expression's references against the same ad. `db` hard-coded it `false` at both call sites (mutable table and archive); this exposes it.

## Wire compatibility

A separate opcode rather than a flag on the existing one, so an older server rejects it cleanly — `stBadReq`, surfaced as `ErrProjectRefsUnsupported` — instead of misparsing a longer frame. Same approach as the transaction-scoped reads in #131. The request shape is otherwise identical.

## Testing

- the plain projection's drop behaviour is pinned, so the new op reads as a deliberate difference rather than a change in the old one
- the refs-chasing op evaluates to the whole-ad answer, and per row (one true, one false from the same expression text)
- both ops return byte-identical results when the projected attributes are literals — chasing costs nothing when there is nothing to chase
- LIMIT, the streaming form, and the unsupported-server sentinel

`go vet` and `go test` are clean in all five modules.

## Follow-up

htcondordb's `repl` should call the refs-chasing form for a plain-column SELECT, which is what actually fixes the user-visible bug. That needs a classad tag and a go.mod bump first; it is tracked by a strict xfail and a skipped test already on htcondordb main (`test_value_shapes.py::TestProjectionDropsExpressionDependencies`, `TestProjectedSelectAgreesWithStar`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
