### PR TITLE
collections,db: separate a stale index that is pending from one left by policy

### DIFF
--- a/collections/archive.go
+++ b/collections/archive.go
@@ -361,6 +361,10 @@ func (a *Archive) ZoneAttrs() []string { return a.c.ZoneAttrs() }
 // failed (it is best-effort per segment); a Reindex retries those segments.
 func (a *Archive) StaleIndexSegments() (stale, sealed int) { return a.c.StaleIndexSegments() }
 
+// StaleIndexSegmentsByPolicy reports segments left on an older index configuration because
+// they fall outside the backfill horizon: expected, and not actionable.
+func (a *Archive) StaleIndexSegmentsByPolicy() int { return a.c.StaleIndexSegmentsByPolicy() }
+
 // --- zone-map helpers (shared with the Collection's per-segment zone maps) ---
 
 // literalFloat extracts a numeric value from a wire literal node (int/real/bool), for

--- a/collections/index_backfill_test.go
+++ b/collections/index_backfill_test.go
@@ -102,3 +102,46 @@ func TestIndexBackfillHorizonLeavesOlderSegments(t *testing.T) {
 		}
 	}
 }
+
+// TestStaleCountsSeparatePolicyFromFailure pins the distinction an alert depends on. With a
+// backfill horizon, segments outside it stay on an older index configuration forever by
+// design; counting them as "stale" would leave the number permanently non-zero and make it
+// useless as a signal that a reindex is stuck.
+func TestStaleCountsSeparatePolicyFromFailure(t *testing.T) {
+	if !mmapSupported {
+		t.Skip("persistence is unix-only")
+	}
+	dir := t.TempDir()
+	c, err := Open(Options{
+		Dir: dir, Shards: 1, SegmentSize: 1 << 13,
+		CategoricalAttrs: []string{"Owner"}, IndexBackfillBytes: 24 << 10,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+	for i := 0; i < 2400; i++ {
+		ad := mustAdOld(t, fmt.Sprintf("Owner = %q\nGroup = %q\nPad = %q",
+			fmt.Sprintf("u%d", i%4), fmt.Sprintf("g%d", (i/4)%8), strings.Repeat("s", 60)))
+		if err := c.Put([]byte(fmt.Sprintf("k%d", i)), ad); err != nil {
+			t.Fatal(err)
+		}
+	}
+	c.Reindex()
+	c.AddIndex([]string{"Group"}, nil)
+	c.Reindex() // carries the change as far as the horizon allows, and no further
+
+	pending, sealed := c.StaleIndexSegments()
+	byPolicy := c.StaleIndexSegmentsByPolicy()
+	if sealed == 0 {
+		t.Fatal("no sealed segments")
+	}
+	if pending != 0 {
+		t.Errorf("%d segments still pending a rebuild after a completed reindex -- an alert "+
+			"on this would fire forever", pending)
+	}
+	if byPolicy == 0 {
+		t.Errorf("no segments reported as left behind by policy, though the horizon is far "+
+			"smaller than the store (%d sealed)", sealed)
+	}
+}

--- a/collections/index_dynamic.go
+++ b/collections/index_dynamic.go
@@ -131,17 +131,35 @@ func (c *Collection) DropIndex(names ...string) bool {
 	}
 }
 
-// StaleIndexSegments counts sealed segments whose index sidecar was built under an older
-// index configuration than the current one, and the total number of sealed segments.
+// StaleIndexSegments reports sealed segments whose index was built under a superseded
+// configuration and is still due a rebuild, out of the sealed segments total.
 //
-// A sealed segment's sidecar is immutable, but it is also derived: Reindex rebuilds a stale
-// one in place (a new mapping beside the live one, swapped atomically) without touching the
-// segment data, so this is normally zero. A non-zero count means some segment's rebuild did
-// not complete -- resealing is best-effort per segment -- and a Reindex will retry it.
+// "Due a rebuild" is the operative part. With Options.IndexBackfillBytes set, a
+// configuration change is deliberately carried only to recent segments; older ones keep the
+// index they have, permanently and by design. Counting those would leave the number
+// permanently non-zero and say nothing about whether anything is wrong -- so they are
+// excluded here and reported separately by StaleIndexSegmentsByPolicy.
+//
+// A persistent non-zero value from this therefore still means what it always meant: a
+// reindex is failing, or never running.
 func (c *Collection) StaleIndexSegments() (stale, sealed int) {
+	stale, _, sealed = c.staleIndexCounts()
+	return stale, sealed
+}
+
+// StaleIndexSegmentsByPolicy reports sealed segments left on a superseded index
+// configuration because they fall outside the backfill horizon. Expected, not actionable:
+// it is the size of the deliberate mixture, and it grows as the store does.
+func (c *Collection) StaleIndexSegmentsByPolicy() int {
+	_, byPolicy, _ := c.staleIndexCounts()
+	return byPolicy
+}
+
+func (c *Collection) staleIndexCounts() (pending, byPolicy, sealed int) {
 	gen := c.spec.Load().gen
 	for _, sh := range c.shards {
 		sh.mu.RLock()
+		window := c.backfillWindow(sh)
 		segs := append([]*segment(nil), sh.segs...)
 		sh.mu.RUnlock()
 		for _, seg := range segs {
@@ -153,12 +171,17 @@ func (c *Collection) StaleIndexSegments() (stale, sealed int) {
 				continue // not sealed to a sidecar: Reindex still rebuilds it in place
 			}
 			sealed++
-			if mm.specGen != gen {
-				stale++
+			if mm.specGen == gen {
+				continue
 			}
+			if window != nil && !window[seg] {
+				byPolicy++ // outside the horizon: never going to be rebuilt, and that is fine
+				continue
+			}
+			pending++
 		}
 	}
-	return stale, sealed
+	return pending, byPolicy, sealed
 }
 
 // IndexedAttrs returns the currently-indexed attribute names, split by kind, in the

--- a/db/archive.go
+++ b/db/archive.go
@@ -491,6 +491,12 @@ func (t *ArchiveTable) ZoneAttrs() []string { return t.a.ZoneAttrs() }
 // a Rewrite).
 func (t *ArchiveTable) StaleIndexSegments() (stale, sealed int) { return t.a.StaleIndexSegments() }
 
+// StaleIndexSegmentsByPolicy reports segments deliberately left on an older index
+// configuration because they fall outside the backfill horizon -- expected, and not a sign of
+// anything failing. Reported apart from StaleIndexSegments so an alert on the latter stays
+// meaningful once a horizon is configured.
+func (t *ArchiveTable) StaleIndexSegmentsByPolicy() int { return t.a.StaleIndexSegmentsByPolicy() }
+
 // Retention returns the archive's current retention bounds.
 func (t *ArchiveTable) Retention() collections.Retention { return t.a.Retention() }
 


### PR DESCRIPTION
`StaleIndexSegments` counted **every** sealed segment whose index predated the current configuration. Since #147 that is the normal state, not a fault: segments outside the backfill horizon keep the index they have permanently and on purpose.

Counting them leaves the number permanently non-zero, which destroys its only use — telling an operator that a reindex is stuck.

## Change

- `StaleIndexSegments` now counts only segments **still due a rebuild**
- `StaleIndexSegmentsByPolicy` reports the deliberate remainder

So a persistent non-zero `StaleIndexSegments` means what it always meant, and the by-policy number is informational: the size of the intended mixture, which grows with the store.

Exposed on `Collection`, `Archive`, and `ArchiveTable`.

## Why now

htcondordb#110 adds `htcondordb_stale_index_segments`, documented as *"normally zero; a persistent non-zero value means a reindex is failing or never runs"*. With #147 merged that alert would fire continuously against a perfectly healthy store. This keeps the metric's promise true; the htcondordb side can then surface the by-policy count separately once this is released.

## Testing

`TestStaleCountsSeparatePolicyFromFailure` builds a store far larger than its horizon, changes the index configuration, reindexes to completion, and asserts **pending is zero** while **by-policy is not** — i.e. an alert on the first would stay quiet exactly when it should.

`go vet` and the full `collections`, `db`, and `dbrpc` suites pass.

## One note

During this work a single `collections` run failed without my capturing which test; four subsequent uncached runs passed clean. I could not attribute it, so I am flagging it rather than calling it noise — if CI shows an intermittent failure here, that is the first thread to pull.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
