### PR TITLE
Chase projected expressions' references on inline-name ads too

### DIFF
--- a/collections/inlinerefs_test.go
+++ b/collections/inlinerefs_test.go
@@ -1,0 +1,145 @@
+package collections
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/classad"
+)
+
+// newInlineColl opens a persistent (inline-name) collection, the storage a daemon runs and
+// the one where reference chasing used to be a no-op.
+func newInlineColl(t *testing.T) *Collection {
+	t.Helper()
+	c, err := Open(Options{Dir: t.TempDir() + "/store", Shards: 2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { c.Close() })
+	if !c.inline {
+		t.Skip("this store is not inline-name; the test targets that representation")
+	}
+	return c
+}
+
+// projectedNames returns the attribute names present in the one projected ad.
+func projectedNames(t *testing.T, c *Collection, projection []string, chaseRefs bool) []string {
+	t.Helper()
+	var names []string
+	n := 0
+	for ra := range c.ScanRawProjected(projection, chaseRefs, false) {
+		n++
+		for _, e := range ra.Exprs {
+			if name, _, ok := strings.Cut(string(e), " = "); ok {
+				names = append(names, strings.TrimSpace(name))
+			}
+		}
+	}
+	if n != 1 {
+		t.Fatalf("got %d ads, want 1", n)
+	}
+	slices.Sort(names)
+	return names
+}
+
+// A projected expression's references come along, so the projected ad evaluates to the
+// same answer the whole ad does. Without chasing, Req loses Memory and goes undefined --
+// which is what a persistent store did regardless of the flag.
+func TestInlineChaseRefsCarriesReferencedAttributes(t *testing.T) {
+	c := newInlineColl(t)
+	putAd(t, c, "a", "Memory = 2048\nReq = Memory > 1024\n")
+
+	if got, want := projectedNames(t, c, []string{"Req"}, false), []string{"Req"}; !slices.Equal(got, want) {
+		t.Errorf("without chasing got %v, want %v (the projection must be served exactly)", got, want)
+	}
+	if got, want := projectedNames(t, c, []string{"Req"}, true), []string{"Memory", "Req"}; !slices.Equal(got, want) {
+		t.Errorf("with chasing got %v, want %v", got, want)
+	}
+}
+
+// The projected ad must actually evaluate, which is the contract the flag promises.
+func TestInlineChaseRefsProjectionEvaluates(t *testing.T) {
+	c := newInlineColl(t)
+	putAd(t, c, "big", "Memory = 2048\nReq = Memory > 1024\n")
+
+	for ra := range c.ScanRawProjected([]string{"Req"}, true, false) {
+		ad, err := classad.ParseOld(strings.Join(exprStrings(ra), "\n") + "\n")
+		if err != nil {
+			t.Fatalf("parsing the projected ad: %v", err)
+		}
+		b, err := ad.EvaluateAttr("Req").BoolValue()
+		if err != nil || !b {
+			t.Errorf("Req evaluated to %v, want true", ad.EvaluateAttr("Req"))
+		}
+	}
+}
+
+// References are followed transitively, and each pass adds strictly more, so a chain
+// terminates rather than looping.
+func TestInlineChaseRefsIsTransitive(t *testing.T) {
+	c := newInlineColl(t)
+	putAd(t, c, "a", "Base = 4\nMid = Base * 2\nTop = Mid > 4\n")
+
+	got := projectedNames(t, c, []string{"Top"}, true)
+	if want := []string{"Base", "Mid", "Top"}; !slices.Equal(got, want) {
+		t.Errorf("got %v, want %v (the chain was not followed all the way)", got, want)
+	}
+}
+
+// A self-referential or mutually-referential ad must not spin: the wanted set only grows,
+// and is capped by the ad's attribute count.
+func TestInlineChaseRefsTerminatesOnCycles(t *testing.T) {
+	c := newInlineColl(t)
+	putAd(t, c, "a", "X = Y + 1\nY = X + 1\nZ = X\n")
+
+	got := projectedNames(t, c, []string{"Z"}, true)
+	if want := []string{"X", "Y", "Z"}; !slices.Equal(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+// Only references that resolve against this ad are chased; TARGET. and PARENT. name a
+// different ad and must not drag attributes in.
+func TestInlineChaseRefsIgnoresOtherScopes(t *testing.T) {
+	c := newInlineColl(t)
+	putAd(t, c, "a", "Memory = 2048\nReq = TARGET.Memory > 1024\n")
+
+	if got, want := projectedNames(t, c, []string{"Req"}, true), []string{"Req"}; !slices.Equal(got, want) {
+		t.Errorf("got %v, want %v (a TARGET. reference must not pull in a local attribute)", got, want)
+	}
+}
+
+// A reference to a private attribute is not a way around redaction.
+func TestInlineChaseRefsRespectsRedaction(t *testing.T) {
+	c := newInlineColl(t)
+	putAd(t, c, "a", "ClaimId = \"secret\"\nReq = ClaimId =!= undefined\n")
+
+	for ra := range c.ScanRawProjected([]string{"Req"}, true, true) {
+		for _, e := range ra.Exprs {
+			if strings.Contains(strings.ToLower(string(e)), "claimid = ") {
+				t.Errorf("a redacted private attribute was pulled in as a reference: %q", e)
+			}
+		}
+	}
+}
+
+// Chasing costs nothing when the projected attributes are literals: same result either way.
+func TestInlineChaseRefsNoopForLiterals(t *testing.T) {
+	c := newInlineColl(t)
+	putAd(t, c, "a", "Owner = \"alice\"\nMemory = 2048\n")
+
+	plain := projectedNames(t, c, []string{"Owner"}, false)
+	chased := projectedNames(t, c, []string{"Owner"}, true)
+	if !slices.Equal(plain, chased) {
+		t.Errorf("literal projection differs: plain %v vs chased %v", plain, chased)
+	}
+}
+
+func exprStrings(ra RawAd) []string {
+	out := make([]string, 0, len(ra.Exprs))
+	for _, e := range ra.Exprs {
+		out = append(out, string(e))
+	}
+	return out
+}

--- a/collections/rawprojected.go
+++ b/collections/rawprojected.go
@@ -23,6 +23,9 @@ import (
 // ad evaluates self-contained. HTCondor's query protocol sends exactly the
 // requested attributes, so a protocol-compatible server passes false.
 //
+// It applies to both representations: an interned collection resolves references
+// by id, a persistent (inline-name) one by name.
+//
 // redact strips private attributes exactly as ScanRawRedacted does. An empty
 // projection means no attribute filter (the whole ad, matching QueryRawProject
 // semantics upstream). Inline-name collections yield nothing, as with ScanRaw.
@@ -101,6 +104,14 @@ type rawProjector struct {
 	inNames  []string
 	inHashes []uint32
 	inDone   []uint32 // gen-marked per projected name (see gen)
+	// Reference-closure additions for the CURRENT inline ad, the name-based twin of
+	// wantGen: names surfaced by chaseRefs that were not in the projection. Reset per ad
+	// (see renderInline) rather than gen-marked, because the set is keyed by name rather
+	// than by a dense id that could index a slot.
+	inRefNames  []string
+	inRefHashes []uint32
+	inRefDone   []bool
+	refNames    [][]byte // per-node reference-name scratch
 
 	haveMyType, haveTargetType bool
 	myTypeID, targetTypeID     uint32
@@ -327,23 +338,54 @@ func boolInt(b bool) int {
 	return 0
 }
 
+// noteInlineRef adds a referenced name to the current ad's wanted set, reporting whether
+// it was new. A name already in the projection is not added: it is either emitted or will
+// be reached by the walk on its own.
+func (p *rawProjector) noteInlineRef(name []byte, gen uint32) bool {
+	h := wire.NameHash32Bytes(name)
+	for i, wh := range p.inHashes {
+		if wh == h && wire.FoldEqualBytes(name, p.inNames[i]) {
+			return false // in the projection already
+		}
+	}
+	for i, rh := range p.inRefHashes {
+		if rh == h && wire.FoldEqualBytes(name, p.inRefNames[i]) {
+			return false // already noted for this ad
+		}
+	}
+	if p.redact && isPrivateNameBytes(name) {
+		return false // a private attribute never leaves a redacted response, reference or not
+	}
+	p.inRefNames = append(p.inRefNames, string(name))
+	p.inRefHashes = append(p.inRefHashes, h)
+	p.inRefDone = append(p.inRefDone, false)
+	return true
+}
+
 // renderInline is render for a persistent (inline-names) collection: entries
 // carry their names in the ad body, so the wanted test is hash-first (the same
 // folded hash the inline hot header uses) verified by a case-insensitive byte
 // compare. The hot fast path resolves (hash, entry-offset) pairs and early-exits
-// when the whole projection plus both type fields were found hot. chaseRefs is
-// not supported for inline ads (their expressions reference attributes by
-// inline name, not id); the projection is served exactly.
+// when the whole projection plus both type fields were found hot.
+//
+// chaseRefs resolves references by inline NAME here, mirroring the id-based closure in
+// render: an emitted expression's unscoped/MY. references are added to a per-ad wanted
+// set and the walk repeats while new ones surface. The hot fast path cannot early-exit
+// once a reference is pending, since the referenced attribute may be cold.
 func (p *rawProjector) renderInline(w []byte) (RawAd, bool) {
 	p.gen++
 	gen := p.gen
 	p.buf = p.buf[:0]
 	p.offs = append(p.offs[:0], 0)
+	p.inRefNames = p.inRefNames[:0]
+	p.inRefHashes = p.inRefHashes[:0]
+	p.inRefDone = p.inRefDone[:0]
 	var myType, targetType string
 	var mtDone, ttDone bool
 	ad := wire.Ad(w)
 
 	good := true
+	again := false
 	handle := func(name, node []byte) bool {
 		if !mtDone && wire.FoldEqualBytes(name, "MyType") {
 			if lit, ok := wire.LiteralValue(node); ok && lit.Kind == wire.LitString {
@@ -373,6 +415,18 @@ func (p *rawProjector) renderInline(w []byte) (RawAd, bool) {
 					break
 				}
 			}
+			// Not in the projection: it may still be wanted as a reference an already
+			// emitted expression made, which is what keeps a projected expression
+			// evaluable at the far end.
+			if !hit {
+				for i, rh := range p.inRefHashes {
+					if rh == h && !p.inRefDone[i] && wire.FoldEqualBytes(name, p.inRefNames[i]) {
+						p.inRefDone[i] = true
+						hit = true
+						break
+					}
+				}
+			}
 			if !hit {
 				return true
 			}
@@ -386,6 +440,14 @@ func (p *rawProjector) renderInline(w []byte) (RawAd, bool) {
 			return false
 		}
 		p.offs = append(p.offs, len(p.buf))
+		if p.chaseRefs && !p.wantAll {
+			p.refNames = wire.AppendNodeRefNames(node, p.refNames[:0])
+			for _, rn := range p.refNames {
+				if p.noteInlineRef(rn, gen) {
+					again = true
+				}
+			}
+		}
 		return true
 	}
 
@@ -401,7 +463,7 @@ func (p *rawProjector) renderInline(w []byte) (RawAd, bool) {
 			return RawAd{}, false
 		}
 		satisfied := (len(p.offs) - 1) + boolInt(mtDone) + boolInt(ttDone)
-		if hotOK && satisfied == needed {
+		if hotOK && satisfied == needed && !again {
 			p.exprs = p.exprs[:0]
 			for i := 0; i+1 < len(p.offs); i++ {
 				p.exprs = append(p.exprs, p.buf[p.offs[i]:p.offs[i+1]])
@@ -410,8 +472,17 @@ func (p *rawProjector) renderInline(w []byte) (RawAd, bool) {
 		}
 	}
 
-	if !ad.ForEachNameNode(handle) || !good {
-		return RawAd{}, false
+	// Repeat while chaseRefs surfaced names not yet emitted: an earlier entry in the walk
+	// may hold one. Bounded -- each pass strictly grows the wanted set, capped by the ad's
+	// own attribute count -- exactly as the id-based closure is.
+	for {
+		again = false
+		if !ad.ForEachNameNode(handle) || !good {
+			return RawAd{}, false
+		}
+		if !again {
+			break
+		}
 	}
 	p.exprs = p.exprs[:0]
 	for i := 0; i+1 < len(p.offs); i++ {

--- a/collections/wire/refs.go
+++ b/collections/wire/refs.go
@@ -25,6 +25,24 @@ func AppendNodeRefIDs(node []byte, dst []uint32) []uint32 {
 	return refNode(c, 0, dst)
 }
 
+// AppendNodeRefNames is AppendNodeRefIDs for an INLINE-NAME ad: it appends the inline
+// name of every attribute reference inside node that could resolve against the enclosing
+// ad -- unscoped and MY.-scoped -- returning the extended slice.
+//
+// A persistent (inline-name) collection stores references as names rather than interned
+// ids, so the id collector finds nothing in one; this is what lets a projection over such
+// a collection build the same reference closure. The appended names are sub-slices of
+// node, valid for as long as node is, and are NOT copied -- a caller that retains them
+// past the record's buffer must copy.
+//
+// Same superset semantics as AppendNodeRefIDs: nested record members are included even
+// though member resolution could shadow them, duplicates are appended as-is, and an
+// encrypted node contributes nothing.
+func AppendNodeRefNames(node []byte, dst [][]byte) [][]byte {
+	c := &cursor{b: node, ok: true}
+	return refNodeNames(c, 0, dst)
+}
+
 func refNode(c *cursor, depth int, dst []uint32) []uint32 {
 	if !c.ok || depth > maxDepth {
 		c.ok = false
@@ -127,6 +145,114 @@ func refAdBody(c *cursor, depth int, dst []uint32) []uint32 {
 	for i := uint64(0); i < attrCount && c.ok; i++ {
 		c.skipKey()
 		dst = refNode(c, depth+1, dst)
+	}
+	return dst
+}
+
+func refNodeNames(c *cursor, depth int, dst [][]byte) [][]byte {
+	if !c.ok || depth > maxDepth {
+		c.ok = false
+		return dst
+	}
+	tag := c.byteAt()
+	switch tag {
+	case nUndefined, nError, nBoolFalse, nBoolTrue:
+		// no payload
+	case nInt:
+		_, n := binary.Varint(c.b[c.pos:])
+		if n <= 0 {
+			c.ok = false
+			return dst
+		}
+		c.pos += n
+	case nReal:
+		c.skip(8)
+	case nString:
+		c.skip(int(c.uvarint()))
+	case nAttrRef:
+		c.skip(1)   // scope byte
+		c.uvarint() // interned id: an inline-name ad resolves by name, nothing to collect
+	case nAttrRefStr:
+		scope := c.byteAt()
+		n := int(c.uvarint())
+		start := c.pos
+		c.skip(n)
+		if c.ok && (ast.AttributeScope(scope) == ast.NoScope || ast.AttributeScope(scope) == ast.MyScope) {
+			dst = append(dst, c.b[start:start+n])
+		}
+	case nBinOp:
+		c.skip(1) // op id
+		dst = refNodeNames(c, depth+1, dst)
+		dst = refNodeNames(c, depth+1, dst)
+	case nBinOpStr:
+		c.skip(int(c.uvarint())) // op string
+		dst = refNodeNames(c, depth+1, dst)
+		dst = refNodeNames(c, depth+1, dst)
+	case nUnOp:
+		c.skip(1)
+		dst = refNodeNames(c, depth+1, dst)
+	case nUnOpStr:
+		c.skip(int(c.uvarint()))
+		dst = refNodeNames(c, depth+1, dst)
+	case nList:
+		n := c.uvarint()
+		for i := uint64(0); i < n && c.ok; i++ {
+			dst = refNodeNames(c, depth+1, dst)
+		}
+	case nRecord:
+		dst = refAdBodyNames(c, depth+1, dst)
+	case nFunc:
+		c.uvarint() // function name id: not an attribute reference
+		n := c.uvarint()
+		for i := uint64(0); i < n && c.ok; i++ {
+			dst = refNodeNames(c, depth+1, dst)
+		}
+	case nFuncStr:
+		c.skip(int(c.uvarint())) // inline function name
+		n := c.uvarint()
+		for i := uint64(0); i < n && c.ok; i++ {
+			dst = refNodeNames(c, depth+1, dst)
+		}
+	case nCond:
+		dst = refNodeNames(c, depth+1, dst)
+		dst = refNodeNames(c, depth+1, dst)
+		dst = refNodeNames(c, depth+1, dst)
+	case nElvis, nSubscript:
+		dst = refNodeNames(c, depth+1, dst)
+		dst = refNodeNames(c, depth+1, dst)
+	case nSelect:
+		dst = refNodeNames(c, depth+1, dst)
+		c.uvarint() // selected member id: resolves inside the record, not the ad
+	case nSelectStr:
+		dst = refNodeNames(c, depth+1, dst)
+		c.skip(int(c.uvarint()))
+	case nParen:
+		dst = refNodeNames(c, depth+1, dst)
+	case nEncrypted:
+		c.skip(int(c.uvarint())) // nonce
+		c.skip(int(c.uvarint())) // ciphertext: opaque, no visible references
+	default:
+		c.ok = false
+	}
+	return dst
+}
+
+// refAdBody walks a nested record body ([hotCount][hot][attrCount][key+node]*),
+// collecting references from each member's value node.
+func refAdBodyNames(c *cursor, depth int, dst [][]byte) [][]byte {
+	if !c.ok || depth > maxDepth {
+		c.ok = false
+		return dst
+	}
+	hotCount := c.uvarint()
+	for i := uint64(0); i < hotCount && c.ok; i++ {
+		c.uvarint()
+		c.uvarint()
+	}
+	attrCount := c.uvarint()
+	for i := uint64(0); i < attrCount && c.ok; i++ {
+		c.skipKey()
+		dst = refNodeNames(c, depth+1, dst)
 	}
 	return dst
 }


### PR DESCRIPTION
Closes #135.

## What was wrong

The reference-chasing projection added in #133 was a no-op on a **persistent** (inline-name) collection — which is what a daemon runs, so the fix never reached the case it was written for. `renderInline` served the projection exactly, and a narrow `SELECT Requirements FROM machines` still evaluated to undefined while `SELECT *` evaluated to true.

The cause: inline-name ads encode attribute references as `nAttrRefStr` (a scope byte plus an inline name), and `wire.AppendNodeRefIDs` only understood `nAttrRef` (scope plus interned id) — it explicitly skipped the string form as "not an interned id, nothing to collect".

## The fix

`wire.AppendNodeRefNames` is the name-based twin: it walks the same TLV structure and collects `nAttrRefStr` names, unscoped and `MY.`-scoped as before, appended as sub-slices of the node so collecting costs no allocation.

`renderInline` keeps a per-ad wanted-name set alongside the projection's, adds each emitted expression's references to it, and repeats the walk while new names surface — the same bounded elevator the id path runs (each pass strictly grows the set, capped by the ad's attribute count). The hot fast path likewise stops early-exiting once a reference is pending, since the referenced attribute may be cold.

Redaction is preserved: a reference to a private attribute is dropped from the closure, so a redacted response cannot be widened by referring to a secret.

## Testing

Seven cases against a real persistent collection:

- references carried, and the projected ad **actually evaluating** to the whole-ad answer
- transitive chains (`Top` → `Mid` → `Base`)
- cycles terminating rather than spinning (`X = Y + 1; Y = X + 1`)
- `TARGET.`/`PARENT.` references not dragging local attributes in
- redaction not bypassable through a reference
- chasing being a byte-identical no-op when the projected attributes are literals

`go vet` and `go test` clean in all five modules.

## Follow-up

htcondordb already calls the refs-chasing form (#108). Once this is tagged and bumped there, two pins flip: `repl/projection_test.go::TestProjectedSelectAgreesWithStar/persistent` (skipped) and `python/tests/test_value_shapes.py::...::test_projection_without_the_dependency_agrees` (strict xfail).
