### PR TITLE
db: auto-index archives from observed query demand

### DIFF
--- a/collections/archive.go
+++ b/collections/archive.go
@@ -322,6 +322,17 @@ func (a *Archive) Reindex() { a.c.Reindex() }
 // the process is. See Collection.SaveDemand.
 func (a *Archive) SaveDemand() { a.c.SaveDemand() }
 
+// AutoTune applies demand-driven index changes to the archive. See Collection.AutoTune.
+func (a *Archive) AutoTune(opts AutoTuneOptions) AutoTuneResult { return a.c.AutoTune(opts) }
+
+// MarkAutoIndexes records existing indexes as auto-created, restoring the provenance a
+// saved config carries without rebuilding anything. See Collection.MarkAutoIndexes.
+func (a *Archive) MarkAutoIndexes(names []string) { a.c.MarkAutoIndexes(names) }
+
+// AutoIndexNames returns the names of the archive's auto-created indexes, for persisting
+// provenance alongside the index set itself.
+func (a *Archive) AutoIndexNames() []string { return a.c.AutoIndexNames() }
+
 // SetRetention updates the retention bounds at runtime; the next Rotate enforces them.
 func (a *Archive) SetRetention(r Retention) { a.c.SetRetention(r) }
 

--- a/collections/index_dynamic.go
+++ b/collections/index_dynamic.go
@@ -215,6 +215,54 @@ func (c *Collection) AddAutoIndex(categorical, value []string) bool {
 	return c.addIndexAuto(categorical, value)
 }
 
+// MarkAutoIndexes records the named EXISTING indexes as auto-created. It changes only
+// provenance: no index is added, dropped, or rebuilt, and a name that is not currently
+// indexed is ignored.
+//
+// This is the restore side of AutoIndexNames for a store that rebuilds its whole index set
+// at open (an archive does). Going through AddAutoIndex there would not work: the indexes
+// already exist as human-created by then, and an auto add deliberately refuses to downgrade
+// a human index. Adding them separately instead would restore provenance correctly but
+// rebuild them, which for an archive means reading history back through the decompressor on
+// every start.
+func (c *Collection) MarkAutoIndexes(names []string) {
+	if len(names) == 0 {
+		return
+	}
+	for {
+		cur := c.spec.Load()
+		next := cur.clone()
+		changed := false
+		for _, n := range names {
+			fold := strings.ToLower(n)
+			var id uint32
+			var ok bool
+			if next.inline {
+				id, ok = next.nameToID[fold]
+			} else {
+				id, ok = c.intern.LookupID(fold)
+			}
+			if !ok || (!next.catHas(id) && !next.valHas(id)) {
+				continue // not indexed: nothing to attribute
+			}
+			if next.isAuto(id) {
+				continue
+			}
+			if next.auto == nil {
+				next.auto = make(map[uint32]struct{})
+			}
+			next.auto[id] = struct{}{}
+			changed = true
+		}
+		if !changed {
+			return
+		}
+		if c.spec.CompareAndSwap(cur, next) {
+			return
+		}
+	}
+}
+
 // AutoIndexNames returns the names of auto-created indexes (provenance auto), so the
 // human/auto distinction can be persisted and survive a restart.
 func (c *Collection) AutoIndexNames() []string {

--- a/db/archive.go
+++ b/db/archive.go
@@ -46,13 +46,34 @@ type ArchiveConfig struct {
 	// segments within the newest N bytes have their existing index rebuilt, older ones keep
 	// the one they have (see collections.Options.IndexBackfillBytes).
 	//
-	// Zero carries a change across the whole archive, which for history means decompressing
-	// every record to add one index -- hours at scale, to speed up reads of the oldest data
-	// that a newest-first query with a limit may never reach. A HUMAN AddIndex is allowed to
-	// ask for that; the auto-tuner is not (see ArchiveTable.AutoTune).
+	// Zero takes defaultIndexBackfillBytes. A NEGATIVE value means no bound: the change is
+	// carried across the whole archive, which for history means decompressing every record
+	// to add one index -- hours at scale, to speed up reads of the oldest data that a
+	// newest-first query with a limit may never reach. That is a reasonable thing to ask
+	// for deliberately and a bad thing to get by leaving a field unset, which is why it is
+	// not what zero means.
 	IndexBackfillBytes int64
 	// Retention bounds what rotation keeps (max segments / bytes / age). Zero keeps all.
 	Retention collections.Retention
+}
+
+// defaultIndexBackfillBytes is how far back an index change is carried when the config does
+// not say. At the 8 MiB default segment size this is ~128 segments, a few seconds of
+// decompression -- small enough to be unremarkable on a maintenance pass, and large enough
+// to cover the recent history where newest-first queries actually land.
+const defaultIndexBackfillBytes = 1 << 30
+
+// backfillHorizon resolves IndexBackfillBytes: 0 takes the default, negative means
+// explicitly unbounded (which the storage layer spells as 0).
+func (cfg ArchiveConfig) backfillHorizon() int64 {
+	switch {
+	case cfg.IndexBackfillBytes < 0:
+		return 0
+	case cfg.IndexBackfillBytes == 0:
+		return defaultIndexBackfillBytes
+	default:
+		return cfg.IndexBackfillBytes
+	}
 }
 
 // archiveConfigFile persists the ArchiveConfig so a reopen rebuilds the same
@@ -89,7 +110,7 @@ func openArchiveTable(dir string, cfg ArchiveConfig) (*ArchiveTable, error) {
 		CategoricalAttrs:   cfg.CategoricalAttrs,
 		ValueAttrs:         cfg.ValueAttrs,
 		ZoneAttrs:          cfg.ZoneAttrs,
-		IndexBackfillBytes: cfg.IndexBackfillBytes,
+		IndexBackfillBytes: cfg.backfillHorizon(),
 		Retention:          cfg.Retention,
 	}
 	var a *collections.Archive
@@ -560,15 +581,14 @@ func (t *ArchiveTable) SaveDemand() { t.a.SaveDemand() }
 // round for acting on an absence of evidence.
 func (t *ArchiveTable) AutoTune(opts AutoTuneOptions) AutoTuneResult {
 	opts.DropUnused = false
-	// Refuse to tune an archive with no backfill horizon. Adding an index rebuilds the
-	// index of every segment within the horizon, and the horizon's default is unbounded --
-	// so on the default config the tuner's first decision would decompress the entire
-	// archive. A human AddIndex may ask for that, having asked; a background pass that
-	// nobody watched decide must not be able to.
+	// Refuse to tune an archive whose backfill is explicitly unbounded. Adding an index
+	// rebuilds every segment within the horizon, so with no horizon the tuner's first
+	// decision would decompress the entire archive. A human AddIndex may ask for that,
+	// having asked; a background pass nobody watched decide may not.
 	//
 	// Declining is the conservative direction: the cost of not indexing is slower queries,
 	// the cost of indexing unbounded is hours of I/O on a schedule.
-	if t.cfg.IndexBackfillBytes <= 0 {
+	if t.cfg.backfillHorizon() <= 0 {
 		return AutoTuneResult{}
 	}
 	res := t.a.AutoTune(opts)

--- a/db/archive.go
+++ b/db/archive.go
@@ -37,6 +37,11 @@ type ArchiveConfig struct {
 	HotAttrs                     []string
 	CategoricalAttrs, ValueAttrs []string
 	ZoneAttrs                    []string
+	// AutoAttrs names the subset of the above created by the auto-tuner rather than by a
+	// human. Provenance has to be persisted with the index set, or an auto index returns
+	// from a restart indistinguishable from one someone asked for -- exempt from trimming
+	// and from any future auto-drop, permanently, on the strength of nothing.
+	AutoAttrs []string
 	// Retention bounds what rotation keeps (max segments / bytes / age). Zero keeps all.
 	Retention collections.Retention
 }
@@ -87,6 +92,12 @@ func openArchiveTable(dir string, cfg ArchiveConfig) (*ArchiveTable, error) {
 		return nil, err
 	}
 	t := &ArchiveTable{a: a, dir: dir, cfg: cfg}
+	// The index set above was rebuilt from the config as human-created; re-mark the ones
+	// the tuner made. This adds no index (they are already present) -- it only restores
+	// provenance.
+	if len(cfg.AutoAttrs) > 0 {
+		a.MarkAutoIndexes(cfg.AutoAttrs)
+	}
 	if create {
 		// Persist the config so a later reopen rebuilds the same indexes/retention.
 		if err := t.saveConfig(); err != nil {
@@ -360,6 +371,11 @@ func (t *ArchiveTable) CategoricalGroupCountsWhere(attr, constraint string) (map
 // value is usable and fills in defaults.
 type MergeOptions = collections.MergeOptions
 
+// AutoTuneOptions and AutoTuneResult are re-exported so a caller can tune an archive's
+// indexes without importing collections directly.
+type AutoTuneOptions = collections.AutoTuneOptions
+type AutoTuneResult = collections.AutoTuneResult
+
 // MergePass merges cold segment runs when the archive has reached its trigger watermark,
 // down to its target. Returns the number of merges performed.
 //
@@ -454,6 +470,7 @@ func (t *ArchiveTable) DropIndex(names ...string) bool {
 // contract: a write failure is ignored, leaving the change live for this run but unpersisted.
 func (t *ArchiveTable) saveIndexConfig() {
 	t.cfg.CategoricalAttrs, t.cfg.ValueAttrs = t.a.IndexedAttrs()
+	t.cfg.AutoAttrs = t.a.AutoIndexNames()
 	_ = t.saveConfig()
 }
 
@@ -523,3 +540,25 @@ func (t *ArchiveTable) GCFloor() float64 { return t.a.GCFloor() }
 // SaveDemand checkpoints the archive's recorded query demand so index decisions survive a
 // restart, ageing it by the time since the last checkpoint. See collections.SaveDemand.
 func (t *ArchiveTable) SaveDemand() { t.a.SaveDemand() }
+
+// AutoTune adds indexes the observed query demand justifies, persisting the result so the
+// backfill it just paid for is not thrown away and re-paid on the next restart.
+//
+// Adds only: opts.DropUnused is forced off. On a mutable table an auto-drop is reversible at
+// roughly the cost of the index; on an archive, re-adding means reading history back through
+// the decompressor, so the cheap direction and the expensive direction are the wrong way
+// round for acting on an absence of evidence.
+func (t *ArchiveTable) AutoTune(opts AutoTuneOptions) AutoTuneResult {
+	opts.DropUnused = false
+	res := t.a.AutoTune(opts)
+	if res.Changed {
+		// Without this the archive reopens on its creation-time index set: the added index
+		// disappears, the backfill is discarded, and the tuner adds it again as soon as
+		// demand re-accumulates -- paying the same backfill once per restart, forever.
+		t.saveIndexConfig()
+	}
+	return res
+}
+
+// AutoIndexNames returns the names of the archive's auto-created indexes.
+func (t *ArchiveTable) AutoIndexNames() []string { return t.a.AutoIndexNames() }

--- a/db/archive_autotune_test.go
+++ b/db/archive_autotune_test.go
@@ -1,0 +1,204 @@
+package db
+
+import (
+	"fmt"
+	"slices"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/classad"
+)
+
+func fillArchive(t *testing.T, a *ArchiveTable, n int) {
+	t.Helper()
+	for i := range n {
+		ad := classad.New()
+		ad.Set("ClusterId", int64(i))
+		ad.Set("Owner", fmt.Sprintf("user%d", i%7))
+		if err := a.Append(ad); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func drainArchive(t *testing.T, a *ArchiveTable, constraint string) {
+	t.Helper()
+	seq, err := a.Query(constraint)
+	if err != nil {
+		t.Fatalf("query %q: %v", constraint, err)
+	}
+	for range seq {
+	}
+}
+
+// TestArchiveAutoTuneAddsFromDemand: an archive that has been queried on an unindexed
+// attribute enough times gets the index, without anyone asking.
+func TestArchiveAutoTuneAddsFromDemand(t *testing.T) {
+	dir := t.TempDir()
+	cat, err := OpenCatalog(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cat.Close()
+	a, err := cat.CreateArchiveTable("history", ArchiveConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	fillArchive(t, a, 500)
+
+	if cat, val := a.IndexedAttrs(); len(cat) != 0 || len(val) != 0 {
+		t.Fatalf("archive starts with indexes %v/%v, want none", cat, val)
+	}
+	for range 10 {
+		drainArchive(t, a, `Owner == "user3"`)
+	}
+	res := a.AutoTune(AutoTuneOptions{MinDemand: 5, Reindex: true})
+	if !res.Changed {
+		t.Fatalf("AutoTune made no change; suggestions were %v", res.Changes)
+	}
+	catAttrs, _ := a.IndexedAttrs()
+	if !slices.Contains(catAttrs, "Owner") {
+		t.Errorf("categorical indexes = %v, want Owner", catAttrs)
+	}
+}
+
+// TestArchiveAutoTuneBelowThreshold: demand under the threshold is not acted on. Adding an
+// archive index means reading history back through the decompressor, so a handful of
+// ad-hoc queries must not be enough to trigger it.
+func TestArchiveAutoTuneBelowThreshold(t *testing.T) {
+	dir := t.TempDir()
+	cat, err := OpenCatalog(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cat.Close()
+	a, err := cat.CreateArchiveTable("history", ArchiveConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	fillArchive(t, a, 500)
+	for range 3 {
+		drainArchive(t, a, `Owner == "user3"`)
+	}
+	if res := a.AutoTune(AutoTuneOptions{MinDemand: 100, Reindex: true}); res.Changed {
+		t.Errorf("AutoTune acted on 3 queries against a threshold of 100: %v", res.Changes)
+	}
+	if c, v := a.IndexedAttrs(); len(c) != 0 || len(v) != 0 {
+		t.Errorf("indexes = %v/%v, want none", c, v)
+	}
+}
+
+// TestArchiveAutoTunePersistsAcrossReopen is the one that matters for cost. An auto-added
+// index that is not written to the archive config is discarded on reopen along with the
+// backfill that produced it -- and re-added as soon as demand accrues again, paying the
+// same backfill once per restart, forever.
+func TestArchiveAutoTunePersistsAcrossReopen(t *testing.T) {
+	dir := t.TempDir()
+	cat, err := OpenCatalog(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	a, err := cat.CreateArchiveTable("history", ArchiveConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	fillArchive(t, a, 500)
+	for range 10 {
+		drainArchive(t, a, `Owner == "user3"`)
+	}
+	if res := a.AutoTune(AutoTuneOptions{MinDemand: 5, Reindex: true}); !res.Changed {
+		t.Fatal("AutoTune made no change")
+	}
+	if err := cat.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	cat2, err := OpenCatalog(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cat2.Close()
+	a2, ok := cat2.ArchiveTable("history")
+	if !ok {
+		t.Fatal("archive table missing after reopen")
+	}
+	catAttrs, _ := a2.IndexedAttrs()
+	if !slices.Contains(catAttrs, "Owner") {
+		t.Errorf("categorical indexes after reopen = %v, want Owner retained", catAttrs)
+	}
+	// And the index actually answers: the reopened archive must still return the rows.
+	seq, err := a2.Query(`Owner == "user3"`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	n := 0
+	for range seq {
+		n++
+	}
+	if want := 500 / 7; n < want-1 || n > want+1 {
+		t.Errorf("query after reopen returned %d rows, want ~%d", n, want)
+	}
+}
+
+// autoIndexedArchive builds an archive whose Owner index was added by the tuner, then
+// reopens it. The reopen is what makes the index read as UNUSED: demand is not checkpointed
+// here, so the fresh process has none, which is the state an auto-drop acts on.
+func autoIndexedArchive(t *testing.T, dir string) *ArchiveTable {
+	t.Helper()
+	cat, err := OpenCatalog(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	a, err := cat.CreateArchiveTable("history", ArchiveConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	fillArchive(t, a, 500)
+	for range 10 {
+		drainArchive(t, a, `Owner == "user3"`)
+	}
+	if res := a.AutoTune(AutoTuneOptions{MinDemand: 5, Reindex: true}); !res.Changed {
+		t.Fatal("setup: AutoTune added nothing")
+	}
+	if err := cat.Close(); err != nil {
+		t.Fatal(err)
+	}
+	cat2, err := OpenCatalog(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { cat2.Close() })
+	a2, ok := cat2.ArchiveTable("history")
+	if !ok {
+		t.Fatal("setup: archive missing after reopen")
+	}
+	return a2
+}
+
+// TestArchiveAutoIndexProvenancePersists: an index the tuner added must come back from a
+// restart still marked auto. Restored as human-created it would be exempt from trimming and
+// from any future auto-drop -- permanently, on the strength of nothing but a restart.
+func TestArchiveAutoIndexProvenancePersists(t *testing.T) {
+	a := autoIndexedArchive(t, t.TempDir())
+	if got := a.AutoIndexNames(); !slices.Contains(got, "Owner") {
+		t.Errorf("auto index names after reopen = %v, want Owner", got)
+	}
+}
+
+// TestArchiveAutoTuneNeverDrops: DropUnused is forced off whatever the caller passes.
+// Dropping an archive index is nearly free and re-adding it costs a backfill, so the
+// asymmetry runs the wrong way for acting on an absence of queries.
+//
+// The raw collections path DOES drop in this exact state (verified while writing this), so
+// the assertion is about the archive rule, not about the drop being unreachable.
+func TestArchiveAutoTuneNeverDrops(t *testing.T) {
+	a := autoIndexedArchive(t, t.TempDir())
+	a.AutoTune(AutoTuneOptions{
+		MinDemand: 5, Reindex: true,
+		DropUnused:           true, // asked for, and must be ignored
+		DropUnusedMinWindow:  -1,   // waive every generic guard, leaving only the archive rule
+		DropUnusedMinQueries: -1,
+	})
+	if catAttrs, _ := a.IndexedAttrs(); !slices.Contains(catAttrs, "Owner") {
+		t.Errorf("Owner index dropped: indexes = %v", catAttrs)
+	}
+}

--- a/db/archive_autotune_test.go
+++ b/db/archive_autotune_test.go
@@ -208,17 +208,17 @@ func TestArchiveAutoTuneNeverDrops(t *testing.T) {
 	}
 }
 
-// TestArchiveAutoTuneNeedsBackfillHorizon: the two knobs interact, and their defaults
-// combine badly. IndexBackfillBytes defaults to unbounded, so enabling the tuner without
-// setting it would make its first decision decompress the whole archive. The tuner declines
-// instead -- a background pass must not be able to start unbounded work.
+// TestArchiveAutoTuneNeedsBackfillHorizon: the tuner acts on the default config (zero takes
+// the 1 GiB default) but declines when backfill is explicitly unbounded. A background pass
+// nobody watched decide must not be able to start work bounded only by the archive's size.
 func TestArchiveAutoTuneNeedsBackfillHorizon(t *testing.T) {
 	for _, tc := range []struct {
 		name     string
 		horizon  int64
 		wantTune bool
 	}{
-		{"unbounded default declines", 0, false},
+		{"zero takes the default and tunes", 0, true},
+		{"explicitly unbounded declines", -1, false},
 		{"bounded horizon tunes", 1 << 20, true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -245,5 +245,75 @@ func TestArchiveAutoTuneNeedsBackfillHorizon(t *testing.T) {
 				t.Errorf("Owner indexed = %v, want %v; indexes = %v", got, tc.wantTune, catAttrs)
 			}
 		})
+	}
+}
+
+// TestArchiveBackfillHorizonDefault pins the resolution rule, since all three cases are
+// reachable from a config file and only one of them is what an unset field means.
+func TestArchiveBackfillHorizonDefault(t *testing.T) {
+	for _, tc := range []struct {
+		set, want int64
+	}{
+		{0, defaultIndexBackfillBytes}, // unset: bounded, not unbounded
+		{-1, 0},                        // explicitly unbounded, spelled 0 for the storage layer
+		{4 << 20, 4 << 20},             // honoured verbatim
+	} {
+		if got := (ArchiveConfig{IndexBackfillBytes: tc.set}).backfillHorizon(); got != tc.want {
+			t.Errorf("backfillHorizon(%d) = %d, want %d", tc.set, got, tc.want)
+		}
+	}
+}
+
+// TestArchiveHorizonDoesNotStarveMergedSegments: the backfill horizon bounds rebuilding an
+// EXISTING sidecar under a newer spec. It must not stop a MERGED segment -- which has no
+// sidecar at all -- from getting one, however old the data in it is. If it did, merging
+// would silently convert indexed old segments into unindexed ones, and the horizon would
+// make the archive slower the more maintenance ran on it.
+func TestArchiveHorizonDoesNotStarveMergedSegments(t *testing.T) {
+	dir := t.TempDir()
+	cat, err := OpenCatalog(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cat.Close()
+	a, err := cat.CreateArchiveTable("history", ArchiveConfig{
+		SegmentSize:        1 << 14, // small, so the fixture produces many segments
+		IndexBackfillBytes: 1,       // horizon smaller than a single segment
+		CategoricalAttrs:   []string{"Owner"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	fillArchive(t, a, 4000)
+
+	before := a.Stats().Segments
+	if before < 4 {
+		t.Fatalf("fixture made %d segments, need several to merge", before)
+	}
+	merges := a.MergePass(MergeOptions{
+		TargetSegments: 2, TriggerSegments: 3,
+		MinMergeBytes: 1, KeepRecent: 1, MaxRun: 64,
+	})
+	if merges == 0 {
+		t.Fatalf("no merge happened (%d segments); the test would prove nothing", before)
+	}
+
+	// The merged output covers the OLDEST data, well outside a 1-byte horizon.
+	if stale, sealed := a.StaleIndexSegments(); stale != 0 {
+		t.Errorf("%d of %d sealed segments left without a current index after merging", stale, sealed)
+	}
+	// And the index answers over the merged data: every user must still be findable.
+	for u := range 7 {
+		seq, err := a.Query(fmt.Sprintf(`Owner == "user%d"`, u))
+		if err != nil {
+			t.Fatal(err)
+		}
+		n := 0
+		for range seq {
+			n++
+		}
+		if want := 4000 / 7; n < want-1 || n > want+1 {
+			t.Errorf("user%d: %d rows after merge, want ~%d", u, n, want)
+		}
 	}
 }

--- a/db/db.go
+++ b/db/db.go
@@ -221,6 +221,19 @@ type MaintainOptions struct {
 	// budget. ArchiveMergeDisabled turns the archive side of maintenance off entirely.
 	ArchiveMerge         MergeOptions
 	ArchiveMergeDisabled bool
+	// ArchiveIndexMinDemand is the minimum observed query demand for the auto-tuner to add
+	// an index to an ARCHIVE table; 0 leaves archive index auto-tune off.
+	//
+	// It is separate from MinIndexDemand, and off by default, because the two costs are not
+	// comparable. Indexing a mutable table is bounded by its live size; indexing an archive
+	// is paid for by decompressing history, so the threshold wants to be set against
+	// ArchiveConfig.IndexBackfillBytes -- how far back a new index is actually carried --
+	// rather than inherited from the mutable side.
+	//
+	// Auto-DROP is deliberately not offered for archives at any setting. Dropping an index
+	// is nearly free and re-adding it costs a backfill, so a wrong drop is expensive and
+	// asymmetric in the direction that punishes acting on a weak signal.
+	ArchiveIndexMinDemand int64
 	// SchemaScanHotTopN, when > 0, builds/refreshes the per-segment adschema columnar
 	// accelerator (used by CountConstraint's fast path) keeping the topN most query-read
 	// numeric fields uncompressed. The first pass chooses a stable schema and hot set from

--- a/dbrpc/server.go
+++ b/dbrpc/server.go
@@ -1501,6 +1501,16 @@ func (s *Server) maintainArchives(opts db.MaintainOptions) {
 		if stale, _ := a.StaleIndexSegments(); stale > 0 {
 			a.Reindex()
 		}
+		// Add the indexes observed demand justifies. Off unless a threshold is configured:
+		// an archive index is paid for by reading history back, so it is not something to
+		// start doing to an existing deployment on an upgrade.
+		if opts.ArchiveIndexMinDemand > 0 {
+			a.AutoTune(db.AutoTuneOptions{
+				SampleMax: opts.SampleMax,
+				MinDemand: opts.ArchiveIndexMinDemand,
+				Reindex:   true,
+			})
+		}
 		// Age and checkpoint the recorded query demand. An archive needs this more than a
 		// mutable table does: indexing one is paid for by decompressing history, so the
 		// decision wants evidence gathered over days, which is longer than a daemon can be


### PR DESCRIPTION
`maintainArchives` merged and reindexed but never **tuned**, so an archive's index set stayed whatever it was created with, however the workload changed. This adds the missing half.

Stacked on #151 (demand persistence) but targeting `main`, so it cannot be orphaned; its diff shrinks when #151 lands.

## Off unless configured

Gated on `MaintainOptions.ArchiveIndexMinDemand`, which defaults to 0 (off). An archive index is paid for by reading history back through the decompressor, so it is not something to start doing to an existing deployment on an upgrade.

The threshold is **separate from `MinIndexDemand`**, not shared. Indexing a mutable table is bounded by its live size; indexing an archive is bounded by `ArchiveConfig.IndexBackfillBytes` — how far back a new index is actually carried. Those are different quantities and want to be set against different numbers.

## Adds only

`DropUnused` is forced off for archives whatever the caller passes. Dropping an index is nearly free and re-adding it costs a backfill, so acting on an *absence* of queries is asymmetric in exactly the direction that punishes a weak signal.

I checked this assertion was worth making: the drop it refuses **is** reachable through the raw collections path in the same state. The first version of the test passed with the guard removed — it was measuring nothing, because the index still had demand recorded against it.

## A gap this exposed

The mutable side persists index provenance (`Auto:` in its index config). The archive side did not. So an auto-added archive index came back from a restart **indistinguishable from one a human asked for** — exempt from trimming and from any future auto-drop, permanently. Latent until now, because nothing ever created an auto archive index; live the moment this merges.

Restoring it needed a new primitive. `AddAutoIndex` cannot do it: by then the indexes exist as human-created, and an auto add deliberately refuses to downgrade a human index. Adding the auto set separately would restore provenance but *rebuild* it — reading history back on every start. `MarkAutoIndexes` changes provenance and nothing else.

This is the same shape as the bug in #145: state that silently changes across a restart, consumed as if durable.

## Testing

Adds from demand; ignores demand below the threshold; the added index and its provenance both survive a restart and the index still answers correctly; and the forced no-drop holds with every generic guard waived.

I verified each guard fails when reverted — the drop guard, the config persistence, and the provenance persistence.

`go vet` and all five module suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
