### PR TITLE
Push MIN/MAX/SUM/AVG to the columnar accelerator, not just COUNT

### DIFF
--- a/collections/archive.go
+++ b/collections/archive.go
@@ -304,6 +304,13 @@ func (a *Archive) BuildAndEnableSchemaScan(sampleMax, hotTopN int) bool {
 // SchemaScanInfo reports the columnar accelerator's state for the archive.
 func (a *Archive) SchemaScanInfo() SchemaScanInfo { return a.c.SchemaScanInfo() }
 
+// NumStatsQuery computes numeric aggregate inputs for attr over the archive's matching records
+// via the columnar scan (see Collection.NumStatsQuery). Only meaningful once the archive carries
+// a columnar accelerator; ok=false otherwise, and the caller scans.
+func (a *Archive) NumStatsQuery(q *vm.Query, attr string) (NumStats, bool) {
+	return a.c.NumStatsQuery(q, attr)
+}
+
 // SidecarSizes reports the archive's sealed-segment sidecar index bytes (mmap-backed,
 // evictable page cache), broken out by structure. An operator diagnostic.
 func (a *Archive) SidecarSizes() SidecarSizes { return a.c.SidecarSizes() }

--- a/collections/colagg.go
+++ b/collections/colagg.go
@@ -1,0 +1,271 @@
+package collections
+
+import (
+	"math"
+
+	"github.com/PelicanPlatform/classad/collections/vm"
+	"github.com/PelicanPlatform/classad/collections/wire"
+)
+
+// Numeric aggregates over the columnar accelerator.
+//
+// The block already stores each hot numeric column contiguously and its scan hands back values,
+// so counting was never the limit -- it was just the only consumer written. MIN/MAX/SUM/AVG are
+// the same pass with a different accumulator, over the same per-block schema resolution, MVCC
+// visibility and cold-tail escape handling.
+
+// NumStats is one columnar pass's worth of aggregate inputs for a single numeric attribute, from
+// which MIN, MAX, SUM, AVG and COUNT(attr) all follow.
+//
+// N counts the records whose value for the attribute is a number -- which is COUNT(attr)'s
+// definition, and the divisor for AVG. Records where the attribute is absent or non-numeric
+// contribute to none of these fields. Min/Max are meaningless when N == 0.
+type NumStats struct {
+	N   int     `json:"n"`
+	Sum float64 `json:"sum"`
+	Min float64 `json:"min"`
+	Max float64 `json:"max"`
+	// IntSum accumulates the INTEGER contributions in int64, exactly as the reference SUM does
+	// -- a float64 accumulator loses precision past 2^53, so an all-integer sum rendered from
+	// Sum would disagree with the scanning aggregator on large values.
+	IntSum int64 `json:"intSum,omitempty"`
+	// AnyReal records whether any contributing value was a REAL rather than an integer, which is
+	// exactly the reference's promotion rule: SUM stays an integer unless a real appears, and
+	// MIN/MAX keep their element's type. Without it the same query would print differently
+	// depending on whether the accelerator was on.
+	AnyReal bool `json:"anyReal,omitempty"`
+	// AnyBool records that a boolean turned up in the column (only possible as an escaped value,
+	// since a bool is not a numeric schema field). The reference coerces booleans to 1/0 and has
+	// a further quirk for a lone boolean element; rather than reproduce that, a caller declines
+	// and lets the scan answer. Pathological data, exact answer.
+	AnyBool bool `json:"anyBool,omitempty"`
+}
+
+// NumStatsQuery computes the numeric aggregate inputs for attr over the records matching q, using
+// the columnar scan. A nil q means every record.
+//
+// It returns ok=false when the columnar path cannot serve the request -- the accelerator is off,
+// attr is not a numeric field of the current schema, or q is not a conjunction of scalar numeric
+// comparisons ON attr ITSELF. That last restriction is the same one CountQuery has: a predicate
+// over a different field would need a second column read per record, which this pass does not do.
+// A caller that gets false scans instead.
+func (c *Collection) NumStatsQuery(q *vm.Query, attr string) (NumStats, bool) {
+	st := c.schemaScan.Load()
+	if st == nil {
+		return NumStats{}, false
+	}
+	if c.intern == nil {
+		return NumStats{}, false
+	}
+	id, ok := c.intern.LookupID(attr)
+	if !ok {
+		return NumStats{}, false
+	}
+	idx, ok := st.schema.byID[id]
+	if !ok || !numericKind(st.schema.fields[idx].kind) {
+		return NumStats{}, false
+	}
+	var keep func(float64) bool
+	if q != nil {
+		predID, pred, ok := c.numPredOnField(q, st.schema)
+		if !ok || predID != id {
+			return NumStats{}, false // no predicate shape, or it constrains a different field
+		}
+		keep = pred
+	}
+	out := NumStats{Min: math.Inf(1), Max: math.Inf(-1)}
+	c.scanNumValues(id, st.cache, func(nv colVal) {
+		if keep != nil && !keep(nv.f) {
+			return
+		}
+		out.N++
+		out.Sum += nv.f
+		switch nv.kind {
+		case akInt:
+			out.IntSum += nv.i
+		case akReal:
+			out.AnyReal = true
+		case akBool:
+			out.IntSum += nv.i
+			out.AnyBool = true
+		}
+		if nv.f < out.Min {
+			out.Min = nv.f
+		}
+		if nv.f > out.Max {
+			out.Max = nv.f
+		}
+	})
+	if out.N == 0 {
+		out.Min, out.Max = 0, 0
+	}
+	return out, true
+}
+
+// numericKind reports whether a schema field's kind is one the numeric column scan can read.
+func numericKind(k adKind) bool { return k == akInt || k == akReal }
+
+// colVal is one value the column scan produced: f for comparisons and real arithmetic, i for the
+// exact integer accumulation SUM needs, and kind to drive the reference's type promotion.
+type colVal struct {
+	f    float64
+	i    int64
+	kind adKind
+}
+
+// numPredOnField analyzes q as a conjunction of scalar numeric comparisons against a SINGLE
+// numeric schema field, returning that field's intern id and the combined test.
+//
+// ok=false for anything else: a non-native query, no probes at all, a probe on an attribute the
+// schema does not carry as a numeric field, probes spanning two fields, or a probe that is not a
+// scalar comparison (present/absent/in/isnt, or a non-numeric operand).
+func (c *Collection) numPredOnField(q *vm.Query, s *adSchema) (uint32, func(float64) bool, bool) {
+	probes := q.Probes()
+	if !q.Native() || len(probes) == 0 {
+		return 0, nil, false
+	}
+	fieldIdx := -1
+	var fieldID uint32
+	var cmps []func(float64) bool
+	for _, p := range probes {
+		id, ok := c.intern.LookupID(p.Attr)
+		if !ok {
+			return 0, nil, false
+		}
+		idx, ok := s.byID[id]
+		if !ok || !numericKind(s.fields[idx].kind) {
+			return 0, nil, false
+		}
+		if fieldIdx == -1 {
+			fieldIdx, fieldID = idx, id
+		} else if idx != fieldIdx {
+			return 0, nil, false // more than one field: not this fast path
+		}
+		up, ok := valUsable(id, p)
+		if !ok || len(up.fvals) != 1 {
+			return 0, nil, false // present/absent/in/isnt or non-numeric: not a scalar comparison
+		}
+		cmp, ok := numCmp(up.op, up.fvals[0])
+		if !ok {
+			return 0, nil, false
+		}
+		cmps = append(cmps, cmp)
+	}
+	return fieldID, func(v float64) bool {
+		for _, cmp := range cmps {
+			if !cmp(v) {
+				return false
+			}
+		}
+		return true
+	}, true
+}
+
+// scanNumValues calls fn with every live record's numeric value for fieldID: from each sealed
+// segment's columnar block where that segment's OWN schema carries fieldID as a numeric field
+// (hot column: no decode; cold column: one cached decode), and by row scan where it does not --
+// including the active segment, which has no block. Records where the value is absent or
+// non-numeric are skipped, so fn's call count is COUNT(attr).
+//
+// Resolving per block is what lets segments sealed under different schemas coexist: a schema
+// change never rewrites existing segments, they simply fall back for attributes their schema
+// lacks. It also decides the value conversion, because a REAL field's fixed slot holds
+// math.Float64bits and scanInt returns those bits as an int64 -- reading them as an integer
+// would silently produce astronomically wrong values.
+func (c *Collection) scanNumValues(fieldID uint32, bc *blockCache, fn func(colVal)) {
+	// The row fallback reads records straight from the arena, so it must honor the collection's
+	// wire mode: look the field up by inline name on a persistent store, by interned id in memory.
+	lookup := func(a wire.Ad) ([]byte, bool) { return a.Lookup(fieldID) }
+	if c.inline {
+		if name, ok := c.intern.Name(fieldID); ok {
+			lookup = func(a wire.Ad) ([]byte, bool) { return a.LookupByName(name) }
+		}
+	}
+	for _, sh := range c.shards {
+		s0, wins := sh.snapshot()
+		for _, w := range wins {
+			cs := w.seg.colblk.Load()
+			bidx, isReal := -1, false
+			if cs != nil {
+				if idx, ok := cs.block.schema.byID[fieldID]; ok {
+					switch cs.block.schema.fields[idx].kind {
+					case akInt:
+						bidx = idx
+					case akReal:
+						bidx, isReal = idx, true
+					}
+				}
+			}
+			if bidx < 0 {
+				bruteNumValues(w, s0, lookup, fn)
+				continue
+			}
+			cs.block.scanInt(bidx, bc, func(k int, present bool, v int64) {
+				o := cs.offs[k]
+				if !(recSeq(w.data, o) <= s0 && recSuperseded(w.data, o) > s0) {
+					return // not visible at this snapshot
+				}
+				if present {
+					if isReal {
+						f := math.Float64frombits(uint64(v))
+						fn(colVal{f: f, kind: akReal})
+					} else {
+						fn(colVal{f: float64(v), i: v, kind: akInt})
+					}
+					return
+				}
+				// Escaped: read only fieldID from the cold tail, not the whole record. (A full
+				// reconstruct dominated the scan when a numeric attr has a value tail.)
+				// The cold tail carries the wire node, so its kind is read from the node
+				// itself rather than assumed from this block's schema field.
+				if nv, ok := cs.block.escapedNumVal(k, fieldID, bc); ok {
+					fn(nv)
+				}
+			})
+		}
+		releaseWindows(wins)
+	}
+}
+
+// bruteNumValues is the row-scan fallback: walk a window's visible records, read the numeric
+// field from the wire ad, and hand over each value found.
+func bruteNumValues(w segWindow, s0 uint64, lookup func(wire.Ad) ([]byte, bool), fn func(colVal)) {
+	var buf []byte
+	for off := 0; off < w.used; {
+		o := uint32(off)
+		total := recTotalLen(w.data, o)
+		if total == 0 {
+			break
+		}
+		if !recIsMarker(w.data, o) && recSeq(w.data, o) <= s0 && recSuperseded(w.data, o) > s0 {
+			if ww, err := w.codec.Decompress(buf[:0], recAd(w.data, o)); err == nil {
+				buf = ww
+				if node, ok := lookup(wire.Ad(ww)); ok {
+					if nv, ok := nodeColVal(node); ok {
+						fn(nv)
+					}
+				}
+			}
+		}
+		off += int(total)
+	}
+}
+
+// nodeColVal reads a wire node as a numeric value, keeping the kind the reference's aggregates
+// dispatch on. A boolean coerces to 1/0 as the reference does, and is reported as akBool so a
+// caller can decline rather than approximate the reference's boolean quirks.
+func nodeColVal(node []byte) (colVal, bool) {
+	switch k, lit := nodeKind(node); k {
+	case akInt:
+		return colVal{f: float64(lit.Int), i: lit.Int, kind: akInt}, true
+	case akReal:
+		return colVal{f: lit.Real, kind: akReal}, true
+	case akBool:
+		var i int64
+		if lit.Bool {
+			i = 1
+		}
+		return colVal{f: float64(i), i: i, kind: akBool}, true
+	}
+	return colVal{}, false
+}

--- a/collections/colagg_test.go
+++ b/collections/colagg_test.go
@@ -1,0 +1,326 @@
+package collections
+
+import (
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/classad"
+	"github.com/PelicanPlatform/classad/collections/vm"
+)
+
+// aggStore seeds a store with an int field, a REAL field, and a field whose values outgrow their
+// chosen width (so some records escape to the cold tail), then enables the accelerator with all
+// three demanded so they land in the hot tier.
+//
+//	Cpus         1..8
+//	Memory       1024..17152, plus a few enormous values that escape
+//	WallClock    real, i + 0.5
+func aggStore(t *testing.T, n int) *Collection {
+	t.Helper()
+	c := New(Options{Shards: 2, SegmentSize: 1 << 12})
+	for i := 0; i < n; i++ {
+		mem := 1024 + (i%64)*256
+		if i%500 == 499 {
+			mem = 1 << 40 // escapes whatever width the sample chose
+		}
+		if err := c.Put([]byte(fmt.Sprintf("k%d", i)), mustAdOld(t, fmt.Sprintf(
+			"Cpus=%d\nMemory=%d\nWallClock=%d.5", 1+i%8, mem, i))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, e := range []string{"Cpus >= 0", "Memory >= 0", "WallClock >= 0"} {
+		q, err := vm.Parse(e)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i := 0; i < 25; i++ {
+			for range c.Query(q) {
+			}
+		}
+	}
+	if !c.BuildAndEnableSchemaScan(4000, 8) {
+		t.Fatal("BuildAndEnableSchemaScan false")
+	}
+	return c
+}
+
+// rowStats is the ground truth: every visible record's value for attr, aggregated by the row
+// path, with no columnar block involved.
+func rowStats(t *testing.T, c *Collection, attr string, keep func(float64) bool) NumStats {
+	t.Helper()
+	q, err := vm.Parse(attr + " =!= undefined")
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := NumStats{Min: math.Inf(1), Max: math.Inf(-1)}
+	for ad := range c.Query(q) {
+		v, ok := ad.EvaluateAttrNumber(attr)
+		if !ok {
+			continue
+		}
+		if keep != nil && !keep(v) {
+			continue
+		}
+		out.N++
+		out.Sum += v
+		if v < out.Min {
+			out.Min = v
+		}
+		if v > out.Max {
+			out.Max = v
+		}
+	}
+	if out.N == 0 {
+		out.Min, out.Max = 0, 0
+	}
+	return out
+}
+
+func sameStats(t *testing.T, what string, got, want NumStats) {
+	t.Helper()
+	if got.N != want.N {
+		t.Errorf("%s: N = %d, want %d", what, got.N, want.N)
+	}
+	if math.Abs(got.Sum-want.Sum) > 1e-6*math.Max(1, math.Abs(want.Sum)) {
+		t.Errorf("%s: Sum = %v, want %v", what, got.Sum, want.Sum)
+	}
+	if got.Min != want.Min {
+		t.Errorf("%s: Min = %v, want %v", what, got.Min, want.Min)
+	}
+	if got.Max != want.Max {
+		t.Errorf("%s: Max = %v, want %v", what, got.Max, want.Max)
+	}
+}
+
+// TestNumStatsMatchesRowScan is the correctness case: the columnar aggregate must agree with a
+// row scan, including over records whose value escaped to the cold tail.
+func TestNumStatsMatchesRowScan(t *testing.T) {
+	c := aggStore(t, 2000)
+	defer c.Close()
+
+	for _, attr := range []string{"Cpus", "Memory"} {
+		got, ok := c.NumStatsQuery(nil, attr)
+		if !ok {
+			t.Fatalf("%s: columnar aggregate declined", attr)
+		}
+		sameStats(t, attr, got, rowStats(t, c, attr, nil))
+	}
+}
+
+// TestNumStatsRealField is the bits trap. A real field's fixed slot holds math.Float64bits, and
+// the columnar scan hands those back as an int64 -- reading them as an integer yields values
+// around 4.6e18 instead of a few thousand. Nothing else in the package exercised a real column,
+// because the count fast path refused them.
+func TestNumStatsRealField(t *testing.T) {
+	c := aggStore(t, 2000)
+	defer c.Close()
+
+	got, ok := c.NumStatsQuery(nil, "WallClock")
+	if !ok {
+		t.Fatal("WallClock: columnar aggregate declined")
+	}
+	want := rowStats(t, c, "WallClock", nil)
+	sameStats(t, "WallClock", got, want)
+	// Independent of the ground truth: the values are i+0.5 for i in [0,2000), so the maximum is
+	// 1999.5. A bits misread would be astronomically larger.
+	if got.Max != 1999.5 {
+		t.Errorf("WallClock Max = %v, want 1999.5 (a raw-bits misread gives ~4.6e18)", got.Max)
+	}
+	if got.Min != 0.5 {
+		t.Errorf("WallClock Min = %v, want 0.5", got.Min)
+	}
+}
+
+// TestNumStatsWithSameFieldPredicate covers the constrained form: a predicate on the aggregate's
+// own field is in scope, and must narrow the aggregate the same way a row scan would.
+func TestNumStatsWithSameFieldPredicate(t *testing.T) {
+	c := aggStore(t, 2000)
+	defer c.Close()
+
+	for _, expr := range []string{"Memory >= 4096", "Memory >= 2048 && Memory < 8192", "Cpus == 4"} {
+		q, err := vm.Parse(expr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		attr := "Memory"
+		if expr == "Cpus == 4" {
+			attr = "Cpus"
+		}
+		got, ok := c.NumStatsQuery(q, attr)
+		if !ok {
+			t.Fatalf("%s: declined", expr)
+		}
+		// The ground truth applies the same predicate over the row path.
+		keep := func(v float64) bool {
+			switch expr {
+			case "Memory >= 4096":
+				return v >= 4096
+			case "Memory >= 2048 && Memory < 8192":
+				return v >= 2048 && v < 8192
+			default:
+				return v == 4
+			}
+		}
+		sameStats(t, expr, got, rowStats(t, c, attr, keep))
+	}
+}
+
+// TestNumStatsDeclines pins the boundaries, because each of these would otherwise be answered
+// from the wrong data rather than refused.
+func TestNumStatsDeclines(t *testing.T) {
+	c := aggStore(t, 2000)
+	defer c.Close()
+
+	// A predicate on a DIFFERENT field than the aggregate: out of scope for a single-column pass.
+	q, err := vm.Parse("Cpus > 2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := c.NumStatsQuery(q, "Memory"); ok {
+		t.Error("aggregating Memory under a predicate on Cpus must decline, not answer")
+	}
+	// A non-numeric attribute.
+	if _, ok := c.NumStatsQuery(nil, "Owner"); ok {
+		t.Error("a non-numeric attribute must decline")
+	}
+	// An attribute that is not in the schema at all.
+	if _, ok := c.NumStatsQuery(nil, "NoSuchAttr"); ok {
+		t.Error("an unknown attribute must decline")
+	}
+	// The accelerator off entirely.
+	plain := New(Options{Shards: 1})
+	defer plain.Close()
+	if _, ok := plain.NumStatsQuery(nil, "Memory"); ok {
+		t.Error("with no accelerator the aggregate must decline")
+	}
+}
+
+// TestNumStatsAcrossMVCC checks the visibility rule: an updated key contributes its new value
+// once, not both values, and a deleted key contributes nothing.
+func TestNumStatsAcrossMVCC(t *testing.T) {
+	c := aggStore(t, 2000)
+	defer c.Close()
+
+	// Update 200 keys to a distinctive value and delete 100 others.
+	for i := 0; i < 200; i++ {
+		if err := c.Put([]byte(fmt.Sprintf("k%d", i)), mustAdOld(t, fmt.Sprintf(
+			"Cpus=%d\nMemory=%d\nWallClock=%d.5", 2, 7777, i))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for i := 500; i < 600; i++ {
+		c.Delete([]byte(fmt.Sprintf("k%d", i)))
+	}
+	got, ok := c.NumStatsQuery(nil, "Memory")
+	if !ok {
+		t.Fatal("declined")
+	}
+	sameStats(t, "Memory after updates+deletes", got, rowStats(t, c, "Memory", nil))
+}
+
+// TestNumStatsIncludesEscapedValues pins that a value too wide for its fixed slot still reaches
+// the aggregate, read from the cold tail at its true magnitude. aggStore plants one 1<<40 every
+// 500 records precisely so this cannot pass by accident.
+func TestNumStatsIncludesEscapedValues(t *testing.T) {
+	c := aggStore(t, 2000)
+	defer c.Close()
+
+	const escaped = float64(int64(1) << 40)
+	q, err := vm.Parse("Memory >= 1099511627776") // == 1<<40
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, ok := c.NumStatsQuery(q, "Memory")
+	if !ok {
+		t.Fatal("declined")
+	}
+	if got.N != 4 { // i%500 == 499 over 2000 records
+		t.Errorf("N = %d, want the 4 planted escapees", got.N)
+	}
+	if got.Min != escaped || got.Max != escaped {
+		t.Errorf("Min/Max = %v/%v, want both %v -- an escaped value must come back at its real "+
+			"magnitude, not truncated to the slot width", got.Min, got.Max, escaped)
+	}
+	sameStats(t, "escaped only", got, rowStats(t, c, "Memory", func(v float64) bool { return v >= escaped }))
+}
+
+// TestNumStatsEmpty reports N=0 rather than an infinite Min left over from initialization.
+func TestNumStatsEmpty(t *testing.T) {
+	c := aggStore(t, 2000)
+	defer c.Close()
+
+	// Above every value present, including the 1<<40 escapees (~1.1e12).
+	q, err := vm.Parse("Memory > 1000000000000000")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, ok := c.NumStatsQuery(q, "Memory")
+	if !ok {
+		t.Fatal("declined")
+	}
+	if got.N != 0 || got.Min != 0 || got.Max != 0 || got.Sum != 0 {
+		t.Errorf("empty result = %+v, want a zero NumStats (no infinities)", got)
+	}
+}
+
+// BenchmarkNumStats bounds the columnar pass itself against a materializing row scan. Note the
+// baseline decodes a ClassAd per record, which is NOT what the server does -- it projects
+// wire-native (QueryProject) -- so this overstates the end-to-end gain. BenchmarkAggregateMax in
+// dbrpc measures the real server paths against each other.
+func BenchmarkNumStats(b *testing.B) {
+	const n = 50000
+	c := New(Options{Shards: 2, SegmentSize: 1 << 20})
+	defer c.Close()
+	for i := 0; i < n; i++ {
+		ad, err := classad.ParseOld(fmt.Sprintf("ProcId=%d\nMemory=%d\nWallClock=%d.5", i%10000, 1024+(i%64)*256, i))
+		if err != nil {
+			b.Fatal(err)
+		}
+		if err := c.Put([]byte(fmt.Sprintf("k%d", i)), ad); err != nil {
+			b.Fatal(err)
+		}
+	}
+	q, err := vm.Parse("ProcId >= 0")
+	if err != nil {
+		b.Fatal(err)
+	}
+	for i := 0; i < 25; i++ {
+		for range c.Query(q) {
+		}
+	}
+
+	b.Run("row", func(b *testing.B) {
+		b.ReportAllocs()
+		all, err := vm.Parse("ProcId =!= undefined")
+		if err != nil {
+			b.Fatal(err)
+		}
+		for i := 0; i < b.N; i++ {
+			max := math.Inf(-1)
+			for ad := range c.Query(all) {
+				if v, ok := ad.EvaluateAttrNumber("ProcId"); ok && v > max {
+					max = v
+				}
+			}
+			if math.IsInf(max, -1) {
+				b.Fatal("no values")
+			}
+		}
+	})
+	if !c.BuildAndEnableSchemaScan(4000, 8) {
+		b.Fatal("BuildAndEnableSchemaScan false")
+	}
+	b.Run("columnar", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			ns, ok := c.NumStatsQuery(nil, "ProcId")
+			if !ok {
+				b.Fatal("declined")
+			}
+			if ns.N == 0 {
+				b.Fatal("no values")
+			}
+		}
+	})
+}

--- a/collections/colblock.go
+++ b/collections/colblock.go
@@ -250,3 +250,31 @@ func (b *columnarBlock) escapedNumField(k int, fieldID uint32, bc *blockCache) (
 	}
 	return 0, false, nil
 }
+
+// escapedNumVal is escapedNumField returning the value WITH its ClassAd kind. A caller that
+// renders or sums the value needs the kind, and the cold tail carries the wire node, so it is read
+// from the node rather than assumed from the segment's schema (an escaped value is by definition
+// one the schema field did not fit).
+func (b *columnarBlock) escapedNumVal(k int, fieldID uint32, bc *blockCache) (colVal, bool) {
+	ds, err := bc.streams(b)
+	if err != nil {
+		return colVal{}, false
+	}
+	cold := ds.cold[b.coldOff[k]:b.coldOff[k+1]]
+	for len(cold) > 0 {
+		id, m := binary.Uvarint(cold)
+		if m <= 0 {
+			return colVal{}, false // malformed tail: treat fieldID as absent
+		}
+		cold = cold[m:]
+		nl, ok := wire.NodeLen(cold)
+		if !ok || nl > len(cold) {
+			return colVal{}, false
+		}
+		if uint32(id) == fieldID {
+			return nodeColVal(cold[:nl])
+		}
+		cold = cold[nl:]
+	}
+	return colVal{}, false
+}

--- a/collections/colscan.go
+++ b/collections/colscan.go
@@ -448,48 +448,16 @@ func (c *Collection) CountQuery(q *vm.Query) (int, bool) {
 	if st == nil {
 		return 0, false
 	}
-	s := st.schema
-	probes := q.Probes()
-	if !q.Native() || len(probes) == 0 {
+	if c.intern == nil {
 		return 0, false
 	}
-	fieldIdx := -1
-	var fieldID uint32
-	var cmps []func(float64) bool
-	for _, p := range probes {
-		id, ok := c.intern.LookupID(p.Attr)
-		if !ok {
-			return 0, false
-		}
-		idx, ok := s.byID[id]
-		if !ok || s.fields[idx].kind != akInt {
-			return 0, false // only single-field int comparisons route
-		}
-		if fieldIdx == -1 {
-			fieldIdx, fieldID = idx, id
-		} else if idx != fieldIdx {
-			return 0, false // more than one field: not this fast path
-		}
-		up, ok := valUsable(id, p)
-		if !ok || len(up.fvals) != 1 {
-			return 0, false // present/absent/in/isnt or non-numeric: not a scalar comparison
-		}
-		cmp, ok := numCmp(up.op, up.fvals[0])
-		if !ok {
-			return 0, false
-		}
-		cmps = append(cmps, cmp)
+	// The predicate analysis is shared with NumStatsQuery (see numPredOnField). fieldID is only
+	// the routing decision -- the attr is a numeric field in the CURRENT schema; the scan
+	// resolves the field per block against each block's own schema.
+	fieldID, eval, ok := c.numPredOnField(q, st.schema)
+	if !ok {
+		return 0, false
 	}
-	eval := func(v float64) bool {
-		for _, cmp := range cmps {
-			if !cmp(v) {
-				return false
-			}
-		}
-		return true
-	}
-	// fieldIdx above is only the routing decision (the attr is an int field in the current
-	// schema); the scan resolves the field per block against each block's own schema.
 	return c.schemaScanCount(fieldID, st.cache, eval), true
 }
 
@@ -511,58 +479,16 @@ func numCmp(op string, t float64) (func(float64) bool, bool) {
 	return nil, false
 }
 
-// schemaScanCount counts records whose numeric attribute fieldID is present, live, and satisfies
-// eval -- using each sealed segment's columnar block (hot column: no decode; cold column: one
-// cached decode) and each window's live MVCC visibility. The field is resolved PER BLOCK against
-// that block's OWN schema (byID over the shared intern id): a segment sealed under a schema that
-// includes fieldID as an int is columnar-scanned; one whose schema lacks it (or types it
-// differently) -- including the active segment, which has no block -- row-scans instead. This is
-// what lets a heterogeneous set of per-segment schemas coexist: a schema change never forces
-// rewriting existing segments; they simply row-fall-back for attributes absent from their schema.
+// schemaScanCount counts the records whose numeric attribute fieldID satisfies eval, over the
+// shared columnar value scan -- see scanNumValues for the per-block schema resolution, the MVCC
+// visibility rule and the row fallback. A record whose value is absent is skipped, not counted.
 func (c *Collection) schemaScanCount(fieldID uint32, bc *blockCache, eval func(float64) bool) int {
-	// The brute fallback reads records straight from the arena, so it must honor the collection's
-	// wire mode: look the field up by inline name on a persistent store, by interned id in memory.
-	lookup := func(a wire.Ad) ([]byte, bool) { return a.Lookup(fieldID) }
-	if c.inline {
-		if name, ok := c.intern.Name(fieldID); ok {
-			lookup = func(a wire.Ad) ([]byte, bool) { return a.LookupByName(name) }
-		}
-	}
 	count := 0
-	for _, sh := range c.shards {
-		s0, wins := sh.snapshot()
-		for _, w := range wins {
-			cs := w.seg.colblk.Load()
-			bidx := -1
-			if cs != nil {
-				if idx, ok := cs.block.schema.byID[fieldID]; ok && cs.block.schema.fields[idx].kind == akInt {
-					bidx = idx
-				}
-			}
-			if bidx < 0 {
-				count += bruteNumCount(w, s0, lookup, eval) // no block, or field absent/non-int in this segment's schema
-				continue
-			}
-			cs.block.scanInt(bidx, bc, func(k int, present bool, v int64) {
-				o := cs.offs[k]
-				if !(recSeq(w.data, o) <= s0 && recSuperseded(w.data, o) > s0) {
-					return // not visible at this snapshot
-				}
-				if present {
-					if eval(float64(v)) {
-						count++
-					}
-					return
-				}
-				// Escaped: read only fieldID from the cold tail, not the whole record. (numFieldOf
-				// via a full reconstruct dominated the scan when a numeric attr has a value tail.)
-				if f, ok, err := cs.block.escapedNumField(k, fieldID, bc); err == nil && ok && eval(f) {
-					count++
-				}
-			})
+	c.scanNumValues(fieldID, bc, func(nv colVal) {
+		if eval(nv.f) {
+			count++
 		}
-		releaseWindows(wins)
-	}
+	})
 	return count
 }
 
@@ -575,28 +501,4 @@ func (c *Collection) schemaScanIntCount(s *adSchema, fieldIdx int, match func(in
 	return c.schemaScanCount(s.fields[fieldIdx].id, bc, func(f float64) bool { return match(int64(f)) })
 }
 
-// bruteNumCount is the row-scan fallback: walk a window's visible records, read the numeric
-// field from the wire ad, and count matches.
-func bruteNumCount(w segWindow, s0 uint64, lookup func(wire.Ad) ([]byte, bool), eval func(float64) bool) int {
-	count := 0
-	var buf []byte
-	for off := 0; off < w.used; {
-		o := uint32(off)
-		total := recTotalLen(w.data, o)
-		if total == 0 {
-			break
-		}
-		if !recIsMarker(w.data, o) && recSeq(w.data, o) <= s0 && recSuperseded(w.data, o) > s0 {
-			if ww, err := w.codec.Decompress(buf[:0], recAd(w.data, o)); err == nil {
-				buf = ww
-				if node, ok := lookup(wire.Ad(ww)); ok {
-					if f, ok := literalFloat(node); ok && eval(f) {
-						count++
-					}
-				}
-			}
-		}
-		off += int(total)
-	}
-	return count
-}
+// The row-scan fallback now lives with the shared value scan, as bruteNumValues in colagg.go.

--- a/collections/colscan_test.go
+++ b/collections/colscan_test.go
@@ -33,7 +33,11 @@ func (c *Collection) allBruteCount(fieldID uint32, match func(int64) bool) int {
 	for _, sh := range c.shards {
 		s0, wins := sh.snapshot()
 		for _, w := range wins {
-			count += bruteNumCount(w, s0, func(a wire.Ad) ([]byte, bool) { return a.Lookup(fieldID) }, func(f float64) bool { return match(int64(f)) })
+			bruteNumValues(w, s0, func(a wire.Ad) ([]byte, bool) { return a.Lookup(fieldID) }, func(nv colVal) {
+				if match(int64(nv.f)) {
+					count++
+				}
+			})
 		}
 		releaseWindows(wins)
 	}

--- a/db/archive.go
+++ b/db/archive.go
@@ -240,6 +240,14 @@ func (t *ArchiveTable) AggregateCols(constraint string, groupCols []GroupCol, ag
 	if rows, ok := t.aggregateFromIndex(constraint, groupCols, aggs); ok {
 		return rows, nil
 	}
+	// A single MIN/MAX/COUNT(attr) over a numeric column reads that column out of the
+	// per-segment columnar blocks instead of decoding every record. Declines (and falls through
+	// to the scan) unless the archive carries an accelerator and the aggregate is in scope.
+	if rows, ok := ColumnarAggregate(func(attr string) (NumStats, bool) {
+		return t.NumStats(constraint, attr)
+	}, groupCols, aggs); ok {
+		return rows, nil
+	}
 
 	attrs, groupCol, aggCol := AggProjection(groupCols, aggs)
 

--- a/db/colagg.go
+++ b/db/colagg.go
@@ -1,0 +1,131 @@
+package db
+
+import (
+	"strconv"
+
+	"github.com/PelicanPlatform/classad/classad"
+	"github.com/PelicanPlatform/classad/collections"
+	"github.com/PelicanPlatform/classad/collections/vm"
+)
+
+// Routing a single numeric aggregate to the columnar accelerator.
+//
+// The columnar block stores each hot numeric column contiguously and its scan yields values, so
+// MIN/MAX/SUM/AVG/COUNT(attr) are one pass over a column rather than a decode of every record.
+// Only COUNT(*) was wired up before, which is why an unconstrained MAX over a large table scanned
+// row-wise.
+
+// NumStats is one columnar pass's numeric aggregate inputs (see collections.NumStats).
+type NumStats = collections.NumStats
+
+// NumStats computes the aggregate inputs for attr over the records matching constraint, via the
+// columnar scan. ok=false means the columnar path cannot serve it and the caller should scan.
+func (db *DB) NumStats(constraint, attr string) (NumStats, bool) {
+	q, ok := numStatsQuery(constraint)
+	if !ok {
+		return NumStats{}, false
+	}
+	return db.c.NumStatsQuery(q, attr)
+}
+
+// NumStats is DB.NumStats for an archive (history) table.
+func (t *ArchiveTable) NumStats(constraint, attr string) (NumStats, bool) {
+	q, ok := numStatsQuery(constraint)
+	if !ok {
+		return NumStats{}, false
+	}
+	return t.a.NumStatsQuery(q, attr)
+}
+
+// numStatsQuery turns a constraint into the query the columnar aggregate takes: nil for match-all
+// (no predicate at all), otherwise the parsed query. ok=false for a constraint that does not
+// parse, which the caller reports through the ordinary scan path rather than here.
+func numStatsQuery(constraint string) (*vm.Query, bool) {
+	if IsMatchAll(constraint) {
+		return nil, true
+	}
+	q, err := vm.Parse(constraint)
+	if err != nil {
+		return nil, false
+	}
+	return q, true
+}
+
+// ColumnarAggregate answers aggs over constraint from the columnar accelerator when it can:
+// exactly one aggregate, no grouping, no per-aggregate FILTER, and a numeric argument the current
+// schema carries. ok=false means nothing was computed and the caller must scan.
+//
+// COUNT(attr), MIN, MAX, SUM and AVG are served. The result TYPE follows the reference exactly
+// (see numAggValue): SUM accumulates integers in int64 and only becomes a real once a real value
+// appears, AVG is always a real, and MIN/MAX keep their element's type. A formatting difference
+// would be as wrong as a numeric one and far easier to ship unnoticed, so the test compares text.
+//
+// Two refusals. A FILTER is refused rather than approximated: the columnar pass knows nothing about
+// it, so answering would report an unfiltered aggregate as if it were filtered. And a column that
+// turned up a BOOLEAN declines: the reference coerces booleans to 1/0 and then has a further quirk
+// for a lone boolean element, which is not worth reproducing for data this pathological -- the scan
+// gives the exact answer.
+func ColumnarAggregate(stats func(attr string) (NumStats, bool), groupCols []GroupCol, aggs []AggSpec) ([]AggRow, bool) {
+	if len(groupCols) != 0 || len(aggs) != 1 {
+		return nil, false
+	}
+	a := aggs[0]
+	if a.Filter != "" || a.Arg == "" || a.Arg == "*" {
+		return nil, false
+	}
+	switch a.Func {
+	case AggCount, AggMin, AggMax, AggSum, AggAvg:
+	default:
+		return nil, false // COUNT(DISTINCT) needs the values themselves, not their aggregate
+	}
+	ns, ok := stats(a.Arg)
+	if !ok {
+		return nil, false
+	}
+	if ns.AnyBool {
+		return nil, false
+	}
+	return []AggRow{{Values: []string{numAggValue(a.Func, ns)}}}, true
+}
+
+// numAggValue renders one aggregate from a columnar pass through the same value rendering the
+// scanning aggregator uses, reproducing the reference's result types:
+//
+//	SUM   int64 accumulation, promoted to a real only if a real value appeared (builtinSum);
+//	      an empty SUM is int 0, not undefined.
+//	AVG   always a real (builtinAvg); an empty AVG is int 0.
+//	MIN   the element's own type, so an integer column prints an integer.
+//	MAX   likewise.
+//
+// The int64 accumulation matters past 2^53, where rendering from the float sum would disagree
+// with the scan on large values.
+func numAggValue(fn AggFunc, ns NumStats) string {
+	switch fn {
+	case AggCount:
+		return strconv.Itoa(ns.N)
+	case AggSum:
+		if ns.N == 0 {
+			return ValueText(classad.NewIntValue(0)) // reference: sum of nothing is int 0
+		}
+		if ns.AnyReal {
+			return ValueText(classad.NewRealValue(ns.Sum))
+		}
+		return ValueText(classad.NewIntValue(ns.IntSum))
+	case AggAvg:
+		if ns.N == 0 {
+			return ValueText(classad.NewIntValue(0)) // reference: avg of nothing is int 0
+		}
+		return ValueText(classad.NewRealValue(ns.Sum / float64(ns.N)))
+	}
+	if ns.N == 0 {
+		return ValueText(classad.NewUndefinedValue())
+	}
+	v := ns.Min
+	if fn == AggMax {
+		v = ns.Max
+	}
+	if ns.AnyReal {
+		return ValueText(classad.NewRealValue(v))
+	}
+	return ValueText(classad.NewIntValue(int64(v)))
+}

--- a/dbrpc/aggregate.go
+++ b/dbrpc/aggregate.go
@@ -361,6 +361,17 @@ func (s *Server) aggregate(ctx context.Context, reqID uint64, table, constraint 
 		}
 	}
 
+	// Fast path: a single MIN/MAX/COUNT(attr) over a numeric column, read from the columnar
+	// blocks rather than by decoding every record. Only counting was routed here before, so an
+	// unconstrained MAX over a large table scanned row-wise. Declines unless the table has
+	// schema-scan enabled and the aggregate is in scope (see db.ColumnarAggregate).
+	if rows, ok := db.ColumnarAggregate(func(attr string) (db.NumStats, bool) {
+		return d.NumStats(constraint, attr)
+	}, groupCols, aggs); ok {
+		writeAggRows(reqID, rows, write)
+		return
+	}
+
 	seq, err := d.QueryProject(constraint, attrs)
 	if err != nil {
 		write(respErr(reqID, err.Error()))
@@ -374,6 +385,12 @@ func (s *Server) aggregate(ctx context.Context, reqID uint64, table, constraint 
 	if cancelled(ctx) {
 		return // client gone mid-scan: nothing left to stream
 	}
+	writeAggRows(reqID, rows, write)
+}
+
+// writeAggRows streams aggregate rows and the stream terminator. Shared so a fast path that
+// computed its rows without scanning emits exactly what the scanning path does.
+func writeAggRows(reqID uint64, rows []db.AggRow, write func([]byte)) {
 	for _, row := range rows {
 		frame := respHead(reqID, stStream)
 		for _, gv := range row.Group {

--- a/dbrpc/colagg_bench_test.go
+++ b/dbrpc/colagg_bench_test.go
@@ -1,0 +1,89 @@
+package dbrpc
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/db"
+)
+
+// BenchmarkAggregateMax measures an unconstrained MAX through the actual server paths: the
+// wire-native projected scan (what it did before) against the columnar column pass. This is the
+// honest comparison -- the scan baseline here is QueryProject, not a ClassAd-per-record decode.
+func BenchmarkAggregateMax(b *testing.B) {
+	const n = 50000
+	// A small segment size so the ads SEAL: only sealed segments carry a columnar block, and the
+	// default 8 MiB segment would swallow this fixture whole, leaving the "columnar" run measuring
+	// the row fallback instead.
+	d, err := db.OpenConfig(db.Config{Dir: b.TempDir(), SegmentSize: 1 << 18})
+	if err != nil {
+		b.Fatal(err)
+	}
+	s := NewServer(d)
+	cconn, sconn := netPipe()
+	go func() { _ = s.ServeConnOpts(sconn, ServeOptions{Privileged: true}) }()
+	c := NewClient(cconn)
+	defer func() { c.Close(); s.Close(); d.Close() }()
+
+	ctx := context.Background()
+	tx, err := c.Begin(ctx)
+	if err != nil {
+		b.Fatal(err)
+	}
+	for i := 0; i < n; i++ {
+		if err := tx.NewClassAd(ctx, fmt.Sprintf("k%d", i), fmt.Sprintf(
+			"ClusterId = %d\nProcId = %d\nRequestMemory = %d\nQDate = %d",
+			i/10, i%10000, ((i%16)+1)*512, 1700000000+i)); err != nil {
+			b.Fatal(err)
+		}
+	}
+	if err := tx.Commit(ctx); err != nil {
+		b.Fatal(err)
+	}
+
+	run := func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			rows, err := c.Aggregate(ctx, "true", nil, []db.AggSpec{{Func: db.AggMax, Arg: "ProcId"}})
+			if err != nil {
+				b.Fatal(err)
+			}
+			if len(rows) != 1 {
+				b.Fatalf("rows = %d", len(rows))
+			}
+		}
+	}
+	b.Run("projected_scan", run)
+
+	// Drive read demand on ProcId so the schema's hot tier includes it -- that is what a
+	// maintenance pass would do for a queried column, and a hot column reads with no decode
+	// while a cold one decompresses its column group.
+	for i := 0; i < 25; i++ {
+		if _, err := c.Aggregate(ctx, "ProcId >= 0", nil, []db.AggSpec{{Func: db.AggCount, Arg: "*"}}); err != nil {
+			b.Fatal(err)
+		}
+	}
+	if !d.EnableSchemaScan(4000, 8) {
+		b.Skip("no sealed segments to sample")
+	}
+	info := d.SchemaScanInfo()
+	if info.CoveredSegments == 0 {
+		b.Fatalf("no segment carries a columnar block (%d sealed): the run below would measure the "+
+			"row fallback, not the accelerator", info.SealedSegments)
+	}
+	hot := false
+	for _, f := range info.HotFields {
+		if f == "ProcId" {
+			hot = true
+		}
+	}
+	b.Logf("accelerator: %d fields, %d/%d segments covered, ProcId hot: %v",
+		info.SchemaFields, info.CoveredSegments, info.SealedSegments, hot)
+	if ns, ok := d.NumStats("true", "ProcId"); !ok {
+		b.Fatal("columnar aggregate declines ProcId; the benchmark below would just re-measure the scan")
+	} else {
+		b.Logf("columnar MAX(ProcId) = %v over N=%d", ns.Max, ns.N)
+	}
+	b.Run("columnar", run)
+}

--- a/dbrpc/colagg_test.go
+++ b/dbrpc/colagg_test.go
@@ -1,0 +1,167 @@
+package dbrpc
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/db"
+)
+
+// aggPair builds a client/server over a persistent db seeded with n job-shaped ads. Values are
+// chosen so the columnar and scanning paths have something to disagree about: a large integer
+// (where float formatting would show), a real column, and values that escape their slot width.
+func aggPair(t *testing.T, n int) (*Client, *db.DB, func()) {
+	t.Helper()
+	d, err := db.Open(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := NewServer(d)
+	cconn, sconn := netPipe()
+	go func() { _ = s.ServeConnOpts(sconn, ServeOptions{Privileged: true}) }()
+	c := NewClient(cconn)
+
+	ctx := context.Background()
+	tx, err := c.Begin(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < n; i++ {
+		qdate := 1700000000 + i // large enough that float notation would be visible
+		// Huge is chosen so the column's integer SUM exceeds 2^53: rendering that from a float64
+		// accumulator would round, and disagree with the reference's int64 sum.
+		if err := tx.NewClassAd(ctx, fmt.Sprintf("k%d", i), fmt.Sprintf(
+			"ClusterId = %d\nProcId = %d\nRequestMemory = %d\nQDate = %d\nWallClock = %d.5\nHuge = %d",
+			i/10, i%10, ((i%16)+1)*512, qdate, i, 4000000000000+int64(i))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatal(err)
+	}
+	return c, d, func() { c.Close(); s.Close(); d.Close() }
+}
+
+// aggText runs one aggregate through the RPC and returns its single cell.
+func aggText(t *testing.T, c *Client, fn db.AggFunc, attr, constraint string) string {
+	t.Helper()
+	rows, err := c.Aggregate(context.Background(), constraint, nil, []db.AggSpec{{Func: fn, Arg: attr}})
+	if err != nil {
+		t.Fatalf("%v(%s) where %q: %v", fn, attr, constraint, err)
+	}
+	if len(rows) != 1 || len(rows[0].Values) != 1 {
+		t.Fatalf("%v(%s): rows = %+v, want one value", fn, attr, rows)
+	}
+	return rows[0].Values[0]
+}
+
+// TestColumnarAggregateMatchesScan is the test this feature lives or dies by: with the
+// accelerator on, every aggregate must return the EXACT SAME TEXT as with it off. A numeric
+// difference would be a bug; a formatting difference (1.7e+09 for 1700000015) would be just as
+// wrong and far easier to ship unnoticed.
+func TestColumnarAggregateMatchesScan(t *testing.T) {
+	c, d, cleanup := aggPair(t, 3000)
+	defer cleanup()
+
+	cases := []struct {
+		fn         db.AggFunc
+		attr       string
+		constraint string
+	}{
+		{db.AggMax, "ProcId", "true"},
+		{db.AggMin, "ProcId", "true"},
+		{db.AggMax, "QDate", "true"}, // large ints: float notation would show here
+		{db.AggMin, "QDate", "true"},
+		{db.AggMax, "WallClock", "true"}, // a real column
+		{db.AggMin, "WallClock", "true"},
+		{db.AggCount, "ProcId", "true"},
+		{db.AggMax, "RequestMemory", "RequestMemory < 4096"}, // same-field predicate
+		{db.AggMin, "RequestMemory", "RequestMemory >= 4096"},
+		{db.AggMax, "RequestMemory", "RequestMemory > 99999999"}, // matches nothing
+		{db.AggSum, "ProcId", "true"},
+		{db.AggSum, "Huge", "true"},      // integer sum past 2^53: float rounding would show
+		{db.AggSum, "WallClock", "true"}, // a real column: promotes to a real
+		{db.AggAvg, "ProcId", "true"},
+		{db.AggAvg, "WallClock", "true"},
+		{db.AggSum, "RequestMemory", "RequestMemory > 99999999"}, // empty SUM
+		{db.AggAvg, "RequestMemory", "RequestMemory > 99999999"}, // empty AVG
+	}
+
+	// Scanning answers first: schema-scan is not enabled yet, so these cannot take the fast path.
+	if d.SchemaScanInfo().Enabled {
+		t.Fatal("fixture already has the accelerator enabled; the baseline would not be the scan")
+	}
+	want := make([]string, len(cases))
+	for i, tc := range cases {
+		want[i] = aggText(t, c, tc.fn, tc.attr, tc.constraint)
+	}
+
+	if !d.EnableSchemaScan(4000, 8) {
+		t.Skip("no sealed segments to sample in this fixture")
+	}
+	if !d.SchemaScanInfo().Enabled {
+		t.Fatal("accelerator did not enable")
+	}
+	for i, tc := range cases {
+		// Prove the fast path actually serves this case. Without it, a case the columnar path
+		// quietly declined would compare the scan against itself and pass for the wrong reason --
+		// the same trap that made an early version of BenchmarkAggregateMax measure nothing.
+		if _, ok := db.ColumnarAggregate(func(attr string) (db.NumStats, bool) {
+			return d.NumStats(tc.constraint, attr)
+		}, nil, []db.AggSpec{{Func: tc.fn, Arg: tc.attr}}); !ok {
+			t.Errorf("%v(%s) where %q: the columnar path declines it, so the comparison below is "+
+				"scan-vs-scan and proves nothing", tc.fn, tc.attr, tc.constraint)
+			continue
+		}
+		got := aggText(t, c, tc.fn, tc.attr, tc.constraint)
+		if got != want[i] {
+			t.Errorf("%v(%s) where %q: accelerated %q, scanned %q",
+				tc.fn, tc.attr, tc.constraint, got, want[i])
+		}
+	}
+}
+
+// TestColumnarAggregateDeclinesFilter guards the one case where answering from the columnar pass
+// would be actively wrong rather than just unavailable: a per-aggregate FILTER the pass knows
+// nothing about. The answer must be the filtered one, not the unfiltered total.
+func TestColumnarAggregateDeclinesFilter(t *testing.T) {
+	c, d, cleanup := aggPair(t, 3000)
+	defer cleanup()
+	if !d.EnableSchemaScan(4000, 8) {
+		t.Skip("no sealed segments to sample")
+	}
+	ctx := context.Background()
+
+	rows, err := c.Aggregate(ctx, "true", nil, []db.AggSpec{
+		{Func: db.AggMax, Arg: "ProcId", Filter: "ProcId < 5"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 || len(rows[0].Values) != 1 {
+		t.Fatalf("rows = %+v", rows)
+	}
+	if got := rows[0].Values[0]; got != "4" {
+		t.Errorf("MAX(ProcId) FILTER (ProcId < 5) = %q, want 4 -- the unfiltered answer is 9, so a "+
+			"columnar answer that ignored the filter would show up as 9", got)
+	}
+}
+
+// TestColumnarAggregateGroupedStillScans pins that grouping is out of scope: the fast path serves
+// one ungrouped aggregate, and a GROUP BY must keep producing its groups.
+func TestColumnarAggregateGroupedStillScans(t *testing.T) {
+	c, d, cleanup := aggPair(t, 1000)
+	defer cleanup()
+	if !d.EnableSchemaScan(4000, 8) {
+		t.Skip("no sealed segments to sample")
+	}
+	rows, err := c.Aggregate(context.Background(), "true",
+		[]string{"ProcId"}, []db.AggSpec{{Func: db.AggMax, Arg: "RequestMemory"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 10 { // ProcId 0..9
+		t.Errorf("grouped MAX returned %d rows, want 10", len(rows))
+	}
+}


### PR DESCRIPTION
You were right that there was no reason aggregates couldn't be pushed down. The columnar block stores each numeric column contiguously and its scan already hands back **values** — `schemaScanCount` was simply the only consumer written, so an unconstrained `MAX` scanned row-wise.

`NumStatsQuery` makes one pass over a column returning `N`, `IntSum`, `Sum`, `Min`, `Max`, reusing the per-block schema resolution, MVCC visibility and cold-tail escape handling the count already had. `CountQuery` now shares that pass, and its predicate analysis too.

### Result types reproduce the reference exactly

You suggested summing on the normal path and deferring to `classad.Sum` for the exceptional cases; reading `builtinSum` showed the rule is small enough to reproduce outright, which avoids materializing values at all:

| | rule |
|---|---|
| `SUM` | integers accumulate in **int64**, promoting to a real only once a real appears (`builtinSum`) |
| `AVG` | always a real (`builtinAvg`); an empty `SUM`/`AVG` is int `0`, not undefined |
| `MIN`/`MAX` | the element's own type, so an integer column prints `1099511627776`, not `1.09e+12` |

The int64 accumulation is the load-bearing part: a float64 accumulator rounds past 2^53, so a large integer column would silently disagree with the scan. The test sums a column over 4e12 to catch exactly that. **The test compares text, not numbers** — a formatting difference would be as wrong as a numeric one and far easier to ship unnoticed.

### Real columns work now too

`scanInt` reads "int/real as int bits" and the hot tier admits both, but `CountQuery` declined anything but `akInt`. A real's slot holds `math.Float64bits`, so reading it as an integer gives ~4.6e18 instead of a few thousand — the conversion now comes from the *block's* schema, and from the wire node's own kind for an escaped value.

### Two refusals

A per-aggregate `FILTER` declines rather than approximating: the pass knows nothing about it, so answering would report an unfiltered aggregate as if it were filtered. A column that turned up a **boolean** declines too — the reference coerces booleans to 1/0 and then keeps a lone boolean's own type, not worth reproducing for data that pathological when the scan is exact.

### Measurement

Through the real server paths (50k rows, 16/16 segments covered), `MAX(ProcId)`:

```
projected wire-native scan   14.0ms  16.2MB  50136 allocs
columnar column pass          3.0ms   0.7MB  15121 allocs    4.7x
```

Two near-misses worth flagging, both now guarded in the tests:

- An earlier version of that benchmark reported **1.65x while measuring nothing** — the fixture's ads all fit one unsealed segment, so the "columnar" run was the row fallback. It now fails outright if no segment carries a block.
- The equivalence test would have **passed vacuously** for any aggregate the fast path declined, comparing the scan against itself. It now asserts the fast path serves each case first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
