### PR TITLE
collections: stop auto-index drops from thrashing

### DIFF
--- a/collections/autoindex.go
+++ b/collections/autoindex.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/PelicanPlatform/classad/collections/vm"
 	"github.com/PelicanPlatform/classad/collections/wire"
@@ -40,11 +41,38 @@ type demandCounts struct {
 // queries.
 type demandTracker struct {
 	m sync.Map // foldedName(string) -> *demandCounts
+
+	// total and startedUnix answer a question the per-attribute counters cannot: whether a
+	// zero means "queried by nobody" or "we have not been watching long enough to say".
+	//
+	// The counters are process-local and never decay, so immediately after a restart EVERY
+	// attribute reads zero. Acting on that drops the whole auto-index set on every restart
+	// and rebuilds it as traffic returns -- which on a large table is an expensive way to
+	// arrive back where it started.
+	total       atomic.Int64
+	startedUnix atomic.Int64
 }
 
-func newDemandTracker() *demandTracker { return &demandTracker{} }
+// hasDropEvidence reports whether the tracker has watched long enough, and seen enough
+// queries, for an attribute's zero to mean anything.
+func (d *demandTracker) hasDropEvidence(minQueries int64, minWindow time.Duration) bool {
+	if d.total.Load() < minQueries {
+		return false // an idle daemon has learned nothing about which indexes matter
+	}
+	st := d.startedUnix.Load()
+	return st != 0 && time.Since(time.Unix(0, st)) >= minWindow
+}
+
+func newDemandTracker() *demandTracker {
+	d := &demandTracker{}
+	d.startedUnix.Store(time.Now().UnixNano())
+	return d
+}
 
 func (d *demandTracker) record(probes []vm.Probe) {
+	if len(probes) > 0 {
+		d.total.Add(int64(len(probes)))
+	}
 	for _, p := range probes {
 		v, _ := d.m.LoadOrStore(strings.ToLower(p.Attr), &demandCounts{})
 		c := v.(*demandCounts)
@@ -173,6 +201,12 @@ const (
 	// watermark before AutoTune trims -- so a small overage does not cause churn. Used
 	// when AutoTuneOptions.BudgetSlackBytes is 0.
 	defaultBudgetSlackBytes = 10 << 20 // 10 MiB
+	// defaultDropWindow and defaultDropMinQueries are the evidence an unused-drop needs.
+	// The window outlasts a restart plus the first maintenance ticks, so a daemon that has
+	// just come up never concludes its indexes are unwanted; the query floor stops an idle
+	// daemon concluding anything at all.
+	defaultDropWindow     = time.Hour
+	defaultDropMinQueries = 100
 )
 
 // RecordDemand notes the attributes a constraint filters on (for SuggestIndexes)
@@ -329,7 +363,26 @@ type AutoTuneOptions struct {
 	// ("unused"). Off by default so AutoTune never removes an index a workload has
 	// simply not exercised yet. Human-created indexes and low-cardinality indexes are
 	// never auto-dropped (SuggestDrops reports them for manual review).
+	//
+	// Two guards keep this from thrashing, because rebuilding a dropped index is far more
+	// expensive than carrying an idle one:
+	//
+	//   - It requires EVIDENCE. Demand counters are process-local and never decay, so
+	//     right after a restart every attribute reads zero; dropping on that would discard
+	//     the whole auto set on every restart and rebuild it as traffic returns. Nothing is
+	//     dropped until the tracker has watched for DropUnusedMinWindow and seen at least
+	//     DropUnusedMinQueries probes.
+	//   - When a memory budget is configured it defers to it entirely. An unused index
+	//     that fits costs little, and budgetTrim already evicts least-demanded first when
+	//     space is actually short -- with hysteresis, which dropping on "unused" alone has
+	//     none of. Reclaim when you need the room, not merely because you could.
 	DropUnused bool
+	// DropUnusedMinWindow and DropUnusedMinQueries are how much observation makes a zero
+	// meaningful. Defaults: defaultDropWindow and defaultDropMinQueries. Negative values
+	// waive the requirement (as with BudgetSlackBytes), which is for tests and for a caller
+	// who has its own evidence that an index is unwanted.
+	DropUnusedMinWindow  time.Duration
+	DropUnusedMinQueries int64
 	// BudgetHighFrac / BudgetLowFrac, when BudgetHighFrac > 0, bound index memory as a
 	// fraction of the live data bytes: AutoTune stops adding demand-driven indexes once
 	// index bytes reach the high mark, and trims the least-used AUTO indexes (never
@@ -375,9 +428,27 @@ func (c *Collection) AutoTune(opts AutoTuneOptions) AutoTuneResult {
 		minDemand = 1
 	}
 	adds := c.SuggestIndexes(opts.SampleMax)
+	// Unused-drops are the churn-prone path: they run on demand counters alone, with no
+	// hysteresis. Gate them on evidence, and stand down entirely when a memory budget is
+	// configured -- the budget trim below reclaims the same indexes when space is actually
+	// short, and only then.
 	var drops []DropSuggestion
-	if opts.DropUnused {
-		drops = c.SuggestDrops(opts.SampleMax)
+	if opts.DropUnused && opts.BudgetHighFrac <= 0 {
+		window := opts.DropUnusedMinWindow
+		if window == 0 {
+			window = defaultDropWindow
+		} else if window < 0 {
+			window = 0
+		}
+		minQ := opts.DropUnusedMinQueries
+		if minQ == 0 {
+			minQ = defaultDropMinQueries
+		} else if minQ < 0 {
+			minQ = 0
+		}
+		if c.demand.hasDropEvidence(minQ, window) {
+			drops = c.SuggestDrops(opts.SampleMax)
+		}
 	}
 
 	slack := opts.BudgetSlackBytes

--- a/collections/index_dynamic_test.go
+++ b/collections/index_dynamic_test.go
@@ -274,7 +274,13 @@ func TestAutoTuneDropsUnused(t *testing.T) {
 	c := New(Options{Shards: 4})
 	c.addIndexAuto([]string{"Ghost"}, nil)
 	putDynAds(t, c, 100)
-	res := c.AutoTune(AutoTuneOptions{DropUnused: true, Reindex: true})
+	// Waive the observation requirement: an unused-drop now needs evidence that the tracker
+	// has watched long enough for a zero to mean something, which a unit test cannot wait
+	// for. See TestAutoTuneDropUnusedNeedsEvidence for the guard itself.
+	res := c.AutoTune(AutoTuneOptions{
+		DropUnused: true, Reindex: true,
+		DropUnusedMinWindow: -1, DropUnusedMinQueries: -1,
+	})
 	if !res.Changed {
 		t.Fatal("AutoTune should have dropped the unused auto Ghost index")
 	}
@@ -364,4 +370,51 @@ func contains(s []string, x string) bool {
 		}
 	}
 	return false
+}
+
+// TestAutoTuneDropUnusedNeedsEvidence covers the guard that stops the auto-index set being
+// discarded on every restart. Demand counters are process-local and never decay, so a
+// freshly started collection reports every attribute as unused -- acting on that drops the
+// whole set and then rebuilds it as traffic returns, which on a large table is an expensive
+// way to end up where it started.
+func TestAutoTuneDropUnusedNeedsEvidence(t *testing.T) {
+	t.Parallel()
+	c := New(Options{Shards: 4})
+	c.addIndexAuto([]string{"Ghost"}, nil)
+	putDynAds(t, c, 100)
+
+	// A tracker that has just started has watched nothing: the index must survive.
+	res := c.AutoTune(AutoTuneOptions{DropUnused: true, Reindex: true})
+	if cat, _ := c.IndexedAttrs(); len(cat) == 0 {
+		t.Fatalf("Ghost dropped with no observation behind it (changed=%v)", res.Changed)
+	}
+
+	// Waiving the window but not the query floor must still hold, since an idle daemon has
+	// learned nothing about which indexes matter.
+	c.AutoTune(AutoTuneOptions{DropUnused: true, Reindex: true, DropUnusedMinWindow: -1})
+	if cat, _ := c.IndexedAttrs(); len(cat) == 0 {
+		t.Error("Ghost dropped though no queries had been observed")
+	}
+}
+
+// TestAutoTuneDropUnusedDefersToBudget covers the second guard: with a memory budget
+// configured, unused-drops stand down entirely. The budget trim reclaims the same indexes
+// when space is actually short, and only then -- and unlike dropping on "unused" alone, it
+// has hysteresis, so it cannot oscillate around the threshold.
+func TestAutoTuneDropUnusedDefersToBudget(t *testing.T) {
+	t.Parallel()
+	c := New(Options{Shards: 4})
+	c.addIndexAuto([]string{"Ghost"}, nil)
+	putDynAds(t, c, 100)
+
+	// Evidence fully waived, so only the budget gate can be keeping Ghost alive. A high
+	// watermark far above actual usage means there is no space pressure.
+	c.AutoTune(AutoTuneOptions{
+		DropUnused: true, Reindex: true,
+		DropUnusedMinWindow: -1, DropUnusedMinQueries: -1,
+		BudgetHighFrac: 1000,
+	})
+	if cat, _ := c.IndexedAttrs(); len(cat) == 0 {
+		t.Error("Ghost dropped as unused while well under the memory budget")
+	}
 }


### PR DESCRIPTION
Two ways the auto-index tuner could discard an index it was about to need — both on the **unused-drop** path, which unlike the budget trim has no hysteresis at all.

## Restart amnesia

Demand counters are process-local and never decay, and `"unused"` means `eq == 0 && rng == 0` — **zero queries since process start**. So immediately after a restart *every* attribute reads unused, and a maintenance pass landing before traffic returns drops the entire auto set, rebuilding it as demand reappears. On a large table that is an expensive way to arrive back where it started, and it repeats on every restart.

Now a zero has to be earned. The tracker records when it began and how many probes it has seen, and nothing is dropped as unused until it has:

- watched for `DropUnusedMinWindow` (default **1 h**, outlasting a restart and the first maintenance ticks), and
- seen `DropUnusedMinQueries` probes (default **100**, so an idle daemon concludes nothing)

Negative values waive each — mirroring `BudgetSlackBytes` — since a one-hour window is not something a test can wait out.

## Budget deference

With a memory budget configured, unused-drops now **stand down entirely**. An unused index that fits costs little, and `budgetTrim` already evicts least-demanded-first when space is actually short — *with* high/low watermarks, so it cannot oscillate. Reclaim when the room is needed, not merely because it could be.

This also removes a redundancy: `budgetTrim` ranks candidates by demand, so unused indexes were already the first thing it took.

## Testing

- `TestAutoTuneDropUnusedNeedsEvidence` — a freshly started collection keeps its index; waiving the window but not the query floor still keeps it
- `TestAutoTuneDropUnusedDefersToBudget` — with evidence fully waived, a budget far above usage still protects the index, so only the budget gate can be responsible
- The existing `TestAutoTuneDropsUnused` now waives both requirements explicitly, which is also what surfaced the need for the negative-waives convention

`go vet` and the full `collections`, `db`, and `dbrpc` suites pass.

## Not addressed here

Auto-indexing is still **not run on archives** — `maintainArchives` deliberately does merge and reindex only. Before it is, an archive needs its own rate limiting: a single auto-add calls `Reindex()`, which decompresses every record in the archive (hours at 10 TB), triggered by a default demand threshold of one query. Recency-prioritised backfill would help too, since an archive is queried newest-first with `LIMIT` and its oldest segments may never be read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
