### PR TITLE
collections: record the segment dictionary's offset so recovery stops searching for it

### DIFF
--- a/collections/colscan.go
+++ b/collections/colscan.go
@@ -140,7 +140,7 @@ func (c *Collection) persistColSeg(sh *shard, seg *segment) {
 		return
 	}
 	container := buildSegmentSidecar(append([]byte(nil), attr...), append([]byte(nil), key...), colBlob,
-		append([]byte(nil), zone...), seg.used)
+		append([]byte(nil), zone...), seg.used, seg.dictRecOff())
 	_ = closer()
 	c.installSidecar(sh, seg, path, container)
 }

--- a/collections/colscan_persist_test.go
+++ b/collections/colscan_persist_test.go
@@ -175,6 +175,11 @@ func TestSchemaScanReloadCorruptSection(t *testing.T) {
 		// longer the col body.
 		var attrLen, keyLen, colLen int
 		switch binary.LittleEndian.Uint32(b[len(b)-4:]) {
+		case sidecarContainerMagicV4:
+			t := b[len(b)-sidecarTrailerLenV4:]
+			attrLen = int(binary.LittleEndian.Uint32(t[0:]))
+			keyLen = int(binary.LittleEndian.Uint32(t[4:]))
+			colLen = int(binary.LittleEndian.Uint32(t[8:]))
 		case sidecarContainerMagicV3:
 			t := b[len(b)-sidecarTrailerLenV3:]
 			attrLen = int(binary.LittleEndian.Uint32(t[0:]))

--- a/collections/compact.go
+++ b/collections/compact.go
@@ -479,7 +479,7 @@ func (c *Collection) compactShard(sh *shard, target Codec) {
 		}
 		// A keyless dict record's body (the serialized dict) starts after the 32-byte header
 		// and the adLen u32 -- the base a segDictHandle probes.
-		seg.dict.Store(&segDictHandle{data: seg.data, base: off + recKeyOff + 4})
+		seg.dict.Store(&segDictHandle{data: seg.data, base: off + recKeyOff + 4, rec: off})
 	}
 	// decodeSrc decodes a source record to an ast, honoring the source segment's own encoding
 	// (inline or interned). Returns nil on any decompress/decode failure.

--- a/collections/keyindex.go
+++ b/collections/keyindex.go
@@ -153,9 +153,11 @@ const (
 	sidecarContainerMagic   = 0x53434e54 // "SCNT" (v1, 2-section)
 	sidecarContainerMagicV2 = 0x53434e32 // "SCN2" (v2, 3-section, adds the columnar blob)
 	sidecarContainerMagicV3 = 0x53434e33 // "SCN3" (v3, adds the zone map + the sealed extent)
+	sidecarContainerMagicV4 = 0x53434e34 // "SCN4" (v4, adds the dictionary record's offset)
 	sidecarTrailerLen       = 12
 	sidecarTrailerLenV2     = 16
 	sidecarTrailerLenV3     = 28 // 4 lengths (u32) + segUsed (u64) + magic (u32)
+	sidecarTrailerLenV4     = 32 // v3 + dictRec (u32)
 )
 
 // buildSegmentSidecar packs the attribute-index blob (may be empty), the key-index blob, and the
@@ -165,9 +167,9 @@ const (
 // CRC-verifying every record just to find where durable data ends -- a sealed segment's extent
 // is final, so re-deriving it on every open is a full integrity scan of the whole archive
 // masquerading as recovery. Zero means "not recorded" and the reader falls back to scanning.
-func buildSegmentSidecar(attrBlob, keyBlob, colBlob, zoneBlob []byte, segUsed int) []byte {
-	if len(zoneBlob) > 0 || segUsed > 0 {
-		b := make([]byte, 0, len(attrBlob)+len(keyBlob)+len(colBlob)+len(zoneBlob)+sidecarTrailerLenV3)
+func buildSegmentSidecar(attrBlob, keyBlob, colBlob, zoneBlob []byte, segUsed int, dictRec uint32) []byte {
+	if len(zoneBlob) > 0 || segUsed > 0 || dictRec > 0 {
+		b := make([]byte, 0, len(attrBlob)+len(keyBlob)+len(colBlob)+len(zoneBlob)+sidecarTrailerLenV4)
 		b = append(b, attrBlob...)
 		b = append(b, keyBlob...)
 		b = append(b, colBlob...)
@@ -177,7 +179,8 @@ func buildSegmentSidecar(attrBlob, keyBlob, colBlob, zoneBlob []byte, segUsed in
 		b = binary.LittleEndian.AppendUint32(b, uint32(len(colBlob)))
 		b = binary.LittleEndian.AppendUint32(b, uint32(len(zoneBlob)))
 		b = binary.LittleEndian.AppendUint64(b, uint64(segUsed))
-		b = binary.LittleEndian.AppendUint32(b, sidecarContainerMagicV3)
+		b = binary.LittleEndian.AppendUint32(b, dictRec)
+		b = binary.LittleEndian.AppendUint32(b, sidecarContainerMagicV4)
 		return b
 	}
 	if len(colBlob) == 0 {
@@ -210,6 +213,36 @@ func splitSegmentSidecar(data []byte) (attr, key, col, zone []byte, ok bool) {
 
 // splitSegmentSidecarFull also returns the recorded sealed extent (0 when absent).
 func splitSegmentSidecarFull(data []byte) (attr, key, col, zone []byte, segUsed int, ok bool) {
+	a, k, c, z, u, _, o := splitSegmentSidecarV4(data)
+	return a, k, c, z, u, o
+}
+
+// splitSegmentSidecarV4 also returns the recorded dictionary record offset (0 when absent).
+func splitSegmentSidecarV4(data []byte) (attr, key, col, zone []byte, segUsed int, dictRec uint32, ok bool) {
+	if len(data) >= sidecarTrailerLenV4 {
+		t := data[len(data)-sidecarTrailerLenV4:]
+		if binary.LittleEndian.Uint32(t[28:]) == sidecarContainerMagicV4 {
+			attrLen := int(binary.LittleEndian.Uint32(t[0:]))
+			keyLen := int(binary.LittleEndian.Uint32(t[4:]))
+			colLen := int(binary.LittleEndian.Uint32(t[8:]))
+			zoneLen := int(binary.LittleEndian.Uint32(t[12:]))
+			used := int(binary.LittleEndian.Uint64(t[16:]))
+			rec := binary.LittleEndian.Uint32(t[24:])
+			body := len(data) - sidecarTrailerLenV4
+			if attrLen >= 0 && keyLen >= 0 && colLen >= 0 && zoneLen >= 0 &&
+				attrLen+keyLen+colLen+zoneLen == body {
+				return data[:attrLen], data[attrLen : attrLen+keyLen],
+					data[attrLen+keyLen : attrLen+keyLen+colLen],
+					data[attrLen+keyLen+colLen : body], used, rec, true
+			}
+			return nil, nil, nil, nil, 0, 0, false
+		}
+	}
+	a, k, c, z, u, o := splitSegmentSidecarOld(data)
+	return a, k, c, z, u, 0, o
+}
+
+func splitSegmentSidecarOld(data []byte) (attr, key, col, zone []byte, segUsed int, ok bool) {
 	if len(data) >= sidecarTrailerLenV3 {
 		t := data[len(data)-sidecarTrailerLenV3:]
 		if binary.LittleEndian.Uint32(t[24:]) == sidecarContainerMagicV3 {
@@ -339,25 +372,49 @@ func parseZoneBlob(b []byte) (map[uint32]zoneRange, bool) {
 // itself a cost worth avoiding). Returns 0 when the file is absent, too short, or not a v3
 // container -- the caller then falls back to scanning.
 func readSidecarExtent(path string) int {
+	used, _ := readSidecarTrailer(path)
+	return used
+}
+
+// readSidecarTrailer reads a sealed segment's sidecar trailer, returning the recorded written
+// extent and the offset of the segment's dictionary record (0 for either when absent). One
+// open+read serves both, so recovering the dictionary's position costs no syscall of its own.
+//
+// v3 containers carry the extent but no dictionary offset, and read with dictRec 0.
+func readSidecarTrailer(path string) (used int, dictRec uint32) {
 	f, err := os.Open(path)
 	if err != nil {
-		return 0
+		return 0, 0
 	}
 	defer f.Close()
 	st, err := f.Stat()
-	if err != nil || st.Size() < int64(sidecarTrailerLenV3) {
-		return 0
+	if err != nil {
+		return 0, 0
+	}
+	if st.Size() >= int64(sidecarTrailerLenV4) {
+		var t [sidecarTrailerLenV4]byte
+		if _, err := f.ReadAt(t[:], st.Size()-int64(sidecarTrailerLenV4)); err == nil &&
+			binary.LittleEndian.Uint32(t[28:]) == sidecarContainerMagicV4 {
+			u := int(binary.LittleEndian.Uint64(t[16:]))
+			if u < 0 {
+				return 0, 0
+			}
+			return u, binary.LittleEndian.Uint32(t[24:])
+		}
+	}
+	if st.Size() < int64(sidecarTrailerLenV3) {
+		return 0, 0
 	}
 	var t [sidecarTrailerLenV3]byte
 	if _, err := f.ReadAt(t[:], st.Size()-int64(sidecarTrailerLenV3)); err != nil {
-		return 0
+		return 0, 0
 	}
 	if binary.LittleEndian.Uint32(t[24:]) != sidecarContainerMagicV3 {
-		return 0
+		return 0, 0
 	}
-	used := int(binary.LittleEndian.Uint64(t[16:]))
-	if used < 0 {
-		return 0
+	u := int(binary.LittleEndian.Uint64(t[16:]))
+	if u < 0 {
+		return 0, 0
 	}
-	return used
+	return u, 0
 }

--- a/collections/persist.go
+++ b/collections/persist.go
@@ -294,6 +294,9 @@ func (c *Collection) loadShard(sh *shard, shardDir string) (uint64, error) {
 	// Complete any merge a crash interrupted, so the directory below is never a half-merged
 	// mixture of a merged segment and the sources it replaced.
 	finishPendingMerges(shardDir)
+	// Each sealed segment's sidecar trailer names the offset of its dictionary record; the
+	// hints are collected while mapping and consumed once every segment is in place.
+	segDictHint := map[*segment]uint32{}
 	entries, err := os.ReadDir(shardDir)
 	if err != nil {
 		return 0, err
@@ -365,7 +368,11 @@ func (c *Collection) loadShard(sh *shard, shardDir string) (uint64, error) {
 		// extent is still checked: it must fit the mapping and the record ending exactly
 		// there must verify, so a truncated file or a sidecar left over from a different
 		// segment falls back to the scan rather than being trusted.
-		if rec := readSidecarExtent(seg.path + ".idx"); rec > 0 && rec <= len(seg.data) &&
+		// The same trailer read also yields the offset of the segment's dictionary record,
+		// used below so publishSegDict need not search for it.
+		extent, dictRec := readSidecarTrailer(seg.path + ".idx")
+		segDictHint[seg] = dictRec
+		if rec := extent; rec > 0 && rec <= len(seg.data) &&
 			recExtentEndsCleanly(seg.data, rec) {
 			used = rec
 		} else {
@@ -443,7 +450,7 @@ func (c *Collection) loadShard(sh *shard, shardDir string) (uint64, error) {
 	// demote it -- the next write then allocates a fresh inline active segment.
 	for _, seg := range sh.segs {
 		if seg != nil {
-			publishSegDict(seg)
+			publishSegDictAt(seg, segDictHint[seg])
 		}
 	}
 	if sh.act != nil && sh.act.dict.Load() != nil {

--- a/collections/retrain_appendonly.go
+++ b/collections/retrain_appendonly.go
@@ -296,7 +296,7 @@ func (c *Collection) resealSegmentsAs(sh *shard, srcs []*segment, targetCodec Co
 		if !ok {
 			return nil
 		}
-		newseg.dict.Store(&segDictHandle{data: newseg.data, base: doff + recKeyOff + 4})
+		newseg.dict.Store(&segDictHandle{data: newseg.data, base: doff + recKeyOff + 4, rec: doff})
 	}
 	// Persistent segments: flush the written extent so recovery sees a complete segment.
 	if newseg.persistent {

--- a/collections/sealed_index.go
+++ b/collections/sealed_index.go
@@ -118,7 +118,7 @@ func (c *Collection) sealSegmentIndex(seg *segment, si *segIndex) {
 		attrBlob = b
 	}
 	container := buildSegmentSidecar(attrBlob, buildKeyIndex(seg.data, seg.used, c.h), c.colBlobForSeg(seg),
-		buildZoneBlob(seg.zones), seg.used)
+		buildZoneBlob(seg.zones), seg.used, seg.dictRecOff())
 	if err := writeFileAtomic(path, container); err != nil {
 		return
 	}
@@ -186,7 +186,7 @@ func (c *Collection) reindexSealedFile(sh *shard, seg *segment, si *segIndex) bo
 		return false
 	}
 	container := buildSegmentSidecar(attrBlob, buildKeyIndex(seg.data, seg.used, c.h), c.colBlobPreserve(seg),
-		buildZoneBlob(c.zonesForSeg(sh, seg)), seg.used)
+		buildZoneBlob(c.zonesForSeg(sh, seg)), seg.used, seg.dictRecOff())
 	return c.installSidecar(sh, seg, path, container)
 }
 

--- a/collections/segdict.go
+++ b/collections/segdict.go
@@ -94,8 +94,11 @@ func appendSegDict(dst []byte, names []string) []byte {
 // one via an atomic pointer (nil => the segment is inline-encoded). All methods are safe for
 // concurrent readers.
 type segDictHandle struct {
-	data  []byte                   // the segment arena (or any buffer) the dict is embedded in
-	base  uint32                   // offset of the dict's first byte within data
+	data []byte // the segment arena (or any buffer) the dict is embedded in
+	base uint32 // offset of the dict's first byte within data
+	// rec is the offset of the dict RECORD (base is its body). Recorded in the segment's
+	// sidecar at seal so a reopen can jump straight to it -- see publishSegDictAt.
+	rec   uint32
 	names atomic.Pointer[[]string] // lazily-built id->name cache for the decode hot path (see resolve)
 }
 
@@ -137,8 +140,25 @@ func (h *segDictHandle) buildNameCache() *[]string {
 // segment's dict handle so its records resolve segment-local ids. A segment with no dict record
 // is inline -- seg.dict stays nil. Called during Open before any body decode. The dict record
 // is a trailer, so this walks to it; the walk reads only record headers (no decompress).
-func publishSegDict(seg *segment) {
+func publishSegDict(seg *segment) { publishSegDictAt(seg, 0) }
+
+// publishSegDictAt is publishSegDict with a hint: the dict record's offset as recorded in the
+// segment's sidecar. The dict is a TRAILER, so the unhinted walk always traverses the whole
+// segment -- reading only headers, but touching a cache line per record, which makes recovery
+// scale with total records rather than with segment count. The writer knows the offset
+// (appendDict returns it); the hint is that offset carried forward.
+//
+// The hint is VERIFIED, not trusted. A wrong offset would publish arbitrary bytes as the
+// dictionary, and every attribute name in the segment would resolve through it -- silent
+// corruption of reads rather than a failure. So it must land inside the written extent, on a
+// record whose length is sane, and on one actually flagged as a dict; anything else falls
+// back to the walk, which is always correct.
+func publishSegDictAt(seg *segment, hint uint32) {
 	if seg == nil || seg.dict.Load() != nil {
+		return
+	}
+	if hint > 0 && dictRecordAt(seg, hint) {
+		seg.dict.Store(&segDictHandle{data: seg.data, base: hint + recKeyOff + 4, rec: hint})
 		return
 	}
 	for off := 0; off < seg.used; {
@@ -149,11 +169,32 @@ func publishSegDict(seg *segment) {
 		}
 		if recIsDict(seg.data, o) {
 			// The keyless dict record's body (the serialized dict) starts after the header + adLen.
-			seg.dict.Store(&segDictHandle{data: seg.data, base: o + recKeyOff + 4})
+			seg.dict.Store(&segDictHandle{data: seg.data, base: o + recKeyOff + 4, rec: o})
 			return
 		}
 		off += int(total)
 	}
+}
+
+// dictRecOff returns the offset of the segment's dictionary record, or 0 if the segment is
+// inline (no dictionary). Recorded in the sidecar so a reopen need not search for it.
+func (s *segment) dictRecOff() uint32 {
+	if h := s.dict.Load(); h != nil {
+		return h.rec
+	}
+	return 0
+}
+
+// dictRecordAt reports whether off names a well-formed dict record inside seg's written data.
+func dictRecordAt(seg *segment, off uint32) bool {
+	if int(off)+recHeaderSize > seg.used {
+		return false
+	}
+	total := recTotalLen(seg.data, off)
+	if total == 0 || int(off)+int(total) > seg.used {
+		return false
+	}
+	return recIsDict(seg.data, off)
 }
 
 // segDictCount returns the number of names in the dict at base.

--- a/collections/segdict_hint_test.go
+++ b/collections/segdict_hint_test.go
@@ -1,0 +1,234 @@
+package collections
+
+import (
+	"encoding/binary"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/classad"
+)
+
+// internedArchive builds a persistent append-only collection whose sealed segments are
+// interned (so they carry dictionaries), and returns it after a reopen.
+func internedArchive(t *testing.T, dir string) *Collection {
+	t.Helper()
+	c, err := Open(Options{AppendOnly: true, Dir: dir, SegmentSize: 1 << 16})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := range 3000 {
+		ad, err := classad.Parse(fmt.Sprintf(
+			`[ ClusterId=%d; Owner="user%d"; JobStatus=%d; Cmd="/bin/sleep" ]`, i, i%7, i%6))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := c.Put([]byte(fmt.Sprintf("%d.0", i)), ad); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := c.RetrainDict(1024); err != nil { // interns the sealed segments
+		t.Fatal(err)
+	}
+	if err := c.Close(); err != nil {
+		t.Fatal(err)
+	}
+	c2, err := Open(Options{AppendOnly: true, Dir: dir, SegmentSize: 1 << 16})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { c2.Close() })
+	return c2
+}
+
+func internedSegments(c *Collection) []*segment {
+	var out []*segment
+	for _, s := range c.shards[0].segs {
+		if s != nil && s.dict.Load() != nil {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// TestSegDictHintMatchesWalk: the offset recorded in the sidecar must be the one the walk
+// would have found. If it were not, every attribute name in the segment would resolve
+// through the wrong dictionary.
+func TestSegDictHintMatchesWalk(t *testing.T) {
+	c := internedArchive(t, t.TempDir())
+	segs := internedSegments(c)
+	if len(segs) == 0 {
+		t.Fatal("fixture produced no interned segments")
+	}
+	for _, seg := range segs {
+		hinted := seg.dict.Load().rec
+		seg.dict.Store(nil)
+		publishSegDictAt(seg, 0) // force the walk
+		walked := seg.dict.Load()
+		if walked == nil {
+			t.Fatalf("walk found no dict in an interned segment")
+		}
+		if walked.rec != hinted {
+			t.Errorf("hint offset %d != walked offset %d", hinted, walked.rec)
+		}
+	}
+}
+
+// TestSegDictHintRejectsBadOffset is the safety property. A hint is data read off disk, so it
+// can be wrong -- stale, truncated, or from another segment. An unverified hint would publish
+// arbitrary bytes as the dictionary and silently corrupt every name lookup in the segment,
+// which is far worse than the walk it replaces. Every bad hint must fall back and still land
+// on the real dictionary.
+func TestSegDictHintRejectsBadOffset(t *testing.T) {
+	c := internedArchive(t, t.TempDir())
+	segs := internedSegments(c)
+	if len(segs) == 0 {
+		t.Fatal("fixture produced no interned segments")
+	}
+	seg := segs[0]
+	real := seg.dict.Load().rec
+	if real == 0 {
+		t.Fatal("dict record at offset 0; the test cannot distinguish hint from fallback")
+	}
+
+	for _, tc := range []struct {
+		name string
+		hint uint32
+	}{
+		{"past the written extent", uint32(seg.used) + 1},
+		{"way out of bounds", 1 << 30},
+		{"a real record that is not the dict", 0}, // offset 0 is the first DATA record
+		{"mid-record, not a record boundary", real + 3},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			hint := tc.hint
+			if tc.name == "a real record that is not the dict" {
+				// Offset 0 is a data record; publishSegDictAt treats hint 0 as "no hint",
+				// so use the second record instead to exercise a non-zero wrong offset.
+				hint = recTotalLen(seg.data, 0)
+				if hint == 0 || recIsDict(seg.data, hint) {
+					t.Skip("fixture layout unsuitable")
+				}
+			}
+			seg.dict.Store(nil)
+			publishSegDictAt(seg, hint)
+			got := seg.dict.Load()
+			if got == nil {
+				t.Fatalf("bad hint %d left the segment with no dict at all", hint)
+			}
+			if got.rec != real {
+				t.Errorf("bad hint %d published dict at %d, want the real one at %d",
+					hint, got.rec, real)
+			}
+			// And the dictionary actually resolves: a wrong base would give nonsense.
+			if n := got.count(); n == 0 || n > 1000 {
+				t.Errorf("dict published from bad hint %d has implausible count %d", hint, n)
+			}
+		})
+	}
+}
+
+// TestSegDictNamesResolveAfterReopen is the end-to-end guard: whichever path published the
+// dictionary, a reopened interned segment must decode its records to the right names.
+func TestSegDictNamesResolveAfterReopen(t *testing.T) {
+	c := internedArchive(t, t.TempDir())
+	n := 0
+	seen := map[string]bool{}
+	for ad := range c.Scan() {
+		n++
+		if v, ok := ad.Lookup("Owner"); ok {
+			seen[fmt.Sprint(v)] = true
+		}
+	}
+	if n != 3000 {
+		t.Errorf("scanned %d records after reopen, want 3000", n)
+	}
+	if len(seen) != 7 {
+		t.Errorf("distinct Owner values = %d, want 7 (names resolved through the dict)", len(seen))
+	}
+}
+
+// TestSegDictFallsBackToWalkOnOldSidecar: a sidecar written by an earlier version carries no
+// dictionary offset. Recovery must still find the dictionary, just by walking.
+func TestSegDictFallsBackToWalkOnOldSidecar(t *testing.T) {
+	dir := t.TempDir()
+	c := internedArchive(t, dir)
+	segs := internedSegments(c)
+	if len(segs) == 0 {
+		t.Fatal("fixture produced no interned segments")
+	}
+	paths := make([]string, 0, len(segs))
+	for _, s := range segs {
+		paths = append(paths, s.path+".idx")
+	}
+	if err := c.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Rewrite each sidecar in the v3 layout (no dict offset), as an older writer produced.
+	for _, p := range paths {
+		data, err := os.ReadFile(p)
+		if err != nil {
+			continue
+		}
+		attr, key, col, zone, used, _, ok := splitSegmentSidecarV4(data)
+		if !ok {
+			continue
+		}
+		if err := os.WriteFile(p, buildV3Sidecar(attr, key, col, zone, used), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	c2, err := Open(Options{AppendOnly: true, Dir: dir, SegmentSize: 1 << 16})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c2.Close()
+	if got := len(internedSegments(c2)); got != len(segs) {
+		t.Errorf("interned segments after v3 reopen = %d, want %d", got, len(segs))
+	}
+	n := 0
+	for range c2.Scan() {
+		n++
+	}
+	if n != 3000 {
+		t.Errorf("scanned %d records from v3 sidecars, want 3000", n)
+	}
+}
+
+// buildV3Sidecar writes the pre-v4 container layout, for the compatibility test above.
+func buildV3Sidecar(attrBlob, keyBlob, colBlob, zoneBlob []byte, segUsed int) []byte {
+	b := make([]byte, 0, len(attrBlob)+len(keyBlob)+len(colBlob)+len(zoneBlob)+sidecarTrailerLenV3)
+	b = append(b, attrBlob...)
+	b = append(b, keyBlob...)
+	b = append(b, colBlob...)
+	b = append(b, zoneBlob...)
+	b = binary.LittleEndian.AppendUint32(b, uint32(len(attrBlob)))
+	b = binary.LittleEndian.AppendUint32(b, uint32(len(keyBlob)))
+	b = binary.LittleEndian.AppendUint32(b, uint32(len(colBlob)))
+	b = binary.LittleEndian.AppendUint32(b, uint32(len(zoneBlob)))
+	b = binary.LittleEndian.AppendUint64(b, uint64(segUsed))
+	b = binary.LittleEndian.AppendUint32(b, sidecarContainerMagicV3)
+	return b
+}
+
+// TestSegDictOffsetIsRecorded: the sidecar of an interned segment must actually carry the
+// dictionary offset, or the fast path is dead code and reopen silently keeps walking.
+func TestSegDictOffsetIsRecorded(t *testing.T) {
+	c := internedArchive(t, t.TempDir())
+	segs := internedSegments(c)
+	if len(segs) == 0 {
+		t.Fatal("fixture produced no interned segments")
+	}
+	for _, seg := range segs {
+		_, dictRec := readSidecarTrailer(seg.path + ".idx")
+		if dictRec == 0 {
+			t.Errorf("segment %s: sidecar records no dict offset", seg.path)
+			continue
+		}
+		if want := seg.dict.Load().rec; dictRec != want {
+			t.Errorf("segment %s: sidecar dict offset %d, live dict at %d", seg.path, dictRec, want)
+		}
+	}
+}

--- a/collections/sidecar_container_test.go
+++ b/collections/sidecar_container_test.go
@@ -15,7 +15,7 @@ func TestSegmentSidecarContainer(t *testing.T) {
 	col := []byte("COLX-columnar-block-payload-bytes")
 
 	// v2: all three sections round-trip.
-	c2 := buildSegmentSidecar(attr, key, col, nil, 0)
+	c2 := buildSegmentSidecar(attr, key, col, nil, 0, 0)
 	if binary.LittleEndian.Uint32(c2[len(c2)-4:]) != sidecarContainerMagicV2 {
 		t.Fatal("v2 container: wrong trailing magic")
 	}
@@ -26,7 +26,7 @@ func TestSegmentSidecarContainer(t *testing.T) {
 
 	// Empty col writes the v1 layout byte-for-byte (identical to a pre-columnar sidecar): trailing
 	// magic is SCNT, length is attr+key+12, and split returns col == nil.
-	c1 := buildSegmentSidecar(attr, key, nil, nil, 0)
+	c1 := buildSegmentSidecar(attr, key, nil, nil, 0, 0)
 	if binary.LittleEndian.Uint32(c1[len(c1)-4:]) != sidecarContainerMagic {
 		t.Fatal("empty col should write the v1 magic")
 	}
@@ -39,7 +39,7 @@ func TestSegmentSidecarContainer(t *testing.T) {
 	}
 
 	// Empty attr (no attribute index) still frames correctly alongside a columnar block.
-	c3 := buildSegmentSidecar(nil, key, col, nil, 0)
+	c3 := buildSegmentSidecar(nil, key, col, nil, 0, 0)
 	a, k, cc, _, ok = splitSegmentSidecar(c3)
 	if !ok || len(a) != 0 || !bytes.Equal(k, key) || !bytes.Equal(cc, col) {
 		t.Fatalf("empty-attr split: ok=%v attr=%q key=%q col=%q", ok, a, k, cc)
@@ -73,7 +73,7 @@ func TestSidecarContainerZones(t *testing.T) {
 	col := []byte("COLBLOB!")
 	zones := map[uint32]zoneRange{7: {Min: -1.5, Max: 100}, 3: {Min: 0, Max: 0}}
 
-	c4 := buildSegmentSidecar(attr, key, col, buildZoneBlob(zones), 4096)
+	c4 := buildSegmentSidecar(attr, key, col, buildZoneBlob(zones), 4096, 0)
 	a, k, cc, z, ok := splitSegmentSidecar(c4)
 	if !ok {
 		t.Fatal("v3 container did not parse")
@@ -95,7 +95,7 @@ func TestSidecarContainerZones(t *testing.T) {
 	}
 
 	// No zones: stays at the older shape, and yields a nil zone section.
-	if _, _, _, z2, ok := splitSegmentSidecar(buildSegmentSidecar(attr, key, col, nil, 0)); !ok || z2 != nil {
+	if _, _, _, z2, ok := splitSegmentSidecar(buildSegmentSidecar(attr, key, col, nil, 0, 0)); !ok || z2 != nil {
 		t.Errorf("container without zones: ok=%v zone=%v, want ok and nil", ok, z2)
 	}
 


### PR DESCRIPTION
An interned segment stores its attribute names once in a per-segment dictionary; its records then reference them by a segment-local id. That dictionary is a **trailer**, appended at seal — and nothing recorded where it went. So `publishSegDict` found it by walking the segment's records from offset 0, header to header, which for a trailer means traversing the entire segment.

The walk reads only headers, no decompression, but it touches a cache line per record across every sealed segment. It was **the last term in recovery that scales with total records** rather than with segment count — everything else #137 left behind is `openat`/`mmap`, which scales with segments.

## Measured

Profiled on 1M records / 27 interned segments (20 reopens):

| | |
|---|---|
| `publishSegDict` | **65% of reopen CPU**, entirely `recTotalLen` → `binary.littleEndian.Uint32` |
| next largest | `loadSealedIndex` at 19%, which is `os.OpenFile` — O(segments) |

Reopen wall clock, same fixture: **32 ms → 9 ms**. Linear in records before (200k → 1M scaled 6×), so the gap widens with the archive.

## The fix

The writer already knew the answer and threw it away: `appendDict` **returns** the offset. It is now carried on the dict handle, written into a **v4 sidecar container**, and read back by the *same trailer read that already recovers the written extent* — so recovering the dictionary's position costs **no additional syscall**.

## The hint is verified, not trusted

This is the part worth reviewing. The offset is data read off disk, so it can be stale, truncated, or left over from a different segment. An unverified offset would publish arbitrary bytes as the dictionary — and then **every attribute name in that segment resolves through it**. That is silent wrong answers, which is much worse than the walk it replaces.

So it must land inside the written extent, on a record whose length is sane, flagged as a dict. Anything else falls back to the walk, which is always correct.

`TestSegDictHintRejectsBadOffset` covers four bad offsets (past the extent, wildly out of bounds, a real non-dict record, mid-record). I verified it fails when the verification is removed.

## Compatibility

v3 and earlier sidecars carry no offset and read unchanged, taking the walk — covered by `TestSegDictFallsBackToWalkOnOldSidecar`, which rewrites real sidecars back to the v3 layout.

Worth stating the converse: **a v4 sidecar read by an older binary does not parse and is rebuilt.** A cost on downgrade, not a correctness problem.

## Testing

The recorded offset equals the one the walk finds; the writer actually records it (otherwise the fast path would be dead code and reopen would silently keep walking); names still resolve end-to-end after reopen; and the v3 fallback works.

One pre-existing test needed teaching about v4 — `TestSchemaScanReloadCorruptSection` locates the columnar body positionally from the trailer, so a trailer length change breaks it. Same trap as the one #137 hit.

`go vet` and all five module suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
