### PR TITLE
dbrpc: refuse the wire-row relay instead of streaming an empty result

### DIFF
--- a/collections/store.go
+++ b/collections/store.go
@@ -779,6 +779,12 @@ func (c *Collection) Len() int {
 // which the COUNT(*) fast path relies on.
 func (c *Collection) Chained() bool { return c.isStructural != nil }
 
+// SupportsRawWire reports whether ScanRawWire/QueryRawWire can serve this collection.
+// Only an inline (persistent) collection can: a RAM collection's ads are not
+// self-contained, so the relay scans yield nothing for one. A caller MUST check this
+// rather than treat an empty relay scan as an empty result -- they look identical.
+func (c *Collection) SupportsRawWire() bool { return c.inline }
+
 // Keys returns every visible key in the collection at a consistent per-shard
 // snapshot, in no particular order. Structural (parent-only) keys of a chained
 // collection are excluded, matching Scan's output. Each key is a fresh copy the

--- a/collections/wire/decodecost_bench_test.go
+++ b/collections/wire/decodecost_bench_test.go
@@ -1,0 +1,68 @@
+package wire_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/classad"
+	"github.com/PelicanPlatform/classad/collections/wire"
+)
+
+const wideAd = `[ ClusterId = 1234; ProcId = 7; Owner = "alice"; JobStatus = 2; QDate = 1700000000;
+RequestMemory = 2048; RequestCpus = 4; RemoteHost = "slot1@node42.example.edu";
+Cmd = "/home/alice/run.sh"; Iwd = "/home/alice/work"; JobUniverse = 5;
+RemoteWallClockTime = 12345.0; NumJobStarts = 1; ExitCode = 0 ]`
+
+// narrowAd is what a projected text fetch returns: the three attributes a grouped query reads.
+const narrowAd = `[ Owner = "alice"; JobStatus = 2; RequestMemory = 2048 ]`
+
+func mustWire(tb testing.TB, text string) []byte {
+	tb.Helper()
+	ad, err := classad.Parse(text)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	return wire.EncodeInline(nil, ad.AST())
+}
+
+func oldText(tb testing.TB, text string) string {
+	tb.Helper()
+	ad, err := classad.Parse(text)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	return strings.TrimSpace(ad.MarshalOld())
+}
+
+// benchDecode measures turning one relayed row into the *classad.ClassAd a consumer evaluates.
+func benchDecode(b *testing.B, w []byte) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		ad, err := wire.DecodeInline(w)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if classad.FromAST(ad) == nil {
+			b.Fatal("nil")
+		}
+	}
+}
+
+func benchParse(b *testing.B, text string) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if _, err := classad.ParseOld(text); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// The question these four answer: is decoding a WHOLE wire ad cheaper than parsing a
+// NARROW projected text ad? If it is, a consumer can drop the text projection entirely --
+// which also restores whole-ad evaluation semantics, since every sibling is present.
+func BenchmarkTextParseWide(b *testing.B)   { benchParse(b, oldText(b, wideAd)) }
+func BenchmarkTextParseNarrow(b *testing.B) { benchParse(b, oldText(b, narrowAd)) }
+func BenchmarkWireDecodeWide(b *testing.B)  { benchDecode(b, mustWire(b, wideAd)) }
+func BenchmarkWireDecodeNarrow(b *testing.B) {
+	benchDecode(b, mustWire(b, narrowAd))
+}

--- a/db/rawwire.go
+++ b/db/rawwire.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"errors"
 	"fmt"
 	"iter"
 	"strings"
@@ -9,6 +10,11 @@ import (
 	"github.com/PelicanPlatform/classad/collections"
 	"github.com/PelicanPlatform/classad/collections/vm"
 )
+
+// ErrRawWireUnsupported reports that a table cannot serve the wire-form relay scan --
+// today, that it is in-memory rather than persistent. Callers fall back to a text row
+// stream, which every table can serve.
+var ErrRawWireUnsupported = errors.New("classad-db: table does not support wire-form rows")
 
 // UpdateOld ingests an ad from old-ClassAd wire text under key, skipping the AST
 // build -- the wire-native ingest path (as collections.UpdateOld). It writes
@@ -145,9 +151,16 @@ func (db *DB) QueryRawProjectedRefs(constraint string, projection []string, reda
 // consumer with the old-ClassAd render deferred to that consumer's client edge.
 // projection restricts the entries (empty = whole ad); redact strips private
 // attributes at the source. At-rest-encrypted values are opened during assembly
-// (the consumer holds no data key). Only meaningful for persistent (inline)
-// stores; an in-memory table yields nothing.
+// (the consumer holds no data key).
+//
+// Only a persistent (inline) store can serve wire rows. An in-memory table returns
+// ErrRawWireUnsupported rather than an empty sequence: a relay scan that yields
+// nothing is indistinguishable from a query that matched nothing, so returning one
+// would turn every RAM-table query into a silent empty result at the consumer.
 func (db *DB) QueryRawWire(constraint string, projection []string, redact bool) (iter.Seq[[]byte], error) {
+	if !db.c.SupportsRawWire() {
+		return nil, ErrRawWireUnsupported
+	}
 	if s := strings.TrimSpace(constraint); s == "" || strings.EqualFold(s, "true") {
 		return db.c.ScanRawWire(projection, redact), nil
 	}

--- a/dbrpc/queryraw.go
+++ b/dbrpc/queryraw.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/PelicanPlatform/classad/collections"
+	"github.com/PelicanPlatform/classad/db"
 )
 
 // QueryRaw is Query but returns each ad as old-ClassAd wire text (the AST-free
@@ -313,14 +314,27 @@ func (s *Server) streamQueryRawProjectOpt(ctx context.Context, reqID uint64, r *
 // batches deeply).
 var WireBatchBudget = 64 << 10
 
+// ErrRawWireUnsupported reports that the wire-form row stream is not available for
+// this request, and the caller should fall back to a text row stream (which every
+// server and every table can serve). Two causes, one response: a server too old to
+// know opQueryRawWire, and a table that cannot produce self-contained rows (an
+// in-memory table -- see db.ErrRawWireUnsupported).
+//
+// It is always delivered BEFORE the first row, so a caller that has already relayed
+// rows can treat it as a hard failure rather than retrying.
+var ErrRawWireUnsupported = errors.New("dbrpc: wire-form rows unavailable for this request")
+
 // QueryRawWireStream streams matching ads as wire-form rows (self-contained
-// inline-names subset ads -- render them with collections.RenderRawAdInline),
-// batched many rows per frame (WireBatchBudget on the server side). The row
-// slice passed to yield aliases the frame buffer and is valid only until yield
-// returns; redact requests source-side private-attribute stripping even on a
-// privileged connection. Requires a server with opQueryRawWire; an older server
-// answers respBad and the error surfaces here (callers fall back to the text
-// row stream).
+// inline-names subset ads -- render them with collections.RenderRawAdInline, or
+// decode them with wire.DecodeInline), batched many rows per frame
+// (WireBatchBudget on the server side). The row slice passed to yield aliases the
+// frame buffer and is valid only until yield returns; redact requests source-side
+// private-attribute stripping even on a privileged connection.
+//
+// It returns ErrRawWireUnsupported, before any row, when the stream is unavailable
+// -- an older server, or a table that cannot serve wire rows. Callers fall back to
+// the text row stream. An empty stream means the query matched nothing; it never
+// means the table could not answer.
 func (c *Client) QueryRawWireStream(ctx context.Context, table, constraint string, attrs []string, limit int, redact bool, yield func(row []byte) bool) error {
 	build := func(id uint64) []byte {
 		b := putStr(req(id, opQueryRawWire), table)
@@ -367,6 +381,10 @@ func (c *Client) QueryRawWireStream(ctx context.Context, table, constraint strin
 						return nil
 					}
 				}
+			case stBadReq:
+				// A server too old to know the opcode rejects the request this way,
+				// and so does a table that cannot serve wire rows: same fallback.
+				return ErrRawWireUnsupported
 			case stErr:
 				return statusErr(status, body)
 			default:
@@ -406,6 +424,14 @@ func (s *Server) streamQueryRawWire(ctx context.Context, reqID uint64, r *reader
 		return
 	}
 	seq, err := d.QueryRawWire(constraint, attrs, redact)
+	if errors.Is(err, db.ErrRawWireUnsupported) {
+		// Not a failure: this table cannot produce self-contained rows (it is in
+		// memory). Reject the request the same way an older server rejects the
+		// opcode, so the client takes the same text fallback rather than seeing an
+		// empty stream and believing the query matched nothing.
+		write(respBad(reqID))
+		return
+	}
 	if err != nil {
 		write(respErr(reqID, err.Error()))
 		return

--- a/dbrpc/queryrawwire_test.go
+++ b/dbrpc/queryrawwire_test.go
@@ -2,6 +2,7 @@ package dbrpc
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
@@ -134,5 +135,76 @@ func TestQueryRawWireUnprivilegedAlwaysRedacts(t *testing.T) {
 		if _, leak := m["ClaimId"]; leak {
 			t.Fatalf("%s: unprivileged wire row leaked ClaimId", name)
 		}
+	}
+}
+
+// TestQueryRawWireRefusesMemoryTable is the guard on the trap this relay sets: a table
+// that cannot produce self-contained rows yields NO rows, which on the wire is
+// indistinguishable from a query that matched nothing. A consumer that switched to this
+// stream would silently return an empty result for every RAM table. It must refuse
+// instead, before any row, so the caller falls back to the text stream.
+func TestQueryRawWireRefusesMemoryTable(t *testing.T) {
+	c, cleanup := catServerPair(t, ServeOptions{Privileged: true})
+	defer cleanup()
+	ctx := context.Background()
+
+	if err := c.CreateTableInMemory(ctx, "scratch"); err != nil {
+		t.Fatal(err)
+	}
+	tx, err := c.BeginTable(ctx, "scratch")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.NewClassAd(ctx, "k1", "Name = \"one\"\nCpus = 4"); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	// The row is really there over the text stream.
+	texts, err := c.QueryRawTable(ctx, "scratch", "true", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(texts) != 1 {
+		t.Fatalf("text stream returned %d rows, want the one that was inserted", len(texts))
+	}
+
+	rows := 0
+	err = c.QueryRawWireStream(ctx, "scratch", "true", nil, 0, false, func([]byte) bool {
+		rows++
+		return true
+	})
+	if !errors.Is(err, ErrRawWireUnsupported) {
+		t.Errorf("err = %v, want ErrRawWireUnsupported", err)
+	}
+	if rows != 0 {
+		t.Errorf("delivered %d rows before refusing; the refusal must precede any row", rows)
+	}
+
+	// A persistent table on the same server still serves wire rows.
+	if err := c.CreateTable(ctx, "durable"); err != nil {
+		t.Fatal(err)
+	}
+	tx, err = c.BeginTable(ctx, "durable")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.NewClassAd(ctx, "k1", "Name = \"two\"\nCpus = 8"); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatal(err)
+	}
+	rows = 0
+	if err := c.QueryRawWireStream(ctx, "durable", "true", nil, 0, false, func([]byte) bool {
+		rows++
+		return true
+	}); err != nil {
+		t.Fatalf("persistent table: %v", err)
+	}
+	if rows != 1 {
+		t.Errorf("persistent table returned %d wire rows, want 1", rows)
 	}
 }


### PR DESCRIPTION
Found while switching htcondordb's read path onto `opQueryRawWire`.

### The trap

An in-memory table cannot produce self-contained wire rows, so `ScanRawWire` yields **nothing** for one. On the wire that is indistinguishable from a query that matched nothing — so a consumer that adopts `opQueryRawWire` silently returns an empty result for every RAM table, with no error anywhere. `CreateTableInMemory` is a first-class feature, and golang-collector already relays through this op (`server/server.go:338`), so the trap is live rather than theoretical.

### The fix

`db.QueryRawWire` returns `ErrRawWireUnsupported` for a table that cannot serve wire rows; the server rejects the request the way it rejects an unknown opcode; the client surfaces `dbrpc.ErrRawWireUnsupported`. That is deliberately the *same* signal, and the same text-stream fallback, that a server too old for the opcode already produces — one sentinel, one fallback, because the caller's action is identical. Both are delivered **before the first row**, so a consumer that has already begun relaying can treat the error as fatal instead of retrying and duplicating rows.

The existing collector fallback (`err != nil && !delivered` → text paths) starts working correctly for RAM tables with no change on its side.

### Why callers want this path

The added benchmark measures decoding a wire row into a `ClassAd` against parsing the old-ClassAd text the other ops render (on top of #150's parser pooling, so this is the current baseline, not the old one):

```
BenchmarkTextParseWide     10.9us  3606 B/op  135 allocs/op
BenchmarkWireDecodeWide     1.7us  1664 B/op   66 allocs/op     6.3x
BenchmarkTextParseNarrow    2.3us   880 B/op   35 allocs/op
BenchmarkWireDecodeNarrow   0.4us   520 B/op   17 allocs/op     5.6x
```

Note the cross-comparison: decoding a **whole** 14-attribute wire ad (1.7us) is cheaper than parsing a **3-attribute projected** text ad (2.3us).

`dbrpc`, `db`, `collections/wire` all pass. New test asserts the refusal precedes any row and that a persistent table on the same server still serves wire rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
