### PR TITLE
collections: bound how far back an index change is carried

### DIFF
--- a/collections/archive.go
+++ b/collections/archive.go
@@ -88,6 +88,10 @@ type ArchiveOptions struct {
 	ZoneAttrs []string
 	// Retention bounds what rotation keeps. Zero ⇒ keep everything.
 	Retention Retention
+	// IndexBackfillBytes bounds how far back an index configuration change is carried (see
+	// Options.IndexBackfillBytes). 0 carries it across the whole archive.
+	IndexBackfillBytes int64
+
 	// InternAtSeal interns each segment as soon as it seals (see Options.InternAtSeal), so an
 	// archive gets the interning density/decode win immediately instead of only after a later
 	// RetrainDict/Rewrite. Optional; default off. Trades a per-seal transcode (off the write
@@ -114,18 +118,19 @@ func archiveCollectionOptions(opts ArchiveOptions) Options {
 		segSize = defaultArchiveSegmentSize
 	}
 	return Options{
-		AppendOnly:       true, // pure append log: no supersession, no compaction, no key dir
-		ReverseScan:      true, // newest-first Query, matching condor_history order
-		Dir:              opts.Dir,
-		SegmentSize:      segSize,
-		Codec:            opts.Codec,
-		HotAttrs:         opts.HotAttrs,
-		CategoricalAttrs: opts.CategoricalAttrs,
-		ValueAttrs:       opts.ValueAttrs, // numeric ValueAttrs are auto-added to the zone maps
-		ZoneAttrs:        opts.ZoneAttrs,
-		Retention:        opts.Retention,
-		InternAtSeal:     opts.InternAtSeal, // intern each segment eagerly at seal
-		WatchHistory:     archiveWatchCap,   // enable the append-stream watch
+		AppendOnly:         true, // pure append log: no supersession, no compaction, no key dir
+		ReverseScan:        true, // newest-first Query, matching condor_history order
+		Dir:                opts.Dir,
+		SegmentSize:        segSize,
+		Codec:              opts.Codec,
+		HotAttrs:           opts.HotAttrs,
+		CategoricalAttrs:   opts.CategoricalAttrs,
+		ValueAttrs:         opts.ValueAttrs, // numeric ValueAttrs are auto-added to the zone maps
+		ZoneAttrs:          opts.ZoneAttrs,
+		Retention:          opts.Retention,
+		InternAtSeal:       opts.InternAtSeal, // intern each segment eagerly at seal
+		IndexBackfillBytes: opts.IndexBackfillBytes,
+		WatchHistory:       archiveWatchCap, // enable the append-stream watch
 	}
 }
 

--- a/collections/index.go
+++ b/collections/index.go
@@ -1,6 +1,7 @@
 package collections
 
 import (
+	"sort"
 	"strings"
 
 	"github.com/RoaringBitmap/roaring/v2"
@@ -31,7 +32,13 @@ import (
 // built under, so Reindex can tell a stale index (built before an add/drop) from a
 // current one. Shared read-only across shards and segments.
 type indexSpec struct {
-	gen    uint64 // bumped on every add/drop, so segIndexes can detect staleness
+	// gen identifies the index CONFIGURATION, so a segment's stored index can be told apart
+	// from one built under a different one. It is a signature over the indexed (id, kind)
+	// set rather than a counter: a counter lives only in memory and restarts at zero, which
+	// made a segment indexed under one configuration look current under an unrelated one --
+	// and made every restart after a configuration change re-index the whole store, because
+	// the reset counter matched nothing on disk.
+	gen    uint64
 	catIDs []uint32
 	valIDs []uint32
 	cat    map[uint32]struct{}
@@ -175,10 +182,40 @@ func newIndexSpec(intern *wire.InternTable, catNames, valNames []string) *indexS
 			s.valIDs = append(s.valIDs, id)
 		}
 	}
+	s.gen = s.signature()
 	return s
 }
 
 // clone returns a deep copy carrying the same gen (callers bump it after mutating).
+// signature derives gen from the indexed set. Stable across processes because attribute ids
+// are derived from their names (see inlineAttrID), so the same configuration always yields
+// the same value and a different one essentially never does.
+func (s *indexSpec) signature() uint64 {
+	cat := append([]uint32(nil), s.catIDs...)
+	val := append([]uint32(nil), s.valIDs...)
+	sort.Slice(cat, func(i, j int) bool { return cat[i] < cat[j] })
+	sort.Slice(val, func(i, j int) bool { return val[i] < val[j] })
+	const (
+		offset64 = 14695981039346656037
+		prime64  = 1099511628211
+	)
+	h := uint64(offset64)
+	mix := func(v uint64) {
+		for i := 0; i < 8; i++ {
+			h ^= (v >> (8 * i)) & 0xff
+			h *= prime64
+		}
+	}
+	for _, id := range cat {
+		mix(uint64(id))
+	}
+	mix(^uint64(0)) // separator, so {cat:[1],val:[]} and {cat:[],val:[1]} differ
+	for _, id := range val {
+		mix(uint64(id))
+	}
+	return h
+}
+
 func (s *indexSpec) clone() *indexSpec {
 	n := &indexSpec{
 		gen:    s.gen,
@@ -247,6 +284,7 @@ func newInlineIndexSpec(catNames, valNames []string) *indexSpec {
 			s.valIDs = append(s.valIDs, id)
 		}
 	}
+	s.gen = s.signature()
 	return s
 }
 

--- a/collections/index_backfill_test.go
+++ b/collections/index_backfill_test.go
@@ -1,0 +1,104 @@
+package collections
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// TestIndexBackfillHorizonLeavesOlderSegments is the payoff for identifying index
+// configurations by content and using whatever a segment's index covers: with backfill
+// bounded, a configuration change reaches only recent segments, older ones keep the index
+// they already had, and that mixture SURVIVES a restart -- which is what makes it worth
+// having, since recovery used to re-index everything and erase it.
+//
+// The bound exists because rebuilding decompresses every record it covers, while the index
+// it would replace still answers for the attributes it holds. On an archive read newest-first
+// with a limit, the oldest segments may never be reached at all.
+func TestIndexBackfillHorizonLeavesOlderSegments(t *testing.T) {
+	if !mmapSupported {
+		t.Skip("persistence is unix-only")
+	}
+	dir := t.TempDir()
+	open := func(cat []string) *Collection {
+		t.Helper()
+		c, err := Open(Options{
+			Dir: dir, Shards: 1, SegmentSize: 1 << 13,
+			CategoricalAttrs: cat,
+			// Small enough that most segments fall outside it.
+			IndexBackfillBytes: 24 << 10,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return c
+	}
+
+	c := open([]string{"Owner"})
+	const n = 2400
+	for i := 0; i < n; i++ {
+		ad := mustAdOld(t, fmt.Sprintf("Owner = %q\nGroup = %q\nPad = %q",
+			fmt.Sprintf("u%d", i%4), fmt.Sprintf("g%d", (i/4)%8), strings.Repeat("s", 60)))
+		if err := c.Put([]byte(fmt.Sprintf("k%d", i)), ad); err != nil {
+			t.Fatal(err)
+		}
+	}
+	c.Reindex()
+
+	// Add a second index. Only segments inside the horizon should pick it up.
+	c.AddIndex([]string{"Group"}, nil)
+	c.Reindex()
+	c.Close()
+
+	c2 := open([]string{"Owner", "Group"})
+	defer c2.Close()
+
+	ownerID := inlineAttrID("owner")
+	groupID := inlineAttrID("group")
+	oldConfig, newConfig := 0, 0
+	sh := c2.shards[0]
+	sh.mu.RLock()
+	for _, seg := range sh.segs {
+		if seg == nil || seg == sh.act {
+			continue
+		}
+		mm := seg.msidx.Load()
+		if mm == nil {
+			continue
+		}
+		_, hasOwner := mm.catDir[ownerID]
+		_, hasGroup := mm.catDir[groupID]
+		switch {
+		case hasOwner && hasGroup:
+			newConfig++
+		case hasOwner:
+			oldConfig++
+		}
+	}
+	sh.mu.RUnlock()
+
+	if oldConfig == 0 {
+		t.Error("every segment was backfilled: the horizon did not bound the rebuild, or " +
+			"recovery re-indexed everything anyway")
+	}
+	if newConfig == 0 {
+		t.Error("no segment carries the new configuration: the horizon bounded too much")
+	}
+	t.Logf("%d segments on the older configuration, %d on the newer, across a restart",
+		oldConfig, newConfig)
+
+	// Whatever the mixture, results must be complete: segments holding Group answer from
+	// their index, the rest are scanned.
+	for _, tc := range []struct {
+		expr string
+		want int
+	}{
+		{`Owner == "u1"`, n / 4},
+		{`Group == "g3"`, n / 8},
+		{`Owner == "u1" && Group == "g3"`, n / 32},
+	} {
+		if got := countWhere(t, c2, tc.expr); got != tc.want {
+			t.Errorf("%s: %d rows, want %d", tc.expr, got, tc.want)
+		}
+	}
+}

--- a/collections/index_containment_test.go
+++ b/collections/index_containment_test.go
@@ -1,0 +1,140 @@
+package collections
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/collections/vm"
+)
+
+func countWhere(t *testing.T, c *Collection, expr string) int {
+	t.Helper()
+	q, err := vm.Parse(expr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	n := 0
+	for range c.Query(q) {
+		n++
+	}
+	return n
+}
+
+// TestIndexSpecSignatureSurvivesReopen covers the staleness half. The configuration id was a
+// counter held only in memory, so it restarted at zero: after any add or drop, every sealed
+// segment looked stale on the next open and the whole store was re-indexed -- on an archive,
+// a full decompress on every restart. Deriving it from the indexed set instead makes it mean
+// the same thing across processes.
+func TestIndexSpecSignatureSurvivesReopen(t *testing.T) {
+	if !mmapSupported {
+		t.Skip("persistence is unix-only")
+	}
+	dir := t.TempDir()
+	c, err := Open(Options{Dir: dir, Shards: 1, SegmentSize: 1 << 13, CategoricalAttrs: []string{"Owner"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 1200; i++ {
+		ad := mustAdOld(t, fmt.Sprintf("Owner = %q\nGroup = %q\nPad = %q",
+			fmt.Sprintf("u%d", i%4), fmt.Sprintf("g%d", i%8), strings.Repeat("s", 60)))
+		if err := c.Put([]byte(fmt.Sprintf("k%d", i)), ad); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// A configuration change, then a full reindex: nothing should be stale afterwards.
+	c.AddIndex([]string{"Group"}, nil)
+	c.Reindex()
+	staleBefore, sealedBefore := c.StaleIndexSegments()
+	if sealedBefore == 0 {
+		t.Fatal("no sealed segments to judge")
+	}
+	if staleBefore != 0 {
+		t.Fatalf("%d/%d stale right after a full reindex", staleBefore, sealedBefore)
+	}
+	c.Close()
+
+	c2, err := Open(Options{Dir: dir, Shards: 1, SegmentSize: 1 << 13,
+		CategoricalAttrs: []string{"Owner", "Group"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c2.Close()
+	stale, sealed := c2.StaleIndexSegments()
+	if sealed == 0 {
+		t.Fatal("no sealed segments after reopen")
+	}
+	if stale != 0 {
+		t.Errorf("%d/%d segments stale after reopen with an unchanged configuration -- the "+
+			"whole store would be re-indexed on every restart", stale, sealed)
+	}
+}
+
+// TestSegmentsMayHoldDifferentIndexConfigs is the containment half: segments indexed under
+// different configurations coexist, each answering the probes its own index covers and
+// scanning for the rest. Every query must return the full, correct count regardless of which
+// segments happen to hold which index.
+func TestSegmentsMayHoldDifferentIndexConfigs(t *testing.T) {
+	if !mmapSupported {
+		t.Skip("persistence is unix-only")
+	}
+	dir := t.TempDir()
+	c, err := Open(Options{Dir: dir, Shards: 1, SegmentSize: 1 << 13, CategoricalAttrs: []string{"Owner"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { c.Close() }()
+
+	const half = 800
+	put := func(from, to int) {
+		for i := from; i < to; i++ {
+			ad := mustAdOld(t, fmt.Sprintf("Owner = %q\nGroup = %q\nPad = %q",
+				fmt.Sprintf("u%d", i%4), fmt.Sprintf("g%d", (i/4)%8), strings.Repeat("s", 60)))
+			if err := c.Put([]byte(fmt.Sprintf("k%d", i)), ad); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	// First half indexed on Owner only, and sealed under that configuration.
+	put(0, half)
+	c.Reindex()
+
+	// Now index Group too. The already-sealed segments keep the Owner-only sidecar; the
+	// segments written from here carry both. Deliberately no full reindex -- that mixture is
+	// the state a bounded backfill horizon would leave behind permanently.
+	c.AddIndex([]string{"Group"}, nil)
+	put(half, 2*half)
+
+	// Reopen. Note what this does NOT yet prove: recovery re-indexes every segment under the
+	// current configuration, so a mixed state cannot survive a restart today and the segments
+	// below are all on the new configuration by the time they are queried. Relaxing the
+	// recovery gate from "configuration matches" to "this index covers this probe" is what
+	// makes a mixed state USABLE; bounding index backfill to recent segments is what will
+	// make one persist. Until then this is a regression guard -- results stay complete when
+	// segments are indexed, re-indexed, and recovered around a configuration change.
+	c.Close()
+	c, err = Open(Options{Dir: dir, Shards: 1, SegmentSize: 1 << 13,
+		CategoricalAttrs: []string{"Owner", "Group"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	total := 2 * half
+	// Owner is indexed everywhere; Group only in the newer segments and scanned in the older
+	// ones. Both must be complete, and so must their conjunction -- Owner (i%4) and Group
+	// ((i/4)%8) are chosen to vary independently so that is a real test rather than a
+	// vacuous one.
+	for _, tc := range []struct {
+		expr string
+		want int
+	}{
+		{`Owner == "u1"`, total / 4},
+		{`Group == "g3"`, total / 8},
+		{`Owner == "u1" && Group == "g3"`, total / 32},
+	} {
+		if got := countWhere(t, c, tc.expr); got != tc.want {
+			t.Errorf("%s: %d rows, want %d -- a segment on an older index configuration "+
+				"answered incompletely", tc.expr, got, tc.want)
+		}
+	}
+}

--- a/collections/index_dynamic.go
+++ b/collections/index_dynamic.go
@@ -84,7 +84,7 @@ func (c *Collection) addIndex(categorical, value []string, auto bool) bool {
 		if next.equalIDs(cur) && next.equalAuto(cur) {
 			return false
 		}
-		next.gen = cur.gen + 1
+		next.gen = next.signature()
 		if c.spec.CompareAndSwap(cur, next) {
 			// An append-only collection zones every value-indexed attribute (New wires
 			// ZoneAttrs and ValueAttrs together), so a value index added at runtime must
@@ -124,7 +124,7 @@ func (c *Collection) DropIndex(names ...string) bool {
 		if next.equalIDs(cur) {
 			return false
 		}
-		next.gen = cur.gen + 1
+		next.gen = next.signature()
 		if c.spec.CompareAndSwap(cur, next) {
 			return true
 		}

--- a/collections/index_query.go
+++ b/collections/index_query.go
@@ -41,6 +41,7 @@ func (c *Collection) Reindex() {
 		sh.mu.RLock()
 		act := sh.act
 		sealRAM := sh.sealRAM
+		window := c.backfillWindow(sh)
 		type target struct {
 			seg    *segment
 			used   int
@@ -57,7 +58,13 @@ func (c *Collection) Reindex() {
 				// index derived from it is not: rebuild the sidecar in place when the index
 				// configuration has moved on, so .addindex/.dropindex reach existing
 				// segments without the whole-store re-encode a rewrite would cost.
-				if spec.any() && seg.used > 0 && mm.specGen != spec.gen {
+				// Rebuilding an already-sealed segment's sidecar is BACKFILL -- carrying a
+				// configuration change to data that already has a working index. That is
+				// the one part of a reindex worth bounding: it decompresses every record it
+				// covers, while the index it replaces still answers for the attributes it
+				// holds. Everything else here is a missing or incomplete index, which is
+				// not optional.
+				if spec.any() && seg.used > 0 && mm.specGen != spec.gen && (window == nil || window[seg]) {
 					tgts = append(tgts, target{seg: seg, used: seg.used, reseal: true})
 				}
 				continue
@@ -1428,4 +1435,30 @@ func scanShardCandidatesGroupsReverse(wins []segWindow, groups [][]usableProbe, 
 		}
 	}
 	return true
+}
+
+// backfillWindow returns the segments within the newest Options.IndexBackfillBytes of a
+// shard, or nil when no bound is configured (carry a configuration change everywhere).
+//
+// Newest-first, because that is the end that gets queried: an archive is read newest-first
+// with a limit, so the oldest segments may never be reached, and re-indexing them costs the
+// whole archive to speed up reads that do not happen. Caller holds sh.mu.
+func (c *Collection) backfillWindow(sh *shard) map[*segment]bool {
+	if c.indexBackfillBytes <= 0 {
+		return nil
+	}
+	window := map[*segment]bool{}
+	var acc int64
+	for i := len(sh.segs) - 1; i >= 0; i-- {
+		seg := sh.segs[i]
+		if seg == nil || seg.used == 0 {
+			continue
+		}
+		window[seg] = true
+		acc += int64(seg.used)
+		if acc >= c.indexBackfillBytes {
+			break
+		}
+	}
+	return window
 }

--- a/collections/sealed_index.go
+++ b/collections/sealed_index.go
@@ -46,7 +46,18 @@ func (c *Collection) publishSidecar(seg *segment, path string, spec *indexSpec) 
 	}
 	var mm *mmapSegIndex
 	if len(attr) > 0 && sidecarCRCValid(attr) {
-		if m, e := parseMmapSidecar(attr); e == nil && m != nil && int(m.upto) == seg.used && (spec == nil || m.specGen == spec.gen) {
+		// Publish the sidecar whatever configuration it was built under, provided it covers
+		// the whole segment. Which probes it can actually answer is decided per probe by
+		// coversProbe, which looks the attribute up in the categorical or value directory
+		// according to the probe's kind -- so an attribute the sidecar does not hold, or
+		// holds under the other kind, simply reads as uncovered and that segment is scanned.
+		//
+		// Requiring the configuration to MATCH instead threw away a whole segment's index
+		// over a single unrelated attribute being added elsewhere, and made it impossible for
+		// segments to sit on different index configurations at once -- which is what bounding
+		// index backfill to recent data needs. The upto check stays: an index that stops
+		// short of the segment's records would silently hide the ones past it.
+		if m, e := parseMmapSidecar(attr); e == nil && m != nil && int(m.upto) == seg.used {
 			mm = m
 		}
 	}

--- a/collections/store.go
+++ b/collections/store.go
@@ -46,6 +46,19 @@ type Options struct {
 	// history archive's aging-out). The zero value keeps everything (Rotate is
 	// then inert). Only meaningful with AppendOnly. See Rotate.
 	Retention Retention
+	// IndexBackfillBytes bounds how far back an index configuration change is carried. When
+	// set, only segments within the newest IndexBackfillBytes have their existing index
+	// rebuilt under a new configuration; older ones keep the index they already have.
+	//
+	// The point is that rebuilding is not free -- it decompresses every record it covers --
+	// while an out-of-date index is still perfectly usable for the attributes it does hold
+	// (recovery uses whatever a segment's index covers, deciding per probe). On an archive
+	// queried newest-first with a limit, the oldest segments may never be reached at all, so
+	// re-indexing them buys little and costs the whole archive.
+	//
+	// 0 carries a change across every segment, which is the historical behaviour.
+	IndexBackfillBytes int64
+
 	// InternAtSeal makes an AppendOnly collection intern each segment as soon as it
 	// seals (when the active segment fills), rather than only when RetrainDict/Rewrite
 	// later reseal it. Interning stores segment-local ids + a per-segment name dictionary
@@ -310,6 +323,8 @@ type Collection struct {
 	// Codec retrain bookkeeping for diagnostics (CodecStats): the wall-clock time of the
 	// last successful RetrainDict in this process (unix nanos; 0 = never) and the trained
 	// dictionary's size in bytes.
+	indexBackfillBytes int64 // see Options.IndexBackfillBytes; 0 = carry changes everywhere
+
 	lastRetrainUnix atomic.Int64
 	lastDictBytes   atomic.Int64
 
@@ -573,6 +588,7 @@ func New(opts Options) *Collection {
 	// Persistent (Dir set) append-only only: c.inline (set later in persist setup) is exactly
 	// Dir != "", and InternSealed is a no-op otherwise, so gate on the option's preconditions here.
 	c.internAtSeal = opts.InternAtSeal && opts.AppendOnly && opts.Dir != ""
+	c.indexBackfillBytes = opts.IndexBackfillBytes
 	c.ret = opts.Retention
 	c.queryPar = resolveQueryParallelism(opts.QueryParallelism)
 	if c.queryPar >= 2 {


### PR DESCRIPTION
> Contains #145 and #146 as a base — merge those first and this diff shrinks to its own commit. All three target `main`, so none can be orphaned.

Adding an index re-indexed **every** segment that already had one. On an archive that is a full decompress of the whole store to speed up reads that may never happen: an archive is read newest-first with a limit, so its oldest segments are often never reached, and the index they already carry still answers for the attributes it holds.

`IndexBackfillBytes` bounds it — only segments within the newest N bytes have their existing index rebuilt under a new configuration; older ones keep theirs. `0` keeps the historical behaviour of carrying a change everywhere.

## Only the backfill is bounded

Rebuilding a sidecar that already works, purely because the configuration moved on, is the optional part. A **missing** index, or one **behind the segment's write watermark**, is still built unconditionally — that is not optional, and skipping it would hide records rather than merely slow a query.

## Why the two preceding PRs were needed

This is what they were for:

- **#145** — identifying attributes by name means a segment left on an older configuration still means what it meant, rather than being misread after a drop
- **#146** — identifying a *configuration* by content means such a segment looks like itself after a restart instead of looking stale; and using whatever its index covers means it is still worth having

Together they let the mixture survive recovery. In `TestIndexBackfillHorizonLeavesOlderSegments`: **36 segments on the older configuration and 3 on the newer, across a restart**, with every query still returning complete results — where before, recovery would have re-indexed all 39.

That test also retroactively validates #146: without containment, recovery discards the older sidecars and the older-configuration count falls to zero.

## Correctness

All three query shapes are checked after the restart — each attribute alone and their conjunction — over attributes chosen to vary *independently* (`i%4` and `(i/4)%8`), so the conjunction is a real test rather than a vacuously empty one.

`go vet` and the full `collections`, `db`, and `dbrpc` suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
