### PR TITLE
collections: decay query demand and checkpoint it to disk

### DIFF
--- a/collections/archive.go
+++ b/collections/archive.go
@@ -317,6 +317,11 @@ func (a *Archive) DropIndex(names ...string) bool { return a.c.DropIndex(names..
 // data is never touched.
 func (a *Archive) Reindex() { a.c.Reindex() }
 
+// SaveDemand checkpoints recorded query demand to the archive's directory, ageing it by the
+// time since the last checkpoint, so index decisions are not restarted from zero every time
+// the process is. See Collection.SaveDemand.
+func (a *Archive) SaveDemand() { a.c.SaveDemand() }
+
 // SetRetention updates the retention bounds at runtime; the next Rotate enforces them.
 func (a *Archive) SetRetention(r Retention) { a.c.SetRetention(r) }
 

--- a/collections/autoindex.go
+++ b/collections/autoindex.go
@@ -42,15 +42,20 @@ type demandCounts struct {
 type demandTracker struct {
 	m sync.Map // foldedName(string) -> *demandCounts
 
-	// total and startedUnix answer a question the per-attribute counters cannot: whether a
-	// zero means "queried by nobody" or "we have not been watching long enough to say".
-	//
-	// The counters are process-local and never decay, so immediately after a restart EVERY
-	// attribute reads zero. Acting on that drops the whole auto-index set on every restart
-	// and rebuilds it as traffic returns -- which on a large table is an expensive way to
-	// arrive back where it started.
-	total       atomic.Int64
-	startedUnix atomic.Int64
+	// total and observedNanos answer a question the per-attribute counters cannot: whether
+	// a zero means "queried by nobody" or "we have not been watching long enough to say".
+	// Acting on the second as if it were the first drops the whole auto-index set and
+	// rebuilds it as traffic returns -- on a large table, an expensive way to arrive back
+	// where it started.
+	total atomic.Int64
+	// startedUnix marks the current session; observedNanos accumulates the sessions before
+	// it, so observation survives a restart (see demand_persist.go) while the downtime
+	// between sessions is not counted as time spent watching.
+	startedUnix   atomic.Int64
+	observedNanos atomic.Int64
+	// lastDecayUnix is when the counters were last scaled down, so decay is charged for
+	// elapsed time rather than per call.
+	lastDecayUnix atomic.Int64
 }
 
 // hasDropEvidence reports whether the tracker has watched long enough, and seen enough
@@ -59,13 +64,14 @@ func (d *demandTracker) hasDropEvidence(minQueries int64, minWindow time.Duratio
 	if d.total.Load() < minQueries {
 		return false // an idle daemon has learned nothing about which indexes matter
 	}
-	st := d.startedUnix.Load()
-	return st != 0 && time.Since(time.Unix(0, st)) >= minWindow
+	return d.observedFor() >= minWindow
 }
 
 func newDemandTracker() *demandTracker {
 	d := &demandTracker{}
-	d.startedUnix.Store(time.Now().UnixNano())
+	now := time.Now().UnixNano()
+	d.startedUnix.Store(now)
+	d.lastDecayUnix.Store(now)
 	return d
 }
 

--- a/collections/demand_persist.go
+++ b/collections/demand_persist.go
@@ -1,0 +1,230 @@
+package collections
+
+import (
+	"encoding/json"
+	"math"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// Making query demand outlive the process, and stop being a lifetime total.
+//
+// The demand counters drive index suggestions, auto-tuning, and hot-set ranking. As
+// process-local monotonic counters they get both ends of the time axis wrong:
+//
+//   - Nothing survives a restart. Every attribute reads zero, so a daemon that restarts
+//     regularly never accumulates enough evidence to justify anything, and anything that
+//     reads a zero as "unwanted" is reading amnesia. Guarding against that (the drop-evidence
+//     window) only suppresses the damage; it does not recover the signal.
+//   - Nothing ever decays. In a long-lived daemon "demand" means "demand since boot",
+//     so a batch job that hammered an attribute once in January keeps its index pinned in
+//     July. The longer the process runs, the more the counters describe history rather than
+//     the current workload.
+//
+// Both are fixed by the same thing: an exponentially decayed counter, checkpointed to disk.
+// Decay is applied by elapsed time -- at each save, and again on load for the interval the
+// process was down -- so the value always means "recent demand, as of now" whether or not
+// there was a restart in between. A restart then costs only the demand accrued since the
+// last checkpoint, instead of all of it.
+//
+// Downtime decays the counters but does not count as observation: observedNanos accumulates
+// only time the process was actually running, so a daemon that has been up for a minute
+// cannot conclude anything from a week-old checkpoint just because the checkpoint is old.
+
+const (
+	demandFile = "demand.json"
+	// defaultDemandHalfLife is how fast demand fades. Index decisions should track the
+	// shape of a workload over days -- long enough that a quiet weekend does not discard
+	// what a week of queries established, short enough that a workload which genuinely
+	// moves on is followed within a couple of weeks.
+	defaultDemandHalfLife = 7 * 24 * time.Hour
+	// demandFloor is the decayed value below which an attribute is forgotten rather than
+	// checkpointed, so the file does not accumulate every attribute ever queried.
+	demandFloor = 0.5
+	// demandDecayThreshold is the smallest scaling worth applying. Counters are integers,
+	// so a decay too small to change one is not free -- it rounds away a fraction of a
+	// count and, charged again on the next pass, erodes counters at a rate set by how often
+	// maintenance runs rather than by the half-life. Below this the elapsed time is left on
+	// the clock to be charged in a later, larger step. At the default half-life this makes
+	// decay land roughly every two hours.
+	demandDecayThreshold = 0.99
+	demandVer            = 1
+)
+
+// persistedDemand is the on-disk checkpoint. Counts are float64 because decay is
+// multiplicative; the in-memory counters round them back to integers.
+type persistedDemand struct {
+	Version   int                        `json:"version"`
+	SavedUnix int64                      `json:"saved_unix"` // nanos, for the elapsed-downtime decay
+	Observed  int64                      `json:"observed_nanos"`
+	Total     float64                    `json:"total"`
+	Attrs     map[string]persistedCounts `json:"attrs"` // folded attribute name -> counts
+}
+
+type persistedCounts struct {
+	Eq    float64 `json:"eq"`
+	Rng   float64 `json:"rng"`
+	Reads float64 `json:"reads"`
+}
+
+// decayFactor is the multiplier for demand that is age old, given a half-life.
+func decayFactor(age, halfLife time.Duration) float64 {
+	if age <= 0 || halfLife <= 0 {
+		return 1
+	}
+	return math.Pow(0.5, float64(age)/float64(halfLife))
+}
+
+// decay scales every counter by f, dropping attributes that fall below the floor. Counters
+// are read-modify-written without atomicity against concurrent record() calls: this runs on
+// the maintenance path against a statistical signal, so losing a probe that lands mid-scale
+// is immaterial, and paying for exact accounting on the query hot path would not be.
+func (d *demandTracker) decay(f float64) {
+	if f >= 1 {
+		return
+	}
+	d.total.Store(scaleCount(d.total.Load(), f))
+	var dead []string
+	d.m.Range(func(k, v any) bool {
+		c := v.(*demandCounts)
+		eq := float64(c.eq.Load()) * f
+		rng := float64(c.rng.Load()) * f
+		reads := float64(c.reads.Load()) * f
+		if eq < demandFloor && rng < demandFloor && reads < demandFloor {
+			dead = append(dead, k.(string))
+			return true
+		}
+		c.eq.Store(int64(math.Round(eq)))
+		c.rng.Store(int64(math.Round(rng)))
+		c.reads.Store(int64(math.Round(reads)))
+		return true
+	})
+	for _, k := range dead {
+		d.m.Delete(k)
+	}
+}
+
+// scaleCount applies a decay factor to an integer counter, rounding rather than truncating.
+// Truncation biases every scaling downward by up to a full count, which for a counter in the
+// tens is a larger effect than the decay being applied.
+func scaleCount(n int64, f float64) int64 { return int64(math.Round(float64(n) * f)) }
+
+// observedFor reports how long this tracker has actually been watching: the time
+// accumulated over previous runs plus this session so far. Downtime is excluded, which is
+// the difference between "we have a week-old checkpoint" and "we have watched for a week".
+func (d *demandTracker) observedFor() time.Duration {
+	var session time.Duration
+	if st := d.startedUnix.Load(); st != 0 {
+		session = time.Since(time.Unix(0, st))
+	}
+	return time.Duration(d.observedNanos.Load()) + session
+}
+
+// snapshot renders the tracker for checkpointing, after folding this session's elapsed time
+// into the accumulated observation total.
+func (d *demandTracker) snapshot(now time.Time) persistedDemand {
+	if st := d.startedUnix.Load(); st != 0 {
+		d.observedNanos.Add(int64(now.Sub(time.Unix(0, st))))
+		d.startedUnix.Store(now.UnixNano()) // this session's time is now accounted for
+	}
+	p := persistedDemand{
+		Version:   demandVer,
+		SavedUnix: now.UnixNano(),
+		Observed:  d.observedNanos.Load(),
+		Total:     float64(d.total.Load()),
+		Attrs:     map[string]persistedCounts{},
+	}
+	d.m.Range(func(k, v any) bool {
+		c := v.(*demandCounts)
+		eq, rng, reads := float64(c.eq.Load()), float64(c.rng.Load()), float64(c.reads.Load())
+		if eq >= demandFloor || rng >= demandFloor || reads >= demandFloor {
+			p.Attrs[k.(string)] = persistedCounts{Eq: eq, Rng: rng, Reads: reads}
+		}
+		return true
+	})
+	return p
+}
+
+// restore loads a checkpoint, decaying it by the time since it was written. Counts are
+// ADDED to whatever the tracker already holds so a restore is safe on a live tracker.
+func (d *demandTracker) restore(p persistedDemand, halfLife time.Duration, now time.Time) {
+	f := decayFactor(now.Sub(time.Unix(0, p.SavedUnix)), halfLife)
+	if f <= 0 {
+		return
+	}
+	d.observedNanos.Add(p.Observed)
+	d.total.Add(int64(math.Round(p.Total * f)))
+	for name, pc := range p.Attrs {
+		eq, rng, reads := pc.Eq*f, pc.Rng*f, pc.Reads*f
+		if eq < demandFloor && rng < demandFloor && reads < demandFloor {
+			continue
+		}
+		v, _ := d.m.LoadOrStore(name, &demandCounts{})
+		c := v.(*demandCounts)
+		c.eq.Add(int64(math.Round(eq)))
+		c.rng.Add(int64(math.Round(rng)))
+		c.reads.Add(int64(math.Round(reads)))
+	}
+}
+
+// demandHalfLife is the configured half-life, or the default.
+func (c *Collection) demandHalfLife() time.Duration {
+	if c.demandHalf > 0 {
+		return c.demandHalf
+	}
+	if c.demandHalf < 0 {
+		return 0 // explicitly disabled: counters do not decay
+	}
+	return defaultDemandHalfLife
+}
+
+// SaveDemand checkpoints query demand to the collection's directory, decaying it first by
+// the time since the last checkpoint. Call it from maintenance; it is a no-op on an
+// in-memory collection.
+//
+// Best-effort by design, as for the other sidecar metadata: a failed write costs the
+// interval's demand, not correctness. Nothing reads this file except a later restore, and a
+// restore that finds it missing or unparseable simply starts from what it has.
+func (c *Collection) SaveDemand() {
+	if c.dir == "" {
+		return
+	}
+	now := time.Now()
+	if hl := c.demandHalfLife(); hl > 0 {
+		if last := c.demand.lastDecayUnix.Load(); last != 0 {
+			// Charge decay only once it is large enough to move an integer counter
+			// honestly; otherwise leave the clock alone so the elapsed time accumulates
+			// into a later step rather than being rounded away now.
+			if f := decayFactor(now.Sub(time.Unix(0, last)), hl); f <= demandDecayThreshold {
+				c.demand.decay(f)
+				c.demand.lastDecayUnix.Store(now.UnixNano())
+			}
+		} else {
+			c.demand.lastDecayUnix.Store(now.UnixNano())
+		}
+	}
+	data, err := json.Marshal(c.demand.snapshot(now))
+	if err != nil {
+		return
+	}
+	_ = writeFileSync(filepath.Join(c.dir, demandFile), data)
+}
+
+// loadDemand restores the checkpoint written by SaveDemand. Any problem reading it leaves
+// the tracker empty, which is exactly the pre-checkpoint behaviour.
+func (c *Collection) loadDemand() {
+	if c.dir == "" {
+		return
+	}
+	c.demand.lastDecayUnix.Store(time.Now().UnixNano())
+	data, err := os.ReadFile(filepath.Join(c.dir, demandFile))
+	if err != nil {
+		return
+	}
+	var p persistedDemand
+	if json.Unmarshal(data, &p) != nil || p.Version != demandVer || p.SavedUnix == 0 {
+		return
+	}
+	c.demand.restore(p, c.demandHalfLife(), time.Now())
+}

--- a/collections/demand_persist_test.go
+++ b/collections/demand_persist_test.go
@@ -1,0 +1,272 @@
+package collections
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/PelicanPlatform/classad/classad"
+)
+
+// fillDemandCollection returns a persistent collection with ads and recorded demand on
+// Owner (equality) and ClusterId (range).
+func fillDemandCollection(t *testing.T, dir string, queries int) *Collection {
+	t.Helper()
+	c, err := Open(Options{Dir: dir, SegmentSize: 1 << 16})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := range 200 {
+		ad, err := classad.Parse(fmt.Sprintf(`[ ClusterId=%d; Owner="user%d" ]`, i, i%7))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := c.Put([]byte(fmt.Sprintf("%d.0", i)), ad); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for range queries {
+		drainQuery(t, c, `Owner == "user3"`)
+		drainQuery(t, c, `ClusterId > 100`)
+	}
+	return c
+}
+
+func demandOf(t *testing.T, c *Collection, attr string) (eq, rng int64) {
+	t.Helper()
+	v, ok := c.demand.m.Load(attr)
+	if !ok {
+		return 0, 0
+	}
+	d := v.(*demandCounts)
+	return d.eq.Load(), d.rng.Load()
+}
+
+// TestDemandSurvivesReopen is the point of the checkpoint: a restart must not erase the
+// evidence that justified the current index set. Without it every attribute reads zero on
+// reopen, which is indistinguishable from "no query has ever wanted this".
+func TestDemandSurvivesReopen(t *testing.T) {
+	dir := t.TempDir()
+	c := fillDemandCollection(t, dir, 20)
+	eq, rng := demandOf(t, c, "owner")
+	if eq != 20 {
+		t.Fatalf("pre-save owner eq = %d, want 20", eq)
+	}
+	c.SaveDemand()
+	if err := c.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	c2, err := Open(Options{Dir: dir, SegmentSize: 1 << 16})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c2.Close()
+	gotEq, _ := demandOf(t, c2, "owner")
+	if gotEq != eq {
+		t.Errorf("owner eq after reopen = %d, want %d", gotEq, eq)
+	}
+	_, cid := demandOf(t, c2, "clusterid")
+	if cid == 0 {
+		t.Errorf("clusterid range demand lost across reopen (had %d)", rng)
+	}
+	// The reopened collection must be able to act on it: suggestions come back too.
+	var got []string
+	for _, s := range c2.SuggestIndexes(1000) {
+		got = append(got, s.Attr+":"+s.Kind)
+	}
+	if len(got) != 2 {
+		t.Errorf("suggestions after reopen = %v, want ClusterId and Owner", got)
+	}
+}
+
+// TestDemandDecaysAcrossDowntime checks the other half: a checkpoint is not a permanent
+// record. Demand written long ago comes back scaled down by the elapsed time, so an index
+// justified by a burst last quarter does not stay justified forever.
+func TestDemandDecaysAcrossDowntime(t *testing.T) {
+	dir := t.TempDir()
+	c := fillDemandCollection(t, dir, 64)
+	c.SaveDemand()
+	if err := c.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Backdate the checkpoint by three half-lives: 64 -> 8.
+	path := filepath.Join(dir, demandFile)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var p persistedDemand
+	if err := json.Unmarshal(data, &p); err != nil {
+		t.Fatal(err)
+	}
+	p.SavedUnix = time.Now().Add(-3 * defaultDemandHalfLife).UnixNano()
+	if data, err = json.Marshal(p); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	c2, err := Open(Options{Dir: dir, SegmentSize: 1 << 16})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c2.Close()
+	eq, _ := demandOf(t, c2, "owner")
+	if eq < 6 || eq > 10 {
+		t.Errorf("owner eq after 3 half-lives = %d, want ~8 (64/2^3)", eq)
+	}
+}
+
+// TestDemandForgottenWhenFullyDecayed: an attribute nothing has queried for long enough
+// drops out entirely rather than lingering in the checkpoint forever.
+func TestDemandForgottenWhenFullyDecayed(t *testing.T) {
+	dir := t.TempDir()
+	c := fillDemandCollection(t, dir, 4)
+	c.SaveDemand()
+	if err := c.Close(); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, demandFile)
+	data, _ := os.ReadFile(path)
+	var p persistedDemand
+	if err := json.Unmarshal(data, &p); err != nil {
+		t.Fatal(err)
+	}
+	p.SavedUnix = time.Now().Add(-30 * defaultDemandHalfLife).UnixNano()
+	data, _ = json.Marshal(p)
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	c2, err := Open(Options{Dir: dir, SegmentSize: 1 << 16})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c2.Close()
+	if eq, rng := demandOf(t, c2, "owner"); eq != 0 || rng != 0 {
+		t.Errorf("owner demand after 30 half-lives = (%d,%d), want dropped", eq, rng)
+	}
+}
+
+// TestDemandDowntimeIsNotObservation: restoring a week-old checkpoint must not let a
+// daemon that has been up for a moment claim it has been watching for a week. Drop
+// decisions are gated on observation time precisely because a zero from a short window
+// means nothing, and downtime is not a window.
+func TestDemandDowntimeIsNotObservation(t *testing.T) {
+	dir := t.TempDir()
+	c := fillDemandCollection(t, dir, 200)
+	c.SaveDemand()
+	if err := c.Close(); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, demandFile)
+	data, _ := os.ReadFile(path)
+	var p persistedDemand
+	if err := json.Unmarshal(data, &p); err != nil {
+		t.Fatal(err)
+	}
+	p.SavedUnix = time.Now().Add(-24 * time.Hour).UnixNano()
+	data, _ = json.Marshal(p)
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	c2, err := Open(Options{Dir: dir, SegmentSize: 1 << 16})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c2.Close()
+	// The queries were observed in well under a second of real running time, so a
+	// one-hour window must not be satisfied by the day of downtime.
+	if c2.demand.hasDropEvidence(1, time.Hour) {
+		t.Error("a day of downtime counted as observation time")
+	}
+	// ...but a window shorter than the real observation is satisfied, so the gate is not
+	// simply always-false.
+	if !c2.demand.hasDropEvidence(1, time.Nanosecond) {
+		t.Error("observation time not accumulated at all")
+	}
+}
+
+// TestDemandDecayDisabled: a negative half-life keeps the old accumulate-forever behaviour
+// for a caller that wants it.
+func TestDemandDecayDisabled(t *testing.T) {
+	dir := t.TempDir()
+	c, err := Open(Options{Dir: dir, SegmentSize: 1 << 16, DemandHalfLife: -1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := range 50 {
+		ad, _ := classad.Parse(fmt.Sprintf(`[ ClusterId=%d; Owner="user%d" ]`, i, i%7))
+		if err := c.Put([]byte(fmt.Sprintf("%d.0", i)), ad); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for range 16 {
+		drainQuery(t, c, `Owner == "user3"`)
+	}
+	c.SaveDemand()
+	c.Close()
+
+	path := filepath.Join(dir, demandFile)
+	data, _ := os.ReadFile(path)
+	var p persistedDemand
+	if err := json.Unmarshal(data, &p); err != nil {
+		t.Fatal(err)
+	}
+	p.SavedUnix = time.Now().Add(-10 * defaultDemandHalfLife).UnixNano()
+	data, _ = json.Marshal(p)
+	os.WriteFile(path, data, 0o644)
+
+	c2, err := Open(Options{Dir: dir, SegmentSize: 1 << 16, DemandHalfLife: -1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c2.Close()
+	if eq, _ := demandOf(t, c2, "owner"); eq != 16 {
+		t.Errorf("owner eq with decay disabled = %d, want 16 (undecayed)", eq)
+	}
+}
+
+func TestDecayFactor(t *testing.T) {
+	hl := time.Hour
+	for _, tc := range []struct {
+		age  time.Duration
+		want float64
+	}{
+		{0, 1}, {hl, 0.5}, {2 * hl, 0.25}, {-time.Hour, 1},
+	} {
+		if got := decayFactor(tc.age, hl); got < tc.want-1e-9 || got > tc.want+1e-9 {
+			t.Errorf("decayFactor(%v) = %v, want %v", tc.age, got, tc.want)
+		}
+	}
+	if got := decayFactor(time.Hour, 0); got != 1 {
+		t.Errorf("decayFactor with no half-life = %v, want 1 (no decay)", got)
+	}
+}
+
+// TestDemandNotErodedByFrequentSaves guards the trap that decaying an INTEGER counter is
+// not free even when the factor is ~1: rounding down a fraction of a count on every
+// checkpoint erodes demand at a rate set by how often maintenance runs rather than by the
+// configured half-life. A day's worth of maintenance passes must leave a week-half-life
+// counter essentially untouched.
+func TestDemandNotErodedByFrequentSaves(t *testing.T) {
+	dir := t.TempDir()
+	c := fillDemandCollection(t, dir, 20)
+	defer c.Close()
+	before, _ := demandOf(t, c, "owner")
+	for range 50 {
+		c.SaveDemand()
+	}
+	after, _ := demandOf(t, c, "owner")
+	if after != before {
+		t.Errorf("owner eq eroded by 50 checkpoints: %d -> %d (half-life is %v)",
+			before, after, defaultDemandHalfLife)
+	}
+}

--- a/collections/persist.go
+++ b/collections/persist.go
@@ -281,6 +281,9 @@ func Open(opts Options) (*Collection, error) {
 	// If sealed segments recovered persisted columnar blocks, re-enable schema-scan from them
 	// (adopt-from-sidecar) so the accelerator is live immediately -- no re-sample, no rebuild.
 	c.adoptPersistedSchemaScan()
+	// Recorded query demand is checkpointed alongside the data, so index decisions do not
+	// restart from zero every time the process does.
+	c.loadDemand()
 	return c, nil
 }
 

--- a/collections/store.go
+++ b/collections/store.go
@@ -92,6 +92,11 @@ type Options struct {
 	// header) instead of decoding the whole ad. Optional; enables the hot-closure match
 	// fast path. The frequency/HotAttrs hot set is unioned in, so queries are unaffected.
 	MatchClosureRoots []string
+	// DemandHalfLife is how quickly recorded query demand fades, so index decisions
+	// track the current workload rather than everything the process has ever seen. 0
+	// uses defaultDemandHalfLife; negative disables decay (counters accumulate for the
+	// lifetime of the data, as they did before decay existed).
+	DemandHalfLife time.Duration
 	// CommitSync, if set, is called once per committed (possibly group-coalesced)
 	// batch on a shard, after the writes are applied — the point at which a future
 	// durable collection would fsync/serialize the batch. Group commit amortizes
@@ -260,7 +265,8 @@ type Collection struct {
 	// ops' internal reindexAfterCompaction must not re-take).
 	reindexMu sync.Mutex
 
-	demand *demandTracker // per-attribute query demand, for SuggestIndexes
+	demand     *demandTracker // per-attribute query demand, for SuggestIndexes
+	demandHalf time.Duration  // Options.DemandHalfLife, verbatim (0 = default, <0 = no decay)
 
 	// Query fan-out (see parallel_scan.go). queryPar is the per-query worker cap
 	// (0/1 ⇒ serial). qsem is a collection-wide token pool bounding total scan
@@ -478,8 +484,9 @@ func New(opts Options) *Collection {
 		// Private attributes are flagged once per unique name at intern time, so a
 		// redacted query (ScanRawRedacted/QueryRawRedacted) strips them with a per-id
 		// bool check instead of re-classifying every attribute of every ad.
-		intern: wire.NewInternTableWithPrivacy(classad.IsPrivateAttribute),
-		demand: newDemandTracker(),
+		intern:     wire.NewInternTableWithPrivacy(classad.IsPrivateAttribute),
+		demand:     newDemandTracker(),
+		demandHalf: opts.DemandHalfLife,
 	}
 	c.codec.Store(&codecHolder{codec})
 	if cfg := newTTConfig(opts.TimeTravel); cfg != nil {

--- a/db/archive.go
+++ b/db/archive.go
@@ -519,3 +519,7 @@ func (t *ArchiveTable) SetGCFloor(floor float64) { t.a.SetGCFloor(floor) }
 
 // GCFloor returns the current runtime GC watermark (0 when unset).
 func (t *ArchiveTable) GCFloor() float64 { return t.a.GCFloor() }
+
+// SaveDemand checkpoints the archive's recorded query demand so index decisions survive a
+// restart, ageing it by the time since the last checkpoint. See collections.SaveDemand.
+func (t *ArchiveTable) SaveDemand() { t.a.SaveDemand() }

--- a/db/db.go
+++ b/db/db.go
@@ -263,6 +263,10 @@ func (db *DB) Maintain(opts MaintainOptions) {
 		// after (idempotent + refresh-safe -- keeps the stable schema/hot set).
 		db.c.BuildAndEnableSchemaScan(opts.SampleMax, opts.SchemaScanHotTopN)
 	}
+	// Checkpoint the query demand these decisions are made from, and age it. Unconditional:
+	// it is a small write, and the signal is worth as much to the next process as to this
+	// one -- more, since that one starts with nothing else.
+	db.c.SaveDemand()
 }
 
 // StartMaintenance starts a background goroutine that runs Maintain with the given

--- a/dbrpc/server.go
+++ b/dbrpc/server.go
@@ -1501,6 +1501,11 @@ func (s *Server) maintainArchives(opts db.MaintainOptions) {
 		if stale, _ := a.StaleIndexSegments(); stale > 0 {
 			a.Reindex()
 		}
+		// Age and checkpoint the recorded query demand. An archive needs this more than a
+		// mutable table does: indexing one is paid for by decompressing history, so the
+		// decision wants evidence gathered over days, which is longer than a daemon can be
+		// relied on to stay up.
+		a.SaveDemand()
 		s.maintainMu.Unlock()
 	}
 }


### PR DESCRIPTION
The demand counters drive index suggestions, auto-tuning, and hot-set ranking. As process-local monotonic counters they were wrong at **both ends of the time axis**:

- **Nothing survived a restart.** Every attribute read zero, which is indistinguishable from "no query has ever wanted this". The drop-evidence window added earlier only suppresses the damage; it does not recover the signal.
- **Nothing ever decayed.** In a long-lived daemon "demand" meant "demand since boot", so a batch job that hammered an attribute once in January kept its index pinned in July.

Both are the same fix: an exponentially decayed counter, checkpointed to `demand.json`. Decay is charged by elapsed time — at each save, and again on load for the interval the process was down — so a value always means "recent demand, **as of now**", restart or not. A restart now costs only the demand accrued since the last checkpoint.

Half-life defaults to 7 days: long enough that a quiet weekend does not discard what a week of queries established, short enough to follow a workload that genuinely moves on. A negative `DemandHalfLife` keeps the old accumulate-forever behaviour.

## Downtime is not observation

`observedNanos` accumulates only time the process was actually running. Without that split, restoring a week-old checkpoint would let a daemon that has been up for a moment claim it had been watching for a week — and `hasDropEvidence` exists precisely to stop conclusions being drawn from a window that short.

## A bug found while testing this

Decaying an **integer** counter is not free even when the factor is ~1. Truncating rounds away a fraction of a count on every pass, and charged again next pass it compounds — so demand eroded at a rate set by **how often maintenance runs**, not by the configured half-life. Measured: a counter of 20 fell to **0 over 50 checkpoints**, with a 7-day half-life and under a second of elapsed time.

Two changes: counters round rather than truncate, and decay is deferred until enough time has accrued to move one honestly (~2 hours at the default half-life) rather than being charged in slices too small to represent.

`TestDemandNotErodedByFrequentSaves` covers it; I verified it fails under the old arithmetic with exactly the 20 → 0 above.

## Why this matters for archives

Indexing an archive is paid for by decompressing history, so the decision wants evidence gathered over **days** — longer than a daemon can be relied on to stay up. Demand that resets on restart cannot support a meaningful minimum-demand threshold, which makes this a prerequisite for auto-indexing archives rather than an optimization of it.

## Testing

Reopen preserves demand and the suggestions derived from it; a backdated checkpoint comes back decayed by the right factor (3 half-lives → ~1/8) and is forgotten entirely at 30; downtime does not satisfy the observation window while real observation does; decay-disabled restores undecayed.

`go vet` and all five module suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
