### PR TITLE
dbrpc: explain a query on an archive table

### DIFF
--- a/collections/archive.go
+++ b/collections/archive.go
@@ -278,6 +278,16 @@ func (a *Archive) Watch(ctx context.Context, cursor []byte) (iter.Seq[WatchEvent
 	return a.c.Watch(ctx, cursor)
 }
 
+// ExplainQuery reports how the archive would execute q -- which conjuncts are index-usable
+// and the resulting access path -- as Collection.ExplainQuery does for a mutable table.
+//
+// Two archive-specific notes on reading the result. An archive's scan is newest-first over
+// sealed segments, and whole segments are additionally skipped by zone map (see ZoneAttrs),
+// which the plan string does not name: a "serial-scan" over an archive may still visit far
+// fewer records than TotalAds. And TotalAds counts everything retained, so probe selectivity
+// is against the whole history rather than a working set.
+func (a *Archive) ExplainQuery(q *vm.Query) QueryExplain { return a.c.ExplainQuery(q) }
+
 // SidecarSizes reports the archive's sealed-segment sidecar index bytes (mmap-backed,
 // evictable page cache), broken out by structure. An operator diagnostic.
 func (a *Archive) SidecarSizes() SidecarSizes { return a.c.SidecarSizes() }

--- a/db/archive.go
+++ b/db/archive.go
@@ -413,6 +413,17 @@ type AutoTuneResult = collections.AutoTuneResult
 // An append-only table never compacts, so its segment count only grows, and every sealed
 // segment costs a memory mapping at open. This is what bounds that; without it running, the
 // count climbs until the daemon cannot start.
+// Explain reports how a query against the archive would be executed (see
+// collections.Archive.ExplainQuery), so `.explain` works on a history table rather than
+// reporting it as a nonexistent table.
+func (t *ArchiveTable) Explain(constraint string) (QueryExplain, error) {
+	q, err := vm.Parse(constraint)
+	if err != nil {
+		return QueryExplain{}, fmt.Errorf("archive: parsing constraint: %w", err)
+	}
+	return t.a.ExplainQuery(q), nil
+}
+
 func (t *ArchiveTable) MergePass(opts MergeOptions) int { return t.a.MergePass(opts) }
 
 // Count is the number of records currently retained (reduced by rotation).

--- a/dbrpc/archiveexplain_test.go
+++ b/dbrpc/archiveexplain_test.go
@@ -1,0 +1,64 @@
+package dbrpc
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/db"
+)
+
+// TestExplainArchiveTable is the regression for `.explain` on a history table reporting
+// "no such table" while queries against that same table worked: the handler resolved only
+// the mutable catalog. An archive is a different table type, not an absent one.
+func TestExplainArchiveTable(t *testing.T) {
+	c, cleanup := catServerPair(t, ServeOptions{Privileged: true})
+	defer cleanup()
+	ctx := context.Background()
+
+	if err := c.CreateArchiveTable(ctx, "history", db.ArchiveConfig{ValueAttrs: []string{"ProcId"}}); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 50; i++ {
+		if err := c.ArchiveAppend(ctx, "history", fmt.Sprintf(
+			"ClusterId = %d\nProcId = %d\nOwner = \"u%d\"", i, i%16, i%4)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// The plain case the user hits: explain a match-all over the archive.
+	ex, err := c.ExplainTable(ctx, "history", "true")
+	if err != nil {
+		t.Fatalf("explain on an archive: %v", err)
+	}
+	if ex.Plan == "" {
+		t.Errorf("explain returned no plan: %+v", ex)
+	}
+	if ex.TotalAds != 50 {
+		t.Errorf("TotalAds = %d, want 50", ex.TotalAds)
+	}
+
+	// A constraint over a value-indexed attribute should be reported as index-usable, which
+	// is the whole reason to run explain on a history table.
+	ex, err = c.ExplainTable(ctx, "history", "ProcId == 3")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ex.Probes) == 0 {
+		t.Errorf("no probes reported for an indexed attribute: %+v", ex)
+	}
+
+	// A malformed constraint is an error about the constraint, not about the table.
+	if _, err := c.ExplainTable(ctx, "history", "ProcId =="); err == nil {
+		t.Error("expected an error for a malformed constraint")
+	} else if strings.Contains(err.Error(), "no such table") {
+		t.Errorf("malformed constraint reported as a missing table: %v", err)
+	}
+
+	// A genuinely absent table still says so.
+	if _, err := c.ExplainTable(ctx, "nope", "true"); err == nil ||
+		!strings.Contains(err.Error(), "no such table") {
+		t.Errorf("err = %v, want a no-such-table error", err)
+	}
+}

--- a/dbrpc/server.go
+++ b/dbrpc/server.go
@@ -1209,11 +1209,21 @@ func (s *Server) handle(sc *serverConn, reqID uint64, o op, r *reader, includePr
 		if r.err != nil {
 			return respBad(reqID)
 		}
-		d, ok := s.cat.Table(table)
-		if !ok {
-			return respErr(reqID, "no such table: "+table)
+		// An archive (history) table is not a mutable table, so resolving only the mutable
+		// catalog reported `.explain` on a history table as a nonexistent table -- while
+		// queries against it worked. Both types can explain.
+		var ex db.QueryExplain
+		var err error
+		switch d, ok := s.cat.Table(table); {
+		case ok:
+			ex, err = d.Explain(constraint)
+		default:
+			a, aok := s.cat.ArchiveTable(table)
+			if !aok {
+				return respErr(reqID, "no such table: "+table)
+			}
+			ex, err = a.Explain(constraint)
 		}
-		ex, err := d.Explain(constraint)
 		if err != nil {
 			return respErr(reqID, err.Error())
 		}


### PR DESCRIPTION
`.explain` on a history table reported the table as absent, while queries against that same table worked:

```
htcondordb> .explain true
error: dbrpc: no such table: history
htcondordb> select max(ProcId) from history
MAX(ProcId)
-----------
15974
(1 row in 5.004s)
```

The handler resolved only `s.cat.Table(table)` — the mutable catalog — so a *different table type* read as a missing one. `ArchiveTable` had no `Explain` at all, but an `Archive` wraps a `Collection`, so the planner it needs was already there; this is delegation plus the missing fallback.

Two archive-specific caveats are documented on the new method, because the shared `QueryExplain` shape can't express them:

- An archive scan is newest-first with **whole-segment zone-map pruning** that the plan string doesn't name, so `serial-scan` over an archive may visit far fewer records than `TotalAds` suggests.
- `TotalAds` counts all retained history rather than a working set, so probe selectivity reads against the whole archive.

Test covers match-all, a probe on a value-indexed attribute, a malformed constraint (must complain about the constraint, not the table), and a genuinely absent table still saying so.

`collections`, `db`, `dbrpc` green. Unrelated note: `collections`' `TestPersistentMultiRetrainReopen` failed once during a full run here and passed on two clean re-runs — it also fails on bare `main`, so it's a pre-existing flake, but worth chasing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
