### PR TITLE
Render raw text with old-ClassAd string quoting

### DIFF
--- a/collections/rawdecode.go
+++ b/collections/rawdecode.go
@@ -180,7 +180,7 @@ func (c *Collection) appendWireAd(wireBytes []byte, buf []byte, offs []int, reda
 		buf = append(buf, ' ', '=', ' ')
 		var aerr error
 		if c.inline {
-			buf, aerr = wire.AppendNodeTextInline(buf, node)
+			buf, aerr = wire.AppendNodeTextInlineOld(buf, node)
 		} else {
 			buf, aerr = appendWireValue(buf, node, c.intern)
 		}
@@ -232,5 +232,5 @@ func appendWireValue(dst, node []byte, table *wire.InternTable) ([]byte, error) 
 	}
 	// Non-scalar: a list, record, or computed expression. Render it straight from
 	// the wire (AST-free) instead of decoding an ast.Expr and calling String().
-	return wire.AppendNodeText(dst, node, table)
+	return wire.AppendNodeTextOld(dst, node, table)
 }

--- a/collections/rawprojected.go
+++ b/collections/rawprojected.go
@@ -380,7 +380,7 @@ func (p *rawProjector) renderInline(w []byte) (RawAd, bool) {
 		p.buf = append(p.buf, name...)
 		p.buf = append(p.buf, ' ', '=', ' ')
 		var aerr error
-		p.buf, aerr = wire.AppendNodeTextInline(p.buf, node)
+		p.buf, aerr = wire.AppendNodeTextInlineOld(p.buf, node)
 		if aerr != nil {
 			good = false
 			return false

--- a/collections/rawquote_test.go
+++ b/collections/rawquote_test.go
@@ -1,0 +1,128 @@
+package collections
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/classad"
+)
+
+func newInlineQuoteColl(t *testing.T) *Collection {
+	t.Helper()
+	c, err := Open(Options{Dir: t.TempDir() + "/store", Shards: 2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { c.Close() })
+	if !c.inline {
+		t.Skip("this store is not inline-name; the test targets that representation")
+	}
+	return c
+}
+
+// bothStores runs fn against each storage representation. The two render raw text through
+// different paths, and the escaping bug this covers appeared in both.
+func bothStores(t *testing.T, fn func(*testing.T, *Collection)) {
+	t.Helper()
+	for _, store := range []struct {
+		name string
+		open func(*testing.T) *Collection
+	}{
+		{"interned", func(t *testing.T) *Collection { return New(Options{}) }},
+		{"inline", newInlineQuoteColl},
+	} {
+		t.Run(store.name, func(t *testing.T) { fn(t, store.open(t)) })
+	}
+}
+
+// rawReparse reads the collection back through the raw (old-ClassAd text) projection and
+// re-parses that text the way every consumer of it does.
+func rawReparse(t *testing.T, c *Collection) *classad.ClassAd {
+	t.Helper()
+	n := 0
+	var out *classad.ClassAd
+	for ra := range c.ScanRawProjected(nil, false, false) {
+		n++
+		lines := make([]string, 0, len(ra.Exprs))
+		for _, e := range ra.Exprs {
+			lines = append(lines, string(e))
+		}
+		back, err := classad.ParseOld(strings.Join(lines, "\n") + "\n")
+		if err != nil {
+			t.Fatalf("re-parsing raw text %q: %v", lines, err)
+		}
+		out = back
+	}
+	if n != 1 {
+		t.Fatalf("got %d ads, want 1", n)
+	}
+	return out
+}
+
+// A raw projection renders old-ClassAd text, read back by a tokenizer that does no escape
+// processing. Quoting it for new-ClassAd rules escaped backslashes and tabs the reader then
+// took literally, doubling them on every round trip.
+//
+// Values are inserted through the ClassAd API rather than parsed from text, so what is
+// being round-tripped is unambiguous -- `"a\\b"` means different things to the two
+// dialects, which is the whole point.
+func TestRawTextRoundTripsStringValues(t *testing.T) {
+	for _, tc := range []struct{ name, value string }{
+		{"backslash", `C:\Users`},
+		{"two backslashes", `a\\b`},
+		{"tab", "a\tb"},
+		{"quote", `say "hi"`},
+		{"regex", `^\d+$`},
+		{"plain", "alice"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			bothStores(t, func(t *testing.T, c *Collection) {
+				ad := classad.New()
+				ad.InsertAttrString("Path", tc.value)
+				if err := c.Put([]byte("k"), ad); err != nil {
+					t.Fatal(err)
+				}
+				got, err := rawReparse(t, c).EvaluateAttr("Path").StringValue()
+				if err != nil {
+					t.Fatalf("Path did not come back a string: %v", err)
+				}
+				if got != tc.value {
+					t.Errorf("round trip gave %q, want %q", got, tc.value)
+				}
+			})
+		})
+	}
+}
+
+// A string nested in a list goes through the general node renderer rather than the
+// top-level string fast path, so it needs the same dialect. On the interned representation
+// that nesting was the only way to reach the bug, since a top-level string already took a
+// correctly-quoting fast path.
+func TestRawTextRoundTripsNestedStrings(t *testing.T) {
+	bothStores(t, func(t *testing.T, c *Collection) {
+		// Built through the new-ClassAd parser, where \\ is one backslash, so the list's
+		// element is exactly `C:\Users`.
+		src, err := classad.Parse(`[Args = {"C:\\Users", "b"}]`)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := c.Put([]byte("k"), src); err != nil {
+			t.Fatal(err)
+		}
+
+		list, err := rawReparse(t, c).EvaluateAttr("Args").ListValue()
+		if err != nil {
+			t.Fatalf("Args did not come back a list: %v", err)
+		}
+		if len(list) != 2 {
+			t.Fatalf("got %d elements, want 2", len(list))
+		}
+		got, err := list[0].StringValue()
+		if err != nil {
+			t.Fatalf("element 0 is not a string: %v", err)
+		}
+		if want := `C:\Users`; got != want {
+			t.Errorf("nested string round-tripped to %q, want %q", got, want)
+		}
+	})
+}

--- a/collections/rawwire_subset.go
+++ b/collections/rawwire_subset.go
@@ -183,7 +183,7 @@ func RenderRawAdInline(w []byte, buf []byte, offs []int) (outBuf []byte, outOffs
 		buf = append(buf, name...)
 		buf = append(buf, ' ', '=', ' ')
 		var aerr error
-		buf, aerr = wire.AppendNodeTextInline(buf, node)
+		buf, aerr = wire.AppendNodeTextInlineOld(buf, node)
 		if aerr != nil {
 			good = false
 			return false

--- a/collections/wire/decode.go
+++ b/collections/wire/decode.go
@@ -22,6 +22,9 @@ type decoder struct {
 	resolve func(uint32) (string, bool) // id -> name (unused in inline mode)
 	inline  bool                        // attribute keys are inline names
 	open    Sealer                      // decrypts nEncrypted nodes; nil => they are errors
+	// oldStrings renders string literals for old-ClassAd text rather than mirroring
+	// ast.Expr.String(). Set by the AppendNodeText*Old renderers; see AppendNodeTextOld.
+	oldStrings bool
 }
 
 // Decode parses an ad encoded with Encode or EncodeInline. Interned ads resolve

--- a/collections/wire/render.go
+++ b/collections/wire/render.go
@@ -25,6 +25,26 @@ func AppendNodeTextInline(dst, node []byte) ([]byte, error) {
 	return d.appendNode(dst, 0)
 }
 
+// AppendNodeTextOld is AppendNodeText rendering string literals for OLD-ClassAd text,
+// whose tokenizer does no escape processing (C++ Lexer::tokenizeStringOld: only a
+// backslash before the closing quote is a sequence).
+//
+// The distinction is not cosmetic. AppendNodeText mirrors ast.Expr.String(), which escapes
+// backslashes, tabs and newlines for the new-ClassAd reader that unescapes them. Feeding
+// that text to an old-ClassAd reader, as every raw-projection consumer does, doubles a
+// backslash on each round trip -- so a caller emitting old text must use this.
+func AppendNodeTextOld(dst, node []byte, t *InternTable) ([]byte, error) {
+	d := &decoder{b: node, resolve: t.Name, oldStrings: true}
+	return d.appendNode(dst, 0)
+}
+
+// AppendNodeTextInlineOld is AppendNodeTextInline with old-ClassAd string quoting; see
+// AppendNodeTextOld for why the dialect has to be chosen explicitly.
+func AppendNodeTextInlineOld(dst, node []byte) ([]byte, error) {
+	d := &decoder{b: node, inline: true, oldStrings: true}
+	return d.appendNode(dst, 0)
+}
+
 // appendNode appends one expression node's text to dst, mirroring decoder.node
 // (which builds an ast.Expr) and the ast String() methods it would call. Keeping
 // the two walks structurally identical is deliberate: any node shape decode.go
@@ -62,6 +82,9 @@ func (d *decoder) appendNode(dst []byte, depth int) ([]byte, error) {
 		s, err := d.readStringBytes()
 		if err != nil {
 			return dst, err
+		}
+		if d.oldStrings {
+			return ast.AppendQuoteStringOldBytes(dst, s), nil
 		}
 		return ast.AppendQuoteStringBytes(dst, s), nil
 	case nAttrRef, nAttrRefStr:


### PR DESCRIPTION
Closes #134.

## Correction to the issue

**#134 blamed the wrong layer, and no migration is needed.** The value on disk was always correct — `SELECT *` returned the right string throughout, while a projected `SELECT` of the same attribute did not. Only the *rendering to text* was wrong, so there is no corrupt stored data to repair.

## What was wrong

A raw projection emits old-ClassAd text, and its consumers read that back with a tokenizer that does no escape processing — C++ `Lexer::tokenizeStringOld`, where the only sequence is a backslash directly before the closing quote. The node renderer quoted string literals for **new**-ClassAd rules instead, escaping backslashes and tabs the reader then took literally. Every render/parse round trip doubled them:

```
stored          C:\Users
raw text        "C:\\Users"      <- new-dialect quoting
re-parsed       C:\\Users        <- old-dialect reading, no unescape
```

The interned representation only reached this through a string nested in a list or expression, because a top-level string already took a correctly-quoting fast path in `appendWireValue`. The inline (persistent) representation had no such fast path, which is why it corrupted every string containing a backslash — and why a daemon showed the bug where an in-memory store did not.

## The fix

The dialect is chosen at the call site rather than baked into the walker.

- `AppendNodeTextOld` / `AppendNodeTextInlineOld` render string literals for old-ClassAd text.
- `AppendNodeText` / `AppendNodeTextInline` keep mirroring `ast.Expr.String()` — their documented contract, and what `render_test.go` asserts. Changing them in place broke those tests, which was the signal that the dialect belongs at the boundary.

The four raw call sites — the projected and unprojected raw scans, and the wire-subset renderer — take the old-dialect pair.

## Testing

A round-trip matrix across both storage representations, for a backslash, two backslashes, a tab, an embedded quote, a regex literal and a plain string, plus a string nested in a list. Values are inserted through the ClassAd API rather than parsed from text, because `"a\\b"` means different things to the two dialects and that ambiguity is exactly what is under test.

Verified each case fails without the change (21 failures on the unfixed tree).

`go vet` and `go test` clean in all five modules.

## Follow-up

Two pins in htcondordb flip once this is tagged and bumped there:
`repl/oldquote_test.go::TestPersistentStoreDoublesBackslashes` (skipped) and
`python/tests/test_integration.py::TestTypes::test_backslash_round_trip` (strict xfail).
