### PR TITLE
dbrpc: schema.fit / schema.rebuild on an archive table

### DIFF
--- a/collections/archive.go
+++ b/collections/archive.go
@@ -301,6 +301,16 @@ func (a *Archive) BuildAndEnableSchemaScan(sampleMax, hotTopN int) bool {
 	return a.c.BuildAndEnableSchemaScan(sampleMax, hotTopN)
 }
 
+// SchemaFit measures the archive's derived schema against a fresh sample, reporting per-field
+// escape rates (see Collection.SchemaFit).
+func (a *Archive) SchemaFit(sampleMax int) ([]SchemaFieldFit, int) { return a.c.SchemaFit(sampleMax) }
+
+// ReschemaScan re-derives the archive's schema and rebuilds every sealed segment's columnar
+// block against it (see Collection.ReschemaScan).
+func (a *Archive) ReschemaScan(sampleMax, hotTopN int) bool {
+	return a.c.ReschemaScan(sampleMax, hotTopN)
+}
+
 // SchemaScanInfo reports the columnar accelerator's state for the archive.
 func (a *Archive) SchemaScanInfo() SchemaScanInfo { return a.c.SchemaScanInfo() }
 

--- a/db/archive.go
+++ b/db/archive.go
@@ -438,6 +438,17 @@ func (t *ArchiveTable) BuildAndEnableSchemaScan(sampleMax, hotTopN int) bool {
 	return t.a.BuildAndEnableSchemaScan(sampleMax, hotTopN)
 }
 
+// SchemaFit measures the archive's derived schema against a fresh sample (see DB.SchemaFit).
+func (t *ArchiveTable) SchemaFit(sampleMax int) ([]SchemaFieldFit, int) {
+	return t.a.SchemaFit(sampleMax)
+}
+
+// ReschemaScan re-derives the archive's schema and rebuilds every sealed segment's columnar
+// block (see DB.ReschemaScan).
+func (t *ArchiveTable) ReschemaScan(sampleMax, hotTopN int) bool {
+	return t.a.ReschemaScan(sampleMax, hotTopN)
+}
+
 // SchemaScanInfo reports the archive's columnar accelerator state.
 func (t *ArchiveTable) SchemaScanInfo() SchemaScanInfo { return t.a.SchemaScanInfo() }
 

--- a/dbrpc/analyze_test.go
+++ b/dbrpc/analyze_test.go
@@ -95,7 +95,7 @@ func TestArchiveAdminAnalyze(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	msg, err := archiveAdmin(a, "analyze", nil)
+	msg, err := archiveAdmin(a, "analyze", nil, 0)
 	if err != nil {
 		t.Fatalf("archive analyze: %v", err)
 	}

--- a/dbrpc/archivecolumnar_test.go
+++ b/dbrpc/archivecolumnar_test.go
@@ -133,3 +133,47 @@ func TestArchiveSchemaScanCountsAgree(t *testing.T) {
 		}
 	}
 }
+
+// TestArchiveSchemaScanOnWhenConfigured is the other half of TestArchiveSchemaScanOffByDefault:
+// with ArchiveSchemaScanHotTopN set, a maintenance pass must actually BUILD the accelerator on an
+// archive. Without this, the option could be plumbed as far as the struct and silently do nothing
+// -- which is how the mutable side's SchemaScanHotTopN sat at 0 and left the accelerator dark.
+func TestArchiveSchemaScanOnWhenConfigured(t *testing.T) {
+	cat, err := db.OpenCatalog(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := NewServerCatalog(cat)
+	cconn, sconn := netPipe()
+	go func() { _ = s.ServeConnOpts(sconn, ServeOptions{Privileged: true}) }()
+	c := NewClient(cconn)
+	defer func() { c.Close(); s.Close(); cat.Close() }()
+
+	ctx := context.Background()
+	if err := c.CreateArchiveTable(ctx, "history", db.ArchiveConfig{SegmentSize: 1 << 16}); err != nil {
+		t.Fatal(err)
+	}
+	seedHistory(t, c, "history", 3000)
+
+	a, ok := cat.ArchiveTable("history")
+	if !ok {
+		t.Fatal("archive table missing")
+	}
+	if a.SchemaScanInfo().Enabled {
+		t.Fatal("accelerator already enabled before any maintenance pass")
+	}
+
+	// The same call the scheduled pass makes, with the option set.
+	s.maintainArchives(db.MaintainOptions{ArchiveSchemaScanHotTopN: 8, SampleMax: 2000})
+
+	info := a.SchemaScanInfo()
+	if !info.Enabled {
+		t.Fatal("a maintenance pass with ArchiveSchemaScanHotTopN set did NOT enable the accelerator")
+	}
+	if info.SchemaFields == 0 {
+		t.Error("no schema fields after the maintenance build")
+	}
+	if info.SealedSegments == 0 || info.CoveredSegments != info.SealedSegments {
+		t.Errorf("coverage %d/%d after the maintenance build", info.CoveredSegments, info.SealedSegments)
+	}
+}

--- a/dbrpc/archiveschemaadmin_test.go
+++ b/dbrpc/archiveschemaadmin_test.go
@@ -1,0 +1,144 @@
+package dbrpc
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/db"
+)
+
+// These cover schema.fit / schema.rebuild ON AN ARCHIVE, over a catalog server -- the shape a
+// deployment actually runs. They exist because the actions shipped mutable-table-only and
+// `.schema rebuild` on a history table failed as an unknown admin action: the earlier tests used
+// a hand-picked single-table mutable fixture, so they passed while the real case was broken.
+
+// archiveSchemaPair builds a catalog server with a populated archive whose segments seal, and
+// returns the client plus the archive table for direct assertions.
+func archiveSchemaPair(t *testing.T, n int) (*Client, *db.ArchiveTable, func()) {
+	t.Helper()
+	cat, err := db.OpenCatalog(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := NewServerCatalog(cat)
+	cconn, sconn := netPipe()
+	go func() { _ = s.ServeConnOpts(sconn, ServeOptions{Privileged: true}) }()
+	c := NewClient(cconn)
+	ctx := context.Background()
+	// A small segment size so segments SEAL: only a sealed segment carries a columnar block, so
+	// an 8 MiB default would leave nothing for a rebuild to cover and the assertions would be
+	// vacuous.
+	if err := c.CreateArchiveTable(ctx, "history", db.ArchiveConfig{SegmentSize: 1 << 16}); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < n; i++ {
+		if err := c.ArchiveAppend(ctx, "history", fmt.Sprintf(
+			"ClusterId = %d\nProcId = %d\nOwner = \"u%d\"\nRequestMemory = %d\nRequestCpus = %d\nWallClock = %d.5",
+			i/10, i%10, i%8, ((i%16)+1)*512, 1+i%8, i)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	a, ok := cat.ArchiveTable("history")
+	if !ok {
+		t.Fatal("archive table missing from the catalog")
+	}
+	return c, a, func() { c.Close(); s.Close(); cat.Close() }
+}
+
+// TestArchiveSchemaRebuildAdmin is the regression: `.schema rebuild` on a history table returned
+// `unknown archive admin action "schema.rebuild"`.
+func TestArchiveSchemaRebuildAdmin(t *testing.T) {
+	c, a, cleanup := archiveSchemaPair(t, 3000)
+	defer cleanup()
+	ctx := context.Background()
+
+	// Works from cold: no accelerator yet, so the rebuild is what BUILDS one. An operator asking
+	// for a schema on a table that has none must not be told the action does not exist.
+	if a.SchemaScanInfo().Enabled {
+		t.Fatal("fixture already has an accelerator; the cold-start path would go untested")
+	}
+	msg, err := c.AdminTable(ctx, "history", "schema.rebuild")
+	if err != nil {
+		t.Fatalf("schema.rebuild on an archive: %v", err)
+	}
+	if !strings.Contains(msg, "schema rebuilt") {
+		t.Errorf("message = %q, want it to report the rebuild", msg)
+	}
+	info := a.SchemaScanInfo()
+	if !info.Enabled {
+		t.Fatal("accelerator still disabled after schema.rebuild on the archive")
+	}
+	if info.SchemaFields == 0 {
+		t.Error("no schema fields after the rebuild")
+	}
+	if info.SealedSegments == 0 || info.CoveredSegments != info.SealedSegments {
+		t.Errorf("coverage %d/%d: the rebuild should cover every sealed segment",
+			info.CoveredSegments, info.SealedSegments)
+	}
+
+	// And again, now that one exists -- the re-derive path, which is the point of the action.
+	if _, err := c.AdminTable(ctx, "history", "schema.rebuild", "2000", "4"); err != nil {
+		t.Fatalf("second schema.rebuild with explicit args: %v", err)
+	}
+}
+
+// TestArchiveSchemaFitAdmin covers the fit report on an archive, both before and after a schema
+// exists, since "no schema to measure" and a real report are different outputs.
+func TestArchiveSchemaFitAdmin(t *testing.T) {
+	c, a, cleanup := archiveSchemaPair(t, 3000)
+	defer cleanup()
+	ctx := context.Background()
+
+	msg, err := c.AdminTable(ctx, "history", "schema.fit")
+	if err != nil {
+		t.Fatalf("schema.fit on an archive with no accelerator: %v", err)
+	}
+	if !strings.Contains(msg, "not enabled") {
+		t.Errorf("with no accelerator, message = %q, want it to say so", msg)
+	}
+
+	if !a.ReschemaScan(2000, 4) {
+		t.Skip("no sealed segments to sample")
+	}
+	msg, err = c.AdminTable(ctx, "history", "schema.fit")
+	if err != nil {
+		t.Fatalf("schema.fit after a rebuild: %v", err)
+	}
+	var rep struct {
+		Sampled int                 `json:"sampled"`
+		Fields  []db.SchemaFieldFit `json:"fields"`
+	}
+	if err := json.Unmarshal([]byte(msg), &rep); err != nil {
+		t.Fatalf("schema.fit did not return the JSON report: %v (%q)", err, msg)
+	}
+	if rep.Sampled == 0 || len(rep.Fields) == 0 {
+		t.Errorf("empty fit report: %+v", rep)
+	}
+	for _, f := range rep.Fields {
+		if f.Name == "" {
+			t.Errorf("field with no name: %+v", f)
+		}
+	}
+}
+
+// TestArchiveSchemaAdminArgErrors pins that the argument checking is the same on both table types
+// -- one implementation, so an operator gets the same message wherever they run it.
+func TestArchiveSchemaAdminArgErrors(t *testing.T) {
+	c, _, cleanup := archiveSchemaPair(t, 500)
+	defer cleanup()
+	ctx := context.Background()
+
+	for _, tc := range []struct{ action, arg, want string }{
+		{"schema.fit", "notanumber", "must be an integer"},
+		{"schema.rebuild", "100", "no arguments or"},
+	} {
+		if _, err := c.AdminTable(ctx, "history", tc.action, tc.arg); err == nil {
+			t.Errorf("%s %s: expected an error", tc.action, tc.arg)
+		} else if !strings.Contains(err.Error(), tc.want) {
+			t.Errorf("%s %s: error %q, want it to mention %q", tc.action, tc.arg, err, tc.want)
+		}
+	}
+}

--- a/dbrpc/diag.go
+++ b/dbrpc/diag.go
@@ -123,6 +123,7 @@ func (s *Server) archiveDiagJSON(a *db.ArchiveTable) ([]byte, error) {
 //	hot.refresh <sampleMax> <topN>    recompute the hot set from sampled frequency
 //	schema.fit [sampleMax]            report how well the derived schema still fits the data
 //	schema.rebuild [sampleMax topN]   re-derive the schema and rebuild every columnar block
+//	                                  (both also available on an archive table)
 //	compact                           reclaim dead space in warranted shards
 //	rewrite                           re-encode all ads with the current hot set
 //	codec.retrain [sampleMax]         train/refresh the ZSTD dictionary + recompress
@@ -243,57 +244,9 @@ func (s *Server) admin(t *db.DB, action string, args []string, privileged bool) 
 		n := t.RefreshHotSet(sampleMax, topN)
 		return fmt.Sprintf("refreshed hot set: %d attribute(s)", n), nil
 	case "schema.fit":
-		// Report, do not change: how well the derived schema still matches the data. The
-		// operator's input to deciding whether schema.rebuild is worth its cost.
-		sampleMax := diagSampleMax
-		if len(args) == 1 {
-			n, err := strconv.Atoi(args[0])
-			if err != nil {
-				return "", fmt.Errorf("schema.fit <sampleMax> must be an integer")
-			}
-			sampleMax = n
-		} else if len(args) > 1 {
-			return "", fmt.Errorf("schema.fit takes at most <sampleMax>")
-		}
-		fit, sampled := t.SchemaFit(sampleMax)
-		if len(fit) == 0 {
-			return "columnar accelerator not enabled: no schema to measure", nil
-		}
-		b, err := json.Marshal(struct {
-			Sampled int                 `json:"sampled"`
-			Fields  []db.SchemaFieldFit `json:"fields"`
-		}{sampled, fit})
-		if err != nil {
-			return "", err
-		}
-		return string(b), nil
+		return schemaFitAction(t, args)
 	case "schema.rebuild":
-		// The deliberate re-schema: routine maintenance keeps the schema pinned forever, so
-		// this is the only way to re-derive it as the workload drifts. Rebuilds a columnar
-		// block per sealed segment.
-		sampleMax, topN := diagSampleMax, s.maintainOpts.HotTopN
-		if topN <= 0 {
-			topN = defaultSchemaHotTopN
-		}
-		switch len(args) {
-		case 0:
-		case 2:
-			n, e1 := strconv.Atoi(args[0])
-			k, e2 := strconv.Atoi(args[1])
-			if e1 != nil || e2 != nil {
-				return "", fmt.Errorf("schema.rebuild arguments must be integers")
-			}
-			sampleMax, topN = n, k
-		default:
-			return "", fmt.Errorf("schema.rebuild takes no arguments or <sampleMax> <topN>")
-		}
-		if !t.ReschemaScan(sampleMax, topN) {
-			return "", fmt.Errorf("schema rebuild did not run: nothing to sample, or the " +
-				"accelerator is unavailable here (encryption at rest)")
-		}
-		info := t.SchemaScanInfo()
-		return fmt.Sprintf("schema rebuilt: %d field(s), %d hot, %d/%d sealed segments covered",
-			info.SchemaFields, len(info.HotFields), info.CoveredSegments, info.SealedSegments), nil
+		return schemaRebuildAction(t, args, s.maintainOpts.HotTopN)
 	case "analyze":
 		// On-demand self-tuning pass ("optimize now"), the manual counterpart to the scheduled
 		// StartMaintenance. Reuses the server's configured maintenance options so it matches the
@@ -333,7 +286,10 @@ func (s *Server) admin(t *db.DB, action string, args []string, privileged bool) 
 // per-segment indexes, rewrite, set retention, rotate -- plus truncate (empty the archive).
 // Encryption/time-travel/hot-set actions do not apply to an archive. DAEMON-gated by the
 // caller, like the mutable-table admin.
-func archiveAdmin(a *db.ArchiveTable, action string, args []string) (string, error) {
+//
+// schema.fit / schema.rebuild run the same shared implementations the mutable path uses, so the
+// two table types cannot drift apart in behaviour or output.
+func archiveAdmin(a *db.ArchiveTable, action string, args []string, hotTopN int) (string, error) {
 	switch action {
 	case "truncate":
 		// Destructive reset: drop every record (a from-scratch re-sync empties the archive,
@@ -391,6 +347,10 @@ func archiveAdmin(a *db.ArchiveTable, action string, args []string) (string, err
 			return "", fmt.Errorf("retention.set: %w", err)
 		}
 		return "retention: " + retentionSummary(r), nil
+	case "schema.fit":
+		return schemaFitAction(a, args)
+	case "schema.rebuild":
+		return schemaRebuildAction(a, args, hotTopN)
 	case "rotate":
 		n, err := a.Rotate(float64(time.Now().Unix()))
 		if err != nil {
@@ -712,4 +672,70 @@ func (c *Client) Tables(ctx context.Context) ([]string, error) {
 		names = append(names, body.str())
 	}
 	return names, nil
+}
+
+// schemaScanTable is the schema-accelerator surface shared by a mutable table and an archive, so
+// schema.fit / schema.rebuild are ONE implementation for both. They were a mutable-table-only
+// action first, which meant `.schema rebuild` on a history table failed as an unknown action --
+// the tables that most want a rebuild being exactly the ones that could not have one.
+type schemaScanTable interface {
+	SchemaFit(sampleMax int) ([]db.SchemaFieldFit, int)
+	ReschemaScan(sampleMax, hotTopN int) bool
+	SchemaScanInfo() db.SchemaScanInfo
+}
+
+// schemaFitAction reports how well the derived schema still matches the data. Report only: the
+// operator's input to deciding whether schema.rebuild is worth its cost.
+func schemaFitAction(t schemaScanTable, args []string) (string, error) {
+	sampleMax := diagSampleMax
+	if len(args) == 1 {
+		n, err := strconv.Atoi(args[0])
+		if err != nil {
+			return "", fmt.Errorf("schema.fit <sampleMax> must be an integer")
+		}
+		sampleMax = n
+	} else if len(args) > 1 {
+		return "", fmt.Errorf("schema.fit takes at most <sampleMax>")
+	}
+	fit, sampled := t.SchemaFit(sampleMax)
+	if len(fit) == 0 {
+		return "columnar accelerator not enabled: no schema to measure", nil
+	}
+	b, err := json.Marshal(struct {
+		Sampled int                 `json:"sampled"`
+		Fields  []db.SchemaFieldFit `json:"fields"`
+	}{sampled, fit})
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// schemaRebuildAction re-derives the schema and rebuilds every sealed segment's columnar block.
+// Routine maintenance keeps the schema pinned forever, so this is the only way to re-derive it as
+// the workload drifts. hotTopN is the server's configured hot-column count, or 0 for the default.
+func schemaRebuildAction(t schemaScanTable, args []string, hotTopN int) (string, error) {
+	sampleMax, topN := diagSampleMax, hotTopN
+	if topN <= 0 {
+		topN = defaultSchemaHotTopN
+	}
+	switch len(args) {
+	case 0:
+	case 2:
+		n, e1 := strconv.Atoi(args[0])
+		k, e2 := strconv.Atoi(args[1])
+		if e1 != nil || e2 != nil {
+			return "", fmt.Errorf("schema.rebuild arguments must be integers")
+		}
+		sampleMax, topN = n, k
+	default:
+		return "", fmt.Errorf("schema.rebuild takes no arguments or <sampleMax> <topN>")
+	}
+	if !t.ReschemaScan(sampleMax, topN) {
+		return "", fmt.Errorf("schema rebuild did not run: nothing to sample, or the " +
+			"accelerator is unavailable here (encryption at rest)")
+	}
+	info := t.SchemaScanInfo()
+	return fmt.Sprintf("schema rebuilt: %d field(s), %d hot, %d/%d sealed segments covered",
+		info.SchemaFields, len(info.HotFields), info.CoveredSegments, info.SealedSegments), nil
 }

--- a/dbrpc/server.go
+++ b/dbrpc/server.go
@@ -1289,7 +1289,7 @@ func (s *Server) handle(sc *serverConn, reqID uint64, o op, r *reader, includePr
 				if !privileged {
 					return respErr(reqID, fmt.Sprintf("admin action %q requires DAEMON authorization", action))
 				}
-				msg, err := archiveAdmin(a, action, args)
+				msg, err := archiveAdmin(a, action, args, s.maintainOpts.HotTopN)
 				if err != nil {
 					return respErr(reqID, err.Error())
 				}


### PR DESCRIPTION
`.schema rebuild` on a history table failed:

```
htcondordb> .schema rebuild
error: dbrpc: unknown archive admin action "schema.rebuild"
```

`schema.fit` / `schema.rebuild` were added to the mutable-table admin only. So the tables that most want a rebuild — a long append-only history, where the schema was sampled once and never revisited — were exactly the ones that couldn't have one.

### One implementation, not two

Both actions now run shared bodies (`schemaFitAction` / `schemaRebuildAction`) over a small interface both table types satisfy, rather than a second copy for archives. Behaviour, argument checking and output can't drift between the two. `archiveAdmin` also now receives the server's configured `HotTopN`, as the mutable path already did, so a rebuild picks the same hot-column count wherever it runs.

Adds the `ArchiveTable.SchemaFit` / `ReschemaScan` delegations this needed — the follow-up I'd deferred, which is precisely why the gap existed.

### Why the tests missed it

They used a hand-picked **single-table mutable** fixture (`dbrpc.NewServer(d)`), which cannot reach an archive at all. So they passed while the real case was broken, and I then wrote the gap into a PR description instead of closing it — which reads as considered rather than untested.

The new tests go through a **catalog server with a populated archive whose segments actually seal** — the shape a deployment runs. They cover:

- **the cold start** — no accelerator yet, so the rebuild is what *builds* one. That's how an operator first meets this, and it's the case that failed.
- the re-derive once one exists, with explicit `sampleMax topN` args
- the fit report both before ("not enabled") and after (the JSON report)
- that argument errors match the mutable path's, since it's now one implementation

Also adds `TestArchiveSchemaScanOnWhenConfigured`: a maintenance pass with `ArchiveSchemaScanHotTopN` set must actually **build** the accelerator. The existing archive test only proved it does *not* build one when unset — the half that can't catch the option being plumbed as far as the struct and doing nothing.

Verified the companion REPL test in htcondordb reproduces the reported error against unfixed `main` and passes with this change, rather than assuming it.

`collections`, `db`, `dbrpc` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
