### PR TITLE
parser: pool the whole-ad parser

### DIFF
--- a/parser/ad_pool.go
+++ b/parser/ad_pool.go
@@ -1,0 +1,71 @@
+package parser
+
+import (
+	"bufio"
+	"strings"
+	"sync"
+
+	"github.com/PelicanPlatform/classad/ast"
+)
+
+// adParser bundles the reader, lexer and goyacc parser for one whole-ad parse, pooled the
+// way exprParser is for expressions.
+//
+// Each Parse otherwise allocated a fresh 4 KB bufio.Reader plus a yyParserImpl carrying an
+// inline parse stack -- around 7 KB of fixed setup per ad, independent of how small the ad
+// is. Decoding rows off the wire is a per-row parse, so that setup, not the parsing, was the
+// dominant allocation in every client that reads ads (a 20k-row query allocated ~140 MB in
+// bufio buffers and parser stacks alone).
+type adParser struct {
+	sr  strings.Reader
+	br  *bufio.Reader
+	slx StreamingLexer
+	lex Lexer
+	p   yyParserImpl
+}
+
+var adParserPool = sync.Pool{
+	New: func() any {
+		ap := &adParser{}
+		ap.br = bufio.NewReader(&ap.sr)
+		ap.slx.r = ap.br
+		ap.lex.lex = &ap.slx
+		return ap
+	},
+}
+
+// reset points the pooled instance at a new input and clears every field the previous parse
+// touched. The whole-ad entry points parse one complete ad from a string, so unlike the
+// streaming lexer this one must not stop early or carry state across calls.
+func (ap *adParser) reset(input string, lenientEscapes bool) {
+	ap.sr.Reset(input)
+	ap.br.Reset(&ap.sr)
+	ap.slx.resetForNext()
+	ap.slx.pos = 0
+	ap.slx.stopAfterClassAd = false
+	ap.slx.lenientEscapes = lenientEscapes
+	ap.lex.input = input
+	ap.lex.pos = 0
+	ap.lex.result = nil
+	ap.lex.err = nil
+}
+
+// parsePooled parses one whole ClassAd from input with a pooled parser. lenientEscapes
+// selects the old-ClassAd string semantics (see StreamingLexer.lenientEscapes).
+func parsePooled(input string, lenientEscapes bool) (ast.Node, error) {
+	ap, ok := adParserPool.Get().(*adParser)
+	if !ok {
+		panic("adParserPool held an unexpected type") // pool's New only makes *adParser
+	}
+	ap.reset(input, lenientEscapes)
+	ap.p.Parse(&ap.lex)
+	node, err := ap.lex.Result()
+	// Return nothing to the pool that outlives this call: the parsed AST is the caller's,
+	// and holding the input string would pin it for as long as the instance is idle.
+	ap.slx.result = nil
+	ap.lex.result = nil
+	ap.lex.input = ""
+	ap.sr.Reset("")
+	adParserPool.Put(ap)
+	return node, err
+}

--- a/parser/adpool_bench_test.go
+++ b/parser/adpool_bench_test.go
@@ -1,0 +1,49 @@
+package parser
+
+import (
+	"strings"
+	"testing"
+)
+
+// jobAdText is a job ad of the width a query actually returns, so the benchmark measures the
+// mix of fixed per-parse setup and per-attribute work that decoding a result set pays.
+var jobAdText = strings.Join([]string{
+	`[ ClusterId = 1234; ProcId = 7; Owner = "alice"; JobStatus = 2; QDate = 1700000000;`,
+	`RequestMemory = 2048; RequestCpus = 4; RemoteHost = "slot1@node42.example.edu";`,
+	`Cmd = "/home/alice/run.sh"; Iwd = "/home/alice/work"; JobUniverse = 5;`,
+	`RemoteWallClockTime = 12345.0; NumJobStarts = 1; ExitCode = 0 ]`,
+}, "\n")
+
+var oldJobAdText = strings.NewReplacer(";", "\n", "[", "", "]", "").Replace(jobAdText)
+
+// BenchmarkParseClassAd is the whole-ad parse every client pays once per returned row.
+func BenchmarkParseClassAd(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if _, err := ParseClassAd(jobAdText); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkParseOldClassAd covers the old-ClassAd form, which is what the server's projected
+// query op streams.
+func BenchmarkParseOldClassAd(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if _, err := ParseOldClassAd(oldJobAdText); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkParseClassAdNarrow is the same parse over a two-attribute ad: with the fixed setup
+// pooled away, the cost should track the ad's width rather than being dominated by a constant.
+func BenchmarkParseClassAdNarrow(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if _, err := ParseClassAd(`[ Owner = "alice"; JobStatus = 2 ]`); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/parser/old_classad_parser.go
+++ b/parser/old_classad_parser.go
@@ -25,10 +25,7 @@ func ParseOldClassAd(input string) (*ast.ClassAd, error) {
 	// "\S", the agetty escapes /etc/issue carries) is kept literally rather than rejected,
 	// matching the C++ old-ClassAd tokenizer. Otherwise one such attribute would fail the
 	// whole ad -- which silently drops every startd ad a collector forwards.
-	lex := NewLexer(newFormat)
-	lex.lex.lenientEscapes = true
-	yyParse(lex)
-	result, err := lex.Result()
+	result, err := parsePooled(newFormat, true)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing old ClassAd format: %w", err)
 	}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -14,9 +14,7 @@ import (
 // returns its AST. It does not accept a bare expression; to parse a standalone
 // expression such as "a + 1" or "{1, 2}", use ParseExpr.
 func Parse(input string) (ast.Node, error) {
-	lex := NewLexer(input)
-	yyParse(lex)
-	return lex.Result()
+	return parsePooled(input, false)
 }
 
 // ParseClassAd parses a ClassAd and returns a ClassAd AST node. It returns an
@@ -66,6 +64,9 @@ func ParseExpr(input string) (ast.Expr, error) {
 // for efficiency.
 type ReaderParser struct {
 	lex *StreamingLexer
+	// p is reused across ads: yyParse() allocates a fresh parser (with an inline parse
+	// stack) per call, which on a multi-ad stream is per-ad garbage for no reason.
+	p yyParserImpl
 }
 
 // NewReaderParser creates a reusable parser that pulls consecutive ClassAds
@@ -87,7 +88,7 @@ func (p *ReaderParser) ParseClassAd() (*ast.ClassAd, error) {
 		return nil, err
 	}
 
-	yyParse(p.lex)
+	p.p.Parse(p.lex)
 	node, err := p.lex.Result()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Every `Parse` allocated a fresh 4 KB `bufio.Reader` plus a `yyParserImpl` carrying an inline parse stack -- around **7 KB of fixed setup per ad, independent of the ad's size**. Decoding a result set is a parse per row, so that setup, not the parsing, was the dominant allocation in every client that reads ads. Profiling a 20k-row query in htcondordb, `bufio.NewReaderSize` and `yyNewParser` alone were 77% of allocated bytes.

This pools the reader/lexer/parser the way `ParseExpr` already pools its own, and reuses `ReaderParser`'s parser across ads instead of allocating one per call.

```
BenchmarkParseClassAd       9.6us  12920 B/op  120 allocs/op
                      ->    7.9us   1745 B/op  105 allocs/op
BenchmarkParseOldClassAd   10.8us  14008 B/op  128 allocs/op
                      ->    9.3us   2834 B/op  113 allocs/op
```

Downstream, an htcondordb query returning 20k rows drops from 167 MB to 20 MB allocated.

`parser`, `classad`, `ast` pass under `-race`; `db` and `dbrpc` pass. (`collections`' `TestPersistentMultiRetrainReopen` fails on this machine with and without the change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
