### PR TITLE
db: let an archive configure its index backfill horizon

### DIFF
--- a/db/archive.go
+++ b/db/archive.go
@@ -37,6 +37,14 @@ type ArchiveConfig struct {
 	HotAttrs                     []string
 	CategoricalAttrs, ValueAttrs []string
 	ZoneAttrs                    []string
+	// IndexBackfillBytes bounds how far back an index configuration change is carried: only
+	// segments within the newest N bytes have their existing index rebuilt, older ones keep
+	// the one they have (see collections.Options.IndexBackfillBytes).
+	//
+	// Zero carries a change across the whole archive, which for history means decompressing
+	// every record to add one index -- hours at scale, to speed up reads of the oldest data
+	// that a newest-first query with a limit may never reach.
+	IndexBackfillBytes int64
 	// Retention bounds what rotation keeps (max segments / bytes / age). Zero keeps all.
 	Retention collections.Retention
 }
@@ -68,14 +76,15 @@ func openArchiveTable(dir string, cfg ArchiveConfig) (*ArchiveTable, error) {
 		return nil, err
 	}
 	opts := collections.ArchiveOptions{
-		Dir:              dir,
-		SegmentSize:      cfg.SegmentSize,
-		Codec:            codec,
-		HotAttrs:         cfg.HotAttrs,
-		CategoricalAttrs: cfg.CategoricalAttrs,
-		ValueAttrs:       cfg.ValueAttrs,
-		ZoneAttrs:        cfg.ZoneAttrs,
-		Retention:        cfg.Retention,
+		Dir:                dir,
+		SegmentSize:        cfg.SegmentSize,
+		Codec:              codec,
+		HotAttrs:           cfg.HotAttrs,
+		CategoricalAttrs:   cfg.CategoricalAttrs,
+		ValueAttrs:         cfg.ValueAttrs,
+		ZoneAttrs:          cfg.ZoneAttrs,
+		IndexBackfillBytes: cfg.IndexBackfillBytes,
+		Retention:          cfg.Retention,
 	}
 	var a *collections.Archive
 	if create {

--- a/db/archive_test.go
+++ b/db/archive_test.go
@@ -1,7 +1,10 @@
 package db
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/PelicanPlatform/classad/collections"
@@ -219,5 +222,47 @@ func TestArchiveRotation(t *testing.T) {
 	}
 	if hist.Count() >= before {
 		t.Fatalf("Count did not shrink after rotation: before=%d after=%d", before, hist.Count())
+	}
+}
+
+// TestArchiveBackfillHorizonReachable pins that the index backfill horizon can actually be
+// configured through the catalog. It existed on the storage layer but not on ArchiveConfig,
+// so a daemon could not set it -- the bound was built and unreachable, which is the same as
+// not having it. The config is persisted, so it must also survive a reopen.
+func TestArchiveBackfillHorizonReachable(t *testing.T) {
+	dir := t.TempDir()
+	cat, err := OpenCatalog(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const horizon = 32 << 20
+	if _, err := cat.CreateArchiveTable("history", ArchiveConfig{
+		SegmentSize:        1 << 20,
+		CategoricalAttrs:   []string{"Owner"},
+		IndexBackfillBytes: horizon,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	cat.Close()
+
+	cat2, err := OpenCatalog(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cat2.Close()
+	if _, ok := cat2.ArchiveTable("history"); !ok {
+		t.Fatal("archive not recovered")
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "archives", "history", archiveConfigFile))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var saved ArchiveConfig
+	if err := json.Unmarshal(data, &saved); err != nil {
+		t.Fatal(err)
+	}
+	if saved.IndexBackfillBytes != horizon {
+		t.Errorf("persisted IndexBackfillBytes = %d, want %d -- the horizon would silently "+
+			"revert to unbounded on restart", saved.IndexBackfillBytes, horizon)
 	}
 }


### PR DESCRIPTION
`IndexBackfillBytes` (#147) bounds how far back an index configuration change is carried — but it existed only on the storage layer's options. `ArchiveConfig` had no field for it, so a catalog, and therefore a daemon, could not set it. **The bound was built and unreachable, which is the same as not having it.**

Zero still carries a change across the whole archive, so nothing changes for anyone who does not set it. For history that default means decompressing every record to add one index — hours at scale, to speed up reads of the oldest data that a newest-first query with a limit may never reach.

## Testing

`TestArchiveBackfillHorizonReachable` sets the horizon through `CreateArchiveTable`, reopens, and asserts it is present in the persisted `archiveconfig.json`. Silently reverting to unbounded on restart would be worse than never setting it, since the cost would then land during recovery.

`go vet` and the `db` and `dbrpc` suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
