### PR TITLE
Let an archive carry the columnar accelerator

### DIFF
--- a/collections/archive.go
+++ b/collections/archive.go
@@ -288,6 +288,22 @@ func (a *Archive) Watch(ctx context.Context, cursor []byte) (iter.Seq[WatchEvent
 // is against the whole history rather than a working set.
 func (a *Archive) ExplainQuery(q *vm.Query) QueryExplain { return a.c.ExplainQuery(q) }
 
+// BuildAndEnableSchemaScan builds (or extends coverage of) the per-segment columnar
+// accelerator over the archive's sealed segments, as Collection.BuildAndEnableSchemaScan does
+// for a mutable table. An archive is the natural target for it -- the segments are immutable
+// once sealed, so a block never needs invalidating -- and the payoff is large: a numeric
+// COUNT over 50k history records drops from ~50ms of row scan to ~1ms.
+//
+// The first call reads every sealed record once to sample and to build a block per segment,
+// which over a long history is the same "paid for by reading history back" cost an archive
+// index backfill has. Later calls only cover segments sealed since.
+func (a *Archive) BuildAndEnableSchemaScan(sampleMax, hotTopN int) bool {
+	return a.c.BuildAndEnableSchemaScan(sampleMax, hotTopN)
+}
+
+// SchemaScanInfo reports the columnar accelerator's state for the archive.
+func (a *Archive) SchemaScanInfo() SchemaScanInfo { return a.c.SchemaScanInfo() }
+
 // SidecarSizes reports the archive's sealed-segment sidecar index bytes (mmap-backed,
 // evictable page cache), broken out by structure. An operator diagnostic.
 func (a *Archive) SidecarSizes() SidecarSizes { return a.c.SidecarSizes() }

--- a/collections/archive_columnar_bench_test.go
+++ b/collections/archive_columnar_bench_test.go
@@ -1,0 +1,141 @@
+package collections
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/classad"
+	"github.com/PelicanPlatform/classad/collections/vm"
+)
+
+// Does the columnar accelerator earn its keep on an ARCHIVE?
+//
+// Maintenance builds it for mutable tables only (DB.Maintain, gated on SchemaScanHotTopN);
+// maintainArchives does merge/reindex/index-autotune and never touches it. So a history table
+// scans row-wise today. These benchmarks measure the same archive with and without it before
+// anything is wired up: an archive is the big append-only scan target, so the answer decides
+// whether it is worth the sampling and the block-per-segment rebuild on merge.
+
+// archiveBenchAds seeds n history-shaped ads.
+func archiveBenchAds(tb testing.TB, a *Archive, n int) {
+	tb.Helper()
+	for i := 0; i < n; i++ {
+		ad, err := classad.ParseOld(fmt.Sprintf(
+			"ClusterId = %d\nProcId = %d\nOwner = \"u%d\"\nJobStatus = %d\n"+
+				"RequestMemory = %d\nRequestCpus = %d\nCompletionDate = %d\n"+
+				"RemoteWallClockTime = %d.5\nExitCode = %d\nCmd = \"/home/u%d/run.sh\"",
+			i/10, i%10, i%64, 3+i%2, ((i%16)+1)*512, 1+i%8, 1700000000+i, i%3600, i%2, i%64))
+		if err != nil {
+			tb.Fatal(err)
+		}
+		if err := a.Append(ad); err != nil {
+			tb.Fatal(err)
+		}
+	}
+}
+
+// benchArchive builds an archive of n ads, optionally enabling the columnar accelerator over
+// its backing collection (which is what a maintainArchives change would do).
+func benchArchive(tb testing.TB, n int, columnar bool) *Archive {
+	tb.Helper()
+	a, err := CreateArchive(ArchiveOptions{Dir: tb.TempDir(), SegmentSize: 1 << 20})
+	if err != nil {
+		tb.Fatal(err)
+	}
+	archiveBenchAds(tb, a, n)
+	if columnar {
+		// Drive demand on the attributes the queries below read, so they land in the hot tier
+		// exactly as a maintenance pass would arrange.
+		for _, e := range []string{"RequestMemory >= 0", "RequestCpus >= 0", "ExitCode >= 0"} {
+			q, err := vm.Parse(e)
+			if err != nil {
+				tb.Fatal(err)
+			}
+			for i := 0; i < 20; i++ {
+				for range a.c.Query(q) {
+				}
+			}
+		}
+		if !a.c.BuildAndEnableSchemaScan(4000, 8) {
+			tb.Fatal("BuildAndEnableSchemaScan returned false on an archive")
+		}
+	}
+	return a
+}
+
+// archiveCountQueries are history-shaped numeric counts -- the shape the columnar path serves.
+var archiveCountQueries = []struct{ name, expr string }{
+	{"memory_range", "RequestMemory >= 4096"},
+	{"cpus_eq", "RequestCpus == 4"},
+	{"exit_nonzero", "ExitCode != 0"},
+	// A same-field range. The columnar fast path serves single-int-field comparisons only, so a
+	// two-field conjunction is outside its scope by design, not because this is an archive.
+	{"memory_band", "RequestMemory >= 2048 && RequestMemory < 8192"},
+}
+
+const archiveBenchN = 50000
+
+// BenchmarkArchiveCount measures COUNT-style queries over an archive with the accelerator off
+// (today's behaviour) and on.
+func BenchmarkArchiveCount(b *testing.B) {
+	for _, columnar := range []bool{false, true} {
+		mode := "row"
+		if columnar {
+			mode = "columnar"
+		}
+		a := benchArchive(b, archiveBenchN, columnar)
+		for _, q := range archiveCountQueries {
+			b.Run(q.name+"/"+mode, func(b *testing.B) {
+				parsed, err := vm.Parse(q.expr)
+				if err != nil {
+					b.Fatal(err)
+				}
+				b.ReportAllocs()
+				for i := 0; i < b.N; i++ {
+					if columnar {
+						if n, ok := a.c.CountQuery(parsed); ok {
+							if n < 0 {
+								b.Fatal("negative")
+							}
+							continue
+						}
+						b.Fatal("columnar count declined; the accelerator is not serving this query")
+					}
+					n := 0
+					for range a.c.Query(parsed) {
+						n++
+					}
+					if n < 0 {
+						b.Fatal("negative")
+					}
+				}
+			})
+		}
+		_ = a.Close()
+	}
+}
+
+// BenchmarkArchiveCountAgreement is not a benchmark of speed but a guard on the above: a
+// columnar count that disagrees with the row scan would make the timings meaningless.
+func BenchmarkArchiveCountAgreement(b *testing.B) {
+	a := benchArchive(b, 5000, true)
+	defer a.Close()
+	for _, q := range archiveCountQueries {
+		parsed, err := vm.Parse(q.expr)
+		if err != nil {
+			b.Fatal(err)
+		}
+		want := 0
+		for range a.c.Query(parsed) {
+			want++
+		}
+		got, ok := a.c.CountQuery(parsed)
+		if !ok {
+			b.Fatalf("%s: columnar count declined", q.name)
+		}
+		if got != want {
+			b.Fatalf("%s: columnar %d != row %d", q.name, got, want)
+		}
+	}
+	b.Logf("all %d queries agree between the columnar and row paths", len(archiveCountQueries))
+}

--- a/db/archive.go
+++ b/db/archive.go
@@ -424,6 +424,15 @@ func (t *ArchiveTable) Explain(constraint string) (QueryExplain, error) {
 	return t.a.ExplainQuery(q), nil
 }
 
+// BuildAndEnableSchemaScan builds or extends the archive's columnar accelerator (see
+// collections.Archive.BuildAndEnableSchemaScan).
+func (t *ArchiveTable) BuildAndEnableSchemaScan(sampleMax, hotTopN int) bool {
+	return t.a.BuildAndEnableSchemaScan(sampleMax, hotTopN)
+}
+
+// SchemaScanInfo reports the archive's columnar accelerator state.
+func (t *ArchiveTable) SchemaScanInfo() SchemaScanInfo { return t.a.SchemaScanInfo() }
+
 func (t *ArchiveTable) MergePass(opts MergeOptions) int { return t.a.MergePass(opts) }
 
 // Count is the number of records currently retained (reduced by rotation).

--- a/db/db.go
+++ b/db/db.go
@@ -234,6 +234,20 @@ type MaintainOptions struct {
 	// is nearly free and re-adding it costs a backfill, so a wrong drop is expensive and
 	// asymmetric in the direction that punishes acting on a weak signal.
 	ArchiveIndexMinDemand int64
+	// ArchiveSchemaScanHotTopN, when > 0, builds the per-segment columnar accelerator on
+	// ARCHIVE tables too, keeping the topN most query-read numeric fields uncompressed.
+	//
+	// Separate from SchemaScanHotTopN, and off by default, for the same reason
+	// ArchiveIndexMinDemand is: the first build reads every sealed record of the whole
+	// history once, so turning it on is a deliberate decision about an existing deployment
+	// rather than something an upgrade should start doing. Once built it is cheap -- an
+	// archive's segments are immutable, so a block is never invalidated, and later passes
+	// only cover newly-sealed segments.
+	//
+	// The payoff is confined to what the accelerator serves: single-int-field COUNT
+	// comparisons (25-65x on a 50k-record archive). Other aggregates -- MAX, SUM, GROUP BY
+	// -- take their existing paths and are unaffected.
+	ArchiveSchemaScanHotTopN int
 	// SchemaScanHotTopN, when > 0, builds/refreshes the per-segment adschema columnar
 	// accelerator (used by CountConstraint's fast path) keeping the topN most query-read
 	// numeric fields uncompressed. The first pass chooses a stable schema and hot set from

--- a/dbrpc/archivecolumnar_test.go
+++ b/dbrpc/archivecolumnar_test.go
@@ -1,0 +1,135 @@
+package dbrpc
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/db"
+)
+
+// seedHistory appends n history-shaped ads to an archive table.
+func seedHistory(t *testing.T, c *Client, name string, n int) {
+	t.Helper()
+	ctx := context.Background()
+	for i := 0; i < n; i++ {
+		if err := c.ArchiveAppend(ctx, name, fmt.Sprintf(
+			"ClusterId = %d\nProcId = %d\nOwner = \"u%d\"\nRequestMemory = %d\nRequestCpus = %d\nExitCode = %d",
+			i/10, i%10, i%8, ((i%16)+1)*512, 1+i%8, i%2)); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+// TestArchiveSchemaScanOffByDefault pins the default: maintenance must not start reading an
+// entire history back on an upgrade. Nothing enables the accelerator unless asked.
+func TestArchiveSchemaScanOffByDefault(t *testing.T) {
+	c, cleanup := catServerPair(t, ServeOptions{Privileged: true})
+	defer cleanup()
+	ctx := context.Background()
+	if err := c.CreateArchiveTable(ctx, "history", db.ArchiveConfig{SegmentSize: 1 << 16}); err != nil {
+		t.Fatal(err)
+	}
+	seedHistory(t, c, "history", 2000)
+
+	diag, err := c.DiagnosticsTable(ctx, "history")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diag.SchemaScan.Enabled {
+		t.Error("the columnar accelerator is enabled on an archive with no option set")
+	}
+}
+
+// TestArchiveSchemaScanReported checks the other half: once built, the archive's diagnostics
+// report it, so `.stats history` can say so. archiveDiagJSON left SchemaScan unset before, so
+// a built accelerator was invisible on an archive.
+func TestArchiveSchemaScanReported(t *testing.T) {
+	cat, err := db.OpenCatalog(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := NewServerCatalog(cat)
+	cconn, sconn := netPipe()
+	go func() { _ = s.ServeConnOpts(sconn, ServeOptions{Privileged: true}) }()
+	c := NewClient(cconn)
+	defer func() { c.Close(); s.Close(); cat.Close() }()
+
+	ctx := context.Background()
+	if err := c.CreateArchiveTable(ctx, "history", db.ArchiveConfig{SegmentSize: 1 << 16}); err != nil {
+		t.Fatal(err)
+	}
+	seedHistory(t, c, "history", 3000)
+
+	a, ok := cat.ArchiveTable("history")
+	if !ok {
+		t.Fatal("archive table missing from the catalog")
+	}
+	if !a.BuildAndEnableSchemaScan(2000, 4) {
+		t.Skip("no sealed segments to sample in this fixture")
+	}
+
+	diag, err := c.DiagnosticsTable(ctx, "history")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ss := diag.SchemaScan
+	if !ss.Enabled {
+		t.Fatal("archive diagnostics report the accelerator disabled after building it")
+	}
+	if ss.SchemaFields == 0 {
+		t.Error("no schema fields reported for the archive")
+	}
+	if ss.SealedSegments == 0 || ss.CoveredSegments == 0 {
+		t.Errorf("coverage %d/%d: a built archive accelerator should cover its sealed segments",
+			ss.CoveredSegments, ss.SealedSegments)
+	}
+}
+
+// TestArchiveSchemaScanCountsAgree is the correctness guard for routing archive counts through
+// a columnar block: the answer must match the row path, over an archive's reverse-ordered,
+// zone-mapped, multi-segment layout.
+func TestArchiveSchemaScanCountsAgree(t *testing.T) {
+	cat, err := db.OpenCatalog(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := NewServerCatalog(cat)
+	cconn, sconn := netPipe()
+	go func() { _ = s.ServeConnOpts(sconn, ServeOptions{Privileged: true}) }()
+	c := NewClient(cconn)
+	defer func() { c.Close(); s.Close(); cat.Close() }()
+
+	ctx := context.Background()
+	if err := c.CreateArchiveTable(ctx, "history", db.ArchiveConfig{SegmentSize: 1 << 16}); err != nil {
+		t.Fatal(err)
+	}
+	seedHistory(t, c, "history", 3000)
+	a, _ := cat.ArchiveTable("history")
+
+	// Counts via the ordinary aggregate path, before and after enabling the accelerator.
+	count := func(constraint string) string {
+		rows, err := a.Aggregate(constraint, nil, []db.AggSpec{{Func: db.AggCount, Arg: "*"}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(rows) == 0 {
+			return ""
+		}
+		return rows[0].Values[0]
+	}
+	exprs := []string{"RequestMemory >= 4096", "RequestCpus == 4", "ExitCode != 0",
+		"RequestMemory >= 2048 && RequestMemory < 8192"}
+	want := map[string]string{}
+	for _, e := range exprs {
+		want[e] = count(e)
+	}
+	if !a.BuildAndEnableSchemaScan(2000, 4) {
+		t.Skip("no sealed segments to sample in this fixture")
+	}
+	for _, e := range exprs {
+		if got := count(e); got != want[e] {
+			t.Errorf("%s: %s with the accelerator, %s without", e, got, want[e])
+		}
+	}
+}

--- a/dbrpc/diag.go
+++ b/dbrpc/diag.go
@@ -107,6 +107,7 @@ func (s *Server) archiveDiagJSON(a *db.ArchiveTable) ([]byte, error) {
 		ZoneAttrs:          a.ZoneAttrs(),
 		SealedSegments:     sealed,
 		StaleIndexSegments: stale,
+		SchemaScan:         a.SchemaScanInfo(),
 	}
 	return json.Marshal(d)
 }

--- a/dbrpc/server.go
+++ b/dbrpc/server.go
@@ -1525,6 +1525,17 @@ func (s *Server) maintainArchives(opts db.MaintainOptions) {
 		if stale, _ := a.StaleIndexSegments(); stale > 0 {
 			a.Reindex()
 		}
+		// The per-segment columnar accelerator, off unless configured (see
+		// ArchiveSchemaScanHotTopN): the first build reads the whole history once. After that
+		// this only extends coverage to segments sealed since, including those a merge just
+		// produced.
+		if opts.ArchiveSchemaScanHotTopN > 0 {
+			sampleMax := opts.SampleMax
+			if sampleMax <= 0 {
+				sampleMax = diagSampleMax
+			}
+			a.BuildAndEnableSchemaScan(sampleMax, opts.ArchiveSchemaScanHotTopN)
+		}
 		// Add the indexes observed demand justifies. Off unless a threshold is configured:
 		// an archive index is paid for by reading history back, so it is not something to
 		// start doing to an existing deployment on an upgrade.


### PR DESCRIPTION
Maintenance built the per-segment columnar accelerator for **mutable tables only**: the per-table loop calls `DB.Maintain` (gated on `SchemaScanHotTopN`), while `maintainArchives` did merge, reindex and index auto-tune and never touched it. So a history table always scanned row-wise — backwards, since an archive is *the* big append-only scan target and its segments are immutable once sealed, so a block there never needs invalidating.

Measured on a 50k-record archive, row scan vs columnar count:

| constraint | row | columnar | |
|---|---|---|---|
| `RequestMemory >= 4096` | 51.4 ms / 41.5 MB | 1.18 ms / 0.22 MB | **44x** |
| `RequestCpus == 4` | 24.0 ms / 11.8 MB | 0.96 ms / 0.22 MB | **25x** |
| `ExitCode != 0` | 47.7 ms / 36.9 MB | 0.76 ms / 0.22 MB | **63x** |
| `RequestMemory` in [2048, 8192) | 78.6 ms / 56.9 MB | 1.21 ms / 0.22 MB | **65x** |

### Off by default, deliberately

`ArchiveSchemaScanHotTopN` follows `ArchiveIndexMinDemand`'s reasoning: the first build reads every sealed record of the whole history once, so enabling it is a decision about an existing deployment, not something an upgrade should start doing quietly. Later passes only extend coverage to newly-sealed segments, including a merge's output.

Whether htcondordb should default it on is a separate call — happy to make it, but the one-time full-history read should be your decision.

### Also fixed

`archiveDiagJSON` never set `SchemaScan`, so a built archive accelerator was **invisible** to `.stats history` even when working.

Tests: off-by-default (maintenance must not start reading history back on an upgrade), the diagnostics reporting it once built, and counts agreeing with the pre-accelerator answers over an archive's reverse-ordered, zone-mapped, multi-segment layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
