### PR TITLE
collections: derive inline attribute ids from the name, not from position

### DIFF
--- a/collections/attrid_collision_test.go
+++ b/collections/attrid_collision_test.go
@@ -1,0 +1,28 @@
+package collections
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestInlineAttrIDCollisionRefused pins the collision behaviour: two names that hash to the
+// same id must not share one index, because that index would answer for both. The second
+// attribute is left unindexed (its queries scan) rather than aliased.
+func TestInlineAttrIDCollisionRefused(t *testing.T) {
+	s := newInlineIndexSpec(nil, nil)
+	first := "Alpha"
+	id, ok := s.inlineID(first)
+	if !ok {
+		t.Fatal("first attribute refused")
+	}
+	// Forge a collision by planting a different name at the same id.
+	s.names[id] = "SomethingElse"
+	if _, ok := s.inlineID("Beta"); ok {
+		// Beta hashes elsewhere, so this is not the collision case; assert the planted
+		// name is what triggers refusal by asking for a name whose id we know is taken.
+		delete(s.nameToID, strings.ToLower(first))
+		if _, ok := s.inlineID(first); ok {
+			t.Error("an id already held by a different attribute was handed out again")
+		}
+	}
+}

--- a/collections/attrid_stability_test.go
+++ b/collections/attrid_stability_test.go
@@ -1,0 +1,89 @@
+package collections
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/collections/vm"
+)
+
+// TestInlineAttrIDsSurviveDropAndReopen is the regression for a silent wrong-answer bug.
+//
+// Inline attribute ids used to be positional -- 0,1,2 in the order of the persisted name
+// list -- while spec.gen, which decides whether a sidecar looks current, is not persisted and
+// resets to 0 on every open. Dropping an index therefore shifted every later attribute's id
+// on the next start, and sidecars written before the drop (gen 0) matched the reset gen and
+// were published under the NEW id mapping. One attribute's postings then answered for
+// another. Candidates are re-verified against the real predicate, so the damage showed up not
+// as wrong rows but as MISSING ones -- the quietest possible failure.
+//
+// The ids now follow the attribute name, so an old sidecar either means what it always meant
+// or matches nothing current, in which case the segment is scanned.
+func TestInlineAttrIDsSurviveDropAndReopen(t *testing.T) {
+	if !mmapSupported {
+		t.Skip("persistence is unix-only")
+	}
+	dir := t.TempDir()
+
+	// Owner is listed FIRST, so under positional ids it owned id 0 and Group owned id 1.
+	c, err := Open(Options{
+		Dir: dir, Shards: 1, SegmentSize: 1 << 13,
+		CategoricalAttrs: []string{"Owner", "Group"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	const n = 1500
+	const wantGroup = "grp7"
+	expect := 0
+	for i := 0; i < n; i++ {
+		grp := fmt.Sprintf("grp%d", i%10)
+		if grp == wantGroup {
+			expect++
+		}
+		ad := mustAdOld(t, fmt.Sprintf("Owner = %q\nGroup = %q\nPad = %q",
+			fmt.Sprintf("user%d", i%4), grp, strings.Repeat("x", 60)))
+		if err := c.Put([]byte(fmt.Sprintf("k%d", i)), ad); err != nil {
+			t.Fatal(err)
+		}
+	}
+	c.Reindex() // seal sidecars for the segments written so far
+	if got := countGroup(t, c, wantGroup); got != expect {
+		t.Fatalf("before drop: %d rows, want %d", got, expect)
+	}
+
+	// Drop the FIRST-listed index. Under positional ids this is what shifted Group onto
+	// Owner's id when the collection was next opened.
+	if !c.DropIndex("Owner") {
+		t.Fatal("DropIndex(Owner) reported no change")
+	}
+	c.Close()
+
+	c2, err := Open(Options{
+		Dir: dir, Shards: 1, SegmentSize: 1 << 13,
+		CategoricalAttrs: []string{"Group"}, // the persisted set after the drop
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c2.Close()
+
+	if got := countGroup(t, c2, wantGroup); got != expect {
+		t.Errorf("after drop+reopen: %d rows, want %d -- an attribute's index answered for "+
+			"a different attribute, so matching records were skipped", got, expect)
+	}
+}
+
+func countGroup(t *testing.T, c *Collection, group string) int {
+	t.Helper()
+	q, err := vm.Parse(fmt.Sprintf("Group == %q", group))
+	if err != nil {
+		t.Fatal(err)
+	}
+	n := 0
+	for range c.Query(q) {
+		n++
+	}
+	return n
+}

--- a/collections/index.go
+++ b/collections/index.go
@@ -42,7 +42,6 @@ type indexSpec struct {
 	// interned mode these are zero/nil and id == the global intern id. Indexes on a
 	// persistent collection are in-memory only and rebuilt on recovery.
 	inline   bool
-	nextID   uint32            // next synthetic id to assign (inline only)
 	names    map[uint32]string // id -> attribute name (inline only)
 	nameToID map[string]uint32 // folded name -> id (inline only)
 
@@ -92,18 +91,51 @@ func (s *indexSpec) equalAuto(o *indexSpec) bool {
 	return true
 }
 
-// inlineID returns the synthetic id for name, assigning a fresh one on first use.
-// Only valid on a freshly built or cloned (unpublished) inline spec.
-func (s *indexSpec) inlineID(name string) uint32 {
+// inlineID returns the id for name, derived from the name itself. ok is false when the id
+// collides with a different attribute already in this spec, in which case the caller must
+// leave that attribute unindexed.
+//
+// Deriving the id from the name rather than assigning a sequence number is a correctness
+// requirement, not tidiness. Ids were positional -- 0,1,2 in the order of the persisted name
+// list -- so DROPPING an index shifted every later attribute's id on the next restart, while
+// spec.gen (which is not persisted) reset to 0 and made stale sidecars look current again. A
+// sidecar written before the drop would then be read with its id 0 meaning one attribute and
+// the spec's id 0 meaning another. Candidates are re-verified against the real predicate, so
+// that surfaced not as wrong rows but as MISSING ones.
+//
+// With the id following the name, an old sidecar's ids either mean the same attributes they
+// always did or match nothing in the current spec -- in which case the attribute reads as
+// uncovered and that segment is scanned. Wrong is not among the outcomes.
+func (s *indexSpec) inlineID(name string) (uint32, bool) {
 	fold := strings.ToLower(name)
 	if id, ok := s.nameToID[fold]; ok {
-		return id
+		return id, true
 	}
-	id := s.nextID
-	s.nextID++
+	id := inlineAttrID(fold)
+	if have, taken := s.names[id]; taken && !strings.EqualFold(have, fold) {
+		// Two attribute names hashing together. Astronomically unlikely, and silently
+		// aliasing them would mean one attribute's index answering for the other, so
+		// refuse: the attribute stays unindexed and its queries scan.
+		return 0, false
+	}
 	s.nameToID[fold] = id
 	s.names[id] = name
-	return id
+	return id, true
+}
+
+// inlineAttrID hashes a folded attribute name to its id (FNV-1a, 32-bit -- the width the
+// sidecar stores attribute ids in).
+func inlineAttrID(fold string) uint32 {
+	const (
+		offset32 = 2166136261
+		prime32  = 16777619
+	)
+	h := uint32(offset32)
+	for i := 0; i < len(fold); i++ {
+		h ^= uint32(fold[i])
+		h *= prime32
+	}
+	return h
 }
 
 // attrNode returns the value node for the attribute with id id in ad, reading it by
@@ -155,7 +187,6 @@ func (s *indexSpec) clone() *indexSpec {
 		cat:    make(map[uint32]struct{}, len(s.cat)),
 		val:    make(map[uint32]struct{}, len(s.val)),
 		inline: s.inline,
-		nextID: s.nextID,
 	}
 	for id := range s.cat {
 		n.cat[id] = struct{}{}
@@ -194,14 +225,20 @@ func newInlineIndexSpec(catNames, valNames []string) *indexSpec {
 		nameToID: map[string]uint32{},
 	}
 	for _, name := range catNames {
-		id := s.inlineID(name)
+		id, ok := s.inlineID(name)
+		if !ok {
+			continue
+		}
 		if _, dup := s.cat[id]; !dup {
 			s.cat[id] = struct{}{}
 			s.catIDs = append(s.catIDs, id)
 		}
 	}
 	for _, name := range valNames {
-		id := s.inlineID(name)
+		id, ok := s.inlineID(name)
+		if !ok {
+			continue
+		}
 		if _, isCat := s.cat[id]; isCat {
 			continue // an attr indexed as both: categorical wins (matches AddIndex)
 		}

--- a/collections/index_dynamic.go
+++ b/collections/index_dynamic.go
@@ -36,11 +36,13 @@ func (c *Collection) addIndex(categorical, value []string, auto bool) bool {
 	for {
 		cur := c.spec.Load()
 		next := cur.clone()
-		intern := func(name string) uint32 {
+		// ok is false only when an inline id collides with a different attribute; that
+		// attribute is then left unindexed rather than aliased onto another's postings.
+		intern := func(name string) (uint32, bool) {
 			if next.inline {
 				return next.inlineID(name)
 			}
-			return c.intern.Intern(name)
+			return c.intern.Intern(name), true
 		}
 		// mark records id's provenance, judged against the PRE-EXISTING spec (cur): an
 		// auto add marks it auto unless it was already a human index (no downgrade); a
@@ -60,13 +62,19 @@ func (c *Collection) addIndex(categorical, value []string, auto bool) bool {
 			}
 		}
 		for _, name := range categorical {
-			id := intern(name)
+			id, ok := intern(name)
+			if !ok {
+				continue
+			}
 			removeID(&next.valIDs, next.val, id) // categorical wins if it was a value index
 			addID(&next.catIDs, next.cat, id)
 			mark(id)
 		}
 		for _, name := range value {
-			id := intern(name)
+			id, ok := intern(name)
+			if !ok {
+				continue
+			}
 			if _, isCat := next.cat[id]; isCat {
 				continue // already categorical; do not double-index
 			}


### PR DESCRIPTION
**Dropping an index could make later queries silently miss most of their matches.**

Inline attribute ids were positional — `0,1,2` in the order of the persisted name list — and `spec.gen`, which decides whether a sidecar still looks current, is **not persisted** and resets to 0 on every open.

So dropping an index shifted every later attribute's id on the next start, while sidecars written *before* the drop still carried gen 0 and therefore matched the reset generation. They were published under the new mapping, and one attribute's postings answered for another.

Candidates are re-verified against the real predicate, so this never returned *wrong* rows — it returned **too few**. In the regression test, a query matching 150 records returns **5** after a drop and reopen.

## The fix

Derive the id from the attribute name. An old sidecar's ids then either mean the attributes they always meant, or match nothing in the current spec — in which case the attribute reads as uncovered and that segment is scanned. **Wrong is not among the outcomes.**

Two names hashing to one id would put us back where we started, with a single index answering for both, so a collision **refuses** the second attribute: it stays unindexed and its queries scan. `nextID` goes away, since it no longer means anything.

## Reproduction

`TestInlineAttrIDsSurviveDropAndReopen` builds a collection indexed on `[Owner, Group]` — `Owner` first, so under positional ids it owned id 0 — drops `Owner`, reopens, and queries `Group`. Verified it fails on the current code with the 5-of-150 result above.

`go vet` and the full `collections`, `db`, and `dbrpc` suites pass.

## Why now

This is a prerequisite for letting segments carry different index generations simultaneously (bounded index backfill on archives, so only recent segments are reindexed). The generation-equality check that gates sidecar use is precisely what currently masks the id instability — relaxing it to per-attribute containment without this would widen the bug from "after a drop" to "routinely".

It stands on its own regardless: the bug is reachable today by any deployment that drops an index and restarts, including via `AutoTune`'s unused-drop path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
