### PR TITLE
collections: identify the index configuration by content, and use what a segment's index covers

### DIFF
--- a/collections/attrid_collision_test.go
+++ b/collections/attrid_collision_test.go
@@ -1,0 +1,28 @@
+package collections
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestInlineAttrIDCollisionRefused pins the collision behaviour: two names that hash to the
+// same id must not share one index, because that index would answer for both. The second
+// attribute is left unindexed (its queries scan) rather than aliased.
+func TestInlineAttrIDCollisionRefused(t *testing.T) {
+	s := newInlineIndexSpec(nil, nil)
+	first := "Alpha"
+	id, ok := s.inlineID(first)
+	if !ok {
+		t.Fatal("first attribute refused")
+	}
+	// Forge a collision by planting a different name at the same id.
+	s.names[id] = "SomethingElse"
+	if _, ok := s.inlineID("Beta"); ok {
+		// Beta hashes elsewhere, so this is not the collision case; assert the planted
+		// name is what triggers refusal by asking for a name whose id we know is taken.
+		delete(s.nameToID, strings.ToLower(first))
+		if _, ok := s.inlineID(first); ok {
+			t.Error("an id already held by a different attribute was handed out again")
+		}
+	}
+}

--- a/collections/attrid_stability_test.go
+++ b/collections/attrid_stability_test.go
@@ -1,0 +1,89 @@
+package collections
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/collections/vm"
+)
+
+// TestInlineAttrIDsSurviveDropAndReopen is the regression for a silent wrong-answer bug.
+//
+// Inline attribute ids used to be positional -- 0,1,2 in the order of the persisted name
+// list -- while spec.gen, which decides whether a sidecar looks current, is not persisted and
+// resets to 0 on every open. Dropping an index therefore shifted every later attribute's id
+// on the next start, and sidecars written before the drop (gen 0) matched the reset gen and
+// were published under the NEW id mapping. One attribute's postings then answered for
+// another. Candidates are re-verified against the real predicate, so the damage showed up not
+// as wrong rows but as MISSING ones -- the quietest possible failure.
+//
+// The ids now follow the attribute name, so an old sidecar either means what it always meant
+// or matches nothing current, in which case the segment is scanned.
+func TestInlineAttrIDsSurviveDropAndReopen(t *testing.T) {
+	if !mmapSupported {
+		t.Skip("persistence is unix-only")
+	}
+	dir := t.TempDir()
+
+	// Owner is listed FIRST, so under positional ids it owned id 0 and Group owned id 1.
+	c, err := Open(Options{
+		Dir: dir, Shards: 1, SegmentSize: 1 << 13,
+		CategoricalAttrs: []string{"Owner", "Group"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	const n = 1500
+	const wantGroup = "grp7"
+	expect := 0
+	for i := 0; i < n; i++ {
+		grp := fmt.Sprintf("grp%d", i%10)
+		if grp == wantGroup {
+			expect++
+		}
+		ad := mustAdOld(t, fmt.Sprintf("Owner = %q\nGroup = %q\nPad = %q",
+			fmt.Sprintf("user%d", i%4), grp, strings.Repeat("x", 60)))
+		if err := c.Put([]byte(fmt.Sprintf("k%d", i)), ad); err != nil {
+			t.Fatal(err)
+		}
+	}
+	c.Reindex() // seal sidecars for the segments written so far
+	if got := countGroup(t, c, wantGroup); got != expect {
+		t.Fatalf("before drop: %d rows, want %d", got, expect)
+	}
+
+	// Drop the FIRST-listed index. Under positional ids this is what shifted Group onto
+	// Owner's id when the collection was next opened.
+	if !c.DropIndex("Owner") {
+		t.Fatal("DropIndex(Owner) reported no change")
+	}
+	c.Close()
+
+	c2, err := Open(Options{
+		Dir: dir, Shards: 1, SegmentSize: 1 << 13,
+		CategoricalAttrs: []string{"Group"}, // the persisted set after the drop
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c2.Close()
+
+	if got := countGroup(t, c2, wantGroup); got != expect {
+		t.Errorf("after drop+reopen: %d rows, want %d -- an attribute's index answered for "+
+			"a different attribute, so matching records were skipped", got, expect)
+	}
+}
+
+func countGroup(t *testing.T, c *Collection, group string) int {
+	t.Helper()
+	q, err := vm.Parse(fmt.Sprintf("Group == %q", group))
+	if err != nil {
+		t.Fatal(err)
+	}
+	n := 0
+	for range c.Query(q) {
+		n++
+	}
+	return n
+}

--- a/collections/index.go
+++ b/collections/index.go
@@ -1,6 +1,7 @@
 package collections
 
 import (
+	"sort"
 	"strings"
 
 	"github.com/RoaringBitmap/roaring/v2"
@@ -31,7 +32,13 @@ import (
 // built under, so Reindex can tell a stale index (built before an add/drop) from a
 // current one. Shared read-only across shards and segments.
 type indexSpec struct {
-	gen    uint64 // bumped on every add/drop, so segIndexes can detect staleness
+	// gen identifies the index CONFIGURATION, so a segment's stored index can be told apart
+	// from one built under a different one. It is a signature over the indexed (id, kind)
+	// set rather than a counter: a counter lives only in memory and restarts at zero, which
+	// made a segment indexed under one configuration look current under an unrelated one --
+	// and made every restart after a configuration change re-index the whole store, because
+	// the reset counter matched nothing on disk.
+	gen    uint64
 	catIDs []uint32
 	valIDs []uint32
 	cat    map[uint32]struct{}
@@ -175,10 +182,40 @@ func newIndexSpec(intern *wire.InternTable, catNames, valNames []string) *indexS
 			s.valIDs = append(s.valIDs, id)
 		}
 	}
+	s.gen = s.signature()
 	return s
 }
 
 // clone returns a deep copy carrying the same gen (callers bump it after mutating).
+// signature derives gen from the indexed set. Stable across processes because attribute ids
+// are derived from their names (see inlineAttrID), so the same configuration always yields
+// the same value and a different one essentially never does.
+func (s *indexSpec) signature() uint64 {
+	cat := append([]uint32(nil), s.catIDs...)
+	val := append([]uint32(nil), s.valIDs...)
+	sort.Slice(cat, func(i, j int) bool { return cat[i] < cat[j] })
+	sort.Slice(val, func(i, j int) bool { return val[i] < val[j] })
+	const (
+		offset64 = 14695981039346656037
+		prime64  = 1099511628211
+	)
+	h := uint64(offset64)
+	mix := func(v uint64) {
+		for i := 0; i < 8; i++ {
+			h ^= (v >> (8 * i)) & 0xff
+			h *= prime64
+		}
+	}
+	for _, id := range cat {
+		mix(uint64(id))
+	}
+	mix(^uint64(0)) // separator, so {cat:[1],val:[]} and {cat:[],val:[1]} differ
+	for _, id := range val {
+		mix(uint64(id))
+	}
+	return h
+}
+
 func (s *indexSpec) clone() *indexSpec {
 	n := &indexSpec{
 		gen:    s.gen,
@@ -247,6 +284,7 @@ func newInlineIndexSpec(catNames, valNames []string) *indexSpec {
 			s.valIDs = append(s.valIDs, id)
 		}
 	}
+	s.gen = s.signature()
 	return s
 }
 

--- a/collections/index.go
+++ b/collections/index.go
@@ -42,7 +42,6 @@ type indexSpec struct {
 	// interned mode these are zero/nil and id == the global intern id. Indexes on a
 	// persistent collection are in-memory only and rebuilt on recovery.
 	inline   bool
-	nextID   uint32            // next synthetic id to assign (inline only)
 	names    map[uint32]string // id -> attribute name (inline only)
 	nameToID map[string]uint32 // folded name -> id (inline only)
 
@@ -92,18 +91,51 @@ func (s *indexSpec) equalAuto(o *indexSpec) bool {
 	return true
 }
 
-// inlineID returns the synthetic id for name, assigning a fresh one on first use.
-// Only valid on a freshly built or cloned (unpublished) inline spec.
-func (s *indexSpec) inlineID(name string) uint32 {
+// inlineID returns the id for name, derived from the name itself. ok is false when the id
+// collides with a different attribute already in this spec, in which case the caller must
+// leave that attribute unindexed.
+//
+// Deriving the id from the name rather than assigning a sequence number is a correctness
+// requirement, not tidiness. Ids were positional -- 0,1,2 in the order of the persisted name
+// list -- so DROPPING an index shifted every later attribute's id on the next restart, while
+// spec.gen (which is not persisted) reset to 0 and made stale sidecars look current again. A
+// sidecar written before the drop would then be read with its id 0 meaning one attribute and
+// the spec's id 0 meaning another. Candidates are re-verified against the real predicate, so
+// that surfaced not as wrong rows but as MISSING ones.
+//
+// With the id following the name, an old sidecar's ids either mean the same attributes they
+// always did or match nothing in the current spec -- in which case the attribute reads as
+// uncovered and that segment is scanned. Wrong is not among the outcomes.
+func (s *indexSpec) inlineID(name string) (uint32, bool) {
 	fold := strings.ToLower(name)
 	if id, ok := s.nameToID[fold]; ok {
-		return id
+		return id, true
 	}
-	id := s.nextID
-	s.nextID++
+	id := inlineAttrID(fold)
+	if have, taken := s.names[id]; taken && !strings.EqualFold(have, fold) {
+		// Two attribute names hashing together. Astronomically unlikely, and silently
+		// aliasing them would mean one attribute's index answering for the other, so
+		// refuse: the attribute stays unindexed and its queries scan.
+		return 0, false
+	}
 	s.nameToID[fold] = id
 	s.names[id] = name
-	return id
+	return id, true
+}
+
+// inlineAttrID hashes a folded attribute name to its id (FNV-1a, 32-bit -- the width the
+// sidecar stores attribute ids in).
+func inlineAttrID(fold string) uint32 {
+	const (
+		offset32 = 2166136261
+		prime32  = 16777619
+	)
+	h := uint32(offset32)
+	for i := 0; i < len(fold); i++ {
+		h ^= uint32(fold[i])
+		h *= prime32
+	}
+	return h
 }
 
 // attrNode returns the value node for the attribute with id id in ad, reading it by
@@ -155,7 +187,6 @@ func (s *indexSpec) clone() *indexSpec {
 		cat:    make(map[uint32]struct{}, len(s.cat)),
 		val:    make(map[uint32]struct{}, len(s.val)),
 		inline: s.inline,
-		nextID: s.nextID,
 	}
 	for id := range s.cat {
 		n.cat[id] = struct{}{}
@@ -194,14 +225,20 @@ func newInlineIndexSpec(catNames, valNames []string) *indexSpec {
 		nameToID: map[string]uint32{},
 	}
 	for _, name := range catNames {
-		id := s.inlineID(name)
+		id, ok := s.inlineID(name)
+		if !ok {
+			continue
+		}
 		if _, dup := s.cat[id]; !dup {
 			s.cat[id] = struct{}{}
 			s.catIDs = append(s.catIDs, id)
 		}
 	}
 	for _, name := range valNames {
-		id := s.inlineID(name)
+		id, ok := s.inlineID(name)
+		if !ok {
+			continue
+		}
 		if _, isCat := s.cat[id]; isCat {
 			continue // an attr indexed as both: categorical wins (matches AddIndex)
 		}

--- a/collections/index_containment_test.go
+++ b/collections/index_containment_test.go
@@ -1,0 +1,140 @@
+package collections
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/collections/vm"
+)
+
+func countWhere(t *testing.T, c *Collection, expr string) int {
+	t.Helper()
+	q, err := vm.Parse(expr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	n := 0
+	for range c.Query(q) {
+		n++
+	}
+	return n
+}
+
+// TestIndexSpecSignatureSurvivesReopen covers the staleness half. The configuration id was a
+// counter held only in memory, so it restarted at zero: after any add or drop, every sealed
+// segment looked stale on the next open and the whole store was re-indexed -- on an archive,
+// a full decompress on every restart. Deriving it from the indexed set instead makes it mean
+// the same thing across processes.
+func TestIndexSpecSignatureSurvivesReopen(t *testing.T) {
+	if !mmapSupported {
+		t.Skip("persistence is unix-only")
+	}
+	dir := t.TempDir()
+	c, err := Open(Options{Dir: dir, Shards: 1, SegmentSize: 1 << 13, CategoricalAttrs: []string{"Owner"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 1200; i++ {
+		ad := mustAdOld(t, fmt.Sprintf("Owner = %q\nGroup = %q\nPad = %q",
+			fmt.Sprintf("u%d", i%4), fmt.Sprintf("g%d", i%8), strings.Repeat("s", 60)))
+		if err := c.Put([]byte(fmt.Sprintf("k%d", i)), ad); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// A configuration change, then a full reindex: nothing should be stale afterwards.
+	c.AddIndex([]string{"Group"}, nil)
+	c.Reindex()
+	staleBefore, sealedBefore := c.StaleIndexSegments()
+	if sealedBefore == 0 {
+		t.Fatal("no sealed segments to judge")
+	}
+	if staleBefore != 0 {
+		t.Fatalf("%d/%d stale right after a full reindex", staleBefore, sealedBefore)
+	}
+	c.Close()
+
+	c2, err := Open(Options{Dir: dir, Shards: 1, SegmentSize: 1 << 13,
+		CategoricalAttrs: []string{"Owner", "Group"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c2.Close()
+	stale, sealed := c2.StaleIndexSegments()
+	if sealed == 0 {
+		t.Fatal("no sealed segments after reopen")
+	}
+	if stale != 0 {
+		t.Errorf("%d/%d segments stale after reopen with an unchanged configuration -- the "+
+			"whole store would be re-indexed on every restart", stale, sealed)
+	}
+}
+
+// TestSegmentsMayHoldDifferentIndexConfigs is the containment half: segments indexed under
+// different configurations coexist, each answering the probes its own index covers and
+// scanning for the rest. Every query must return the full, correct count regardless of which
+// segments happen to hold which index.
+func TestSegmentsMayHoldDifferentIndexConfigs(t *testing.T) {
+	if !mmapSupported {
+		t.Skip("persistence is unix-only")
+	}
+	dir := t.TempDir()
+	c, err := Open(Options{Dir: dir, Shards: 1, SegmentSize: 1 << 13, CategoricalAttrs: []string{"Owner"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { c.Close() }()
+
+	const half = 800
+	put := func(from, to int) {
+		for i := from; i < to; i++ {
+			ad := mustAdOld(t, fmt.Sprintf("Owner = %q\nGroup = %q\nPad = %q",
+				fmt.Sprintf("u%d", i%4), fmt.Sprintf("g%d", (i/4)%8), strings.Repeat("s", 60)))
+			if err := c.Put([]byte(fmt.Sprintf("k%d", i)), ad); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	// First half indexed on Owner only, and sealed under that configuration.
+	put(0, half)
+	c.Reindex()
+
+	// Now index Group too. The already-sealed segments keep the Owner-only sidecar; the
+	// segments written from here carry both. Deliberately no full reindex -- that mixture is
+	// the state a bounded backfill horizon would leave behind permanently.
+	c.AddIndex([]string{"Group"}, nil)
+	put(half, 2*half)
+
+	// Reopen. Note what this does NOT yet prove: recovery re-indexes every segment under the
+	// current configuration, so a mixed state cannot survive a restart today and the segments
+	// below are all on the new configuration by the time they are queried. Relaxing the
+	// recovery gate from "configuration matches" to "this index covers this probe" is what
+	// makes a mixed state USABLE; bounding index backfill to recent segments is what will
+	// make one persist. Until then this is a regression guard -- results stay complete when
+	// segments are indexed, re-indexed, and recovered around a configuration change.
+	c.Close()
+	c, err = Open(Options{Dir: dir, Shards: 1, SegmentSize: 1 << 13,
+		CategoricalAttrs: []string{"Owner", "Group"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	total := 2 * half
+	// Owner is indexed everywhere; Group only in the newer segments and scanned in the older
+	// ones. Both must be complete, and so must their conjunction -- Owner (i%4) and Group
+	// ((i/4)%8) are chosen to vary independently so that is a real test rather than a
+	// vacuous one.
+	for _, tc := range []struct {
+		expr string
+		want int
+	}{
+		{`Owner == "u1"`, total / 4},
+		{`Group == "g3"`, total / 8},
+		{`Owner == "u1" && Group == "g3"`, total / 32},
+	} {
+		if got := countWhere(t, c, tc.expr); got != tc.want {
+			t.Errorf("%s: %d rows, want %d -- a segment on an older index configuration "+
+				"answered incompletely", tc.expr, got, tc.want)
+		}
+	}
+}

--- a/collections/index_dynamic.go
+++ b/collections/index_dynamic.go
@@ -36,11 +36,13 @@ func (c *Collection) addIndex(categorical, value []string, auto bool) bool {
 	for {
 		cur := c.spec.Load()
 		next := cur.clone()
-		intern := func(name string) uint32 {
+		// ok is false only when an inline id collides with a different attribute; that
+		// attribute is then left unindexed rather than aliased onto another's postings.
+		intern := func(name string) (uint32, bool) {
 			if next.inline {
 				return next.inlineID(name)
 			}
-			return c.intern.Intern(name)
+			return c.intern.Intern(name), true
 		}
 		// mark records id's provenance, judged against the PRE-EXISTING spec (cur): an
 		// auto add marks it auto unless it was already a human index (no downgrade); a
@@ -60,13 +62,19 @@ func (c *Collection) addIndex(categorical, value []string, auto bool) bool {
 			}
 		}
 		for _, name := range categorical {
-			id := intern(name)
+			id, ok := intern(name)
+			if !ok {
+				continue
+			}
 			removeID(&next.valIDs, next.val, id) // categorical wins if it was a value index
 			addID(&next.catIDs, next.cat, id)
 			mark(id)
 		}
 		for _, name := range value {
-			id := intern(name)
+			id, ok := intern(name)
+			if !ok {
+				continue
+			}
 			if _, isCat := next.cat[id]; isCat {
 				continue // already categorical; do not double-index
 			}

--- a/collections/index_dynamic.go
+++ b/collections/index_dynamic.go
@@ -84,7 +84,7 @@ func (c *Collection) addIndex(categorical, value []string, auto bool) bool {
 		if next.equalIDs(cur) && next.equalAuto(cur) {
 			return false
 		}
-		next.gen = cur.gen + 1
+		next.gen = next.signature()
 		if c.spec.CompareAndSwap(cur, next) {
 			// An append-only collection zones every value-indexed attribute (New wires
 			// ZoneAttrs and ValueAttrs together), so a value index added at runtime must
@@ -124,7 +124,7 @@ func (c *Collection) DropIndex(names ...string) bool {
 		if next.equalIDs(cur) {
 			return false
 		}
-		next.gen = cur.gen + 1
+		next.gen = next.signature()
 		if c.spec.CompareAndSwap(cur, next) {
 			return true
 		}

--- a/collections/sealed_index.go
+++ b/collections/sealed_index.go
@@ -46,7 +46,18 @@ func (c *Collection) publishSidecar(seg *segment, path string, spec *indexSpec) 
 	}
 	var mm *mmapSegIndex
 	if len(attr) > 0 && sidecarCRCValid(attr) {
-		if m, e := parseMmapSidecar(attr); e == nil && m != nil && int(m.upto) == seg.used && (spec == nil || m.specGen == spec.gen) {
+		// Publish the sidecar whatever configuration it was built under, provided it covers
+		// the whole segment. Which probes it can actually answer is decided per probe by
+		// coversProbe, which looks the attribute up in the categorical or value directory
+		// according to the probe's kind -- so an attribute the sidecar does not hold, or
+		// holds under the other kind, simply reads as uncovered and that segment is scanned.
+		//
+		// Requiring the configuration to MATCH instead threw away a whole segment's index
+		// over a single unrelated attribute being added elsewhere, and made it impossible for
+		// segments to sit on different index configurations at once -- which is what bounding
+		// index backfill to recent data needs. The upto check stays: an index that stops
+		// short of the segment's records would silently hide the ones past it.
+		if m, e := parseMmapSidecar(attr); e == nil && m != nil && int(m.upto) == seg.used {
 			mm = m
 		}
 	}


### PR DESCRIPTION
> Contains #145 as a base — merge that first and this diff shrinks to its own commit. Both target `main`, so neither can be orphaned.

Two changes with one purpose: let segments sit on different index configurations at once, which is what bounding index backfill to recent data will need.

## The configuration id restarted at zero

It was a counter held only in memory. So **every restart after an index add or drop re-indexed the entire store**, because the reset counter matched nothing written under the old one — on an archive, a full decompress on every start.

It is now derived from the indexed `(id, kind)` set. Attribute ids follow their names (#145), so the same configuration yields the same value in every process, and staleness finally means the same thing across a restart.

`TestIndexSpecSignatureSurvivesReopen` covers it, and **does** discriminate: it fails on the old code.

## Recovery discarded indexes over unrelated attributes

Recovery required a segment's index to have been built under the *current* configuration before it would use it at all — so adding one unrelated attribute threw away every segment's index until a full reindex caught up.

Now it requires only that the index covers the segment. Which probes it can answer is already decided per probe by `coversProbe`, which looks the attribute up in the categorical or value directory **according to the probe's kind** — so an attribute the sidecar lacks, or holds under the other kind, reads as uncovered and that segment is scanned. The `upto` check stays: an index stopping short of a segment's records would hide the ones past it.

## What this does *not* yet do

Worth being precise, because it is less than it sounds:

- Within a live process, `sealSegmentIndex` publishes a freshly sealed sidecar with a **nil spec**, bypassing the gate entirely — so mixed configurations already worked there. It was *recovery* that insisted on a match.
- Recovery still runs a full `Reindex()` on open, so **a mixed state cannot persist across a restart yet.**

This makes such a state *usable*. Bounding backfill is what will make one *exist*. `TestSegmentsMayHoldDifferentIndexConfigs` is therefore a regression guard for now — results stay complete when segments are indexed, re-indexed, and recovered around a configuration change — and it does not yet assert containment, because the state it would assert cannot be produced.

`go vet` and the full `collections`, `db`, and `dbrpc` suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
