### PR TITLE
collections: make the derived schema visible, measurable and rebuildable

### DIFF
--- a/collections/colscan.go
+++ b/collections/colscan.go
@@ -39,6 +39,40 @@ type SchemaScanInfo struct {
 	SchemaFields    int      `json:"schemaFields,omitempty"`
 	SealedSegments  int      `json:"sealedSegments,omitempty"`
 	CoveredSegments int      `json:"coveredSegments,omitempty"`
+	// Schema is the derived schema itself, field by field, in layout order. The counts above
+	// say how much of the table the accelerator covers; this says what it decided the ads
+	// look like -- which is what you need to judge whether the sampling recovered the shape
+	// you expected, or picked up something odd.
+	Schema []SchemaScanField `json:"schema,omitempty"`
+}
+
+// SchemaScanField is one attribute in the derived schema: the name it was recovered under, the
+// storable kind chosen for it, and the fixed width its slot occupies. Hot marks the numeric
+// columns kept uncompressed for O(1) scan.
+//
+// Width is bytes for an int (1/2/4/6/8, the narrowest that fits the sampled values), 8 for a
+// real or a string slot, and 0 for a bool (bit-packed).
+type SchemaScanField struct {
+	Name     string `json:"name"`
+	Kind     string `json:"kind"` // bool, int, real, string
+	Width    int    `json:"width,omitempty"`
+	Unsigned bool   `json:"unsigned,omitempty"`
+	Hot      bool   `json:"hot,omitempty"`
+}
+
+// String names a schema field's kind for display.
+func (k adKind) String() string {
+	switch k {
+	case akBool:
+		return "bool"
+	case akInt:
+		return "int"
+	case akReal:
+		return "real"
+	case akString:
+		return "string"
+	}
+	return "none"
 }
 
 // SchemaScanInfo returns the columnar accelerator's current state (see SchemaScanInfo).
@@ -47,12 +81,29 @@ func (c *Collection) SchemaScanInfo() SchemaScanInfo {
 	if st := c.schemaScan.Load(); st != nil {
 		info.Enabled = true
 		info.SchemaFields = len(st.schema.fields)
+		hot := make(map[int]bool, len(st.hot))
 		for _, idx := range st.hot {
 			if idx >= 0 && idx < len(st.schema.fields) {
-				if name, ok := c.intern.Name(st.schema.fields[idx].id); ok {
+				hot[idx] = true
+				if name, ok := c.schemaFieldName(st.schema.fields[idx].id); ok {
 					info.HotFields = append(info.HotFields, name)
 				}
 			}
+		}
+		for i, f := range st.schema.fields {
+			name, ok := c.schemaFieldName(f.id)
+			if !ok {
+				// An id with no name in the intern table cannot be reported usefully; say so
+				// rather than drop the field, so the count still lines up with SchemaFields.
+				name = "?"
+			}
+			info.Schema = append(info.Schema, SchemaScanField{
+				Name:     name,
+				Kind:     f.kind.String(),
+				Width:    f.width,
+				Unsigned: f.unsigned,
+				Hot:      hot[i],
+			})
 		}
 	}
 	for _, sh := range c.shards {
@@ -69,6 +120,16 @@ func (c *Collection) SchemaScanInfo() SchemaScanInfo {
 		sh.mu.RUnlock()
 	}
 	return info
+}
+
+// schemaFieldName resolves a schema field's interned id to its attribute name. A collection
+// with no intern table cannot have a schema (buildAdSchema reads the id-keyed form), but guard
+// it rather than depend on that.
+func (c *Collection) schemaFieldName(id uint32) (string, bool) {
+	if c.intern == nil {
+		return "", false
+	}
+	return c.intern.Name(id)
 }
 
 // EnableSchemaScan builds a columnar block over every currently-sealed segment (skipping the
@@ -241,9 +302,22 @@ func (c *Collection) BuildAndEnableSchemaScan(sampleMax, hotTopN int) bool {
 		c.EnableSchemaScan(st.schema, st.hot)
 		return true
 	}
+	s, hot, ok := c.deriveSchema(sampleMax, hotTopN)
+	if !ok {
+		return false
+	}
+	c.EnableSchemaScan(s, hot)
+	return true
+}
+
+// deriveSchema samples the collection and derives a schema plus its hot numeric tier, without
+// touching the current state. Shared by BuildAndEnableSchemaScan (first enable) and
+// ReschemaScan (a deliberate rebuild). Returns false if there is nothing to sample or no field
+// survived the presence threshold.
+func (c *Collection) deriveSchema(sampleMax, hotTopN int) (*adSchema, []int, bool) {
 	samples := c.CollectSamples(sampleMax)
 	if len(samples) == 0 {
-		return false
+		return nil, nil, false
 	}
 	// buildAdSchema reads the id-keyed wire form; a persistent (inline) collection's records
 	// store names, so canonicalize them to interned wire first (else the schema is empty and
@@ -257,12 +331,12 @@ func (c *Collection) BuildAndEnableSchemaScan(sampleMax, hotTopN int) bool {
 		}
 		samples = interned
 		if len(samples) == 0 {
-			return false
+			return nil, nil, false
 		}
 	}
 	s := buildAdSchema(samples, adSchemaOpts{Presence: 0.90, Fit: 0.95, Strings: true})
 	if len(s.fields) == 0 {
-		return false
+		return nil, nil, false
 	}
 	type fieldDemand struct {
 		idx   int
@@ -296,8 +370,7 @@ func (c *Collection) BuildAndEnableSchemaScan(sampleMax, hotTopN int) bool {
 	// width that covers essentially all its values. Cold fields keep the tight base width. See
 	// refitHotIntWidths.
 	s, hot = refitHotIntWidths(s, samples, hot, hotIntFit)
-	c.EnableSchemaScan(s, hot)
-	return true
+	return s, hot, true
 }
 
 // hotIntFit is the width fit percentile for HOT (demand-queried) int columns: high enough to

--- a/collections/schema_info_test.go
+++ b/collections/schema_info_test.go
@@ -48,3 +48,84 @@ func TestSchemaScanInfo(t *testing.T) {
 		t.Fatalf("Memory (queried) not in hot fields %v", info.HotFields)
 	}
 }
+
+// TestSchemaScanInfoSchema covers the derived schema itself, which is the part an operator
+// actually needs to see: the accelerator can be "on" over a schema that recovered the wrong
+// shape, and the counts alone cannot show that.
+func TestSchemaScanInfoSchema(t *testing.T) {
+	store := New(Options{Shards: 1, SegmentSize: 1 << 12})
+	for i := 0; i < 2000; i++ {
+		// A mix of kinds and int widths: JobStatus fits in one byte, QDate does not; Owner is
+		// a string; Held is a bool.
+		ad := fmt.Sprintf("Cpus=%d\nMemory=%d\nJobStatus=%d\nQDate=%d\nOwner=\"u%d\"\nHeld=%t",
+			1+i%8, 1024+(i%64)*256, 1+i%5, 1700000000+i, i%5, i%2 == 0)
+		if err := store.Put([]byte(fmt.Sprintf("k%d", i)), mustAdOld(t, ad)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mc, _ := vm.Parse("Memory >= 0")
+	for i := 0; i < 30; i++ {
+		for range store.Query(mc) {
+		}
+	}
+	if !store.BuildAndEnableSchemaScan(2000, 4) {
+		t.Fatal("BuildAndEnableSchemaScan false")
+	}
+
+	info := store.SchemaScanInfo()
+	if len(info.Schema) != info.SchemaFields {
+		t.Fatalf("Schema has %d fields but SchemaFields says %d -- the two must agree",
+			len(info.Schema), info.SchemaFields)
+	}
+	if len(info.Schema) == 0 {
+		t.Fatal("no schema reported")
+	}
+	byName := map[string]SchemaScanField{}
+	for _, f := range info.Schema {
+		if f.Name == "" || f.Name == "?" {
+			t.Errorf("field with unresolved name: %+v", f)
+		}
+		byName[f.Name] = f
+	}
+	// The kinds the sampler should have recovered.
+	for name, wantKind := range map[string]string{
+		"Cpus": "int", "Memory": "int", "JobStatus": "int", "QDate": "int",
+		"Owner": "string", "Held": "bool",
+	} {
+		f, ok := byName[name]
+		if !ok {
+			t.Errorf("%s missing from the derived schema (fields: %v)", name, info.Schema)
+			continue
+		}
+		if f.Kind != wantKind {
+			t.Errorf("%s kind = %q, want %q", name, f.Kind, wantKind)
+		}
+	}
+	// Width is the point of the exercise: a narrow int must not be given eight bytes.
+	if js, ok := byName["JobStatus"]; ok {
+		if js.Width == 0 || js.Width > 2 {
+			t.Errorf("JobStatus width = %d, want the narrowest that fits 1..5", js.Width)
+		}
+	}
+	if qd, ok := byName["QDate"]; ok {
+		if qd.Width <= 2 {
+			t.Errorf("QDate width = %d, too narrow for a unix timestamp", qd.Width)
+		}
+	}
+	if h, ok := byName["Held"]; ok && h.Width != 0 {
+		t.Errorf("Held width = %d, want 0 (bools are bit-packed)", h.Width)
+	}
+	// The Hot flag must agree with HotFields -- two views of one decision.
+	hotFromList := map[string]bool{}
+	for _, n := range info.HotFields {
+		hotFromList[n] = true
+	}
+	for _, f := range info.Schema {
+		if f.Hot != hotFromList[f.Name] {
+			t.Errorf("%s: Schema says hot=%v but HotFields says %v", f.Name, f.Hot, hotFromList[f.Name])
+		}
+	}
+	if m, ok := byName["Memory"]; !ok || !m.Hot {
+		t.Errorf("Memory was the queried attribute; it should be marked hot: %+v", m)
+	}
+}

--- a/collections/schemafit.go
+++ b/collections/schemafit.go
@@ -1,0 +1,162 @@
+package collections
+
+import (
+	"github.com/PelicanPlatform/classad/collections/wire"
+)
+
+// Rebuilding the derived schema, and deciding when to.
+//
+// The schema is recovered by sampling once, at first enable, and then deliberately held stable:
+// every segment's columnar block is built against a particular schema, so swapping the current
+// schema mid-flight would leave earlier blocks unmatched. That stability is right for routine
+// maintenance and wrong forever -- a workload drifts, and nothing here noticed. SchemaFit
+// measures the drift; ReschemaScan acts on it.
+
+// SchemaFieldFit reports how well one schema field still fits the data, measured against a fresh
+// sample rather than the one the schema was built from.
+//
+// A field escapes when its value is not in the fixed slot -- either the attribute is absent
+// (Missing) or it is present but unstorable in the slot: a different kind, or an int too wide for
+// the width chosen (Escaped - Missing). Escapes are what the schema exists to avoid: a queried
+// column that escapes forces the block's cold-stream decompression and a cold-tail walk, which is
+// the slow path the accelerator was meant to skip.
+//
+// Rates are fractions of Sampled (see SchemaFit), in [0,1].
+type SchemaFieldFit struct {
+	Name string `json:"name"`
+	Kind string `json:"kind"`
+	// Width is the fixed slot's size in bytes (0 for a bit-packed bool).
+	Width int  `json:"width,omitempty"`
+	Hot   bool `json:"hot,omitempty"`
+	// Escaped is the fraction of sampled records whose value was not in the fixed slot, for
+	// any reason. This is the number that matters for speed.
+	Escaped float64 `json:"escaped"`
+	// Missing is the fraction absent from the record entirely -- an escape that no width or
+	// kind change would fix. Escaped-Missing is the part a re-schema could recover.
+	Missing float64 `json:"missing"`
+}
+
+// SchemaFit measures the current schema against a fresh sample of up to sampleMax records,
+// reporting per-field escape rates and the number of records actually sampled.
+//
+// It reads samples and re-runs the encoder's storability test on each; it encodes nothing and
+// writes nothing. Returns nil when the accelerator is not enabled (there is no schema to judge)
+// or there is nothing to sample.
+func (c *Collection) SchemaFit(sampleMax int) ([]SchemaFieldFit, int) {
+	st := c.schemaScan.Load()
+	if st == nil {
+		return nil, 0
+	}
+	samples := c.CollectSamples(sampleMax)
+	if c.inline {
+		interned := make([][]byte, 0, len(samples))
+		for _, w := range samples {
+			if iw, ok := c.recordToInterned(nil, w); ok {
+				interned = append(interned, iw)
+			}
+		}
+		samples = interned
+	}
+	if len(samples) == 0 {
+		return nil, 0
+	}
+	s := st.schema
+	hot := make(map[int]bool, len(st.hot))
+	for _, idx := range st.hot {
+		hot[idx] = true
+	}
+	missing := make([]int, len(s.fields))
+	escaped := make([]int, len(s.fields))
+	present := make([]bool, len(s.fields)) // reused per record
+	stored := make([]bool, len(s.fields))  // reused per record
+	for _, w := range samples {
+		for i := range present {
+			present[i] = false
+			stored[i] = false
+		}
+		wire.Ad(w).ForEach(func(id uint32, node []byte) bool {
+			idx, ok := s.byID[id]
+			if !ok {
+				return true // not a schema field: lives in the cold tail either way
+			}
+			present[idx] = true
+			// The same test adSchema.encode applies when deciding the fixed slot.
+			f := &s.fields[idx]
+			k, lit := nodeKind(node)
+			if k == f.kind && (f.kind != akInt || intFits(lit.Int, f.width, f.unsigned)) {
+				stored[idx] = true
+			}
+			return true
+		})
+		for i := range s.fields {
+			if !present[i] {
+				missing[i]++
+			}
+			if !stored[i] {
+				escaped[i]++
+			}
+		}
+	}
+	n := float64(len(samples))
+	out := make([]SchemaFieldFit, 0, len(s.fields))
+	for i, f := range s.fields {
+		name, ok := c.schemaFieldName(f.id)
+		if !ok {
+			name = "?"
+		}
+		out = append(out, SchemaFieldFit{
+			Name:    name,
+			Kind:    f.kind.String(),
+			Width:   f.width,
+			Hot:     hot[i],
+			Escaped: float64(escaped[i]) / n,
+			Missing: float64(missing[i]) / n,
+		})
+	}
+	return out, len(samples)
+}
+
+// ReschemaScan derives a NEW schema from a fresh sample and rebuilds every sealed segment's
+// columnar block against it, replacing the schema that BuildAndEnableSchemaScan pinned at first
+// enable. This is the deliberate, heavy operation that routine maintenance refuses to do: it
+// re-encodes and re-persists a block per sealed segment, so its cost scales with the whole
+// table, not with what changed.
+//
+// Use it when SchemaFit shows the schema no longer matching the data -- escapes climbing on a
+// queried column, or a field that has become common since. Returns false if the accelerator
+// cannot run here (encryption at rest) or there was nothing to sample, leaving the existing
+// schema in place.
+//
+// Existing blocks are dropped first: EnableSchemaScan builds only where a segment has none, so
+// without that it would keep every old block and the new schema would match none of them.
+// Queries during the rebuild take the row path, which is correct but slower.
+func (c *Collection) ReschemaScan(sampleMax, hotTopN int) bool {
+	if c.sealer != nil {
+		return false // see EnableSchemaScan: incompatible with encryption at rest
+	}
+	s, hot, ok := c.deriveSchema(sampleMax, hotTopN)
+	if !ok {
+		return false
+	}
+	// Stand down before dropping blocks, so a concurrent query sees "no accelerator" (row
+	// path) rather than a live schema with no blocks behind it.
+	c.schemaScan.Store(nil)
+	for _, sh := range c.shards {
+		sh.mu.RLock()
+		act := sh.act
+		segs := make([]*segment, 0, len(sh.segs))
+		for _, seg := range sh.segs {
+			if seg != nil && seg != act && seg.used > 0 {
+				segs = append(segs, seg)
+			}
+		}
+		sh.mu.RUnlock()
+		for _, seg := range segs {
+			// A scan that already loaded the old block keeps reading it safely; only new
+			// lookups see nil and fall back until the rebuild republishes.
+			seg.colblk.Store(nil)
+		}
+	}
+	c.EnableSchemaScan(s, hot)
+	return true
+}

--- a/collections/schemafit_test.go
+++ b/collections/schemafit_test.go
@@ -1,0 +1,217 @@
+package collections
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/collections/vm"
+)
+
+// fitStore seeds a store whose ads all fit a narrow schema, drives read demand on Memory so it
+// lands in the hot tier, and enables the accelerator.
+func fitStore(t *testing.T) *Collection {
+	t.Helper()
+	c := New(Options{Shards: 1, SegmentSize: 1 << 12})
+	for i := 0; i < 2000; i++ {
+		if err := c.Put([]byte(fmt.Sprintf("k%d", i)), mustAdOld(t, fmt.Sprintf(
+			"Cpus=%d\nMemory=%d\nJobStatus=%d", 1+i%8, 1024+(i%64)*256, 1+i%5))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mc, _ := vm.Parse("Memory >= 0")
+	for i := 0; i < 30; i++ {
+		for range c.Query(mc) {
+		}
+	}
+	if !c.BuildAndEnableSchemaScan(2000, 4) {
+		t.Fatal("BuildAndEnableSchemaScan false")
+	}
+	return c
+}
+
+// fitOf measures fit and indexes it by attribute name, dropping the sample count.
+func fitOf(c *Collection, sampleMax int) map[string]SchemaFieldFit {
+	fit, _ := c.SchemaFit(sampleMax)
+	return fitByName(fit)
+}
+
+// fitByName indexes a fit report by attribute name.
+func fitByName(fit []SchemaFieldFit) map[string]SchemaFieldFit {
+	m := map[string]SchemaFieldFit{}
+	for _, f := range fit {
+		m[f.Name] = f
+	}
+	return m
+}
+
+// TestSchemaFitOnMatchingData is the baseline: over the data the schema was built from, nothing
+// should escape. If this drifts, the numbers below mean nothing.
+func TestSchemaFitOnMatchingData(t *testing.T) {
+	c := fitStore(t)
+	defer c.Close()
+
+	fit, sampled := c.SchemaFit(2000)
+	if len(fit) == 0 || sampled == 0 {
+		t.Fatalf("no fit reported (fields=%d sampled=%d)", len(fit), sampled)
+	}
+	for _, f := range fitByName(fit) {
+		if f.Escaped != 0 || f.Missing != 0 {
+			t.Errorf("%s escapes on the data its schema was built from: escaped=%.3f missing=%.3f",
+				f.Name, f.Escaped, f.Missing)
+		}
+	}
+}
+
+// TestSchemaFitDetectsDrift is the point of the measurement. The schema pins Memory to the
+// narrowest int width covering the sampled values; write values far outside that and they can no
+// longer live in the fixed slot. The accelerator stays "enabled" and the coverage counts stay
+// full, so this rate is the only thing that shows it.
+func TestSchemaFitDetectsDrift(t *testing.T) {
+	c := fitStore(t)
+	defer c.Close()
+
+	before := fitOf(c, 2000)
+	if m, ok := before["Memory"]; !ok || m.Escaped != 0 {
+		t.Fatalf("Memory should start fitting: %+v", m)
+	}
+
+	// Half the table gains a Memory far beyond the chosen width, and a brand-new attribute the
+	// schema has never seen.
+	for i := 0; i < 2000; i += 2 {
+		if err := c.Put([]byte(fmt.Sprintf("k%d", i)), mustAdOld(t, fmt.Sprintf(
+			"Cpus=%d\nMemory=%d\nJobStatus=%d\nGPUs=%d",
+			1+i%8, int64(1)<<50+int64(i), 1+i%5, i%4))); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	after := fitOf(c, 4000)
+	m, ok := after["Memory"]
+	if !ok {
+		t.Fatal("Memory vanished from the schema")
+	}
+	if m.Escaped == 0 {
+		t.Errorf("Memory escape rate still 0 after half the values outgrew the slot: %+v", m)
+	}
+	if m.Missing != 0 {
+		t.Errorf("Memory is present in every record; missing should be 0, got %.3f", m.Missing)
+	}
+	// The counts an operator would otherwise rely on are unmoved -- which is why the rate exists.
+	if info := c.SchemaScanInfo(); !info.Enabled {
+		t.Error("accelerator reports disabled; the drift should not disable it")
+	}
+}
+
+// TestSchemaFitMissingIsDistinct separates the two escape causes: an absent attribute is an
+// escape no width could fix, so it must not read as a bad width choice.
+func TestSchemaFitMissingIsDistinct(t *testing.T) {
+	c := fitStore(t)
+	defer c.Close()
+
+	// Rewrite a quarter of the records without JobStatus at all.
+	for i := 0; i < 2000; i += 4 {
+		if err := c.Put([]byte(fmt.Sprintf("k%d", i)), mustAdOld(t, fmt.Sprintf(
+			"Cpus=%d\nMemory=%d", 1+i%8, 1024+(i%64)*256))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	fit := fitOf(c, 4000)
+	js, ok := fit["JobStatus"]
+	if !ok {
+		t.Fatal("JobStatus vanished from the schema")
+	}
+	if js.Missing == 0 {
+		t.Errorf("JobStatus is absent from a quarter of records; missing should be > 0: %+v", js)
+	}
+	if js.Escaped < js.Missing {
+		t.Errorf("escaped (%.3f) must include missing (%.3f)", js.Escaped, js.Missing)
+	}
+}
+
+// TestReschemaScanRecovers is the fix for the drift: a rebuild re-derives the schema from the
+// data as it now is, so the field that had outgrown its slot fits again.
+func TestReschemaScanRecovers(t *testing.T) {
+	c := fitStore(t)
+	defer c.Close()
+
+	for i := 0; i < 2000; i += 2 {
+		if err := c.Put([]byte(fmt.Sprintf("k%d", i)), mustAdOld(t, fmt.Sprintf(
+			"Cpus=%d\nMemory=%d\nJobStatus=%d", 1+i%8, int64(1)<<50+int64(i), 1+i%5))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mc, _ := vm.Parse("Memory >= 0")
+	for i := 0; i < 30; i++ {
+		for range c.Query(mc) { // keep Memory hot across the rebuild
+		}
+	}
+	if drifted := fitOf(c, 4000)["Memory"]; drifted.Escaped == 0 {
+		t.Fatal("expected Memory to be escaping before the rebuild")
+	}
+
+	if !c.ReschemaScan(2000, 4) {
+		t.Fatal("ReschemaScan returned false")
+	}
+	info := c.SchemaScanInfo()
+	if !info.Enabled {
+		t.Fatal("accelerator disabled after a rebuild")
+	}
+	if info.SealedSegments > 0 && info.CoveredSegments != info.SealedSegments {
+		t.Errorf("coverage %d/%d after a rebuild: every sealed segment should carry a new block",
+			info.CoveredSegments, info.SealedSegments)
+	}
+	after := fitOf(c, 4000)["Memory"]
+	if after.Escaped > 0.02 {
+		t.Errorf("Memory still escaping %.3f after the rebuild; the new schema should fit it",
+			after.Escaped)
+	}
+	if after.Width <= 4 {
+		t.Errorf("Memory width = %d after values needing 2^50; the rebuild should have widened it",
+			after.Width)
+	}
+}
+
+// TestReschemaScanKeepsCountsCorrect is the correctness guard: the rebuild rewrites every
+// segment's block, so a COUNT that routes through the accelerator must still agree with the
+// truth afterwards.
+func TestReschemaScanKeepsCountsCorrect(t *testing.T) {
+	c := fitStore(t)
+	defer c.Close()
+
+	exprs := []string{"Memory >= 4096", "Cpus == 3", "JobStatus == 2", "Memory < 2048 && Cpus > 4"}
+	truth := func(e string) int {
+		q, err := vm.Parse(e)
+		if err != nil {
+			t.Fatal(err)
+		}
+		n := 0
+		for range c.Query(q) {
+			n++
+		}
+		return n
+	}
+	want := map[string]int{}
+	for _, e := range exprs {
+		want[e] = truth(e)
+	}
+	if !c.ReschemaScan(2000, 4) {
+		t.Fatal("ReschemaScan returned false")
+	}
+	for _, e := range exprs {
+		if got, ok := c.CountConstraint(e); ok && got != want[e] {
+			t.Errorf("%s: count %d after rebuild, want %d", e, got, want[e])
+		}
+		if got := truth(e); got != want[e] {
+			t.Errorf("%s: scan %d after rebuild, want %d", e, got, want[e])
+		}
+	}
+}
+
+// TestSchemaFitDisabled reports nothing rather than inventing zeroes when there is no schema.
+func TestSchemaFitDisabled(t *testing.T) {
+	c := New(Options{Shards: 1})
+	defer c.Close()
+	if fit, sampled := c.SchemaFit(100); fit != nil || sampled != 0 {
+		t.Errorf("fit on a store with no accelerator = %v/%d, want nil/0", fit, sampled)
+	}
+}

--- a/db/db.go
+++ b/db/db.go
@@ -356,6 +356,8 @@ type (
 	Retention       = collections.Retention
 	CodecStats      = collections.CodecStats
 	SchemaScanInfo  = collections.SchemaScanInfo
+	SchemaScanField = collections.SchemaScanField
+	SchemaFieldFit  = collections.SchemaFieldFit
 	QueryExplain    = collections.QueryExplain
 	ProbeExplain    = collections.ProbeExplain
 	MatchExplain    = collections.MatchExplain
@@ -409,6 +411,19 @@ func (db *DB) HotAttrs() []string { return db.c.HotAttrNames() }
 // SchemaScanInfo reports the columnar (adschema) accelerator's state: whether it is enabled (so a
 // numeric COUNT(*) WHERE routes to the columnar fast path), its hot columns, and segment coverage.
 func (db *DB) SchemaScanInfo() SchemaScanInfo { return db.c.SchemaScanInfo() }
+
+// SchemaFit measures the current derived schema against a fresh sample, reporting each field's
+// escape rate -- how often its value is not in the fixed slot, and how much of that is the
+// attribute simply being absent. This is how you tell whether the schema still matches the data
+// (see collections.Collection.SchemaFit). Returns nil when the accelerator is not enabled.
+func (db *DB) SchemaFit(sampleMax int) ([]SchemaFieldFit, int) { return db.c.SchemaFit(sampleMax) }
+
+// ReschemaScan derives a new schema from a fresh sample and rebuilds every sealed segment's
+// columnar block against it, replacing the one pinned at first enable. Heavy -- a block per
+// sealed segment is re-encoded and re-persisted -- and never done by routine maintenance, which
+// deliberately keeps the schema stable. Returns false if there was nothing to sample or the
+// accelerator cannot run here.
+func (db *DB) ReschemaScan(sampleMax, hotTopN int) bool { return db.c.ReschemaScan(sampleMax, hotTopN) }
 
 // IndexedAttrs returns the currently-indexed attribute names, split into
 // categorical (string equality/membership) and value (numeric + range) indexes.

--- a/dbrpc/diag.go
+++ b/dbrpc/diag.go
@@ -57,6 +57,10 @@ type Diagnostics struct {
 // diagSampleMax bounds the ad sample the server takes for index suggestions.
 const diagSampleMax = 2000
 
+// defaultSchemaHotTopN is the hot-column count schema.rebuild uses when the server carries no
+// configured HotTopN, matching the size a default maintenance pass would choose.
+const defaultSchemaHotTopN = 32
+
 // defaultAnalyzeHotTopN is the hot-set size an on-demand "analyze" uses when the server was
 // started without a maintenance hot-set target (HotTopN == 0), so analyze still refreshes the
 // hot set from read demand.
@@ -116,6 +120,8 @@ func (s *Server) archiveDiagJSON(a *db.ArchiveTable) ([]byte, error) {
 //	                                  stale segment sidecars in place, no data rewrite)
 //	hot.add <attr>...                 pin attributes into the hot set
 //	hot.refresh <sampleMax> <topN>    recompute the hot set from sampled frequency
+//	schema.fit [sampleMax]            report how well the derived schema still fits the data
+//	schema.rebuild [sampleMax topN]   re-derive the schema and rebuild every columnar block
 //	compact                           reclaim dead space in warranted shards
 //	rewrite                           re-encode all ads with the current hot set
 //	codec.retrain [sampleMax]         train/refresh the ZSTD dictionary + recompress
@@ -235,6 +241,58 @@ func (s *Server) admin(t *db.DB, action string, args []string, privileged bool) 
 		}
 		n := t.RefreshHotSet(sampleMax, topN)
 		return fmt.Sprintf("refreshed hot set: %d attribute(s)", n), nil
+	case "schema.fit":
+		// Report, do not change: how well the derived schema still matches the data. The
+		// operator's input to deciding whether schema.rebuild is worth its cost.
+		sampleMax := diagSampleMax
+		if len(args) == 1 {
+			n, err := strconv.Atoi(args[0])
+			if err != nil {
+				return "", fmt.Errorf("schema.fit <sampleMax> must be an integer")
+			}
+			sampleMax = n
+		} else if len(args) > 1 {
+			return "", fmt.Errorf("schema.fit takes at most <sampleMax>")
+		}
+		fit, sampled := t.SchemaFit(sampleMax)
+		if len(fit) == 0 {
+			return "columnar accelerator not enabled: no schema to measure", nil
+		}
+		b, err := json.Marshal(struct {
+			Sampled int                 `json:"sampled"`
+			Fields  []db.SchemaFieldFit `json:"fields"`
+		}{sampled, fit})
+		if err != nil {
+			return "", err
+		}
+		return string(b), nil
+	case "schema.rebuild":
+		// The deliberate re-schema: routine maintenance keeps the schema pinned forever, so
+		// this is the only way to re-derive it as the workload drifts. Rebuilds a columnar
+		// block per sealed segment.
+		sampleMax, topN := diagSampleMax, s.maintainOpts.HotTopN
+		if topN <= 0 {
+			topN = defaultSchemaHotTopN
+		}
+		switch len(args) {
+		case 0:
+		case 2:
+			n, e1 := strconv.Atoi(args[0])
+			k, e2 := strconv.Atoi(args[1])
+			if e1 != nil || e2 != nil {
+				return "", fmt.Errorf("schema.rebuild arguments must be integers")
+			}
+			sampleMax, topN = n, k
+		default:
+			return "", fmt.Errorf("schema.rebuild takes no arguments or <sampleMax> <topN>")
+		}
+		if !t.ReschemaScan(sampleMax, topN) {
+			return "", fmt.Errorf("schema rebuild did not run: nothing to sample, or the " +
+				"accelerator is unavailable here (encryption at rest)")
+		}
+		info := t.SchemaScanInfo()
+		return fmt.Sprintf("schema rebuilt: %d field(s), %d hot, %d/%d sealed segments covered",
+			info.SchemaFields, len(info.HotFields), info.CoveredSegments, info.SealedSegments), nil
 	case "analyze":
 		// On-demand self-tuning pass ("optimize now"), the manual counterpart to the scheduled
 		// StartMaintenance. Reuses the server's configured maintenance options so it matches the

--- a/dbrpc/schemadiag_test.go
+++ b/dbrpc/schemadiag_test.go
@@ -1,0 +1,70 @@
+package dbrpc
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/db"
+)
+
+// TestDiagnosticsCarriesDerivedSchema pins the wire contract the `.schema` command depends on:
+// the derived per-segment schema has to reach the client, not just the summary counts. It is
+// carried by the existing diagnostics op (SchemaScanInfo is a type alias all the way down), so
+// this is the test that would fail if that ever stopped being true.
+func TestDiagnosticsCarriesDerivedSchema(t *testing.T) {
+	d, err := db.Open(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := NewServer(d)
+	cconn, sconn := netPipe()
+	go func() { _ = s.ServeConnOpts(sconn, ServeOptions{Privileged: true}) }()
+	c := NewClient(cconn)
+	defer func() { c.Close(); s.Close(); d.Close() }()
+
+	ctx := context.Background()
+	tx, err := c.Begin(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 500; i++ {
+		if err := tx.NewClassAd(ctx, fmt.Sprintf("k%d", i), fmt.Sprintf(
+			"Cpus = %d\nMemory = %d\nOwner = \"u%d\"", 1+i%8, 1024+(i%16)*256, i%5)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatal(err)
+	}
+	// Build the accelerator; without it there is no schema to report and the assertion below
+	// would pass vacuously.
+	if !d.EnableSchemaScan(2000, 4) {
+		t.Skip("no sealed segments to sample in this fixture")
+	}
+
+	diag, err := c.Diagnostics(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ss := diag.SchemaScan
+	if !ss.Enabled {
+		t.Fatal("schema scan reported disabled after EnableSchemaScan")
+	}
+	if len(ss.Schema) == 0 {
+		t.Fatal("diagnostics carried no derived schema; `.schema` has nothing to print")
+	}
+	if len(ss.Schema) != ss.SchemaFields {
+		t.Errorf("Schema has %d fields, SchemaFields says %d", len(ss.Schema), ss.SchemaFields)
+	}
+	for _, f := range ss.Schema {
+		if f.Name == "" {
+			t.Errorf("field with no name: %+v", f)
+		}
+		switch f.Kind {
+		case "bool", "int", "real", "string":
+		default:
+			t.Errorf("%s: unexpected kind %q", f.Name, f.Kind)
+		}
+	}
+}


### PR DESCRIPTION
Answers "show me the derived schema" — and the follow-on "how do I force a recalculation?", which turned out to have no answer at all.

### The situation

The columnar accelerator's schema is **recovered by sampling**, once, at first enable, and then deliberately pinned: every segment's block is built against a particular schema, so swapping the current one mid-flight would leave earlier blocks unmatched and silently demote them to the brute-scan fallback. `BuildAndEnableSchemaScan` short-circuits when already enabled for exactly that reason.

That stability is right for a maintenance pass and wrong forever. A workload drifts and nothing noticed, because nothing could **see** the schema, **judge** it, or **replace** it — `EnableSchemaScan` takes an unexported `*adSchema` so it isn't callable from outside, there's no reset, and a restart re-adopts the persisted schema.

### Three parts

**1. See it.** `SchemaScanInfo.Schema` reports each field's recovered name, kind, slot width, unsigned flag and hot flag. The diagnostics already said the accelerator was on, how many segments it covered and how many fields it had — everything except what it decided the ads look like. Rides the existing diagnostics op (`SchemaScanInfo` is a type alias `collections` → `db` → `dbrpc`), so **no protocol change**; a dbrpc test pins that it actually reaches the client.

**2. Judge it.** `SchemaFit(sampleMax)` measures the schema against a *fresh* sample: per field, how often the value isn't in the fixed slot, split into

- `Missing` — absent from the record; no width or kind change would fix it
- `Escaped − Missing` — present but unstorable (wrong kind, or an int too wide), which a re-schema *would* recover

This is the only signal that shows drift. `TestSchemaFitDetectsDrift` makes the point by asserting the opposite side too: after half the `Memory` values outgrow their slot, `Enabled` and the coverage counts are **completely unmoved**.

**3. Rebuild it.** `ReschemaScan(sampleMax, hotTopN)` re-derives the schema and rebuilds every sealed segment's block against it. It drops the existing blocks first (`EnableSchemaScan` only builds where a segment has none, so otherwise every old block would survive and the new schema would match none of them), and stands the accelerator down before doing so, so a concurrent query takes the row path rather than seeing a live schema with no blocks behind it.

Driven by two admin actions rather than maintenance, since the cost scales with the whole table:

```
schema.fit [sampleMax]            report how well the derived schema still fits the data
schema.rebuild [sampleMax topN]   re-derive the schema and rebuild every columnar block
```

### Testing

`TestReschemaScanRecovers` walks the whole arc — fits, drifts, rebuilds, fits again, and the width actually widened. `TestReschemaScanKeepsCountsCorrect` is the correctness guard: the rebuild rewrites every block, so accelerated `COUNT`s must still agree with a plain scan afterwards. Plus the baseline (nothing escapes on the data the schema came from), missing-vs-unstorable separation, and the disabled case.

`collections`, `db`, `dbrpc` all green.

The `.schema` / `.analyze`-style repl surface for this goes in htcondordb once this is tagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
