### PR TITLE
collections: ingest transactional writes straight to wire, without an AST

### DIFF
--- a/collections/ingest_bench_test.go
+++ b/collections/ingest_bench_test.go
@@ -1,0 +1,81 @@
+package collections
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/classad"
+)
+
+// benchAdText is a job ad of the width a writer actually inserts, in old-ClassAd form --
+// what arrives over dbrpc's opNewAd/opNewAdBatch and over a CEDAR socket.
+func benchAdText(i int) string {
+	return fmt.Sprintf(`ClusterId = %d
+ProcId = 0
+Owner = "u%d"
+JobStatus = %d
+QDate = %d
+RequestMemory = %d
+RequestCpus = %d
+RemoteHost = "slot1@node%d.example.edu"
+Cmd = "/home/u%d/run.sh"
+Iwd = "/home/u%d/work"
+JobUniverse = 5
+RemoteWallClockTime = 1234.5
+NumJobStarts = 1
+ExitCode = 0`, i, i%5, (i%5)+1, 1700000000+i, ((i%16)+1)*512, (i%8)+1, i%64, i%5, i%5)
+}
+
+const ingestBatch = 200
+
+// These two are the BATCHED comparison -- one Update/UpdateOld call for the whole batch --
+// which is the shape a transactional commit and the RPC server's batch insert actually
+// take. BenchmarkIngestOldDirect/ParseOldThenPut above compare the same two encoders one
+// Put at a time, where per-ad commit overhead dominates and the encoder difference does not
+// stand out.
+//
+// BenchmarkIngestParseThenUpdate is what the RPC server did: parse each ad's text into a
+// ClassAd, then hand the ClassAd to the store, which encodes it to wire.
+func BenchmarkIngestParseThenUpdate(b *testing.B) {
+	texts := make([]string, ingestBatch)
+	keys := make([][]byte, ingestBatch)
+	for i := range texts {
+		texts[i] = benchAdText(i)
+		keys[i] = []byte(fmt.Sprintf("%d.0", i))
+	}
+	c := New(Options{})
+	defer c.Close()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		batch := make([]AdUpdate, len(texts))
+		for j, t := range texts {
+			ad, err := classad.ParseOld(t)
+			if err != nil {
+				b.Fatal(err)
+			}
+			batch[j] = AdUpdate{Key: keys[j], Ad: ad}
+		}
+		if err := c.Update(batch); err != nil {
+			b.Fatal(err)
+		}
+	}
+	b.ReportMetric(float64(b.Elapsed().Nanoseconds())/float64(b.N*ingestBatch), "ns/ad")
+}
+
+// BenchmarkIngestUpdateOld is the wire-native ingest: the same text encoded straight to the
+// stored wire form, attribute by attribute, with no intermediate ast.ClassAd.
+func BenchmarkIngestUpdateOld(b *testing.B) {
+	batch := make([]OldAdUpdate, ingestBatch)
+	for i := range batch {
+		batch[i] = OldAdUpdate{Key: []byte(fmt.Sprintf("%d.0", i)), Text: benchAdText(i)}
+	}
+	c := New(Options{})
+	defer c.Close()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if err := c.UpdateOld(batch); err != nil {
+			b.Fatal(err)
+		}
+	}
+	b.ReportMetric(float64(b.Elapsed().Nanoseconds())/float64(b.N*ingestBatch), "ns/ad")
+}

--- a/collections/txn.go
+++ b/collections/txn.go
@@ -118,7 +118,10 @@ type txnWrite struct {
 	del   bool
 	base  uint64 // snapshot S0: conflict if the key changed after this
 	adObj *classad.ClassAd
-	ok    bool // committed (true) or conflicted (false)
+	// buf is the originating buffered write, so ordered-index maintenance can materialize
+	// a wire-ingested ad on demand -- a collection with no ordered index never does.
+	buf *txnBuf
+	ok  bool // committed (true) or conflicted (false)
 }
 
 // commitTxn applies a shard's buffered transactional writes with per-write conflict
@@ -211,8 +214,37 @@ type Txn struct {
 
 type txnBuf struct {
 	key []byte
-	ad  *classad.ClassAd // nil for a delete
-	del bool
+	ad  *classad.ClassAd // nil for a delete, and for a wire-encoded put until materialized
+	// wire holds the uncompressed wire form of an ad ingested by PutOld, encoded from
+	// old-ClassAd text at Put time with no intermediate ast.ClassAd. Commit stores these
+	// bytes directly; ad stays nil unless something needs the object (see materialize).
+	wire []byte
+	// text is retained beside wire only so materialize can rebuild the object faithfully
+	// through the reference parser rather than round-tripping the encoding.
+	text string
+	del  bool
+}
+
+// live reports whether this buffer holds an ad -- as an object OR as wire bytes not yet
+// materialized. Anything scanning the buffered writes must ask this rather than testing
+// ad != nil, which silently skips every wire-ingested write.
+func (b *txnBuf) live() bool { return !b.del && (b.ad != nil || b.wire != nil) }
+
+// materialize returns the buffered ad as an object, decoding a wire-ingested one on
+// first use. Only two things need it -- a read-your-writes Get and ordered-index
+// maintenance -- so the common insert path never pays for it.
+func (b *txnBuf) materialize() (*classad.ClassAd, bool) {
+	if b.del {
+		return nil, false
+	}
+	if b.ad == nil && b.wire != nil {
+		ad, err := classad.ParseOld(b.text)
+		if err != nil {
+			return nil, false
+		}
+		b.ad = ad
+	}
+	return b.ad, b.ad != nil
 }
 
 // CommitResult reports a transaction's outcome. Conflicts holds the keys whose
@@ -277,10 +309,7 @@ func (tx *Txn) Get(key []byte) (*classad.ClassAd, bool) {
 // mutate (buffered writes are returned as-is -- the caller owns the buffered ad).
 func (tx *Txn) getOwn(key []byte) (*classad.ClassAd, bool) {
 	if b, ok := tx.writes[string(key)]; ok {
-		if b.del {
-			return nil, false
-		}
-		return b.ad, true
+		return b.materialize()
 	}
 	h := tx.c.h.Hash(key)
 	idx := tx.c.shardOf(key, h)
@@ -302,6 +331,31 @@ func (tx *Txn) Put(key []byte, ad *classad.ClassAd) {
 	tx.writes[string(key)] = &txnBuf{key: append([]byte(nil), key...), ad: ad}
 }
 
+// PutOld buffers an insert or update of key whose ad arrives as old-ClassAd text,
+// encoding it straight to the stored wire form here rather than building an
+// ast.ClassAd for Commit to encode. Every transactional guarantee is unchanged --
+// the write is buffered, conflict-checked against the same snapshot, and committed
+// identically; only the encoding path differs.
+//
+// It reports whether the fast path was taken. False means the caller should parse the
+// text and use Put: an encrypted collection stores sealed values, and the streaming
+// encoder does not seal.
+func (tx *Txn) PutOld(key []byte, text string) bool {
+	if tx.c.EncryptionEnabled() {
+		return false
+	}
+	enc := tx.c.newStreamEncoder()
+	seen := make(map[uint32]struct{}, 64)
+	var unesc []byte
+	w, err := tx.c.encodeOld(text, enc, seen, &unesc)
+	if err != nil {
+		return false // malformed, or a shape the streaming encoder defers: let the caller parse
+	}
+	tx.snapOf(tx.c.shardOf(key, tx.c.h.Hash(key)))
+	tx.writes[string(key)] = &txnBuf{key: append([]byte(nil), key...), wire: w, text: text}
+	return true
+}
+
 // Delete buffers a delete of key. Nothing is written until Commit.
 func (tx *Txn) Delete(key []byte) {
 	tx.snapOf(tx.c.shardOf(key, tx.c.h.Hash(key)))
@@ -318,10 +372,15 @@ func (tx *Txn) Commit() CommitResult {
 	for _, b := range tx.writes {
 		h := tx.c.h.Hash(b.key)
 		idx := tx.c.shardOf(b.key, h)
-		w := &txnWrite{hash: h, key: b.key, del: b.del, base: tx.snap[idx], adObj: b.ad}
+		w := &txnWrite{hash: h, key: b.key, del: b.del, base: tx.snap[idx], adObj: b.ad, buf: b}
 		if !b.del {
 			w.codec = tx.c.currentCodec()
-			w.ad = w.codec.Compress(nil, tx.c.encodeAd(b.ad.AST()))
+			// A wire-ingested put is already encoded; only an object put encodes here.
+			raw := b.wire
+			if raw == nil {
+				raw = tx.c.encodeAd(b.ad.AST())
+			}
+			w.ad = w.codec.Compress(nil, raw)
 		}
 		byShard[idx] = append(byShard[idx], w)
 	}
@@ -391,7 +450,11 @@ func (tx *Txn) Commit() CommitResult {
 			if w.del {
 				tx.c.removeOrdered(w.key)
 			} else {
-				tx.c.maintainOrdered(w.key, w.adObj)
+				ad := w.adObj
+				if ad == nil && w.buf != nil {
+					ad, _ = w.buf.materialize()
+				}
+				tx.c.maintainOrdered(w.key, ad)
 			}
 		}
 	}

--- a/collections/txningest_test.go
+++ b/collections/txningest_test.go
@@ -1,0 +1,282 @@
+package collections
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/classad"
+	"github.com/PelicanPlatform/classad/collections/vm"
+)
+
+// Txn.PutOld encodes old-ClassAd text straight to the stored wire form, so the buffered
+// write holds bytes rather than an *classad.ClassAd. Everything that reads the buffer has
+// to cope with that -- and anything that tests `ad != nil` silently skips the write instead
+// of failing, so these tests exercise each reader deliberately.
+
+// putOldText is one ad in the old-ClassAd form a socket delivers.
+const putOldText = `ClusterId = 42
+Owner = "alice"
+JobStatus = 2
+RequestMemory = 2048
+Ratio = 1.5
+Held = false
+Args = {1, 2, 3}
+Meta = [ a = 1 ]
+Doubled = RequestMemory * 2
+Note = "a \"quoted\" word"`
+
+// TestPutOldMatchesParsedPut is the equivalence this whole path rests on: an ad ingested as
+// text must be stored exactly as the same ad parsed and Put would be, value for value.
+func TestPutOldMatchesParsedPut(t *testing.T) {
+	fast := New(Options{Shards: 2})
+	defer fast.Close()
+	slow := New(Options{Shards: 2})
+	defer slow.Close()
+
+	tx := fast.Begin()
+	if !tx.PutOld([]byte("k1"), putOldText) {
+		t.Fatal("PutOld declined a plain ad")
+	}
+	if res := tx.Commit(); len(res.Conflicts) != 0 {
+		t.Fatalf("conflicts on a fresh key: %v", res.Conflicts)
+	}
+
+	ref, err := classad.ParseOld(putOldText)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tx2 := slow.Begin()
+	tx2.Put([]byte("k1"), ref)
+	tx2.Commit()
+
+	got, ok := fast.Get([]byte("k1"))
+	if !ok {
+		t.Fatal("ad missing after PutOld + Commit")
+	}
+	want, ok := slow.Get([]byte("k1"))
+	if !ok {
+		t.Fatal("ad missing from the reference collection")
+	}
+	if !got.Equal(want) {
+		t.Errorf("wire-ingested ad differs from the parsed one:\n got  = %s\n want = %s",
+			got.String(), want.String())
+	}
+	// The expression attribute must still evaluate against its sibling.
+	if v, ok := got.EvaluateAttrNumber("Doubled"); !ok || v != 4096 {
+		t.Errorf("Doubled = %v (ok=%v), want 4096", v, ok)
+	}
+}
+
+// TestPutOldReadYourWrites covers the point lookup: a buffered wire write has to be visible
+// to Get inside the same transaction, which means materializing it on demand.
+func TestPutOldReadYourWrites(t *testing.T) {
+	c := New(Options{Shards: 2})
+	defer c.Close()
+
+	tx := c.Begin()
+	if !tx.PutOld([]byte("k1"), putOldText) {
+		t.Fatal("PutOld declined")
+	}
+	ad, ok := tx.Get([]byte("k1"))
+	if !ok {
+		t.Fatal("Get inside the transaction did not see its own PutOld")
+	}
+	if owner, _ := ad.EvaluateAttrString("Owner"); owner != "alice" {
+		t.Errorf("Owner = %q, want alice", owner)
+	}
+	tx.Commit()
+}
+
+// TestPutOldVisibleToTransactionalQuery covers the buffered-write overlay, which scans the
+// transaction's writes rather than looking one up. It tested `ad != nil` and therefore
+// skipped every wire write -- a query inside the transaction quietly returned fewer rows.
+func TestPutOldVisibleToTransactionalQuery(t *testing.T) {
+	c := New(Options{Shards: 2})
+	defer c.Close()
+
+	tx := c.Begin()
+	for i := 0; i < 3; i++ {
+		text := fmt.Sprintf("ClusterId = %d\nOwner = \"alice\"\nJobStatus = 2", i)
+		if !tx.PutOld([]byte(fmt.Sprintf("k%d", i)), text) {
+			t.Fatal("PutOld declined")
+		}
+	}
+	q, err := vm.Parse(`Owner == "alice"`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	n := 0
+	tx.forEachBufferedMatch(q, func(string, *classad.ClassAd) bool { n++; return true })
+	if n != 3 {
+		t.Errorf("the transactional query overlay saw %d buffered rows, want 3", n)
+	}
+	tx.Commit()
+}
+
+// TestPutOldComposesWithSetAttribute pins the read-modify-write inside one transaction: the
+// wire write must materialize so the attribute is added to the ad it wrote, not to nothing.
+func TestPutOldComposesWithSetAttribute(t *testing.T) {
+	c := New(Options{Shards: 2})
+	defer c.Close()
+
+	tx := c.Begin()
+	if !tx.PutOld([]byte("k1"), putOldText) {
+		t.Fatal("PutOld declined")
+	}
+	ad, ok := tx.Get([]byte("k1"))
+	if !ok {
+		t.Fatal("Get did not see the PutOld")
+	}
+	ad.InsertAttr("Extra", 7)
+	tx.Put([]byte("k1"), ad)
+	tx.Commit()
+
+	got, ok := c.Get([]byte("k1"))
+	if !ok {
+		t.Fatal("ad missing after commit")
+	}
+	if v, ok := got.EvaluateAttrNumber("Extra"); !ok || v != 7 {
+		t.Errorf("Extra = %v (ok=%v), want 7", v, ok)
+	}
+	if owner, _ := got.EvaluateAttrString("Owner"); owner != "alice" {
+		t.Errorf("Owner = %q, want the original alice -- the read-modify-write lost the base ad", owner)
+	}
+}
+
+// TestPutOldConflictDetection checks that the wire path is still a transactional write: a
+// key changed by another committer since this transaction's snapshot must conflict, not
+// silently overwrite.
+func TestPutOldConflictDetection(t *testing.T) {
+	c := New(Options{Shards: 2})
+	defer c.Close()
+
+	base, err := classad.ParseOld("ClusterId = 1\nOwner = \"orig\"")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Put([]byte("k1"), base); err != nil {
+		t.Fatal(err)
+	}
+
+	tx := c.Begin()
+	if _, ok := tx.Get([]byte("k1")); !ok { // take the snapshot
+		t.Fatal("base ad missing")
+	}
+	if !tx.PutOld([]byte("k1"), "ClusterId = 1\nOwner = \"txn\"") {
+		t.Fatal("PutOld declined")
+	}
+	// Another committer wins the race.
+	other, _ := classad.ParseOld("ClusterId = 1\nOwner = \"other\"")
+	if err := c.Put([]byte("k1"), other); err != nil {
+		t.Fatal(err)
+	}
+	res := tx.Commit()
+	if len(res.Conflicts) != 1 {
+		t.Fatalf("conflicts = %v, want the one key that raced", res.Conflicts)
+	}
+	got, _ := c.Get([]byte("k1"))
+	if owner, _ := got.EvaluateAttrString("Owner"); owner != "other" {
+		t.Errorf("Owner = %q, want other -- the conflicted wire write must not have applied", owner)
+	}
+}
+
+// TestPutOldMaintainsOrderedIndex covers the other reader of the buffered object: ordered
+// indexes are maintained from the ad at commit, so a wire write has to materialize there.
+func TestPutOldMaintainsOrderedIndex(t *testing.T) {
+	c := New(Options{
+		Shards: 2,
+		Ordered: []OrderSpec{{
+			Partition: "Owner",
+			Where:     "JobStatus == 1",
+			Keys:      []SortKey{{Expr: "JobPrio", Desc: true}},
+		}},
+	})
+	defer c.Close()
+
+	tx := c.Begin()
+	for i, prio := range []int{5, 20, 10} {
+		text := fmt.Sprintf("Owner = \"alice\"\nJobStatus = 1\nJobPrio = %d\nJob = \"j%d\"", prio, i)
+		if !tx.PutOld([]byte(fmt.Sprintf("j%d", i)), text) {
+			t.Fatal("PutOld declined")
+		}
+	}
+	tx.Commit()
+
+	var got []string
+	for r := range c.Ordered(0, classad.NewStringValue("alice"), OrderCursor{}) {
+		j, _ := r.Ad.EvaluateAttrString("Job")
+		got = append(got, j)
+	}
+	want := []string{"j1", "j2", "j0"} // JobPrio 20, 10, 5
+	if len(got) != len(want) {
+		t.Fatalf("ordered partition = %v, want %v -- wire writes must reach the ordered index", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("ordered partition = %v, want %v", got, want)
+			break
+		}
+	}
+}
+
+// TestPutOldDeclinesWhereItCannotBeFaithful pins the cases the caller must handle by
+// parsing: an encrypted collection (the streaming encoder does not seal) and malformed
+// text. Declining is the contract -- a silent wrong encoding would not be.
+func TestPutOldDeclinesWhereItCannotBeFaithful(t *testing.T) {
+	plain := New(Options{Shards: 1})
+	defer plain.Close()
+	tx := plain.Begin()
+	if tx.PutOld([]byte("bad"), "this is not = = an ad {{{") {
+		t.Error("PutOld accepted malformed text; it must decline so the caller reports the parse error")
+	}
+	tx.Commit()
+
+	if !mmapSupported {
+		t.Skip("encrypted collections need the persistent path")
+	}
+	_, dataKey := deriveDataKey(t)
+	enc, err := Open(Options{
+		Shards:         1,
+		Dir:            t.TempDir(),
+		DataKey:        dataKey,
+		EncryptedAttrs: []string{"ClaimId"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer enc.Close()
+	etx := enc.Begin()
+	if etx.PutOld([]byte("k1"), "ClaimId = \"secret\"\nOwner = \"alice\"") {
+		t.Error("PutOld accepted an encrypted collection; the streaming encoder cannot seal")
+	}
+	etx.Commit()
+}
+
+// TestPutOldDuplicateAttributeDefers covers the shape the streaming encoder hands back to
+// the reference parser: a repeated attribute name, where streaming would keep the first and
+// the parser keeps the last. Either PutOld declines, or it stores the parser's answer --
+// what it must not do is store the other one.
+func TestPutOldDuplicateAttributeDefers(t *testing.T) {
+	c := New(Options{Shards: 1})
+	defer c.Close()
+
+	const dup = "Owner = \"first\"\nJobStatus = 1\nOwner = \"second\""
+	tx := c.Begin()
+	if !tx.PutOld([]byte("k1"), dup) {
+		t.Skip("PutOld declined the duplicate outright, which is also correct")
+	}
+	tx.Commit()
+
+	ref, err := classad.ParseOld(dup)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, ok := c.Get([]byte("k1"))
+	if !ok {
+		t.Fatal("ad missing")
+	}
+	if !got.Equal(ref) {
+		t.Errorf("duplicate-attribute ad stored as %s, want the reference parser's %s",
+			got.String(), ref.String())
+	}
+}

--- a/collections/txnquery.go
+++ b/collections/txnquery.go
@@ -76,7 +76,7 @@ func (tx *Txn) scanCommitted(q *vm.Query, visit func(key string, ad *classad.Cla
 func (tx *Txn) forEachBufferedMatch(q *vm.Query, visit func(key string, ad *classad.ClassAd) bool) {
 	keys := make([]string, 0, len(tx.writes))
 	for key, buf := range tx.writes {
-		if buf.del || buf.ad == nil {
+		if !buf.live() {
 			continue
 		}
 		if IsSystemKey(key) {

--- a/db/db.go
+++ b/db/db.go
@@ -707,6 +707,19 @@ func (t *Txn) NewClassAd(key string, ad *classad.ClassAd) {
 	t.tx.Put([]byte(key), ad)
 }
 
+// NewClassAdOld stores an ad supplied as old-ClassAd text under key, encoding it
+// straight to the stored wire form instead of parsing it into a ClassAd for the commit
+// to re-encode. The transaction is unaffected: the write is buffered, conflict-checked
+// and committed exactly as NewClassAd's is.
+//
+// It reports whether the wire-native path was taken. False means the caller must parse
+// the text and use NewClassAd -- an encrypted store seals its values and the streaming
+// encoder does not seal, and a few ad shapes (a repeated attribute name, an escape the
+// fast lexer would read differently) defer to the reference parser by design.
+func (t *Txn) NewClassAdOld(key, text string) bool {
+	return t.tx.PutOld([]byte(key), text)
+}
+
 // DestroyClassAd removes key (classad_log.h LogDestroyClassAd).
 func (t *Txn) DestroyClassAd(key string) {
 	t.tx.Delete([]byte(key))

--- a/dbrpc/insert_bench_test.go
+++ b/dbrpc/insert_bench_test.go
@@ -1,0 +1,69 @@
+package dbrpc
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/db"
+)
+
+// insertAdText is a job ad of the width a writer actually inserts, in the old-ClassAd form
+// opNewAd/opNewAdBatch carry.
+func insertAdText(i int) string {
+	return fmt.Sprintf(`ClusterId = %d
+ProcId = 0
+Owner = "u%d"
+JobStatus = %d
+QDate = %d
+RequestMemory = %d
+RequestCpus = %d
+RemoteHost = "slot1@node%d.example.edu"
+Cmd = "/home/u%d/run.sh"
+Iwd = "/home/u%d/work"
+JobUniverse = 5
+RemoteWallClockTime = 1234.5
+NumJobStarts = 1
+ExitCode = 0`, i, i%5, (i%5)+1, 1700000000+i, ((i%16)+1)*512, (i%8)+1, i%64, i%5, i%5)
+}
+
+// BenchmarkInsertBatch measures the whole write path a client sees: one transaction, one
+// batched insert of `batch` ads, one commit -- server-side parse (or wire-native ingest)
+// included.
+func BenchmarkInsertBatch(b *testing.B) {
+	const batch = 200
+	items := make([]AdKV, batch)
+	for i := range items {
+		items[i] = AdKV{Key: fmt.Sprintf("%d.0", i), Ad: insertAdText(i)}
+	}
+	// A persistent db: the wire-native ingest is the path a deployment runs.
+	d, err := db.Open(b.TempDir())
+	if err != nil {
+		b.Fatal(err)
+	}
+	s := NewServer(d)
+	cconn, sconn := netPipe()
+	go func() { _ = s.ServeConnOpts(sconn, ServeOptions{Privileged: true}) }()
+	c := NewClient(cconn)
+	defer func() { c.Close(); s.Close(); d.Close() }()
+	ctx := context.Background()
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		tx, berr := c.Begin(ctx)
+		if berr != nil {
+			b.Fatal(berr)
+		}
+		rej, err := tx.NewClassAdBatch(ctx, items)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if len(rej) != 0 {
+			b.Fatalf("%d ads rejected", len(rej))
+		}
+		if err := tx.Commit(ctx); err != nil {
+			b.Fatal(err)
+		}
+	}
+	b.ReportMetric(float64(b.Elapsed().Nanoseconds())/float64(b.N*batch), "ns/ad")
+}

--- a/dbrpc/server.go
+++ b/dbrpc/server.go
@@ -1053,11 +1053,17 @@ func (s *Server) handle(sc *serverConn, reqID uint64, o op, r *reader, includePr
 			if r.err != nil {
 				return respBad(reqID)
 			}
-			ad, err := classad.ParseOld(adText)
-			if err != nil {
-				return respErr(reqID, err.Error())
+			// Wire-native ingest: the ad arrived as text and is stored as wire bytes, so
+			// building an ast.ClassAd in between is pure overhead. NewClassAdOld declines
+			// where it cannot be faithful (an encrypted store, an ad shape that defers to
+			// the reference parser) and the parse path below answers those.
+			if !st.tx.NewClassAdOld(key, adText) {
+				ad, err := classad.ParseOld(adText)
+				if err != nil {
+					return respErr(reqID, err.Error())
+				}
+				st.tx.NewClassAd(key, ad)
 			}
-			st.tx.NewClassAd(key, ad)
 			st.record(s, WriteOp{Kind: WriteNewClassAd, Key: key, Value: adText})
 			return resp(reqID, stOK)
 		})
@@ -1079,13 +1085,17 @@ func (s *Server) handle(sc *serverConn, reqID uint64, o op, r *reader, includePr
 				if r.err != nil {
 					return respBad(reqID)
 				}
-				ad, err := classad.ParseOld(adText)
-				if err != nil {
-					rejIdx = append(rejIdx, i)
-					rejMsg = append(rejMsg, err.Error())
-					continue
+				// As opNewAd: wire-native first, parse only where that declines -- which is
+				// also where a malformed ad is rejected, by index, without losing the batch.
+				if !st.tx.NewClassAdOld(key, adText) {
+					ad, err := classad.ParseOld(adText)
+					if err != nil {
+						rejIdx = append(rejIdx, i)
+						rejMsg = append(rejMsg, err.Error())
+						continue
+					}
+					st.tx.NewClassAd(key, ad)
 				}
-				st.tx.NewClassAd(key, ad)
 				st.record(s, WriteOp{Kind: WriteNewClassAd, Key: key, Value: adText})
 			}
 			b := putI32(resp(reqID, stOK), int32(len(rejIdx)))


### PR DESCRIPTION
The write half of the wire-relay work (read half: #153).

### The redundancy

An ad inserted over dbrpc arrives as **old-ClassAd text** and is stored as **wire bytes** — but the server parsed it into an `ast.ClassAd` so the commit could encode it. Two conversions between two representations, neither of which was ever the one being used.

`collections.UpdateOld` already encodes text straight to wire, but it bypasses the optimistic-concurrency layer (last-writer-wins), so the transactional insert path — which is what `opNewAd`/`opNewAdBatch` use — could not call it.

### The change

`Txn.PutOld` encodes at Put time and buffers the wire bytes. **Every transactional guarantee is unchanged**: buffered, conflict-checked against the same snapshot, committed identically. Only the encoding path differs — no new opcode, no protocol change, no caller changes.

It declines where the streaming encoder cannot be faithful — an encrypted collection (it does not seal), malformed text, and the shapes `encodeOld` already defers to the reference parser — and the RPC handlers parse those. **No ad is stored differently than before**; `TestPutOldMatchesParsedPut` compares wire-ingested against parsed-and-Put value for value.

Only two things need the object rather than the bytes — a read-your-writes `Get` and ordered-index maintenance — and both materialize on demand, so a collection with no ordered index never builds one.

### A bug this introduced, and the guard against the next one

Buffered writes became "an object **or** bytes", and the transactional query overlay tested `ad != nil` — so it skipped every wire write, and a query inside a transaction quietly returned fewer rows. Four existing `dbrpc` tests caught it. `txnBuf.live()` is now the single predicate for "does this buffer hold an ad", so the next reader can't get it wrong by testing a field.

### Measurements

```
collections, batched ingest:   18.0us/ad  274 allocs/ad  ->   1.7us/ad  3.5 allocs/ad   8.5x
dbrpc, batch insert + commit:  34.6us/ad  311 allocs/ad  ->  23.4us/ad  166 allocs/ad   1.5x
```

The end-to-end figure is much smaller than the storage-level one because the parse was only about a third of an insert; the rest is transport, transaction machinery and the durable commit. Both benchmarks are included.

### Testing

Eight new tests covering the equivalence, read-your-writes, the query overlay, `SetAttribute` composing with a wire write in the same transaction, conflict detection, ordered-index maintenance, and the two decline paths (encrypted, malformed) plus the duplicate-attribute deferral.

`collections`, `db`, `dbrpc` all pass; transaction paths pass under `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
