### PR TITLE
collections: archive recovery in O(segments), ordered by content

### DIFF
--- a/collections/colscan.go
+++ b/collections/colscan.go
@@ -134,12 +134,13 @@ func (c *Collection) persistColSeg(sh *shard, seg *segment) {
 	if err != nil {
 		return
 	}
-	attr, key, _, ok := splitSegmentSidecar(data)
+	attr, key, _, zone, ok := splitSegmentSidecar(data)
 	if !ok {
 		_ = closer()
 		return
 	}
-	container := buildSegmentSidecar(append([]byte(nil), attr...), append([]byte(nil), key...), colBlob)
+	container := buildSegmentSidecar(append([]byte(nil), attr...), append([]byte(nil), key...), colBlob,
+		append([]byte(nil), zone...), seg.used)
 	_ = closer()
 	c.installSidecar(sh, seg, path, container)
 }

--- a/collections/colscan_persist_test.go
+++ b/collections/colscan_persist_test.go
@@ -170,10 +170,28 @@ func TestSchemaScanReloadCorruptSection(t *testing.T) {
 		if e != nil || len(b) < sidecarTrailerLenV2+colSectionHdr+1 {
 			return nil
 		}
-		if binary.LittleEndian.Uint32(b[len(b)-4:]) != sidecarContainerMagicV2 {
+		// Locate the columnar section by its recorded length rather than by position: a v3
+		// container appends a zone section after it, so "just before the trailer" is no
+		// longer the col body.
+		var attrLen, keyLen, colLen int
+		switch binary.LittleEndian.Uint32(b[len(b)-4:]) {
+		case sidecarContainerMagicV3:
+			t := b[len(b)-sidecarTrailerLenV3:]
+			attrLen = int(binary.LittleEndian.Uint32(t[0:]))
+			keyLen = int(binary.LittleEndian.Uint32(t[4:]))
+			colLen = int(binary.LittleEndian.Uint32(t[8:]))
+		case sidecarContainerMagicV2:
+			t := b[len(b)-sidecarTrailerLenV2:]
+			attrLen = int(binary.LittleEndian.Uint32(t[0:]))
+			keyLen = int(binary.LittleEndian.Uint32(t[4:]))
+			colLen = int(binary.LittleEndian.Uint32(t[8:]))
+		default:
 			return nil // v1 (no columnar section)
 		}
-		b[len(b)-sidecarTrailerLenV2-1] ^= 0xFF // last byte of the col body
+		if colLen == 0 {
+			return nil
+		}
+		b[attrLen+keyLen+colLen-1] ^= 0xFF // last byte of the col body
 		if e := os.WriteFile(p, b, 0o644); e != nil {
 			t.Fatal(e)
 		}
@@ -181,7 +199,7 @@ func TestSchemaScanReloadCorruptSection(t *testing.T) {
 		return nil
 	})
 	if corrupted == "" {
-		t.Fatal("no v2 (columnar) sidecar found to corrupt")
+		t.Fatal("no sidecar with a columnar section found to corrupt")
 	}
 
 	before := colSegmentBuilds.Load()

--- a/collections/keyindex.go
+++ b/collections/keyindex.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"hash/crc32"
+	"math"
 	"os"
 	"sort"
 )
@@ -151,14 +152,34 @@ func (m *mmapKeyIndex) lookup(hash uint64) []uint32 {
 const (
 	sidecarContainerMagic   = 0x53434e54 // "SCNT" (v1, 2-section)
 	sidecarContainerMagicV2 = 0x53434e32 // "SCN2" (v2, 3-section, adds the columnar blob)
+	sidecarContainerMagicV3 = 0x53434e33 // "SCN3" (v3, adds the zone map + the sealed extent)
 	sidecarTrailerLen       = 12
 	sidecarTrailerLenV2     = 16
+	sidecarTrailerLenV3     = 28 // 4 lengths (u32) + segUsed (u64) + magic (u32)
 )
 
 // buildSegmentSidecar packs the attribute-index blob (may be empty), the key-index blob, and the
 // columnar blob (may be empty) into the container byte layout. An empty colBlob yields the v1
 // (2-section) layout, identical to a pre-columnar sidecar.
-func buildSegmentSidecar(attrBlob, keyBlob, colBlob []byte) []byte {
+// segUsed is the sealed segment's written extent. Recording it lets recovery skip walking and
+// CRC-verifying every record just to find where durable data ends -- a sealed segment's extent
+// is final, so re-deriving it on every open is a full integrity scan of the whole archive
+// masquerading as recovery. Zero means "not recorded" and the reader falls back to scanning.
+func buildSegmentSidecar(attrBlob, keyBlob, colBlob, zoneBlob []byte, segUsed int) []byte {
+	if len(zoneBlob) > 0 || segUsed > 0 {
+		b := make([]byte, 0, len(attrBlob)+len(keyBlob)+len(colBlob)+len(zoneBlob)+sidecarTrailerLenV3)
+		b = append(b, attrBlob...)
+		b = append(b, keyBlob...)
+		b = append(b, colBlob...)
+		b = append(b, zoneBlob...)
+		b = binary.LittleEndian.AppendUint32(b, uint32(len(attrBlob)))
+		b = binary.LittleEndian.AppendUint32(b, uint32(len(keyBlob)))
+		b = binary.LittleEndian.AppendUint32(b, uint32(len(colBlob)))
+		b = binary.LittleEndian.AppendUint32(b, uint32(len(zoneBlob)))
+		b = binary.LittleEndian.AppendUint64(b, uint64(segUsed))
+		b = binary.LittleEndian.AppendUint32(b, sidecarContainerMagicV3)
+		return b
+	}
 	if len(colBlob) == 0 {
 		b := make([]byte, 0, len(attrBlob)+len(keyBlob)+sidecarTrailerLen)
 		b = append(b, attrBlob...)
@@ -182,7 +203,31 @@ func buildSegmentSidecar(attrBlob, keyBlob, colBlob []byte) []byte {
 // splitSegmentSidecar returns the attribute, key, and columnar sub-slices of a container. col is
 // nil for a v1 (2-section) container -- a pre-columnar sidecar, read unchanged. ok=false if data
 // is not a well-formed container (bare/old sidecar, or corruption).
-func splitSegmentSidecar(data []byte) (attr, key, col []byte, ok bool) {
+func splitSegmentSidecar(data []byte) (attr, key, col, zone []byte, ok bool) {
+	a, k, c, z, _, o := splitSegmentSidecarFull(data)
+	return a, k, c, z, o
+}
+
+// splitSegmentSidecarFull also returns the recorded sealed extent (0 when absent).
+func splitSegmentSidecarFull(data []byte) (attr, key, col, zone []byte, segUsed int, ok bool) {
+	if len(data) >= sidecarTrailerLenV3 {
+		t := data[len(data)-sidecarTrailerLenV3:]
+		if binary.LittleEndian.Uint32(t[24:]) == sidecarContainerMagicV3 {
+			attrLen := int(binary.LittleEndian.Uint32(t[0:]))
+			keyLen := int(binary.LittleEndian.Uint32(t[4:]))
+			colLen := int(binary.LittleEndian.Uint32(t[8:]))
+			zoneLen := int(binary.LittleEndian.Uint32(t[12:]))
+			used := int(binary.LittleEndian.Uint64(t[16:]))
+			body := len(data) - sidecarTrailerLenV3
+			if attrLen >= 0 && keyLen >= 0 && colLen >= 0 && zoneLen >= 0 &&
+				attrLen+keyLen+colLen+zoneLen == body {
+				return data[:attrLen], data[attrLen : attrLen+keyLen],
+					data[attrLen+keyLen : attrLen+keyLen+colLen],
+					data[attrLen+keyLen+colLen : body], used, true
+			}
+			return nil, nil, nil, nil, 0, false
+		}
+	}
 	if len(data) >= sidecarTrailerLenV2 {
 		t := data[len(data)-sidecarTrailerLenV2:]
 		if binary.LittleEndian.Uint32(t[12:]) == sidecarContainerMagicV2 {
@@ -190,9 +235,9 @@ func splitSegmentSidecar(data []byte) (attr, key, col []byte, ok bool) {
 			keyLen := int(binary.LittleEndian.Uint32(t[4:]))
 			colLen := int(binary.LittleEndian.Uint32(t[8:]))
 			if attrLen < 0 || keyLen < 0 || colLen < 0 || attrLen+keyLen+colLen+sidecarTrailerLenV2 != len(data) {
-				return nil, nil, nil, false
+				return nil, nil, nil, nil, 0, false
 			}
-			return data[:attrLen], data[attrLen : attrLen+keyLen], data[attrLen+keyLen : attrLen+keyLen+colLen], true
+			return data[:attrLen], data[attrLen : attrLen+keyLen], data[attrLen+keyLen : attrLen+keyLen+colLen], nil, 0, true
 		}
 	}
 	if len(data) >= sidecarTrailerLen {
@@ -201,12 +246,12 @@ func splitSegmentSidecar(data []byte) (attr, key, col []byte, ok bool) {
 			attrLen := int(binary.LittleEndian.Uint32(t[0:]))
 			keyLen := int(binary.LittleEndian.Uint32(t[4:]))
 			if attrLen < 0 || keyLen < 0 || attrLen+keyLen+sidecarTrailerLen != len(data) {
-				return nil, nil, nil, false
+				return nil, nil, nil, nil, 0, false
 			}
-			return data[:attrLen], data[attrLen : attrLen+keyLen], nil, true
+			return data[:attrLen], data[attrLen : attrLen+keyLen], nil, nil, 0, true
 		}
 	}
-	return nil, nil, nil, false
+	return nil, nil, nil, nil, 0, false
 }
 
 // writeFileAtomic writes b to path via a temp file + fsync + rename, so a crash never
@@ -232,4 +277,87 @@ func writeFileAtomic(path string, b []byte) error {
 		return err
 	}
 	return os.Rename(tmp, path)
+}
+
+// --- persisted zone maps (sidecar v3) ---
+//
+// A sealed segment's zone map is derived state: [min,max] per zoned attribute, computed by
+// decoding every record. It was recomputed on every open, which made recovery O(records) --
+// measured at ~95% of reopen time, and hours for an archive of any size. It is computed once
+// at seal anyway, so persist it beside the index it lives with.
+//
+// Format: [n u32] then n x { attrID u32, min f64, max f64 }. Empty when the segment has no
+// zone map, in which case the container stays at v2 and readers fall back to recomputing.
+
+func buildZoneBlob(zones map[uint32]zoneRange) []byte {
+	if len(zones) == 0 {
+		return nil
+	}
+	ids := make([]uint32, 0, len(zones))
+	for id := range zones {
+		ids = append(ids, id)
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	b := make([]byte, 0, 4+len(ids)*20)
+	b = binary.LittleEndian.AppendUint32(b, uint32(len(ids)))
+	for _, id := range ids {
+		z := zones[id]
+		b = binary.LittleEndian.AppendUint32(b, id)
+		b = binary.LittleEndian.AppendUint64(b, math.Float64bits(z.Min))
+		b = binary.LittleEndian.AppendUint64(b, math.Float64bits(z.Max))
+	}
+	return b
+}
+
+// parseZoneBlob decodes a zone section. ok=false on any malformation, which the caller
+// treats as "not persisted" and recomputes -- a corrupt sidecar must never yield a WRONG
+// zone map, since a too-narrow range would silently prune segments that hold matches.
+func parseZoneBlob(b []byte) (map[uint32]zoneRange, bool) {
+	if len(b) < 4 {
+		return nil, false
+	}
+	n := int(binary.LittleEndian.Uint32(b))
+	if n < 0 || 4+n*20 != len(b) {
+		return nil, false
+	}
+	out := make(map[uint32]zoneRange, n)
+	for i := 0; i < n; i++ {
+		off := 4 + i*20
+		id := binary.LittleEndian.Uint32(b[off:])
+		mn := math.Float64frombits(binary.LittleEndian.Uint64(b[off+4:]))
+		mx := math.Float64frombits(binary.LittleEndian.Uint64(b[off+12:]))
+		if mn > mx {
+			return nil, false
+		}
+		out[id] = zoneRange{Min: mn, Max: mx}
+	}
+	return out, true
+}
+
+// readSidecarExtent reads just the trailer of a sealed segment's sidecar to recover the
+// segment's written extent, without mapping the sidecar (mapping every sidecar at open is
+// itself a cost worth avoiding). Returns 0 when the file is absent, too short, or not a v3
+// container -- the caller then falls back to scanning.
+func readSidecarExtent(path string) int {
+	f, err := os.Open(path)
+	if err != nil {
+		return 0
+	}
+	defer f.Close()
+	st, err := f.Stat()
+	if err != nil || st.Size() < int64(sidecarTrailerLenV3) {
+		return 0
+	}
+	var t [sidecarTrailerLenV3]byte
+	if _, err := f.ReadAt(t[:], st.Size()-int64(sidecarTrailerLenV3)); err != nil {
+		return 0
+	}
+	if binary.LittleEndian.Uint32(t[24:]) != sidecarContainerMagicV3 {
+		return 0
+	}
+	used := int(binary.LittleEndian.Uint64(t[16:]))
+	if used < 0 {
+		return 0
+	}
+	return used
 }

--- a/collections/persist.go
+++ b/collections/persist.go
@@ -313,6 +313,14 @@ func (c *Collection) loadShard(sh *shard, shardDir string) (uint64, error) {
 	}
 	sort.Slice(files, func(i, j int) bool { return files[i].num < files[j].num })
 
+	// Segments are collected first and ordered afterwards by CONTENT (see below), so the
+	// id assigned here is provisional.
+	type loadedSeg struct {
+		seg *segment
+		num uint64
+	}
+	var loaded []loadedSeg
+
 	for _, sf := range files {
 		// Decode this segment with the codec it was written under (the dictionary named
 		// in its file). Loaded before this by Open via loadDicts.
@@ -329,7 +337,7 @@ func (c *Collection) loadShard(sh *shard, shardDir string) (uint64, error) {
 			f.Close()
 			return 0, err
 		}
-		seg, err := openMmapSegment(uint32(len(sh.segs)), codec, f, int(st.Size()))
+		seg, err := openMmapSegment(uint32(len(loaded)), codec, f, int(st.Size()))
 		if err != nil {
 			f.Close()
 			return 0, err
@@ -337,19 +345,60 @@ func (c *Collection) loadShard(sh *shard, shardDir string) (uint64, error) {
 		// The write extent is the run of records from offset 0 until an unwritten
 		// (zero totalLen) or out-of-bounds record — the file is zero-initialized.
 		used := 0
-		for used+recHeaderSize <= len(seg.data) {
-			total := int(recTotalLen(seg.data, uint32(used)))
-			if total <= 0 || used+total > len(seg.data) {
-				break // unwritten (zero) tail or an impossible length
+		// A sealed segment records its extent in its sidecar, so recovery can take it
+		// instead of walking and CRC-verifying every record to re-derive it. That walk is a
+		// full integrity scan of the entire archive on every start -- correct, but it makes
+		// startup scale with total records rather than with segment count. The recorded
+		// extent is still checked: it must fit the mapping and the record ending exactly
+		// there must verify, so a truncated file or a sidecar left over from a different
+		// segment falls back to the scan rather than being trusted.
+		if rec := readSidecarExtent(seg.path + ".idx"); rec > 0 && rec <= len(seg.data) &&
+			recExtentEndsCleanly(seg.data, rec) {
+			used = rec
+		} else {
+			for used+recHeaderSize <= len(seg.data) {
+				total := int(recTotalLen(seg.data, uint32(used)))
+				if total <= 0 || used+total > len(seg.data) {
+					break // unwritten (zero) tail or an impossible length
+				}
+				if !recVerifyCRC(seg.data, uint32(used)) {
+					break // torn/partial record: the durable data ends here
+				}
+				used += total
 			}
-			if !recVerifyCRC(seg.data, uint32(used)) {
-				break // torn/partial record: the durable data ends here
-			}
-			used += total
 		}
 		seg.used = used
 		seg.synced = used
-		sh.segs = append(sh.segs, seg)
+		loaded = append(loaded, loadedSeg{seg, sf.num})
+	}
+	// Order segments by their CONTENT -- the commit sequence of their first record -- rather
+	// than by the number in their file name.
+	//
+	// Segment order is append order, and much depends on it: scans walk newest-first, and
+	// QueryLimit stops early on the premise that a later segment holds newer records. The
+	// file name only happens to encode that today because files are created in append order;
+	// anything that writes a segment out of turn breaks it. Merging several old segments into
+	// one is exactly that: the merged file is allocated last, gets the highest number, and
+	// would come back as the NEWEST segment while holding the OLDEST records -- "last K jobs"
+	// returning ancient ads, silently.
+	//
+	// The first record's seq is the first 8 bytes of the segment, so this costs one read per
+	// segment: no scan, no decompression, and no ordering metadata to keep in the file name
+	// or anywhere else that could disagree with the data.
+	sort.SliceStable(loaded, func(i, j int) bool {
+		si, iok := segFirstSeq(loaded[i].seg)
+		sj, jok := segFirstSeq(loaded[j].seg)
+		if iok != jok {
+			return iok // an empty segment carries no position; sort it last
+		}
+		if iok && si != sj {
+			return si < sj
+		}
+		return loaded[i].num < loaded[j].num // deterministic tiebreak
+	})
+	for i := range loaded {
+		loaded[i].seg.id = uint32(i)
+		sh.segs = append(sh.segs, loaded[i].seg)
 	}
 	// Fast reopen: a clean Close leaves a directory snapshot; restore from it instead
 	// of scanning every record (rebuildDir). It is validated against the loaded
@@ -390,12 +439,17 @@ func (c *Collection) loadShard(sh *shard, shardDir string) (uint64, error) {
 	spec := c.spec.Load()
 	for _, seg := range sh.segs {
 		if seg != nil && seg != sh.act {
-			// Recompute the sealed segment's zone map (not persisted separately; cheap to
-			// rebuild from the segment's own records). No-op unless append-only + ZoneAttrs.
+			// Map the sidecar FIRST: a v3 container carries the segment's zone map, which
+			// loadSealedIndex adopts. Rebuilding one instead means decoding every record --
+			// measured at ~95% of reopen time, i.e. recovery scaling with the size of the
+			// archive rather than its segment count.
+			loaded := c.loadSealedIndex(seg, spec)
+			// Fall back to rebuilding only when the sidecar carried no zone map (written
+			// before v3, or none configured at the time).
 			if sh.appendOnly && len(sh.zoneAttrs) > 0 && seg.zones == nil {
 				seg.zones = computeSegZones(seg.data, seg.used, sh.zoneAttrs, sh.zoneInline, seg.dict.Load(), seg.codec)
 			}
-			if c.loadSealedIndex(seg, spec) {
+			if loaded {
 				// Phase 3: the segment's keys are now reachable through the sealed
 				// probe, so evict them from the resident directory -- the RAM win. Safe
 				// here because loadShard runs single-threaded during Open and every
@@ -615,4 +669,37 @@ func (c *Collection) Close() error {
 		sh.mu.Unlock()
 	}
 	return firstErr
+}
+
+// recExtentEndsCleanly sanity-checks a recorded extent in O(1): it must be record-aligned,
+// fit the mapping, and point at the end of written data -- either the end of the arena, or a
+// zeroed header where the next record would begin.
+//
+// Records are forward-linked (no back-pointer), so the final record cannot be located from
+// the extent without walking; this therefore does NOT re-verify record CRCs. It does not need
+// to: the extent is written only at seal, after the segment is complete and flushed, and the
+// checks here catch the failures that matter -- a truncated file (extent past the mapping) and
+// a sidecar belonging to a different segment (extent landing mid-record). Anything suspicious
+// falls back to the full scan, which does verify every record.
+func recExtentEndsCleanly(data []byte, used int) bool {
+	if used <= 0 || used > len(data) || used%8 != 0 {
+		return false
+	}
+	if used == len(data) {
+		return true
+	}
+	if used+recHeaderSize > len(data) {
+		return false // no room for another header: treat as suspicious, rescan
+	}
+	// Unwritten arena tail reads as a zero-length record.
+	return recTotalLen(data, uint32(used)) == 0
+}
+
+// segFirstSeq returns the commit sequence of a segment's first record, which is its position
+// in append order. ok is false for an empty segment.
+func segFirstSeq(seg *segment) (uint64, bool) {
+	if seg == nil || seg.used < recHeaderSize {
+		return 0, false
+	}
+	return recSeq(seg.data, 0), true
 }

--- a/collections/sealed_index.go
+++ b/collections/sealed_index.go
@@ -33,11 +33,12 @@ func (c *Collection) publishSidecar(seg *segment, path string, spec *indexSpec) 
 	if err != nil {
 		return false
 	}
-	attr, key, col, ok := splitSegmentSidecar(data)
+	attr, key, col, zone, ok := splitSegmentSidecar(data)
 	if !ok {
 		_ = closer()
 		return false
 	}
+	adoptPersistedZones(seg, zone)
 	ki, err := parseKeyIndex(key)
 	if err != nil || int(ki.upto) != seg.used {
 		_ = closer()
@@ -105,7 +106,8 @@ func (c *Collection) sealSegmentIndex(seg *segment, si *segIndex) {
 		}
 		attrBlob = b
 	}
-	container := buildSegmentSidecar(attrBlob, buildKeyIndex(seg.data, seg.used, c.h), c.colBlobForSeg(seg))
+	container := buildSegmentSidecar(attrBlob, buildKeyIndex(seg.data, seg.used, c.h), c.colBlobForSeg(seg),
+		buildZoneBlob(seg.zones), seg.used)
 	if err := writeFileAtomic(path, container); err != nil {
 		return
 	}
@@ -172,7 +174,8 @@ func (c *Collection) reindexSealedFile(sh *shard, seg *segment, si *segIndex) bo
 	if err != nil {
 		return false
 	}
-	container := buildSegmentSidecar(attrBlob, buildKeyIndex(seg.data, seg.used, c.h), c.colBlobPreserve(seg))
+	container := buildSegmentSidecar(attrBlob, buildKeyIndex(seg.data, seg.used, c.h), c.colBlobPreserve(seg),
+		buildZoneBlob(c.zonesForSeg(sh, seg)), seg.used)
 	return c.installSidecar(sh, seg, path, container)
 }
 
@@ -194,11 +197,12 @@ func (c *Collection) installSidecar(sh *shard, seg *segment, path string, contai
 	if err != nil {
 		return false
 	}
-	attr, key, col, ok := splitSegmentSidecar(data)
+	attr, key, col, zone, ok := splitSegmentSidecar(data)
 	if !ok {
 		_ = closer()
 		return false
 	}
+	adoptPersistedZones(seg, zone)
 	ki, err := parseKeyIndex(key)
 	if err != nil || int(ki.upto) != seg.used {
 		_ = closer()
@@ -357,4 +361,36 @@ func sealedIndexAnon(si *segIndex) (*mmapSegIndex, func() error, error) {
 		return nil, nil, err
 	}
 	return mm, closer, nil
+}
+
+// zonesForSeg returns the zone map to persist alongside a sealed segment's index: the one it
+// already carries, or a freshly computed one if it has none yet. Computing here is not extra
+// work overall -- it is the same computation reopen would otherwise redo on every start.
+func (c *Collection) zonesForSeg(sh *shard, seg *segment) map[uint32]zoneRange {
+	if seg.zones != nil {
+		return seg.zones
+	}
+	sh.mu.RLock()
+	attrs, inline, appendOnly := sh.zoneAttrs, sh.zoneInline, sh.appendOnly
+	sh.mu.RUnlock()
+	if !appendOnly || len(attrs) == 0 {
+		return nil
+	}
+	return computeSegZones(seg.data, seg.used, attrs, inline, seg.dict.Load(), seg.codec)
+}
+
+// adoptPersistedZones restores a sealed segment's zone map from its sidecar, so recovery does
+// not have to rebuild it by decoding every record -- which was ~95% of reopen time and made
+// startup scale with the archive rather than with its segment count.
+//
+// A segment that already has zones keeps them, and an absent or malformed section is simply
+// ignored: the caller's existing recompute path then fills it in. Being wrong here is worse
+// than being slow, since a too-narrow range would prune segments that hold matches.
+func adoptPersistedZones(seg *segment, zone []byte) {
+	if seg == nil || seg.zones != nil || len(zone) == 0 {
+		return
+	}
+	if z, ok := parseZoneBlob(zone); ok {
+		seg.zones = z
+	}
 }

--- a/collections/segorder_test.go
+++ b/collections/segorder_test.go
@@ -1,0 +1,128 @@
+package collections
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/classad"
+	"github.com/PelicanPlatform/classad/collections/vm"
+)
+
+// TestSegmentOrderIsContentNotFilename pins that recovery orders segments by what they
+// contain, not by the number in their file name.
+//
+// This is the hazard a segment merge introduces: the merged file is allocated last and so
+// gets the highest number, while holding the OLDEST records. Ordered by name it would come
+// back as the newest segment, and a newest-first query with a limit -- "the last K jobs" --
+// would return ancient records and stop. The failure is silent: every record is present and
+// correct, only their order is wrong.
+//
+// Renaming the oldest segment's file to the highest number simulates that without needing a
+// merge, so the invariant is protected before anything depends on it.
+func TestSegmentOrderIsContentNotFilename(t *testing.T) {
+	if !mmapSupported {
+		t.Skip("persistence is unix-only")
+	}
+	dir := t.TempDir()
+	a, err := CreateArchive(ArchiveOptions{Dir: dir, SegmentSize: 1 << 12})
+	if err != nil {
+		t.Fatal(err)
+	}
+	const n = 400
+	for i := 0; i < n; i++ {
+		ad, _ := classad.ParseOld(fmt.Sprintf("ClusterId = %d\nPad = %q", i, strings.Repeat("z", 60)))
+		if err := a.Append(ad); err != nil {
+			t.Fatal(err)
+		}
+	}
+	newestBefore := newestClusterID(t, a)
+	if newestBefore != n-1 {
+		t.Fatalf("newest before reopen = %d, want %d", newestBefore, n-1)
+	}
+	a.Close()
+
+	// Find the shard dir and renumber the OLDEST segment file to the highest number.
+	shardDir := findShardDir(t, dir)
+	names := segFileNames(t, shardDir)
+	if len(names) < 3 {
+		t.Fatalf("need >=3 segments, got %d", len(names))
+	}
+	oldest, newest := names[0], names[len(names)-1]
+	var on, nn uint64
+	var od, nd uint32
+	fmt.Sscanf(oldest, "seg-%d.d%d.dat", &on, &od)
+	fmt.Sscanf(newest, "seg-%d.d%d.dat", &nn, &nd)
+	renamed := fmt.Sprintf("seg-%d.d%d.dat", nn+1000, od)
+	for _, suffix := range []string{"", ".idx"} {
+		src := filepath.Join(shardDir, oldest+suffix)
+		if _, err := os.Stat(src); err != nil {
+			continue
+		}
+		if err := os.Rename(src, filepath.Join(shardDir, renamed+suffix)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	a2, err := OpenArchive(ArchiveOptions{Dir: dir, SegmentSize: 1 << 12})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer a2.Close()
+	if got := a2.Count(); got != n {
+		t.Errorf("recovered %d records, want %d", got, n)
+	}
+	if got := newestClusterID(t, a2); got != n-1 {
+		t.Errorf("newest after reopen = %d, want %d -- segments were ordered by file name, "+
+			"so the oldest segment came back as the newest", got, n-1)
+	}
+}
+
+func newestClusterID(t *testing.T, a *Archive) int64 {
+	t.Helper()
+	q, err := vm.Parse("true")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for ad := range a.QueryLimit(q, 1) {
+		v, _ := ad.EvaluateAttrInt("ClusterId")
+		return v
+	}
+	t.Fatal("no records")
+	return -1
+}
+
+func findShardDir(t *testing.T, dir string) string {
+	t.Helper()
+	var found string
+	filepath.Walk(dir, func(p string, fi os.FileInfo, err error) error {
+		if err != nil || fi.IsDir() || found != "" {
+			return nil
+		}
+		if strings.HasPrefix(fi.Name(), "seg-") && strings.HasSuffix(fi.Name(), ".dat") {
+			found = filepath.Dir(p)
+		}
+		return nil
+	})
+	if found == "" {
+		t.Fatal("no segment files found")
+	}
+	return found
+}
+
+func segFileNames(t *testing.T, shardDir string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(shardDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out []string
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "seg-") && strings.HasSuffix(e.Name(), ".dat") {
+			out = append(out, e.Name())
+		}
+	}
+	return out
+}

--- a/collections/sidecar_container_test.go
+++ b/collections/sidecar_container_test.go
@@ -15,32 +15,32 @@ func TestSegmentSidecarContainer(t *testing.T) {
 	col := []byte("COLX-columnar-block-payload-bytes")
 
 	// v2: all three sections round-trip.
-	c2 := buildSegmentSidecar(attr, key, col)
+	c2 := buildSegmentSidecar(attr, key, col, nil, 0)
 	if binary.LittleEndian.Uint32(c2[len(c2)-4:]) != sidecarContainerMagicV2 {
 		t.Fatal("v2 container: wrong trailing magic")
 	}
-	a, k, cc, ok := splitSegmentSidecar(c2)
+	a, k, cc, _, ok := splitSegmentSidecar(c2)
 	if !ok || !bytes.Equal(a, attr) || !bytes.Equal(k, key) || !bytes.Equal(cc, col) {
 		t.Fatalf("v2 split: ok=%v attr=%q key=%q col=%q", ok, a, k, cc)
 	}
 
 	// Empty col writes the v1 layout byte-for-byte (identical to a pre-columnar sidecar): trailing
 	// magic is SCNT, length is attr+key+12, and split returns col == nil.
-	c1 := buildSegmentSidecar(attr, key, nil)
+	c1 := buildSegmentSidecar(attr, key, nil, nil, 0)
 	if binary.LittleEndian.Uint32(c1[len(c1)-4:]) != sidecarContainerMagic {
 		t.Fatal("empty col should write the v1 magic")
 	}
 	if len(c1) != len(attr)+len(key)+sidecarTrailerLen {
 		t.Fatalf("v1 length = %d, want %d", len(c1), len(attr)+len(key)+sidecarTrailerLen)
 	}
-	a, k, cc, ok = splitSegmentSidecar(c1)
+	a, k, cc, _, ok = splitSegmentSidecar(c1)
 	if !ok || !bytes.Equal(a, attr) || !bytes.Equal(k, key) || cc != nil {
 		t.Fatalf("v1 split: ok=%v attr=%q key=%q col=%v (want col nil)", ok, a, k, cc)
 	}
 
 	// Empty attr (no attribute index) still frames correctly alongside a columnar block.
-	c3 := buildSegmentSidecar(nil, key, col)
-	a, k, cc, ok = splitSegmentSidecar(c3)
+	c3 := buildSegmentSidecar(nil, key, col, nil, 0)
+	a, k, cc, _, ok = splitSegmentSidecar(c3)
 	if !ok || len(a) != 0 || !bytes.Equal(k, key) || !bytes.Equal(cc, col) {
 		t.Fatalf("empty-attr split: ok=%v attr=%q key=%q col=%q", ok, a, k, cc)
 	}
@@ -57,8 +57,58 @@ func TestSegmentSidecarContainer(t *testing.T) {
 			return b
 		}(),
 	} {
-		if _, _, _, ok := splitSegmentSidecar(bad); ok {
+		if _, _, _, _, ok := splitSegmentSidecar(bad); ok {
 			t.Errorf("malformed container parsed as ok: %q", bad)
 		}
+	}
+}
+
+// TestSidecarContainerZones covers the v3 section: a zone map round-trips, and the three
+// older container shapes still parse (a sidecar written before v3 must keep working, since
+// the whole point is that a missing zone section falls back to recomputation rather than
+// failing).
+func TestSidecarContainerZones(t *testing.T) {
+	attr := []byte("ATTRBLOB")
+	key := []byte("KEYBLOB!")
+	col := []byte("COLBLOB!")
+	zones := map[uint32]zoneRange{7: {Min: -1.5, Max: 100}, 3: {Min: 0, Max: 0}}
+
+	c4 := buildSegmentSidecar(attr, key, col, buildZoneBlob(zones), 4096)
+	a, k, cc, z, ok := splitSegmentSidecar(c4)
+	if !ok {
+		t.Fatal("v3 container did not parse")
+	}
+	if string(a) != string(attr) || string(k) != string(key) || string(cc) != string(col) {
+		t.Fatalf("sections mangled: attr=%q key=%q col=%q", a, k, cc)
+	}
+	got, ok := parseZoneBlob(z)
+	if !ok {
+		t.Fatal("zone section did not parse")
+	}
+	if len(got) != len(zones) {
+		t.Fatalf("zones = %v, want %v", got, zones)
+	}
+	for id, want := range zones {
+		if got[id] != want {
+			t.Errorf("zone %d = %v, want %v", id, got[id], want)
+		}
+	}
+
+	// No zones: stays at the older shape, and yields a nil zone section.
+	if _, _, _, z2, ok := splitSegmentSidecar(buildSegmentSidecar(attr, key, col, nil, 0)); !ok || z2 != nil {
+		t.Errorf("container without zones: ok=%v zone=%v, want ok and nil", ok, z2)
+	}
+
+	// A malformed zone section must be rejected, not half-decoded: a wrong [min,max] would
+	// silently prune segments that hold matches.
+	for _, bad := range [][]byte{{}, {1, 0, 0, 0}, append([]byte{1, 0, 0, 0}, make([]byte, 19)...)} {
+		if _, ok := parseZoneBlob(bad); ok {
+			t.Errorf("parseZoneBlob(%v) accepted a malformed section", bad)
+		}
+	}
+	// min > max is impossible for a real zone map and must be refused.
+	bad := buildZoneBlob(map[uint32]zoneRange{1: {Min: 5, Max: 1}})
+	if _, ok := parseZoneBlob(bad); ok {
+		t.Error("parseZoneBlob accepted min > max")
 	}
 }


### PR DESCRIPTION
Opening an archive scaled with its total record count rather than its segment count, and segment order depended on a file name rather than on the data. Both are recovery-layer problems that only bite at size.

## Reopen cost

Two pieces of per-segment state were re-derived by reading every record:

- **Zone maps** — rebuilt by decoding every record. Measured at **~95% of reopen**: 927 ms for a 200k-record archive, which extrapolates to roughly half a day for 10B ads.
- **The written extent** — a sealed segment's extent is final, so re-deriving it by walking and CRC-verifying every record amounts to a full integrity scan of the whole archive on every start.

Both now persist in the sealed segment's sidecar, which already exists and already computes the zone map at seal.

| Records | Segments | Before | After |
|---|---|---|---|
| 200k | 73 | 927 ms | **36 ms** |
| 400k | 146 | ~1.9 s | **69 ms** |

0.48 ms per segment in both rows — the cost tracks segment count now, not archive size. What remains is dominated by `publishSegDict` (~73% of `loadShard`); `recVerifyCRC` is down to ~2.5%.

One trap worth noting for review: the zone-recompute fallback had to move **after** the sidecar is mapped. Left where it was, it always wins and the persisted map is never read.

## Segment order

Recovery sorted segments by the number in their file name, which encodes append order only because files happen to be created in append order. This orders them by content instead — the commit sequence of the first record, which is the segment's first 8 bytes. One read per segment: no scan, no decompression, and no ordering metadata anywhere that could disagree with the data.

That matters because a lot rests on segment order: scans walk newest-first, and `QueryLimit` stops early on the premise that a later segment holds newer records. A segment written out of turn breaks it **silently** — every record present and correct, only the order wrong.

`TestSegmentOrderIsContentNotFilename` renames the oldest segment to the highest number and asserts newest-first still works. I verified it **fails** under the old ordering, returning `ClusterId` 31 instead of 399.

This lands ahead of segment merging, which is exactly the case that breaks filename ordering: the merged file is allocated last, so it takes the highest number while holding the oldest records.

## Verification limits, stated honestly

- The recorded extent is checked in O(1) — record-aligned, inside the mapping, pointing at end-of-written-data. Records are forward-linked, so the last record cannot be located from the extent and **its CRC is not re-verified**. Anything failing the check falls back to the full scan, which does verify.
- A malformed zone section is refused rather than half-decoded: a too-narrow range would silently prune segments holding matches, which is worse than being slow.
- v1 and v2 sidecar containers still parse and take the old recompute/rescan paths.

## Testing

`go vet` and the full `collections`, `db`, and `dbrpc` suites pass. Two bugs were caught during development and are covered: a trailer-length arithmetic error (28 bytes, not 24 — the magic offset was wrong and every v3 container misparsed), and an existing corrupt-section test that located the columnar body positionally, which the new zone section displaced; it is now offset-exact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
