### PR TITLE
db,dbrpc: run maintenance on archive tables

### DIFF
--- a/collections/archive_merge.go
+++ b/collections/archive_merge.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 )
 
 // Segment merging for append-only (archive) collections.
@@ -33,6 +34,14 @@ import (
 // is removed, so no window can lose records. The cost of that choice is that a crash can
 // leave the target and its sources briefly coexisting, which recovery resolves by completing
 // the merge rather than by trying to detect duplicates after the fact.
+
+// mergedBytes accumulates the source bytes every completed merge has rewritten. Merging is
+// the only maintenance that rewrites archive data, so this is what a byte budget for it has
+// to be sized against.
+var mergedBytes atomic.Int64
+
+// MergedBytes reports the total source bytes rewritten by merges since this process started.
+func MergedBytes() int64 { return mergedBytes.Load() }
 
 const (
 	mergeTmpPrefix    = "tmp-merge"
@@ -105,6 +114,11 @@ func (c *Collection) mergeSegments(sh *shard, run []*segment) bool {
 		}
 	}
 	sh.mu.Unlock()
+	var moved int64
+	for _, s := range run {
+		moved += int64(s.used)
+	}
+	mergedBytes.Add(moved)
 	for _, s := range toReap {
 		s.reapAndHook() // munmap + unlink, off-lock
 	}

--- a/collections/archive_mergepolicy.go
+++ b/collections/archive_mergepolicy.go
@@ -1,0 +1,192 @@
+package collections
+
+// Which segments to merge.
+//
+// The mechanism (mergeSegments) collapses an adjacent run; this decides which runs, and it
+// answers to one number: how many segments the archive may hold. That number is set by
+// mappings, not by query cost -- every sealed segment is mmap'd at open and each queried
+// sidecar adds a second, so a table costs about 2 mappings per segment against a process-wide
+// vm.max_map_count (65530 by default, shared with every other table in the same database).
+//
+// Two shapes have to be respected at once, and they disagree:
+//
+//   - Fewer segments is better for mappings, and for open cost (recovery is O(segments)).
+//   - Smaller segments are better for queries, because the OPEN segment is rescanned on
+//     every index-resident query -- its size is a per-query cost, forever.
+//
+// Merging cold runs while leaving the newest segments alone satisfies both: the tail stays
+// finely divided where queries land, and the body consolidates where only mappings care.
+//
+// Run size is driven by BYTES, not by a fixed fan-in. Segments are not uniformly full -- a
+// seal can land early, and a resealed segment is sized exactly to its contents -- so "merge 8
+// at a time" produces wildly different results depending on how full they happen to be. The
+// target size is derived from the goal rather than configured: to land at TargetSegments, the
+// average segment has to be about total/TargetSegments, so runs grow toward that (clamped),
+// which makes the policy self-adjusting as the archive grows.
+
+// MergeOptions tunes a merge pass. The zero value is usable: it fills in the defaults below.
+type MergeOptions struct {
+	// TargetSegments is the segment count to get at or below. Merging stops once the
+	// archive is under it. Default defaultTargetSegments.
+	TargetSegments int
+	// MaxSegmentBytes caps a merged segment. Segment offsets are uint32 throughout the
+	// record and sidecar formats, so 4 GiB is a hard structural ceiling; the default stays
+	// well under it. A run stops before exceeding this.
+	MaxSegmentBytes int64
+	// MinMergeBytes is the smallest output worth producing. A run below it is still merged
+	// if it is the best available -- reducing the count is the point -- but the policy
+	// prefers to keep accumulating.
+	MinMergeBytes int64
+	// MaxRun bounds how many segments one merge consumes, so a single merge's work and
+	// memory stay predictable however small the segments are.
+	MaxRun int
+	// KeepRecent leaves the newest sealed segments untouched, keeping the hot end of the
+	// archive finely divided (and away from the open segment the writer is appending to).
+	KeepRecent int
+	// MaxMerges bounds one pass, so maintenance stays interruptible and a large backlog is
+	// worked down over several passes instead of one long stall.
+	MaxMerges int
+}
+
+const (
+	// defaultTargetSegments is deliberately far below the mapping ceiling. At ~2 mappings
+	// per segment this is ~16k for one table, leaving room for the other tables sharing the
+	// process's vm.max_map_count.
+	defaultTargetSegments  = 8192
+	defaultMaxSegmentBytes = 1 << 30 // 1 GiB; the uint32 offset ceiling is 4 GiB
+	defaultMinMergeBytes   = 64 << 20
+	defaultMaxRun          = 64
+	defaultKeepRecent      = 16
+	defaultMaxMerges       = 64
+)
+
+func (o MergeOptions) withDefaults() MergeOptions {
+	if o.TargetSegments <= 0 {
+		o.TargetSegments = defaultTargetSegments
+	}
+	if o.MaxSegmentBytes <= 0 {
+		o.MaxSegmentBytes = defaultMaxSegmentBytes
+	}
+	if o.MinMergeBytes <= 0 {
+		o.MinMergeBytes = defaultMinMergeBytes
+	}
+	if o.MaxRun <= 1 {
+		o.MaxRun = defaultMaxRun
+	}
+	if o.KeepRecent < 0 {
+		o.KeepRecent = defaultKeepRecent
+	}
+	if o.MaxMerges <= 0 {
+		o.MaxMerges = defaultMaxMerges
+	}
+	return o
+}
+
+// MergePass merges cold segment runs until the archive is at or below opts.TargetSegments,
+// or until no eligible run remains, or until opts.MaxMerges merges have been done. It
+// returns the number of merges performed.
+//
+// Safe to call on a live archive: merges take the maintenance lock (so they never overlap a
+// reseal or another pass), the writer's open segment is never a candidate, and an in-flight
+// scan holding a source keeps its mapping alive through the usual pin/reap path.
+func (a *Archive) MergePass(opts MergeOptions) int {
+	return a.c.mergePass(opts.withDefaults())
+}
+
+func (c *Collection) mergePass(opts MergeOptions) int {
+	if !c.appendOnly() {
+		return 0
+	}
+	c.maintMu.Lock()
+	defer c.maintMu.Unlock()
+
+	merges := 0
+	for merges < opts.MaxMerges {
+		run, ok := c.nextMergeRun(opts)
+		if !ok {
+			break
+		}
+		if !c.mergeSegments(c.shards[0], run) {
+			break // a failed merge leaves its sources in place; do not spin on them
+		}
+		merges++
+	}
+	if merges > 0 {
+		// The merged segments have no sidecar yet; build them so queries do not fall back
+		// to scanning what they just consolidated.
+		c.Reindex()
+	}
+	return merges
+}
+
+// nextMergeRun picks the oldest adjacent run worth merging, or ok=false when the archive is
+// already at or below target, or nothing eligible remains.
+//
+// Oldest-first is deliberate: the oldest data is the coldest, so merging it disturbs the
+// fewest queries and the page cache least, and it produces the size gradient the two
+// competing constraints want -- large at the tail of the archive, small at its head.
+func (c *Collection) nextMergeRun(opts MergeOptions) ([]*segment, bool) {
+	sh := c.shards[0]
+	sh.mu.RLock()
+	defer sh.mu.RUnlock()
+
+	// Sealed segments in append order (id order), excluding the open segment.
+	var sealed []*segment
+	var total int64
+	for _, s := range sh.segs {
+		if s == nil || s == sh.act || s.used == 0 {
+			continue
+		}
+		sealed = append(sealed, s)
+		total += int64(s.used)
+	}
+	if len(sealed) <= opts.TargetSegments {
+		return nil, false
+	}
+	// Leave the newest KeepRecent alone: that is where queries land, and where the size of
+	// a segment is a per-query cost rather than just a mapping.
+	eligible := sealed
+	if opts.KeepRecent < len(eligible) {
+		eligible = eligible[:len(eligible)-opts.KeepRecent]
+	} else {
+		return nil, false
+	}
+	if len(eligible) < 2 {
+		return nil, false
+	}
+
+	// Size runs from the goal: landing at TargetSegments means an average segment of about
+	// total/TargetSegments, so grow toward that rather than toward a configured constant.
+	want := total / int64(opts.TargetSegments)
+	if want < opts.MinMergeBytes {
+		want = opts.MinMergeBytes
+	}
+	if want > opts.MaxSegmentBytes {
+		want = opts.MaxSegmentBytes
+	}
+
+	var run []*segment
+	var bytes int64
+	for _, s := range eligible {
+		sz := int64(s.used)
+		// Skip past segments that are already at the target size. Without this the run
+		// always restarts on the segment the previous pass just produced, growing it by one
+		// small neighbour at a time: a merge per segment, and the big segment rewritten
+		// every time -- quadratic in bytes moved, for a result the first merge nearly had.
+		if len(run) == 0 && sz >= want {
+			continue
+		}
+		if len(run) > 0 && (bytes+sz > opts.MaxSegmentBytes || len(run) >= opts.MaxRun) {
+			break // this run is as large as it may get
+		}
+		run = append(run, s)
+		bytes += sz
+		if bytes >= want && len(run) >= 2 {
+			break
+		}
+	}
+	if len(run) < 2 {
+		return nil, false // a single segment already at the size cap: nothing to do here
+	}
+	return run, true
+}

--- a/collections/archive_mergepolicy.go
+++ b/collections/archive_mergepolicy.go
@@ -51,6 +51,19 @@ type MergeOptions struct {
 	// MaxMerges bounds one pass, so maintenance stays interruptible and a large backlog is
 	// worked down over several passes instead of one long stall.
 	MaxMerges int
+	// MaxBytesPerPass bounds the SOURCE bytes one pass rewrites. MaxMerges alone does not
+	// bound the work, because a merge's cost is its inputs' size, not its count -- one pass
+	// of large runs can move orders of magnitude more than another of the same length.
+	//
+	// This exists for the catch-up case: an archive that grew while merging was off has a
+	// backlog measured in the size of the archive, and without a byte bound the first pass
+	// would try to rewrite all of it at once. Steady state does not need it -- a pass stops
+	// at the low watermark long before this -- so the default is sized to cap one pass at a
+	// tolerable stall (~25s at the ~160 MB/s merging sustains) rather than to throttle.
+	//
+	// Sustained RATE is the scheduler's job, not this: pace passes so the long-run average
+	// stays within the byte budget the deployment allows.
+	MaxBytesPerPass int64
 }
 
 const (
@@ -63,6 +76,7 @@ const (
 	defaultMaxRun          = 64
 	defaultKeepRecent      = 16
 	defaultMaxMerges       = 64
+	defaultMaxBytesPerPass = 4 << 30 // ~25s of merging at the measured throughput
 )
 
 func (o MergeOptions) withDefaults() MergeOptions {
@@ -86,6 +100,9 @@ func (o MergeOptions) withDefaults() MergeOptions {
 	}
 	if o.MaxMerges <= 0 {
 		o.MaxMerges = defaultMaxMerges
+	}
+	if o.MaxBytesPerPass <= 0 {
+		o.MaxBytesPerPass = defaultMaxBytesPerPass
 	}
 	return o
 }
@@ -117,15 +134,21 @@ func (c *Collection) mergePass(opts MergeOptions) int {
 		return 0 // below the high watermark: leave it alone
 	}
 	merges := 0
-	for merges < opts.MaxMerges {
-		run, ok := c.nextMergeRun(opts)
+	var moved int64
+	for merges < opts.MaxMerges && moved < opts.MaxBytesPerPass {
+		run, ok := c.nextMergeRun(opts, opts.MaxBytesPerPass-moved)
 		if !ok {
 			break
+		}
+		var runBytes int64
+		for _, s := range run {
+			runBytes += int64(s.used)
 		}
 		if !c.mergeSegments(c.shards[0], run) {
 			break // a failed merge leaves its sources in place; do not spin on them
 		}
 		merges++
+		moved += runBytes
 	}
 	if merges > 0 {
 		// The merged segments have no sidecar yet; build them so queries do not fall back
@@ -141,7 +164,10 @@ func (c *Collection) mergePass(opts MergeOptions) int {
 // Oldest-first is deliberate: the oldest data is the coldest, so merging it disturbs the
 // fewest queries and the page cache least, and it produces the size gradient the two
 // competing constraints want -- large at the tail of the archive, small at its head.
-func (c *Collection) nextMergeRun(opts MergeOptions) ([]*segment, bool) {
+// remaining is what is left of the pass's byte budget; a run is capped by it as well as by
+// MaxSegmentBytes, so a pass overshoots its budget by at most the last segment it adds rather
+// than by a whole run -- which, with a large target, can be the entire archive.
+func (c *Collection) nextMergeRun(opts MergeOptions, remaining int64) ([]*segment, bool) {
 	sh := c.shards[0]
 	sh.mu.RLock()
 	defer sh.mu.RUnlock()
@@ -181,6 +207,14 @@ func (c *Collection) nextMergeRun(opts MergeOptions) ([]*segment, bool) {
 		want = opts.MaxSegmentBytes
 	}
 
+	sizeCap := opts.MaxSegmentBytes
+	if remaining > 0 && remaining < sizeCap {
+		sizeCap = remaining
+	}
+	if want > sizeCap {
+		want = sizeCap
+	}
+
 	var run []*segment
 	var bytes int64
 	for _, s := range eligible {
@@ -192,7 +226,7 @@ func (c *Collection) nextMergeRun(opts MergeOptions) ([]*segment, bool) {
 		if len(run) == 0 && sz >= want {
 			continue
 		}
-		if len(run) > 0 && (bytes+sz > opts.MaxSegmentBytes || len(run) >= opts.MaxRun) {
+		if len(run) > 0 && (bytes+sz > sizeCap || len(run) >= opts.MaxRun) {
 			break // this run is as large as it may get
 		}
 		run = append(run, s)

--- a/collections/archive_mergepolicy.go
+++ b/collections/archive_mergepolicy.go
@@ -26,9 +26,14 @@ package collections
 
 // MergeOptions tunes a merge pass. The zero value is usable: it fills in the defaults below.
 type MergeOptions struct {
-	// TargetSegments is the segment count to get at or below. Merging stops once the
-	// archive is under it. Default defaultTargetSegments.
+	// TargetSegments is the LOW watermark: once a pass starts it merges until the archive
+	// is at or below this. Default defaultTargetSegments.
 	TargetSegments int
+	// TriggerSegments is the HIGH watermark: a pass does nothing until the archive reaches
+	// it. The gap between the two is what stops the policy from merging a run on every pass
+	// forever once it is sitting on the target -- rewriting data continuously to hold a line
+	// that does not need holding to the segment. Default: TargetSegments plus a quarter.
+	TriggerSegments int
 	// MaxSegmentBytes caps a merged segment. Segment offsets are uint32 throughout the
 	// record and sidecar formats, so 4 GiB is a hard structural ceiling; the default stays
 	// well under it. A run stops before exceeding this.
@@ -64,6 +69,9 @@ func (o MergeOptions) withDefaults() MergeOptions {
 	if o.TargetSegments <= 0 {
 		o.TargetSegments = defaultTargetSegments
 	}
+	if o.TriggerSegments <= o.TargetSegments {
+		o.TriggerSegments = o.TargetSegments + o.TargetSegments/4
+	}
 	if o.MaxSegmentBytes <= 0 {
 		o.MaxSegmentBytes = defaultMaxSegmentBytes
 	}
@@ -82,9 +90,14 @@ func (o MergeOptions) withDefaults() MergeOptions {
 	return o
 }
 
-// MergePass merges cold segment runs until the archive is at or below opts.TargetSegments,
-// or until no eligible run remains, or until opts.MaxMerges merges have been done. It
-// returns the number of merges performed.
+// MergePass merges cold segment runs when the archive has reached opts.TriggerSegments,
+// continuing until it is at or below opts.TargetSegments, no eligible run remains, or
+// opts.MaxMerges merges have been done. It returns the number of merges performed.
+//
+// The two watermarks are the point: merging is rewriting, so it should happen in occasional
+// batches with headroom either side, not continuously to pin the count at one value. Below
+// the trigger a pass is a cheap no-op (a segment count and a comparison), so it is safe to
+// call often.
 //
 // Safe to call on a live archive: merges take the maintenance lock (so they never overlap a
 // reseal or another pass), the writer's open segment is never a candidate, and an in-flight
@@ -100,6 +113,9 @@ func (c *Collection) mergePass(opts MergeOptions) int {
 	c.maintMu.Lock()
 	defer c.maintMu.Unlock()
 
+	if c.sealedSegmentCount() < opts.TriggerSegments {
+		return 0 // below the high watermark: leave it alone
+	}
 	merges := 0
 	for merges < opts.MaxMerges {
 		run, ok := c.nextMergeRun(opts)
@@ -189,4 +205,19 @@ func (c *Collection) nextMergeRun(opts MergeOptions) ([]*segment, bool) {
 		return nil, false // a single segment already at the size cap: nothing to do here
 	}
 	return run, true
+}
+
+// sealedSegmentCount counts the segments a merge pass could act on: sealed, non-empty, and
+// not the open append target.
+func (c *Collection) sealedSegmentCount() int {
+	sh := c.shards[0]
+	sh.mu.RLock()
+	defer sh.mu.RUnlock()
+	n := 0
+	for _, s := range sh.segs {
+		if s != nil && s != sh.act && s.used > 0 {
+			n++
+		}
+	}
+	return n
 }

--- a/collections/archive_mergepolicy_test.go
+++ b/collections/archive_mergepolicy_test.go
@@ -18,9 +18,10 @@ func TestMergePassReachesTarget(t *testing.T) {
 	}
 
 	opts := MergeOptions{
-		TargetSegments: 8,
-		MinMergeBytes:  1, // the corpus is tiny; let run size come from the target
-		KeepRecent:     2,
+		TargetSegments:  8,
+		TriggerSegments: 16, // well below the current count, so this pass runs
+		MinMergeBytes:   1,  // the corpus is tiny; let run size come from the target
+		KeepRecent:      2,
 	}
 	n := a.MergePass(opts)
 	if n == 0 {
@@ -72,7 +73,7 @@ func TestMergePassRespectsLimits(t *testing.T) {
 		a := buildMergeArchive(t, dir, 4000)
 		defer a.Close()
 		newest := newestSealedSegments(t, a, 3)
-		a.MergePass(MergeOptions{TargetSegments: 4, MinMergeBytes: 1, KeepRecent: 3})
+		a.MergePass(MergeOptions{TargetSegments: 4, TriggerSegments: 8, MinMergeBytes: 1, KeepRecent: 3})
 		live := map[*segment]bool{}
 		for _, s := range policySegments(t, a) {
 			live[s] = true
@@ -89,13 +90,50 @@ func TestMergePassRespectsLimits(t *testing.T) {
 		a := buildMergeArchive(t, dir, 4000)
 		defer a.Close()
 		const cap = 24 << 10
-		a.MergePass(MergeOptions{TargetSegments: 1, MinMergeBytes: 1, MaxSegmentBytes: cap, KeepRecent: 0})
+		a.MergePass(MergeOptions{TargetSegments: 1, TriggerSegments: 2, MinMergeBytes: 1, MaxSegmentBytes: cap, KeepRecent: 0})
 		for _, s := range policySegments(t, a) {
 			if int64(s.used) > cap*2 {
 				t.Errorf("segment holds %d bytes, well past the %d cap", s.used, cap)
 			}
 		}
 	})
+}
+
+// TestMergePassHysteresis pins the two watermarks: a pass between the target and the trigger
+// does nothing, and once the trigger is reached it merges all the way down to the target.
+// Without the gap the policy would merge a run on every pass forever while sitting just over
+// the target, rewriting data continuously to hold a line that does not need holding.
+func TestMergePassHysteresis(t *testing.T) {
+	if !mmapSupported {
+		t.Skip("persistence is unix-only")
+	}
+	dir := t.TempDir()
+	a := buildMergeArchive(t, dir, 4000)
+	defer a.Close()
+	segs := a.c.Stats().Segments
+
+	// Between the watermarks: over target, under trigger -> nothing happens.
+	if n := a.MergePass(MergeOptions{
+		TargetSegments: segs - 10, TriggerSegments: segs + 50, MinMergeBytes: 1, KeepRecent: 0,
+	}); n != 0 {
+		t.Errorf("merged %d runs while below the trigger", n)
+	}
+	if got := a.c.Stats().Segments; got != segs {
+		t.Errorf("segments changed to %d while below the trigger", got)
+	}
+
+	// Past the trigger: merge down to the target, not merely under the trigger. (The
+	// trigger counts SEALED segments; the open one is not mergeable, hence a value clearly
+	// below the total rather than exactly it.)
+	target := 8
+	if n := a.MergePass(MergeOptions{
+		TargetSegments: target, TriggerSegments: 20, MinMergeBytes: 1, KeepRecent: 0,
+	}); n == 0 {
+		t.Fatal("no merges though the trigger was reached")
+	}
+	if got := a.c.Stats().Segments; got > target+1 {
+		t.Errorf("segments = %d, want <= %d: a pass must run to the LOW watermark", got, target+1)
+	}
 }
 
 func policySegments(t *testing.T, a *Archive) []*segment {

--- a/collections/archive_mergepolicy_test.go
+++ b/collections/archive_mergepolicy_test.go
@@ -1,0 +1,130 @@
+package collections
+
+import "testing"
+
+// TestMergePassReachesTarget drives the policy end to end: an archive well over its segment
+// target is merged down to it, and every record survives in order -- checked again after a
+// reopen, since that is where a merge landing in the wrong position would surface.
+func TestMergePassReachesTarget(t *testing.T) {
+	if !mmapSupported {
+		t.Skip("persistence is unix-only")
+	}
+	dir := t.TempDir()
+	a := buildMergeArchive(t, dir, 4000)
+	before := allClusterIDs(t, a)
+	segsBefore := a.c.Stats().Segments
+	if segsBefore < 40 {
+		t.Fatalf("need a lot of segments to exercise the policy, got %d", segsBefore)
+	}
+
+	opts := MergeOptions{
+		TargetSegments: 8,
+		MinMergeBytes:  1, // the corpus is tiny; let run size come from the target
+		KeepRecent:     2,
+	}
+	n := a.MergePass(opts)
+	if n == 0 {
+		t.Fatal("MergePass did no merges though the archive is far over target")
+	}
+	after := a.c.Stats().Segments
+	if after >= segsBefore {
+		t.Fatalf("segments %d -> %d: no reduction", segsBefore, after)
+	}
+	// KeepRecent segments are exempt, so the floor is the target plus those.
+	if after > opts.TargetSegments+opts.KeepRecent+1 {
+		t.Errorf("segments = %d after %d merges, want <= ~%d", after, n, opts.TargetSegments+opts.KeepRecent+1)
+	}
+	if got := allClusterIDs(t, a); !equalIDs(got, before) {
+		t.Fatalf("records changed: %d, want %d", len(got), len(before))
+	}
+	a.Close()
+
+	a2, err := OpenArchive(ArchiveOptions{Dir: dir, SegmentSize: 1 << 12})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer a2.Close()
+	if got := allClusterIDs(t, a2); !equalIDs(got, before) {
+		t.Errorf("after reopen: %d records, want %d", len(got), len(before))
+	}
+	t.Logf("segments %d -> %d in %d merges, %d records preserved", segsBefore, after, n, len(before))
+}
+
+// TestMergePassRespectsLimits pins the guards that keep a pass bounded and the hot tail
+// intact: nothing happens under target, the newest segments are never consumed, and no
+// merged segment exceeds the size cap.
+func TestMergePassRespectsLimits(t *testing.T) {
+	if !mmapSupported {
+		t.Skip("persistence is unix-only")
+	}
+	t.Run("no-op under target", func(t *testing.T) {
+		dir := t.TempDir()
+		a := buildMergeArchive(t, dir, 500)
+		defer a.Close()
+		segs := a.c.Stats().Segments
+		if n := a.MergePass(MergeOptions{TargetSegments: segs + 10}); n != 0 {
+			t.Errorf("merged %d runs though already under target", n)
+		}
+	})
+
+	t.Run("keeps the newest segments", func(t *testing.T) {
+		dir := t.TempDir()
+		a := buildMergeArchive(t, dir, 4000)
+		defer a.Close()
+		newest := newestSealedSegments(t, a, 3)
+		a.MergePass(MergeOptions{TargetSegments: 4, MinMergeBytes: 1, KeepRecent: 3})
+		live := map[*segment]bool{}
+		for _, s := range policySegments(t, a) {
+			live[s] = true
+		}
+		for i, s := range newest {
+			if !live[s] {
+				t.Errorf("newest sealed segment %d was merged away despite KeepRecent", i)
+			}
+		}
+	})
+
+	t.Run("honors the size cap", func(t *testing.T) {
+		dir := t.TempDir()
+		a := buildMergeArchive(t, dir, 4000)
+		defer a.Close()
+		const cap = 24 << 10
+		a.MergePass(MergeOptions{TargetSegments: 1, MinMergeBytes: 1, MaxSegmentBytes: cap, KeepRecent: 0})
+		for _, s := range policySegments(t, a) {
+			if int64(s.used) > cap*2 {
+				t.Errorf("segment holds %d bytes, well past the %d cap", s.used, cap)
+			}
+		}
+	})
+}
+
+func policySegments(t *testing.T, a *Archive) []*segment {
+	t.Helper()
+	sh := a.c.shards[0]
+	sh.mu.RLock()
+	defer sh.mu.RUnlock()
+	var out []*segment
+	for _, s := range sh.segs {
+		if s != nil && s.used > 0 {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func newestSealedSegments(t *testing.T, a *Archive, k int) []*segment {
+	t.Helper()
+	sh := a.c.shards[0]
+	sh.mu.RLock()
+	defer sh.mu.RUnlock()
+	var sealed []*segment
+	for _, s := range sh.segs {
+		if s != nil && s != sh.act && s.used > 0 {
+			sealed = append(sealed, s)
+		}
+	}
+	if len(sealed) <= k {
+		t.Fatalf("need >%d sealed segments, got %d", k, len(sealed))
+	}
+	return sealed[len(sealed)-k:]
+}

--- a/collections/archive_mergepolicy_test.go
+++ b/collections/archive_mergepolicy_test.go
@@ -166,3 +166,36 @@ func newestSealedSegments(t *testing.T, a *Archive, k int) []*segment {
 	}
 	return sealed[len(sealed)-k:]
 }
+
+// TestMergePassByteBudget pins that a pass stops on bytes rewritten, not just on merge count.
+// A merge costs its inputs' size, so bounding the count alone lets one pass of large runs
+// move arbitrarily more than another of the same length -- which is exactly the catch-up case
+// this guards, where the backlog is the size of the archive.
+func TestMergePassByteBudget(t *testing.T) {
+	if !mmapSupported {
+		t.Skip("persistence is unix-only")
+	}
+	dir := t.TempDir()
+	a := buildMergeArchive(t, dir, 4000)
+	defer a.Close()
+
+	before := MergedBytes()
+	const budget = 40 << 10
+	a.MergePass(MergeOptions{
+		TargetSegments: 1, TriggerSegments: 2, MinMergeBytes: 1,
+		KeepRecent: 0, MaxBytesPerPass: budget,
+	})
+	moved := MergedBytes() - before
+	if moved == 0 {
+		t.Fatal("no merges ran")
+	}
+	// The bound is checked between merges, so one run may overshoot it; what must not happen
+	// is the pass ignoring it and running to the target.
+	if moved > budget*4 {
+		t.Errorf("pass rewrote %d bytes against a %d budget -- the byte bound is not stopping it",
+			moved, budget)
+	}
+	if a.c.Stats().Segments <= 2 {
+		t.Error("pass reached the target despite the byte budget")
+	}
+}

--- a/db/archive.go
+++ b/db/archive.go
@@ -345,6 +345,18 @@ func (t *ArchiveTable) CategoricalGroupCountsWhere(attr, constraint string) (map
 	return t.a.CategoricalGroupCountsWhere(attr, constraint)
 }
 
+// MergeOptions tunes a merge pass over an archive; see collections.MergeOptions. The zero
+// value is usable and fills in defaults.
+type MergeOptions = collections.MergeOptions
+
+// MergePass merges cold segment runs when the archive has reached its trigger watermark,
+// down to its target. Returns the number of merges performed.
+//
+// An append-only table never compacts, so its segment count only grows, and every sealed
+// segment costs a memory mapping at open. This is what bounds that; without it running, the
+// count climbs until the daemon cannot start.
+func (t *ArchiveTable) MergePass(opts MergeOptions) int { return t.a.MergePass(opts) }
+
 // Count is the number of records currently retained (reduced by rotation).
 func (t *ArchiveTable) Count() int { return t.a.Count() }
 

--- a/db/archive_scale_test.go
+++ b/db/archive_scale_test.go
@@ -1,0 +1,301 @@
+package db
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Scale profile for the history archive.
+//
+// What this establishes, and what it corrected.
+//
+// The index-resident GROUP BY was originally claimed to be O(segments x distinct values) and
+// independent of record count. Measurement says otherwise: it is LINEAR in archive size, like
+// the scan it replaces, just ~300x cheaper. The original claim came from a microbenchmark
+// whose configurations were too small and too warm to separate the terms.
+//
+// Profiling the path shows why. ~87% of its time is countAttrRange -- decompressing the
+// records of the UNSEALED active segment, which by design carries no sidecar index -- and
+// ~89% of that is zstd. Reading the actual index (catCanonicalValues) is ~13%. So the real
+// cost model is:
+//
+//	per query ~= O(segments x ndv)      // index reads: the cheap part
+//	          +  O(SegmentSize)          // rescan of the open segment: the dominant part
+//
+// The second term is paid on EVERY query and is bounded by segment size, not archive size.
+// That is an independent argument for keeping segments small, and it points at the obvious
+// next optimization: cache or incrementally index the active segment's contribution, which
+// would remove ~87% of the cost.
+//
+// Sweeping record count at fixed segment size and segment size at fixed record count is what
+// separates the two terms; either sweep alone is confounded, because at fixed segment size
+// the segment count is proportional to the record count.
+//
+// Skipped unless CLASSAD_SCALE is set (it builds and queries multi-hundred-MB archives):
+//
+//	CLASSAD_SCALE=1 go test -run TestArchiveScaleProfile -v -timeout 60m ./db/
+//
+// CLASSAD_SCALE=N multiplies the record counts, so the same harness can be pointed at a
+// realistic corpus size on a machine that has the disk for it.
+
+// scaleAd renders one history-shaped record: a spread of typed attributes plus padding, so
+// bytes/record is in the range a real completed-job ad occupies rather than a toy.
+func scaleAd(i int, ndv int) string {
+	return fmt.Sprintf(
+		"ClusterId = %d\nProcId = 0\nOwner = %q\nAccountingGroup = %q\n"+
+			"CompletionDate = %d\nEnteredHistoryTime = %d\nJobStatus = 4\nExitCode = %d\n"+
+			"RequestMemory = %d\nRequestCpus = %d\nRequestDisk = %d\nNumJobStarts = %d\n"+
+			"RemoteWallClockTime = %d.0\nBytesSent = %d\nBytesRecvd = %d\n"+
+			"GlobalJobId = %q\nCmd = \"/usr/bin/payload\"\nIwd = \"/home/user/work\"\n"+
+			"Args = %q\n",
+		i, fmt.Sprintf("user%04d", i%ndv), fmt.Sprintf("grp%02d", i%16),
+		1700000000+i, 1700000005+i, i%3,
+		1024+(i%8)*512, 1+(i%4), 10240+(i%16)*1024, 1+(i%3),
+		60+(i%3600), 1<<20+i, 1<<19+i,
+		fmt.Sprintf("sched.example.org#%d.0#%d", i, 1700000000+i),
+		strings.Repeat("x", 120),
+	)
+}
+
+type scaleResult struct {
+	group     string
+	records   int
+	segSize   int
+	segments  int
+	diskBytes int64
+	buildMS   float64
+	reopenMS  float64
+	heapMB    float64
+	indexedMS float64 // GROUP BY on the categorically indexed attribute (index-resident)
+	scanMS    float64 // GROUP BY on an identical-cardinality UNindexed attribute (scan)
+	groups    int
+}
+
+func TestArchiveScaleProfile(t *testing.T) {
+	if os.Getenv("CLASSAD_SCALE") == "" {
+		t.Skip("set CLASSAD_SCALE=1 (or N) to run the archive scale profile")
+	}
+	mult, err := strconv.Atoi(os.Getenv("CLASSAD_SCALE"))
+	if err != nil || mult < 1 {
+		mult = 1
+	}
+
+	const ndv = 64
+	// Two sweeps. Varying records at fixed segment size is the deployment-realistic axis;
+	// varying segment size at fixed records isolates the active-segment rescan, which is
+	// the term that dominates and the one segment size controls.
+	cases := []struct {
+		records, segSize int
+		group            string
+	}{
+		// Fixed segment SIZE, 4x records: the deployment-realistic axis. Segment count
+		// grows with the corpus, so both paths grow -- what must hold is the gap between
+		// them.
+		{100_000 * mult, 1 << 20, "fixed-segsize"},
+		{200_000 * mult, 1 << 20, "fixed-segsize"},
+		{400_000 * mult, 1 << 20, "fixed-segsize"},
+		// Fixed records, varying segment count: isolates the per-segment cost.
+		{400_000 * mult, 2 << 20, "fixed-records"},
+		{400_000 * mult, 8 << 20, "fixed-records"},
+		{400_000 * mult, 64 << 20, "fixed-records"},
+	}
+
+	var out []scaleResult
+	for _, c := range cases {
+		r := runScaleCase(t, c.records, c.segSize, ndv)
+		r.group = c.group
+		out = append(out, r)
+	}
+
+	t.Log("")
+	t.Logf("%-15s %10s %8s %9s %10s %9s %9s %11s %10s %8s",
+		"sweep", "records", "segSize", "segments", "disk", "reopen", "heap", "indexed", "scan", "speedup")
+	for _, r := range out {
+		speed := 0.0
+		if r.indexedMS > 0 {
+			speed = r.scanMS / r.indexedMS
+		}
+		t.Logf("%-15s %10d %8s %9d %10s %8.1fms %8.1fMB %10.2fms %8.0fms %7.1fx",
+			r.group, r.records, humanSize(int64(r.segSize)), r.segments, humanSize(r.diskBytes),
+			r.reopenMS, r.heapMB, r.indexedMS, r.scanMS, speed)
+	}
+	t.Log("")
+
+	// The load-bearing assertion is about the GAP, not the slope. Both paths are linear in
+	// archive size; what the index-resident path buys is a ~300x smaller constant, and that
+	// is what must not silently regress (e.g. if the fast path stopped engaging and quietly
+	// fell through to the scan, the speedup would collapse to ~1x while every result stayed
+	// correct).
+	// A tripwire for "the fast path stopped engaging", not a performance gate: a silent
+	// fall-through to the scan shows up as ~1x while every result stays correct. Set well
+	// below the ~270-450x observed, because run-to-run variance on a loaded machine is
+	// large (identical configurations have differed by 8x here).
+	const minSpeedup = 20
+	for _, r := range out {
+		if r.indexedMS <= 0 {
+			continue
+		}
+		if got := r.scanMS / r.indexedMS; got < minSpeedup {
+			t.Errorf("%s records=%d segSize=%s: indexed path only %.1fx faster than the scan "+
+				"(want >= %dx) -- the index-resident path is probably not engaging",
+				r.group, r.records, humanSize(int64(r.segSize)), got, minSpeedup)
+		}
+	}
+
+	// Report the observed slopes rather than asserting a shape, since the shape is linear.
+	var lo, hi *scaleResult
+	for i := range out {
+		if out[i].group != "fixed-segsize" {
+			continue
+		}
+		if lo == nil || out[i].records < lo.records {
+			lo = &out[i]
+		}
+		if hi == nil || out[i].records > hi.records {
+			hi = &out[i]
+		}
+	}
+	if lo != nil && hi != nil && lo != hi && lo.indexedMS > 0 {
+		t.Logf("fixed segment size, %.0fx records (%.2fx segments): indexed %.2fx, scan %.2fx, reopen %.2fx",
+			float64(hi.records)/float64(lo.records), float64(hi.segments)/float64(lo.segments),
+			hi.indexedMS/lo.indexedMS, hi.scanMS/lo.scanMS, hi.reopenMS/lo.reopenMS)
+	}
+}
+
+func runScaleCase(t *testing.T, records, segSize, ndv int) scaleResult {
+	t.Helper()
+	dir := t.TempDir()
+	res := scaleResult{records: records, segSize: segSize}
+
+	cat, err := OpenCatalog(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Owner is categorically indexed; Owner2 carries the SAME values but is not indexed, so
+	// grouping on it forces the scan over an identical corpus -- an honest A/B rather than a
+	// comparison against a different query.
+	hist, err := cat.CreateArchiveTable("history", ArchiveConfig{
+		SegmentSize:      segSize,
+		CategoricalAttrs: []string{"Owner"},
+		ValueAttrs:       []string{"ClusterId"},
+		ZoneAttrs:        []string{"CompletionDate", "EnteredHistoryTime"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	start := time.Now()
+	for i := 0; i < records; i++ {
+		ad := scaleAd(i, ndv) + fmt.Sprintf("Owner2 = %q\n", fmt.Sprintf("user%04d", i%ndv))
+		if err := hist.AppendOld(ad); err != nil {
+			t.Fatal(err)
+		}
+	}
+	res.buildMS = float64(time.Since(start).Microseconds()) / 1000
+	res.segments = hist.Stats().Segments
+	res.diskBytes = dirBytes(t, dir)
+	cat.Close()
+
+	// Reopen from cold: recovery is documented as O(segments), and startup cost is what
+	// makes a large segment count operationally expensive rather than merely untidy.
+	runtime.GC()
+	var before runtime.MemStats
+	runtime.ReadMemStats(&before)
+	start = time.Now()
+	cat2, err := OpenCatalog(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	h2, ok := cat2.ArchiveTable("history")
+	if !ok {
+		t.Fatal("archive not recovered")
+	}
+	res.reopenMS = float64(time.Since(start).Microseconds()) / 1000
+	defer cat2.Close()
+	runtime.GC()
+	var after runtime.MemStats
+	runtime.ReadMemStats(&after)
+	// Go-heap only. Sidecars and segment data are mmap-backed and demand-paged, so they do
+	// not appear here -- which is the point: what grows with segment count is the resident
+	// catalog, not the index bytes.
+	if after.HeapAlloc > before.HeapAlloc {
+		res.heapMB = float64(after.HeapAlloc-before.HeapAlloc) / (1 << 20)
+	}
+
+	aggs := []AggSpec{{Func: AggCount, Arg: "*"}}
+	start = time.Now()
+	rows, err := h2.Aggregate("true", []string{"Owner"}, aggs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res.indexedMS = float64(time.Since(start).Microseconds()) / 1000
+	res.groups = len(rows)
+	if res.groups != ndv {
+		t.Errorf("indexed GROUP BY produced %d groups, want %d", res.groups, ndv)
+	}
+
+	start = time.Now()
+	rows2, err := h2.Aggregate("true", []string{"Owner2"}, aggs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res.scanMS = float64(time.Since(start).Microseconds()) / 1000
+	if len(rows2) != ndv {
+		t.Errorf("scan GROUP BY produced %d groups, want %d", len(rows2), ndv)
+	}
+	// Same corpus, same cardinality: the two paths must agree, or the speedup is measuring
+	// a different answer.
+	got := map[string]string{}
+	for _, r := range rows {
+		got[r.Group[0]] = r.Values[0]
+	}
+	for _, r := range rows2 {
+		if got[r.Group[0]] != r.Values[0] {
+			t.Errorf("group %q: indexed=%s scan=%s", r.Group[0], got[r.Group[0]], r.Values[0])
+		}
+	}
+	return res
+}
+
+func dirBytes(t *testing.T, dir string) int64 {
+	t.Helper()
+	var total int64
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return 0
+	}
+	var walk func(string, []os.DirEntry)
+	walk = func(base string, es []os.DirEntry) {
+		for _, e := range es {
+			p := base + string(os.PathSeparator) + e.Name()
+			if e.IsDir() {
+				sub, err := os.ReadDir(p)
+				if err == nil {
+					walk(p, sub)
+				}
+				continue
+			}
+			if fi, err := e.Info(); err == nil {
+				total += fi.Size()
+			}
+		}
+	}
+	walk(dir, entries)
+	return total
+}
+
+func humanSize(b int64) string {
+	switch {
+	case b >= 1<<30:
+		return fmt.Sprintf("%.1fG", float64(b)/(1<<30))
+	case b >= 1<<20:
+		return fmt.Sprintf("%.0fM", float64(b)/(1<<20))
+	case b >= 1<<10:
+		return fmt.Sprintf("%.0fK", float64(b)/(1<<10))
+	}
+	return fmt.Sprintf("%dB", b)
+}

--- a/db/db.go
+++ b/db/db.go
@@ -216,6 +216,11 @@ type MaintainOptions struct {
 	IndexBudgetHighFrac   float64
 	IndexBudgetLowFrac    float64
 	IndexBudgetSlackBytes int64
+	// ArchiveMerge tunes the merge pass run over each archive table. The zero value uses
+	// the policy defaults, which target a segment count well clear of the process's mapping
+	// budget. ArchiveMergeDisabled turns the archive side of maintenance off entirely.
+	ArchiveMerge         MergeOptions
+	ArchiveMergeDisabled bool
 	// SchemaScanHotTopN, when > 0, builds/refreshes the per-segment adschema columnar
 	// accelerator (used by CountConstraint's fast path) keeping the topN most query-read
 	// numeric fields uncompressed. The first pass chooses a stable schema and hot set from

--- a/dbrpc/archive_maintenance_test.go
+++ b/dbrpc/archive_maintenance_test.go
@@ -1,0 +1,127 @@
+package dbrpc
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/PelicanPlatform/classad/db"
+)
+
+// TestArchiveMaintenanceMerges is the regression for a gap that made every piece of archive
+// maintenance dead code: StartMaintenance iterated only cat.Tables(), which excludes archive
+// tables, so nothing ever merged or reindexed an archive. The failure mode is quiet -- the
+// segment count simply climbs until the daemon cannot map them all at startup.
+func TestArchiveMaintenanceMerges(t *testing.T) {
+	c, srv, cleanup := catServerPairWithServer(t)
+	defer cleanup()
+
+	if err := c.CreateArchiveTable(context.Background(), "history", db.ArchiveConfig{
+		SegmentSize: 1 << 12,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 3000; i++ {
+		if err := c.ArchiveAppend(context.Background(), "history",
+			fmt.Sprintf("ClusterId = %d\nPad = %q", i, strings.Repeat("z", 60))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	before, err := c.ArchiveQuery(context.Background(), "history", "true", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	arch, ok := srv.cat.ArchiveTable("history")
+	if !ok {
+		t.Fatal("archive missing from the catalog")
+	}
+	segsBefore := arch.Stats().Segments
+	if segsBefore < 10 {
+		t.Fatalf("need enough segments to merge, got %d", segsBefore)
+	}
+
+	srv.maintainArchives(db.MaintainOptions{
+		ArchiveMerge: db.MergeOptions{
+			TargetSegments: 4, TriggerSegments: 8, MinMergeBytes: 1, KeepRecent: 2,
+		},
+	})
+
+	after, err := c.ArchiveQuery(context.Background(), "history", "true", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(after) != len(before) {
+		t.Fatalf("records after maintenance = %d, want %d", len(after), len(before))
+	}
+	// Records surviving is necessary but not sufficient: it would also hold if maintenance
+	// did nothing at all, which is exactly the bug this covers.
+	if segsAfter := arch.Stats().Segments; segsAfter >= segsBefore {
+		t.Errorf("segments %d -> %d: the archive maintenance pass did not merge anything",
+			segsBefore, segsAfter)
+	}
+	for i := range before {
+		if after[i] != before[i] {
+			t.Fatalf("record %d changed across maintenance", i)
+		}
+	}
+}
+
+// TestArchiveMaintenanceDisabled checks the off switch, since merging rewrites data and an
+// operator may want it under their own control.
+func TestArchiveMaintenanceDisabled(t *testing.T) {
+	c, srv, cleanup := catServerPairWithServer(t)
+	defer cleanup()
+	if err := c.CreateArchiveTable(context.Background(), "history", db.ArchiveConfig{
+		SegmentSize: 1 << 12,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 2000; i++ {
+		if err := c.ArchiveAppend(context.Background(), "history",
+			fmt.Sprintf("ClusterId = %d\nPad = %q", i, strings.Repeat("y", 60))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	archBefore, ok := srv.cat.ArchiveTable("history")
+	if !ok {
+		t.Fatal("archive missing from the catalog")
+	}
+	segsBefore := archBefore.Stats().Segments
+	done := make(chan struct{})
+	go func() {
+		srv.maintainArchives(db.MaintainOptions{
+			ArchiveMergeDisabled: true,
+			ArchiveMerge:         db.MergeOptions{TargetSegments: 1, TriggerSegments: 2, MinMergeBytes: 1},
+		})
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("disabled maintenance did not return promptly")
+	}
+	arch, ok := srv.cat.ArchiveTable("history")
+	if !ok {
+		t.Fatal("archive missing from the catalog")
+	}
+	if got := arch.Stats().Segments; got != segsBefore {
+		t.Errorf("segments %d -> %d while merging was disabled", segsBefore, got)
+	}
+}
+
+// catServerPairWithServer is catServerPair keeping the Server, so a test can drive a
+// maintenance pass directly instead of waiting on the scheduled one.
+func catServerPairWithServer(t *testing.T) (*Client, *Server, func()) {
+	t.Helper()
+	cat, err := db.OpenCatalog(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := NewServerCatalog(cat)
+	cconn, sconn := netPipe()
+	go func() { _ = s.ServeConnOpts(sconn, ServeOptions{}) }()
+	c := NewClient(cconn)
+	return c, s, func() { c.Close(); s.Close(); cat.Close() }
+}

--- a/dbrpc/server.go
+++ b/dbrpc/server.go
@@ -266,6 +266,7 @@ func (s *Server) StartMaintenance(interval time.Duration, opts db.MaintainOption
 					s.maintainMu.Unlock()
 				}
 			}
+			s.maintainArchives(opts)
 			// Keep the duty cycle under the cap: wait at least pass/dutyCycle before the
 			// next pass, never less than the configured floor.
 			next := interval
@@ -1462,3 +1463,38 @@ func respErr(reqID uint64, msg string) []byte {
 	return putStr(respHead(reqID, stErr), msg)
 }
 func respBad(reqID uint64) []byte { return resp(reqID, stBadReq) }
+
+// maintainArchives runs the append-only side of a maintenance pass. Archive tables are a
+// separate catalog namespace, so the loop over cat.Tables() above does not reach them -- and
+// until it did, nothing ever ran on an archive: no merge, no reindex, no tuning.
+//
+// That omission matters more for an archive than it would for a mutable table. An
+// append-only table never compacts, so its segment count only grows, and every sealed
+// segment costs a memory mapping at open plus a second for its sidecar. Exhausting
+// vm.max_map_count stops the daemon STARTING, and the condition is not self-correcting: with
+// nothing merging, the count only rises, and the symptom does not appear until a restart.
+//
+// The work is deliberately narrow -- merge cold runs, and rebuild indexes left stale by an
+// interrupted pass. Retraining and rewriting are excluded: both re-encode the whole archive,
+// which is not something to do on a timer.
+func (s *Server) maintainArchives(opts db.MaintainOptions) {
+	if opts.ArchiveMergeDisabled {
+		return
+	}
+	for _, name := range s.cat.ArchiveTables() {
+		a, ok := s.cat.ArchiveTable(name)
+		if !ok {
+			continue
+		}
+		s.maintainMu.Lock()
+		// Below its trigger watermark this is a segment count and a comparison, so the
+		// common case costs nothing.
+		a.MergePass(opts.ArchiveMerge)
+		// A merge leaves its output without a sidecar, and an interrupted reindex leaves
+		// segments stale; either way queries fall back to scanning until it is rebuilt.
+		if stale, _ := a.StaleIndexSegments(); stale > 0 {
+			a.Reindex()
+		}
+		s.maintainMu.Unlock()
+	}
+}


### PR DESCRIPTION
> Targets `main`, and **contains #141's commits** as well as its own — merge #141 first and this diff shrinks to just the maintenance wiring. Both target `main` rather than each other, so neither can be orphaned when the other lands.

`StartMaintenance` iterated `cat.Tables()`, which is **mutable tables only**, so nothing ever ran on an archive: no merge, no reindex, no tuning. Every piece of archive maintenance built so far — #138's merge mechanism, #141's policy — was unreachable.

The omission matters more for an append-only table than it would for a mutable one. An archive never compacts, so its segment count only grows, and every sealed segment costs a memory mapping at open plus a second for its sidecar. Exhausting `vm.max_map_count` stops the daemon **starting**, not merely slows a query — and it does not correct itself: with nothing merging, the count only rises, and the symptom first appears at a restart.

## What the archive half does

- **Merge pass** — below its trigger watermark this is a segment count and a comparison, so the common case costs nothing
- **Reindex when segments are stale** — a merge leaves its output without a sidecar, and an interrupted pass leaves others stale; either way queries fall back to scanning until rebuilt

Deliberately excluded: **retrain and rewrite**. Both re-encode the whole archive, which is not something to put on a timer.

## Options

| Option | Effect |
|---|---|
| `ArchiveMerge` | tunes the policy (watermarks, byte budget, size bounds) |
| `ArchiveMergeDisabled` | turns the archive half off entirely |

The off switch exists because merging rewrites data, and an operator may reasonably want that under their own control.

## Testing

The tests assert the **segment count actually falls**, not merely that records survive — surviving records would also hold if the pass did nothing, which is exactly the bug being fixed. The disabled case asserts the count is *unchanged*.

`go vet` and the full `collections`, `db`, and `dbrpc` suites pass.

## Pacing note

`StartMaintenance` already paces itself to `maintenanceMaxDutyCycle` (1%), and a merge pass's duration feeds that, so a long pass automatically spaces out the next one.

Worth knowing when tuning: at the ~160 MB/s merging sustains, a 1% duty cycle yields ~1.6 MB/s — which is almost exactly the steady-state merge demand at a 10 TB/year ingest, with no margin. Merging may want a larger share, or its own budget. `MaxBytesPerPass` bounds a single pass so raising the cadence does not risk a long stall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
