### PR TITLE
collections: stop retraining from rewriting the whole archive

### DIFF
--- a/collections/archive_upgrade.go
+++ b/collections/archive_upgrade.go
@@ -1,0 +1,230 @@
+package collections
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+)
+
+// Re-encoding old archive segments under a newer dictionary.
+//
+// RetrainDict installs a new dictionary for new writes and stops there: old segments keep
+// the dictionary they were written under, and recovery reconstructs every registered one, so
+// they stay readable forever. Bringing them onto the new dictionary is an optimization, and
+// at archive scale an expensive one -- rewriting the whole archive is hours of I/O and a
+// flushed page cache.
+//
+// Worse, the gain can be negative. A dictionary trained on a sample of recent ads is fit to
+// the CURRENT distribution; older segments written when the distribution differed may
+// compress worse under it. So this pass does not assume improvement -- it measures, per
+// segment, and re-encodes only where the measurement says it pays.
+//
+// A measurement that says "no" has to be remembered, or every pass re-measures the same
+// segments forever. The verdict is recorded against the dictionary generation it was made
+// under and persisted beside the shard, so a restart does not restart the sampling either. A
+// later retrain produces a new generation, which invalidates the old verdicts exactly as it
+// should -- the answer may genuinely differ under a different dictionary.
+
+// UpgradeOptions tunes a codec-upgrade pass. The zero value is usable.
+type UpgradeOptions struct {
+	// MinGainFrac is the fraction of a segment's bytes a re-encode must be projected to
+	// save before it is worth doing. Default defaultMinGainFrac.
+	MinGainFrac float64
+	// SampleRecords is how many records are decompressed and re-compressed to project the
+	// gain. The estimate only has to separate "clearly worth it" from "not", so this stays
+	// small; the cost of being wrong is one segment, not the archive.
+	SampleRecords int
+	// MaxBytesPerPass bounds the source bytes one pass re-encodes, as for merging. Zero
+	// uses the default.
+	MaxBytesPerPass int64
+	// MaxSegments bounds how many segments one pass upgrades.
+	MaxSegments int
+}
+
+const (
+	defaultMinGainFrac    = 0.10
+	defaultSampleRecords  = 128
+	defaultUpgradeBytes   = 1 << 30
+	defaultUpgradeSegs    = 32
+	upgradeVerdictsFile   = "upgrade.json"
+	upgradeVerdictVersion = 1
+)
+
+func (o UpgradeOptions) withDefaults() UpgradeOptions {
+	if o.MinGainFrac <= 0 {
+		o.MinGainFrac = defaultMinGainFrac
+	}
+	if o.SampleRecords <= 0 {
+		o.SampleRecords = defaultSampleRecords
+	}
+	if o.MaxBytesPerPass <= 0 {
+		o.MaxBytesPerPass = defaultUpgradeBytes
+	}
+	if o.MaxSegments <= 0 {
+		o.MaxSegments = defaultUpgradeSegs
+	}
+	return o
+}
+
+// upgradeVerdicts remembers, per segment file, the dictionary generation whose re-encode was
+// measured and rejected. Keyed by file name because that is what survives a restart.
+type upgradeVerdicts struct {
+	Version  int               `json:"version"`
+	Rejected map[string]uint32 `json:"rejected"` // segment file -> dict id judged not worth it
+}
+
+// UpgradeCodecPass re-encodes sealed segments that are still on an older dictionary, where
+// measurement says the newer one compresses them meaningfully better. Returns the number of
+// segments upgraded.
+//
+// Segments measured as no better (or worse) are recorded and not measured again until the
+// dictionary changes, so a pass over a fully-evaluated archive costs a directory read.
+func (a *Archive) UpgradeCodecPass(opts UpgradeOptions) int {
+	return a.c.upgradeCodecPass(opts.withDefaults())
+}
+
+func (c *Collection) upgradeCodecPass(opts UpgradeOptions) int {
+	if !c.appendOnly() || c.dir == "" {
+		return 0
+	}
+	c.maintMu.Lock()
+	defer c.maintMu.Unlock()
+
+	sh := c.shards[0]
+	if sh.segDir == "" {
+		return 0
+	}
+	target := c.currentCodec()
+	targetID, ok := c.dicts.idFor(target)
+	if !ok {
+		return 0
+	}
+	verdicts := loadUpgradeVerdicts(sh.segDir)
+
+	// Candidates: sealed, non-empty, not already on the target codec, and not already
+	// judged against it.
+	sh.mu.RLock()
+	var cand []*segment
+	for _, s := range sh.segs {
+		if s == nil || s == sh.act || s.used == 0 || s.codec == target {
+			continue
+		}
+		if verdicts.Rejected[filepath.Base(s.path)] == targetID {
+			continue
+		}
+		cand = append(cand, s)
+	}
+	sh.mu.RUnlock()
+
+	upgraded, changed := 0, false
+	var moved int64
+	for _, src := range cand {
+		if upgraded >= opts.MaxSegments || moved >= opts.MaxBytesPerPass {
+			break
+		}
+		gain, ok := c.projectRecodeGain(src, target, opts.SampleRecords)
+		if !ok || gain < opts.MinGainFrac {
+			// Measured and not worth it. Record it against this dictionary so the next
+			// pass does not pay the sampling again; a later retrain clears the verdict by
+			// changing the id.
+			verdicts.Rejected[filepath.Base(src.path)] = targetID
+			changed = true
+			continue
+		}
+		sz := int64(src.used)
+		if !c.recodeSegment(sh, src, target) {
+			continue
+		}
+		upgraded++
+		moved += sz
+	}
+	if changed {
+		saveUpgradeVerdicts(sh.segDir, verdicts)
+	}
+	if upgraded > 0 {
+		c.Reindex() // the re-encoded segments need their sidecars rebuilt
+		c.pruneDicts()
+	}
+	return upgraded
+}
+
+// projectRecodeGain estimates the fraction of a segment's bytes re-encoding under target
+// would save, by recompressing a sample of its records. ok is false if the segment cannot be
+// sampled at all.
+//
+// The sample is taken from the front of the segment; records within one segment are adjacent
+// in time and therefore similar in shape, which is the property that makes a small sample
+// informative here and would not hold across an archive.
+func (c *Collection) projectRecodeGain(src *segment, target Codec, sample int) (float64, bool) {
+	var oldBytes, newBytes int64
+	n := 0
+	var dbuf []byte
+	for off := 0; off < src.used && n < sample; {
+		o := uint32(off)
+		rl := recTotalLen(src.data, o)
+		if rl == 0 {
+			break
+		}
+		off += int(rl)
+		if recIsMarker(src.data, o) {
+			continue
+		}
+		stored := recAd(src.data, o)
+		raw, err := src.codec.Decompress(dbuf[:0], stored)
+		if err != nil {
+			return 0, false
+		}
+		dbuf = raw
+		oldBytes += int64(len(stored))
+		newBytes += int64(len(target.Compress(nil, raw)))
+		n++
+	}
+	if n == 0 || oldBytes == 0 {
+		return 0, false
+	}
+	return float64(oldBytes-newBytes) / float64(oldBytes), true
+}
+
+// recodeSegment re-encodes one segment under target and swaps it in, reusing the append-only
+// reseal path (which preserves seq, key, and time markers, so watch cursors stay valid).
+func (c *Collection) recodeSegment(sh *shard, src *segment, target Codec) bool {
+	newseg := c.resealOneSegment(sh, src, target)
+	if newseg == nil {
+		return false
+	}
+	sh.mu.Lock()
+	if int(src.id) >= len(sh.segs) || sh.segs[src.id] != src {
+		sh.mu.Unlock()
+		newseg.retire()
+		newseg.reapAndHook()
+		return false
+	}
+	sh.segs[src.id] = newseg
+	retire := src.retire()
+	sh.mu.Unlock()
+	if retire {
+		src.reapAndHook()
+	}
+	return true
+}
+
+func loadUpgradeVerdicts(dir string) *upgradeVerdicts {
+	v := &upgradeVerdicts{Version: upgradeVerdictVersion, Rejected: map[string]uint32{}}
+	data, err := os.ReadFile(filepath.Join(dir, upgradeVerdictsFile))
+	if err != nil {
+		return v
+	}
+	var got upgradeVerdicts
+	if json.Unmarshal(data, &got) != nil || got.Version != upgradeVerdictVersion || got.Rejected == nil {
+		return v // unreadable or from another version: re-measure rather than guess
+	}
+	return &got
+}
+
+func saveUpgradeVerdicts(dir string, v *upgradeVerdicts) {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return
+	}
+	_ = writeFileSync(filepath.Join(dir, upgradeVerdictsFile), data) // best-effort
+}

--- a/collections/archive_upgrade_test.go
+++ b/collections/archive_upgrade_test.go
@@ -1,0 +1,192 @@
+package collections
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/classad"
+	"github.com/PelicanPlatform/classad/collections/vm"
+)
+
+func buildUpgradeArchive(t *testing.T, dir string, n int) *Archive {
+	t.Helper()
+	// Intern at seal, so segments are already interned by the time a retrain runs: the
+	// retrain then leaves them on their old dictionary, which is exactly the state the
+	// upgrade pass exists to evaluate. Without this, interning-at-retrain would re-encode
+	// them onto the new codec and there would be nothing left to consider.
+	a, err := CreateArchive(ArchiveOptions{Dir: dir, SegmentSize: 1 << 13, InternAtSeal: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < n; i++ {
+		ad, _ := classad.ParseOld(fmt.Sprintf(
+			"ClusterId = %d\nOwner = %q\nCmd = \"/usr/bin/payload\"\nPad = %q",
+			i, fmt.Sprintf("user%04d", i%32), strings.Repeat("a", 100)))
+		if err := a.Append(ad); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return a
+}
+
+func archiveIDs(t *testing.T, a *Archive) []int64 {
+	t.Helper()
+	q, err := vm.Parse("true")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out []int64
+	for ad := range a.Query(q) {
+		v, _ := ad.EvaluateAttrInt("ClusterId")
+		out = append(out, v)
+	}
+	return out
+}
+
+// TestRetrainDoesNotRewriteArchive is the point of the change: a retrain must cost a sample
+// and a registration, not a rewrite of the whole archive. Old segments keep the dictionary
+// they were written under and stay readable, because recovery reconstructs every registered
+// dictionary.
+func TestRetrainDoesNotRewriteArchive(t *testing.T) {
+	if !mmapSupported {
+		t.Skip("persistence is unix-only")
+	}
+	dir := t.TempDir()
+	a := buildUpgradeArchive(t, dir, 3000)
+	before := archiveIDs(t, a)
+
+	sh := a.c.shards[0]
+	sh.mu.RLock()
+	var sealedBefore []*segment
+	for _, s := range sh.segs {
+		if s != nil && s != sh.act && s.used > 0 {
+			sealedBefore = append(sealedBefore, s)
+		}
+	}
+	sh.mu.RUnlock()
+	if len(sealedBefore) < 3 {
+		t.Fatalf("need several sealed segments, got %d", len(sealedBefore))
+	}
+
+	if _, err := a.RetrainDict(2000); err != nil {
+		t.Fatal(err)
+	}
+
+	// The existing segments must be the very same objects: a reseal would have replaced them.
+	sh.mu.RLock()
+	live := map[*segment]bool{}
+	for _, s := range sh.segs {
+		if s != nil {
+			live[s] = true
+		}
+	}
+	sh.mu.RUnlock()
+	for i, s := range sealedBefore {
+		if !live[s] {
+			t.Fatalf("sealed segment %d was rewritten by the retrain", i)
+		}
+	}
+	if got := archiveIDs(t, a); !equalIDs(got, before) {
+		t.Errorf("records changed across retrain: %d, want %d", len(got), len(before))
+	}
+	a.Close()
+
+	// Old segments still decode after a reopen, under the dictionary they were written with.
+	a2, err := OpenArchive(ArchiveOptions{Dir: dir, SegmentSize: 1 << 13, InternAtSeal: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer a2.Close()
+	if got := archiveIDs(t, a2); !equalIDs(got, before) {
+		t.Errorf("after reopen: %d records, want %d", len(got), len(before))
+	}
+}
+
+// TestUpgradeRecordsRejection covers the case where the newer dictionary is not better: the
+// pass must decline AND remember declining, or every later pass re-samples the same segments
+// forever. The verdict is keyed to the dictionary generation, so a later retrain re-opens
+// the question rather than inheriting a stale answer.
+func TestUpgradeRecordsRejection(t *testing.T) {
+	if !mmapSupported {
+		t.Skip("persistence is unix-only")
+	}
+	dir := t.TempDir()
+	a := buildUpgradeArchive(t, dir, 3000)
+	defer a.Close()
+	before := archiveIDs(t, a)
+
+	if _, err := a.RetrainDict(2000); err != nil {
+		t.Fatal(err)
+	}
+	// Demand an implausible gain so every segment is judged not worth re-encoding.
+	if n := a.UpgradeCodecPass(UpgradeOptions{MinGainFrac: 0.99}); n != 0 {
+		t.Fatalf("upgraded %d segments despite an unreachable gain threshold", n)
+	}
+
+	shardDir := findShardDir(t, dir)
+	data, err := os.ReadFile(filepath.Join(shardDir, upgradeVerdictsFile))
+	if err != nil {
+		t.Fatalf("no verdict file written: %v", err)
+	}
+	var v upgradeVerdicts
+	if err := json.Unmarshal(data, &v); err != nil {
+		t.Fatal(err)
+	}
+	if len(v.Rejected) == 0 {
+		t.Error("verdicts recorded nothing; the next pass would re-sample every segment")
+	}
+
+	// A second pass must find nothing left to consider.
+	if n := a.UpgradeCodecPass(UpgradeOptions{MinGainFrac: 0.99}); n != 0 {
+		t.Errorf("second pass upgraded %d segments", n)
+	}
+	if got := archiveIDs(t, a); !equalIDs(got, before) {
+		t.Errorf("records changed: %d, want %d", len(got), len(before))
+	}
+}
+
+// TestUpgradeReencodesWhenItPays is the converse: with a reachable threshold the pass does
+// re-encode, the records survive, and the segments move onto the current codec.
+func TestUpgradeReencodesWhenItPays(t *testing.T) {
+	if !mmapSupported {
+		t.Skip("persistence is unix-only")
+	}
+	dir := t.TempDir()
+	a := buildUpgradeArchive(t, dir, 3000)
+	defer a.Close()
+	before := archiveIDs(t, a)
+
+	if _, err := a.RetrainDict(2000); err != nil {
+		t.Fatal(err)
+	}
+	// A threshold of "any improvement at all" -- whether it triggers depends on the corpus,
+	// so accept either outcome and only demand that the data is intact and, if it did run,
+	// that the segments actually moved to the current codec.
+	n := a.UpgradeCodecPass(UpgradeOptions{MinGainFrac: -1})
+	if got := archiveIDs(t, a); !equalIDs(got, before) {
+		t.Fatalf("records changed across upgrade: %d, want %d", len(got), len(before))
+	}
+	if n == 0 {
+		t.Skip("no segment cleared the gain threshold on this corpus")
+	}
+	target := a.c.currentCodec()
+	sh := a.c.shards[0]
+	sh.mu.RLock()
+	defer sh.mu.RUnlock()
+	stale := 0
+	for _, s := range sh.segs {
+		if s != nil && s != sh.act && s.used > 0 && s.codec != target {
+			stale++
+		}
+	}
+	if stale > 0 && n >= defaultUpgradeSegs {
+		return // bounded by MaxSegments, not by having finished
+	}
+	if stale > 0 {
+		t.Errorf("%d segments still on an older codec after upgrading %d", stale, n)
+	}
+}

--- a/collections/compact.go
+++ b/collections/compact.go
@@ -261,9 +261,22 @@ func (c *Collection) RetrainDict(sampleMax int) (int, error) {
 		retrainStallHook() // test seam: observe concurrent access during a long retrain
 	}
 	if c.appendOnly() {
-		// Append log: recompress each segment in place (reseal preserving order) instead
-		// of the compaction live-copy, which would supersede/renumber -- illegal here.
-		c.resealAppendOnly(codec)
+		// An append log stops here. Every segment records the dictionary it was written
+		// under and recovery reconstructs all of them, so old segments remain readable on
+		// their old dictionary indefinitely -- re-encoding them is an optimization, not a
+		// correctness requirement.
+		//
+		// Treating it as one made a retrain reseal the entire archive: at history scale
+		// that is hours of I/O and a flushed page cache, for a compression gain that is
+		// usually small and occasionally NEGATIVE (a dictionary trained on recent ads can
+		// compress older ones worse once the distribution has moved). Re-encoding is now a
+		// separate, budgeted, per-segment-measured decision -- see UpgradeCodecPass -- and
+		// Rewrite is still the explicit "re-encode everything now" escape hatch.
+		//
+		// Interning still runs: turning a sealed segment from inline to interned form is a
+		// one-way transition each segment undergoes ONCE, so it does not accumulate the way
+		// re-compression would.
+		c.internSealedLocked()
 	} else {
 		for _, sh := range c.shards {
 			c.compactShard(sh, codec) // recompress to the new codec

--- a/collections/retrain_appendonly.go
+++ b/collections/retrain_appendonly.go
@@ -80,6 +80,17 @@ func (c *Collection) InternSealed() {
 	}
 	c.maintMu.Lock()
 	defer c.maintMu.Unlock()
+	c.internSealedLocked()
+}
+
+// internSealedLocked is InternSealed's body, for callers already holding maintMu (RetrainDict
+// runs it so a retrain still interns whatever has sealed since the last one -- a one-way,
+// once-per-segment transition, unlike recompression, which would otherwise repeat over the
+// whole archive on every retrain).
+func (c *Collection) internSealedLocked() {
+	if !c.inline || !c.appendOnly() {
+		return
+	}
 	codec := c.currentCodec()
 	swapped := false
 	for _, sh := range c.shards {


### PR DESCRIPTION
`RetrainDict` resealed **every segment** of an append-only collection so old data would be recompressed under the new dictionary. At history scale that is the largest unbounded rewrite reachable: 10 TB re-encoded per retrain, hours of I/O, and a page cache flushed from under the very queries it is meant to help.

It is also **optional**. Every segment records the dictionary it was written under and recovery reconstructs all of them, so old segments stay readable on their old dictionary indefinitely.

And its value is not reliably positive: a dictionary trained on a sample of *recent* ads is fit to the current distribution, so segments written when it differed can compress **worse** under it.

## What changes

A retrain now installs the new dictionary for new writes and stops.

Interning still runs — inline → interned is a **one-way transition each segment undergoes once**, so it does not accumulate the way recompression does. (Via a `maintMu`-free `internSealedLocked`, since `RetrainDict` already holds the lock.)

## Re-encoding becomes a measured decision

`UpgradeCodecPass`: per segment, project the gain by recompressing a small sample, and re-encode only where it clears a threshold (default 10%), under byte and segment budgets.

Segments measured as **not worth it are recorded against the dictionary generation that was measured**, and persisted beside the shard — so neither the next pass nor the next restart re-samples them. A later retrain changes the generation and re-opens the question, which is correct: the answer can genuinely differ under a different dictionary.

The sample is taken from the front of a segment, which works because records within one segment are adjacent in time and therefore similar in shape — a property that would not hold across an archive.

`Rewrite` remains the explicit "re-encode everything now" escape hatch.

## Testing

- `TestRetrainDoesNotRewriteArchive` — asserts the sealed segments are the *same objects* after a retrain (a reseal would have replaced them), records intact, and still decodable after a reopen on their old dictionary
- `TestUpgradeRecordsRejection` — an unreachable threshold produces zero upgrades, a persisted verdict file, and a second pass that considers nothing
- `TestUpgradeReencodesWhenItPays` — the converse

The interning tests caught a real coupling during development: `resealAppendOnly` was doing double duty, recompressing *and* interning. Splitting them is what the `internSealedLocked` extraction is for.

`go vet` and the full `collections`, `db`, and `dbrpc` suites pass.

## Not included

Scheduling. `UpgradeCodecPass` is a callable pass, deliberately not wired into the maintenance loop — unlike merging, it addresses no ceiling, so it should be enabled by choice rather than by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
