### PR TITLE
collections: decompress one block region per read; connect the hot-tier demand signal

### DIFF
--- a/collections/blockcache.go
+++ b/collections/blockcache.go
@@ -11,18 +11,43 @@ type decodedStreams struct {
 
 func (d *decodedStreams) cost() int64 { return int64(len(d.coldNum) + len(d.str) + len(d.cold)) }
 
-// blockCache caches columnar blocks' decompressed cold streams so repeated full-ad reads and
-// escaped-record lookups within a row-group decompress once, not per record. Backed by
+// streamKind names one of a block's three independently-compressed regions. They are cached and
+// decompressed SEPARATELY because most readers want exactly one of them:
+//
+//	kindColdNum  the cold numeric column groups -- a cold column scan
+//	kindStr      the string region              -- only a full-ad read
+//	kindCold     the cold tail (row-wise)       -- an escaped value's node
+//
+// Decompressing all three together meant reading one escaped integer also inflated the string
+// region, which on wide ads (a history record carries dozens of string attributes) is the largest
+// of the three by far. It also spent the cache's byte budget on regions nobody read, evicting the
+// ones they did.
+type streamKind uint8
+
+const (
+	kindColdNum streamKind = iota
+	kindStr
+	kindCold
+)
+
+// streamKey derives a per-stream cache key. Block ids come from a monotonic counter
+// (colBlockSeq), so id*3+kind is unique per (block, stream).
+func streamKey(id uint64, k streamKind) uint64 { return id*3 + uint64(k) }
+
+// blockCache caches columnar blocks' decompressed regions, one entry PER REGION, so repeated
+// full-ad reads and escaped-record lookups within a row-group decompress once, not per record.
+// Per-region entries mean a reader pays only for what it reads, and the byte budget is not spent
+// holding regions nobody touched. Backed by
 // ristretto: byte-cost-bounded (each entry's cost is its decompressed size) and concurrent, a
 // good fit for large, variable-size, hot items under parallel scans. A nil *blockCache is
 // valid and simply decompresses every time (used by tests and unconfigured collections).
 type blockCache struct {
-	c *ristretto.Cache[uint64, *decodedStreams]
+	c *ristretto.Cache[uint64, []byte]
 }
 
 // newBlockCache creates a cache bounded to about maxBytes of decompressed block streams.
 func newBlockCache(maxBytes int64) (*blockCache, error) {
-	c, err := ristretto.NewCache(&ristretto.Config[uint64, *decodedStreams]{
+	c, err := ristretto.NewCache(&ristretto.Config[uint64, []byte]{
 		NumCounters: 1 << 20, // ~10x the expected item count, for TinyLFU admission
 		MaxCost:     maxBytes,
 		BufferItems: 64,
@@ -37,29 +62,50 @@ func newBlockCache(maxBytes int64) (*blockCache, error) {
 // decompresses all three and inserts them (cost = decompressed bytes). Safe for concurrent use;
 // ristretto's Set is asynchronous, so a get-immediately-after-set may miss -- harmless here (an
 // occasional redundant decompress, never a wrong result).
-func (bc *blockCache) streams(b *columnarBlock) (*decodedStreams, error) {
+// stream returns one of b's decompressed regions, from the cache when present. A reader that needs
+// a single region pays for that region only -- see streamKind.
+func (bc *blockCache) stream(b *columnarBlock, k streamKind) ([]byte, error) {
+	key := streamKey(b.id, k)
 	if bc != nil {
-		if ds, ok := bc.c.Get(b.id); ok {
-			return ds, nil
+		if raw, ok := bc.c.Get(key); ok {
+			return raw, nil
 		}
 	}
-	coldNum, err := b.codec.Decompress(nil, b.coldNumComp)
+	var comp []byte
+	switch k {
+	case kindColdNum:
+		comp = b.coldNumComp
+	case kindStr:
+		comp = b.strComp
+	case kindCold:
+		comp = b.coldComp
+	}
+	raw, err := b.codec.Decompress(nil, comp)
 	if err != nil {
 		return nil, err
 	}
-	str, err := b.codec.Decompress(nil, b.strComp)
-	if err != nil {
-		return nil, err
-	}
-	cold, err := b.codec.Decompress(nil, b.coldComp)
-	if err != nil {
-		return nil, err
-	}
-	ds := &decodedStreams{coldNum: coldNum, str: str, cold: cold}
 	if bc != nil {
-		bc.c.Set(b.id, ds, ds.cost())
+		bc.c.Set(key, raw, int64(len(raw)))
 	}
-	return ds, nil
+	return raw, nil
+}
+
+// streams returns all three regions, for a reader that genuinely needs them (a full-ad
+// reconstruction). Each is cached separately, so a later single-stream read hits.
+func (bc *blockCache) streams(b *columnarBlock) (*decodedStreams, error) {
+	coldNum, err := bc.stream(b, kindColdNum)
+	if err != nil {
+		return nil, err
+	}
+	str, err := bc.stream(b, kindStr)
+	if err != nil {
+		return nil, err
+	}
+	cold, err := bc.stream(b, kindCold)
+	if err != nil {
+		return nil, err
+	}
+	return &decodedStreams{coldNum: coldNum, str: str, cold: cold}, nil
 }
 
 // close releases the cache's resources.

--- a/collections/blockcache_bound_test.go
+++ b/collections/blockcache_bound_test.go
@@ -1,0 +1,91 @@
+package collections
+
+import (
+	"fmt"
+	"testing"
+)
+
+// TestBlockCacheRejectsOversizedRegion pins the consequence of a block being SEGMENT-sized rather
+// than chunked into row groups.
+//
+// A block covers one whole segment, and the merge ladder's MaxSegmentBytes defaults to 1 GiB. Its
+// three regions are each a single compressed blob, so a merged segment's decompressed string or
+// cold-tail region can run to hundreds of megabytes -- while the block cache is bounded at 256 MiB.
+// Ristretto cannot admit an item whose cost exceeds the whole cache, so past that size a region is
+// never cached and EVERY query re-decompresses it: a permanent penalty, not a cold-start one.
+//
+// This is the mechanism behind a repeated ~60s query with an occasional fast one -- fast when the
+// working set happens to fit, slow forever when it does not.
+func TestBlockCacheRejectsOversizedRegion(t *testing.T) {
+	const cacheBytes = 1 << 20 // 1 MiB stand-in for the production 256 MiB
+	bc, err := newBlockCache(cacheBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer bc.close()
+
+	codec, err := NewZSTDCodec(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Compressible but not trivially so, and larger than the whole cache when decompressed.
+	raw := make([]byte, 4<<20)
+	for i := range raw {
+		raw[i] = byte(i%251) ^ byte(i>>11)
+	}
+	fits := make([]byte, cacheBytes/8)
+	for i := range fits {
+		fits[i] = byte(i % 251)
+	}
+
+	newBlock := func(payload []byte) *columnarBlock {
+		return &columnarBlock{
+			id:       colBlockSeq.Add(1),
+			codec:    codec,
+			coldComp: codec.Compress(nil, payload),
+		}
+	}
+
+	// A region that fits is retained: a second read is a cache hit.
+	small := newBlock(fits)
+	if _, err := bc.stream(small, kindCold); err != nil {
+		t.Fatal(err)
+	}
+	waitForCache()
+	if _, ok := bc.c.Get(streamKey(small.id, kindCold)); !ok {
+		t.Error("a region well under the bound was not retained; the cache is not working at all")
+	}
+
+	// A region larger than the entire cache cannot be admitted, so every read re-decompresses.
+	big := newBlock(raw)
+	for i := 0; i < 3; i++ {
+		got, err := bc.stream(big, kindCold)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(got) != len(raw) {
+			t.Fatalf("read %d bytes, want %d", len(got), len(raw))
+		}
+	}
+	waitForCache()
+	if _, ok := bc.c.Get(streamKey(big.id, kindCold)); ok {
+		t.Log("oversized region was admitted after all; the bound is softer than assumed")
+	} else {
+		t.Logf("CONFIRMED: a %d-byte region is never cached under a %d-byte bound, so every query "+
+			"re-decompresses it. A segment-sized block (merge ladder default 1 GiB) can exceed the "+
+			"256 MiB production bound, making this permanent rather than a cold start.",
+			len(raw), cacheBytes)
+	}
+}
+
+// waitForCache lets ristretto's asynchronous Set land before we assert on membership.
+func waitForCache() {
+	for i := 0; i < 100; i++ {
+		if i > 0 {
+			// A short spin is enough; ristretto processes its buffer promptly.
+			for j := 0; j < 1e5; j++ {
+				_ = fmt.Sprint()
+			}
+		}
+	}
+}

--- a/collections/colagg.go
+++ b/collections/colagg.go
@@ -73,6 +73,14 @@ func (c *Collection) NumStatsQuery(q *vm.Query, attr string) (NumStats, bool) {
 		}
 		keep = pred
 	}
+	// Record the read so the hot tier learns about it. The tier holds the top-N numeric fields by
+	// query read demand, uncompressed; a cold field's column group has to be decompressed. But the
+	// accelerated paths recorded NO demand, so a column that is only ever aggregated -- never
+	// filtered on through a path that does record -- could not earn a slot, and serving the query
+	// faster made it invisible to the mechanism meant to make it faster still. The feedback loop
+	// was open.
+	c.demand.recordReads([]string{attr})
+
 	out := NumStats{Min: math.Inf(1), Max: math.Inf(-1)}
 	c.scanNumValues(id, st.cache, func(nv colVal) {
 		if keep != nil && !keep(nv.f) {

--- a/collections/colagg_retrain_test.go
+++ b/collections/colagg_retrain_test.go
@@ -1,0 +1,104 @@
+package collections
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/collections/vm"
+)
+
+// A columnar block's three regions are stored COMPRESSED, and marshalColSegment writes those bytes
+// verbatim -- so a dictionary retrain, which swaps the codec and recompacts, must not leave a block
+// whose streams were compressed under the old dictionary reachable through a codec that no longer
+// has it. These check that a retrain (and a rewrite, which also recompacts) leaves the columnar
+// path both working and correct.
+
+// retrainStore seeds a store with enough similar ads for dictionary training to be meaningful, and
+// enables the columnar accelerator.
+func retrainStore(t *testing.T) *Collection {
+	t.Helper()
+	c := New(Options{Shards: 2, SegmentSize: 1 << 12})
+	for i := 0; i < 3000; i++ {
+		mem := 1024 + (i%64)*256
+		if i%500 == 499 {
+			mem = 1 << 40 // escapees, so the cold tail is exercised too
+		}
+		if err := c.Put([]byte(fmt.Sprintf("k%d", i)), mustAdOld(t, fmt.Sprintf(
+			"Cpus=%d\nMemory=%d\nOwner=\"user%03d\"\nCmd=\"/home/user%03d/run.sh\"\nWallClock=%d.5",
+			1+i%8, mem, i%200, i%200, i))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mc, _ := vm.Parse("Memory >= 0")
+	for i := 0; i < 25; i++ {
+		for range c.Query(mc) {
+		}
+	}
+	if !c.BuildAndEnableSchemaScan(4000, 8) {
+		t.Fatal("BuildAndEnableSchemaScan false")
+	}
+	return c
+}
+
+// aggAll reads the aggregate via the columnar path, insisting it is actually served there.
+func aggAll(t *testing.T, c *Collection, attr string) NumStats {
+	t.Helper()
+	ns, ok := c.NumStatsQuery(nil, attr)
+	if !ok {
+		t.Fatalf("columnar aggregate declined for %s", attr)
+	}
+	return ns
+}
+
+// TestColumnarSurvivesRetrain is the load-bearing one: a retrain trains a NEW dictionary from
+// record samples and recompacts every segment under it. If a preserved block's streams were still
+// compressed under the previous dictionary, reading them through the new codec would fail or return
+// nonsense -- so the aggregate has to keep returning the same answers.
+func TestColumnarSurvivesRetrain(t *testing.T) {
+	c := retrainStore(t)
+	defer c.Close()
+
+	before := aggAll(t, c, "Memory")
+	beforeCpus := aggAll(t, c, "Cpus")
+
+	if _, err := c.RetrainDict(2000); err != nil {
+		t.Fatalf("RetrainDict: %v", err)
+	}
+
+	after := aggAll(t, c, "Memory")
+	if after.N != before.N || after.Min != before.Min || after.Max != before.Max || after.Sum != before.Sum {
+		t.Errorf("Memory aggregate changed across a retrain:\n before %+v\n after  %+v", before, after)
+	}
+	if got := aggAll(t, c, "Cpus"); got.N != beforeCpus.N || got.Max != beforeCpus.Max {
+		t.Errorf("Cpus aggregate changed across a retrain:\n before %+v\n after  %+v", beforeCpus, got)
+	}
+	// And the row path must agree with the columnar one afterwards.
+	q, _ := vm.Parse("Memory =!= undefined")
+	rows := 0
+	rowMax := 0.0
+	for ad := range c.Query(q) {
+		if v, ok := ad.EvaluateAttrNumber("Memory"); ok {
+			rows++
+			if v > rowMax {
+				rowMax = v
+			}
+		}
+	}
+	if rows != after.N || rowMax != after.Max {
+		t.Errorf("after retrain: columnar N/Max = %d/%v, row scan = %d/%v", after.N, after.Max, rows, rowMax)
+	}
+}
+
+// TestColumnarSurvivesRewrite covers the other recompacting path, which an operator reaches as
+// `.rewrite`.
+func TestColumnarSurvivesRewrite(t *testing.T) {
+	c := retrainStore(t)
+	defer c.Close()
+
+	before := aggAll(t, c, "Memory")
+	c.Rewrite()
+	after := aggAll(t, c, "Memory")
+	if after.N != before.N || after.Min != before.Min || after.Max != before.Max {
+		t.Errorf("Memory aggregate changed across a rewrite:\n before %+v\n after  %+v", before, after)
+	}
+}

--- a/collections/colblock.go
+++ b/collections/colblock.go
@@ -171,7 +171,7 @@ func (b *columnarBlock) scanInt(fieldIdx int, bc *blockCache, fn func(rec int, p
 	if !ok {
 		return errNotNumericField
 	}
-	ds, err := bc.streams(b)
+	coldNum, err := bc.stream(b, kindColdNum)
 	if err != nil {
 		return err
 	}
@@ -180,7 +180,7 @@ func (b *columnarBlock) scanInt(fieldIdx int, bc *blockCache, fn func(rec int, p
 			fn(k, false, 0)
 			continue
 		}
-		fn(k, true, readIntLE(ds.coldNum[start+k*f.width:], f.width, f.unsigned))
+		fn(k, true, readIntLE(coldNum[start+k*f.width:], f.width, f.unsigned))
 	}
 	return nil
 }
@@ -227,11 +227,11 @@ func (b *columnarBlock) reconstruct(k int, bc *blockCache) ([]byte, error) {
 // on one block share a single decompression. Callers use this only for records the scan has
 // already found escaped for fieldID; a hot/cold-column value never reaches here.
 func (b *columnarBlock) escapedNumField(k int, fieldID uint32, bc *blockCache) (float64, bool, error) {
-	ds, err := bc.streams(b)
+	tail, err := bc.stream(b, kindCold)
 	if err != nil {
 		return 0, false, err
 	}
-	cold := ds.cold[b.coldOff[k]:b.coldOff[k+1]]
+	cold := tail[b.coldOff[k]:b.coldOff[k+1]]
 	for len(cold) > 0 {
 		id, m := binary.Uvarint(cold)
 		if m <= 0 {
@@ -256,11 +256,11 @@ func (b *columnarBlock) escapedNumField(k int, fieldID uint32, bc *blockCache) (
 // from the node rather than assumed from the segment's schema (an escaped value is by definition
 // one the schema field did not fit).
 func (b *columnarBlock) escapedNumVal(k int, fieldID uint32, bc *blockCache) (colVal, bool) {
-	ds, err := bc.streams(b)
+	tail, err := bc.stream(b, kindCold)
 	if err != nil {
 		return colVal{}, false
 	}
-	cold := ds.cold[b.coldOff[k]:b.coldOff[k+1]]
+	cold := tail[b.coldOff[k]:b.coldOff[k+1]]
 	for len(cold) > 0 {
 		id, m := binary.Uvarint(cold)
 		if m <= 0 {

--- a/collections/colscan.go
+++ b/collections/colscan.go
@@ -458,6 +458,11 @@ func (c *Collection) CountQuery(q *vm.Query) (int, bool) {
 	if !ok {
 		return 0, false
 	}
+	// As NumStatsQuery: record the predicate's attribute so the hot tier keeps tracking the
+	// columns queries actually read, instead of freezing once the accelerator starts serving them.
+	if name, ok := c.schemaFieldName(fieldID); ok {
+		c.demand.recordReads([]string{name})
+	}
 	return c.schemaScanCount(fieldID, st.cache, eval), true
 }
 

--- a/collections/dictreal_test.go
+++ b/collections/dictreal_test.go
@@ -1,0 +1,128 @@
+package collections
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/classad"
+	"github.com/PelicanPlatform/classad/collections/vm"
+)
+
+// realOSPoolAds loads the committed OSPool slot corpus (condor_status -l), skipping when absent.
+func realOSPoolAds(tb testing.TB, max int) []*classad.ClassAd {
+	tb.Helper()
+	data, err := os.ReadFile("testdata/ospool_slots.ldif")
+	if err != nil {
+		tb.Skip("no OSPool testdata: " + err.Error())
+	}
+	var ads []*classad.ClassAd
+	for _, blk := range strings.Split(string(data), "\n\n") {
+		if strings.TrimSpace(blk) == "" {
+			continue
+		}
+		ad, err := classad.ParseOld(blk)
+		if err != nil {
+			continue
+		}
+		ads = append(ads, ad)
+		if len(ads) >= max {
+			break
+		}
+	}
+	if len(ads) == 0 {
+		tb.Skip("corpus parsed to zero ads")
+	}
+	return ads
+}
+
+// TestDictStrategiesRealOSPool repeats the dictionary comparison on REAL OSPool ads rather than a
+// synthetic fixture whose numeric columns were regular enough to flatter a region-trained
+// dictionary. These ads carry ~568 attributes apiece, so all three regions are populated naturally.
+func TestDictStrategiesRealOSPool(t *testing.T) {
+	ads := realOSPoolAds(t, 20000)
+	t.Logf("corpus: %d real OSPool ads, %d attributes in the first",
+		len(ads), len(ads[0].AST().Attributes))
+
+	c := New(Options{Shards: 1, SegmentSize: 1 << 18})
+	defer c.Close()
+	for i, ad := range ads {
+		if err := c.Put([]byte(fmt.Sprintf("slot%d", i)), ad); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Drive demand on a couple of numeric attributes real queries use, so the hot tier is realistic
+	// and the rest of the numeric fields land in the cold column groups.
+	for _, e := range []string{"Memory >= 0", "Cpus >= 0"} {
+		q, err := vm.Parse(e)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i := 0; i < 20; i++ {
+			for range c.Query(q) {
+			}
+		}
+	}
+	if !c.BuildAndEnableSchemaScan(4000, 8) {
+		t.Skip("no sealed segments to sample")
+	}
+	info := c.SchemaScanInfo()
+	t.Logf("schema: %d fields, hot %v, %d/%d segments covered",
+		info.SchemaFields, info.HotFields, info.CoveredSegments, info.SealedSegments)
+
+	adSamples := c.CollectSamples(2000)
+	regionSamples := c.CollectRegionSamples(DefaultDictSize, 0)
+	if len(adSamples) == 0 || len(regionSamples) == 0 {
+		t.Skip("need both sample kinds")
+	}
+	adDict, err := TrainDict(adSamples)
+	if err != nil {
+		t.Fatal(err)
+	}
+	regionDict, err := TrainDict(regionSamples)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mk := func(d []byte) Codec {
+		cd, err := NewZSTDCodec(d)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return cd
+	}
+	none, adTrained, regionTrained := mk(nil), mk(adDict), mk(regionDict)
+
+	compare := func(label string, payloads [][]byte) {
+		var raw, n, a, r int
+		for _, p := range payloads {
+			raw += len(p)
+			n += len(none.Compress(nil, p))
+			a += len(adTrained.Compress(nil, p))
+			r += len(regionTrained.Compress(nil, p))
+		}
+		if raw == 0 {
+			return
+		}
+		t.Logf("%-14s raw=%9d  no-dict=%8d  ad-dict=%8d (%+.1f%%)  region-dict=%8d (%+.1f%%)",
+			label, raw, n, a, 100*float64(a-n)/float64(n), r, 100*float64(r-n)/float64(n))
+	}
+
+	for _, kv := range []struct {
+		kind streamKind
+		name string
+	}{{kindColdNum, "cold-numeric"}, {kindStr, "strings"}, {kindCold, "cold-tail"}} {
+		var payloads [][]byte
+		for _, b := range c.sampleableBlocks(0) {
+			if raw, err := b.regionRaw(kv.kind); err == nil && len(raw) > 0 {
+				payloads = append(payloads, raw)
+			}
+		}
+		compare(kv.name, payloads)
+	}
+	recs := adSamples
+	if len(recs) > 500 {
+		recs = recs[:500]
+	}
+	compare("records", recs)
+}

--- a/collections/regionsamples.go
+++ b/collections/regionsamples.go
@@ -1,0 +1,143 @@
+package collections
+
+// Dictionary training samples drawn from columnar block REGIONS rather than whole ads.
+//
+// The dictionary is trained from CollectSamples: whole ClassAd records. That content is a good
+// match for compressing a record -- small, independent, and full of the attribute names and values
+// the dictionary carries. It is a poor match for a block's three regions, which are aggregates over
+// a whole segment: column-major fixed-width integers, concatenated string values, and the
+// record-shaped cold tail. Measured on a 4000-record fixture, an ad-trained dictionary gained
+// -0.1% on the cold numeric region, -14.7% on the strings, and -3.7% on the cold tail -- it helped
+// none of them.
+//
+// Sampling the regions themselves gives training content drawn from what is actually being
+// compressed. The interesting case is a SMALL block, which has little internal redundancy of its
+// own to exploit and is therefore where a dictionary can still earn something; a large block
+// compresses well unaided either way.
+
+// regionKinds is the number of region kinds sampled, and the number of equal shares the byte budget
+// is split into.
+const regionKinds = 3
+
+// regionChunk is the size of one sample taken from a region. Many smaller samples spread across
+// segments and regions make better dictionary content than a few large ones, which would let a
+// single segment's bytes crowd out the rest.
+const regionChunk = 4 << 10
+
+// CollectRegionSamples returns dictionary-training samples drawn from sealed segments' columnar
+// block regions, in equal byte shares across the three kinds, up to about maxBytes in total.
+//
+// For an APPEND-ONLY collection the draw is biased to recent segments: future writes resemble
+// recent history far more than the oldest retained records, and an archive's oldest segments may
+// predate schema or workload changes entirely. lookBackBytes caps how far back the draw reaches,
+// measured in segment bytes from the newest; 0 means no limit.
+//
+// Returns nil when no sealed segment carries a block -- there is nothing to sample from, and the
+// caller should fall back to record samples (see CollectSamples).
+func (c *Collection) CollectRegionSamples(maxBytes, lookBackBytes int) [][]byte {
+	if maxBytes <= 0 {
+		return nil
+	}
+	blocks := c.sampleableBlocks(lookBackBytes)
+	if len(blocks) == 0 {
+		return nil
+	}
+	share := maxBytes / regionKinds
+	var out [][]byte
+	// Round-robin the kinds so a shortfall in one (an empty cold tail, say) does not eat another's
+	// share, and so the samples interleave rather than arriving in three solid runs.
+	for kind := 0; kind < regionKinds; kind++ {
+		out = append(out, sampleKind(blocks, streamKind(kind), share)...)
+	}
+	return out
+}
+
+// sampleableBlocks returns the blocks to draw from, newest first, honoring the look-back budget.
+func (c *Collection) sampleableBlocks(lookBackBytes int) []*columnarBlock {
+	type seg struct {
+		b    *columnarBlock
+		used int
+	}
+	var segs []seg
+	for _, sh := range c.shards {
+		sh.mu.RLock()
+		act := sh.act
+		// sh.segs is oldest-first, so walking backwards is newest-first.
+		for i := len(sh.segs) - 1; i >= 0; i-- {
+			s := sh.segs[i]
+			if s == nil || s == act || s.used == 0 {
+				continue
+			}
+			if cs := s.colblk.Load(); cs != nil {
+				segs = append(segs, seg{cs.block, s.used})
+			}
+		}
+		sh.mu.RUnlock()
+	}
+	out := make([]*columnarBlock, 0, len(segs))
+	bytes := 0
+	for _, s := range segs {
+		out = append(out, s.b)
+		bytes += s.used
+		if lookBackBytes > 0 && bytes >= lookBackBytes {
+			break // far enough back: older segments predate what future writes will look like
+		}
+	}
+	return out
+}
+
+// sampleKind takes up to share bytes of one region kind, spread evenly across blocks.
+func sampleKind(blocks []*columnarBlock, kind streamKind, share int) [][]byte {
+	if share <= 0 || len(blocks) == 0 {
+		return nil
+	}
+	perBlock := share / len(blocks)
+	if perBlock < regionChunk {
+		perBlock = regionChunk // few blocks: take a whole chunk from each rather than slivers
+	}
+	var out [][]byte
+	taken := 0
+	for _, b := range blocks {
+		if taken >= share {
+			break
+		}
+		raw, err := b.regionRaw(kind)
+		if err != nil || len(raw) == 0 {
+			continue
+		}
+		// Spread the take across the region instead of always its head, so the samples are
+		// representative of the whole rather than of whatever sorts first.
+		for off := 0; off < len(raw) && taken < share; off += regionChunk * 2 {
+			end := off + regionChunk
+			if end > len(raw) {
+				end = len(raw)
+			}
+			cp := make([]byte, end-off)
+			copy(cp, raw[off:end])
+			out = append(out, cp)
+			taken += len(cp)
+			if taken-len(cp) >= perBlock {
+				break // this block has given its share; move on so one segment cannot dominate
+			}
+		}
+	}
+	return out
+}
+
+// regionRaw decompresses one of a block's regions without touching the block cache: training reads
+// each region once, and caching them would evict what live queries are using.
+func (b *columnarBlock) regionRaw(kind streamKind) ([]byte, error) {
+	var comp []byte
+	switch kind {
+	case kindColdNum:
+		comp = b.coldNumComp
+	case kindStr:
+		comp = b.strComp
+	case kindCold:
+		comp = b.coldComp
+	}
+	if len(comp) == 0 {
+		return nil, nil
+	}
+	return b.codec.Decompress(nil, comp)
+}

--- a/collections/regionsamples_test.go
+++ b/collections/regionsamples_test.go
@@ -1,0 +1,156 @@
+package collections
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/collections/vm"
+)
+
+// dictFixture builds a collection with all three block regions populated and the accelerator on,
+// so its blocks can be sampled.
+func dictFixture(t *testing.T, n int) *Collection {
+	t.Helper()
+	c := New(Options{Shards: 1, SegmentSize: 1 << 14})
+	for i := 0; i < n; i++ {
+		var b strings.Builder
+		for k := 0; k < 20; k++ {
+			v := (i*7 + k) % 1000
+			if k == 3 && i%50 == 49 {
+				v = 1 << 30 // escapes its fitted width -> cold tail
+			}
+			fmt.Fprintf(&b, "Num%02d = %d\n", k, v)
+		}
+		for k := 0; k < 6; k++ {
+			fmt.Fprintf(&b, "Str%02d = \"user%03d-path-%d-with-some-length\"\n", k, i%200, k)
+		}
+		if err := c.Put([]byte(fmt.Sprintf("k%d", i)), mustAdOld(t, b.String())); err != nil {
+			t.Fatal(err)
+		}
+	}
+	q, _ := vm.Parse("Num00 >= 0")
+	for i := 0; i < 25; i++ {
+		for range c.Query(q) {
+		}
+	}
+	if !c.BuildAndEnableSchemaScan(4000, 2) { // 2 hot slots => 18 cold numeric columns
+		t.Fatal("BuildAndEnableSchemaScan false")
+	}
+	return c
+}
+
+// TestRegionSamplesShape checks the sampler does what it claims: equal-ish shares across the three
+// region kinds, drawn from block regions rather than records.
+func TestRegionSamplesShape(t *testing.T) {
+	c := dictFixture(t, 4000)
+	defer c.Close()
+
+	samples := c.CollectRegionSamples(DefaultDictSize, 0)
+	if len(samples) == 0 {
+		t.Fatal("no region samples collected")
+	}
+	total := 0
+	for _, s := range samples {
+		total += len(s)
+	}
+	t.Logf("region samples: %d chunks, %d bytes (budget %d)", len(samples), total, DefaultDictSize)
+	if total > DefaultDictSize {
+		t.Errorf("sampled %d bytes, over the %d budget", total, DefaultDictSize)
+	}
+
+	// A collection with no blocks at all has nothing to sample and must say so, so the caller can
+	// fall back to record sampling rather than train on nothing.
+	plain := New(Options{Shards: 1})
+	defer plain.Close()
+	if got := plain.CollectRegionSamples(DefaultDictSize, 0); got != nil {
+		t.Errorf("expected nil from a collection with no columnar blocks, got %d samples", len(got))
+	}
+}
+
+// TestRegionSamplesLookBack checks the recency bias: a look-back budget must restrict the draw to
+// recent segments, which is what future writes resemble.
+func TestRegionSamplesLookBack(t *testing.T) {
+	c := dictFixture(t, 6000)
+	defer c.Close()
+
+	all := c.sampleableBlocks(0)
+	recent := c.sampleableBlocks(1 << 14) // roughly one segment's worth
+	t.Logf("blocks: %d without a look-back, %d within one segment's bytes", len(all), len(recent))
+	if len(all) < 2 {
+		t.Skip("fixture produced too few blocks to distinguish")
+	}
+	if len(recent) >= len(all) {
+		t.Errorf("look-back of one segment selected %d of %d blocks; it should restrict the draw",
+			len(recent), len(all))
+	}
+	if len(recent) == 0 {
+		t.Error("look-back selected no blocks at all")
+	}
+}
+
+// TestDictStrategies is the decision: for each of the three regions AND for whole records, compare
+// no dictionary, the ad-trained dictionary (status quo), and a region-trained one.
+//
+// The two uses pull in opposite directions. A record is small and independent, which is exactly what
+// a dictionary is for. A block region is a large aggregate with its own redundancy, where a
+// dictionary has little to add. Since ONE codec compresses both, the numbers below decide whether
+// training on regions is an improvement or a trade.
+func TestDictStrategies(t *testing.T) {
+	c := dictFixture(t, 4000)
+	defer c.Close()
+
+	adSamples := c.CollectSamples(2000)
+	regionSamples := c.CollectRegionSamples(DefaultDictSize, 0)
+	if len(adSamples) == 0 || len(regionSamples) == 0 {
+		t.Fatal("need both sample kinds")
+	}
+	adDict, err := TrainDict(adSamples)
+	if err != nil {
+		t.Fatal(err)
+	}
+	regionDict, err := TrainDict(regionSamples)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mk := func(d []byte) Codec {
+		cd, err := NewZSTDCodec(d)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return cd
+	}
+	none, adTrained, regionTrained := mk(nil), mk(adDict), mk(regionDict)
+
+	compare := func(label string, payloads [][]byte) {
+		var raw, n, a, r int
+		for _, p := range payloads {
+			raw += len(p)
+			n += len(none.Compress(nil, p))
+			a += len(adTrained.Compress(nil, p))
+			r += len(regionTrained.Compress(nil, p))
+		}
+		t.Logf("%-14s raw=%8d  no-dict=%7d  ad-dict=%7d (%+.1f%%)  region-dict=%7d (%+.1f%%)",
+			label, raw, n, a, 100*float64(a-n)/float64(n), r, 100*float64(r-n)/float64(n))
+	}
+
+	// The regions, as whole payloads (what actually gets compressed).
+	for kind, name := range map[streamKind]string{
+		kindColdNum: "cold-numeric", kindStr: "strings", kindCold: "cold-tail",
+	} {
+		var payloads [][]byte
+		for _, b := range c.sampleableBlocks(0) {
+			if raw, err := b.regionRaw(kind); err == nil && len(raw) > 0 {
+				payloads = append(payloads, raw)
+			}
+		}
+		if len(payloads) > 0 {
+			compare(name, payloads)
+		}
+	}
+	// And whole records, compressed individually -- the row path, where a dictionary earns its keep.
+	if len(adSamples) > 500 {
+		adSamples = adSamples[:500]
+	}
+	compare("records", adSamples)
+}

--- a/collections/streamdict_test.go
+++ b/collections/streamdict_test.go
@@ -1,0 +1,111 @@
+package collections
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/collections/vm"
+)
+
+// TestStreamDictionaryFit reports how well the collection's ZSTD dictionary serves each of a
+// columnar block's three compressed regions.
+//
+// The dictionary is trained by TrainDict on CollectSamples output: whole ClassAd RECORDS, flattened
+// to inline wire, concatenated as the builder's history (TrainDictSize does no ZDICT cover
+// selection -- the content is the samples). The same codec then compresses three regions whose byte
+// distributions are nothing alike:
+//
+//	cold numeric  column-major fixed-width little-endian integers
+//	strings       concatenated length-prefixed string values
+//	cold tail     uvarint(id)+node pairs, i.e. record-shaped
+//
+// A dictionary of record bytes should help the cold tail (same shape) and the strings (their values
+// appear in records), and do little for column-major integers. This measures that rather than
+// assuming it, since a dictionary that does not fit a region is wasted work on every compress.
+func TestStreamDictionaryFit(t *testing.T) {
+	// A fixture that populates ALL THREE regions: many numeric attributes but few hot slots (so
+	// most are cold), several string attributes, and values that escape their fitted width.
+	c := New(Options{Shards: 1, SegmentSize: 1 << 14})
+	defer c.Close()
+	for i := 0; i < 4000; i++ {
+		var b strings.Builder
+		for k := 0; k < 20; k++ {
+			v := (i*7 + k) % 1000
+			if k == 3 && i%50 == 49 {
+				v = 1 << 30 // escapes a narrow fitted width, landing in the cold tail
+			}
+			fmt.Fprintf(&b, "Num%02d = %d\n", k, v)
+		}
+		for k := 0; k < 6; k++ {
+			fmt.Fprintf(&b, "Str%02d = \"user%03d-path-%d-with-some-length\"\n", k, i%200, k)
+		}
+		if err := c.Put([]byte(fmt.Sprintf("k%d", i)), mustAdOld(t, b.String())); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := c.RetrainDict(2000); err != nil {
+		t.Fatalf("RetrainDict: %v", err)
+	}
+	mc, _ := vm.Parse("Num00 >= 0")
+	for i := 0; i < 25; i++ {
+		for range c.Query(mc) {
+		}
+	}
+	if !c.BuildAndEnableSchemaScan(4000, 2) { // only 2 hot slots => 18 cold numeric columns
+		t.Fatal("BuildAndEnableSchemaScan false")
+	}
+
+	plain, err := NewZSTDCodec(nil) // same codec, no dictionary
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var found bool
+	for _, sh := range c.shards {
+		sh.mu.RLock()
+		segs := append([]*segment(nil), sh.segs...)
+		act := sh.act
+		sh.mu.RUnlock()
+		for _, seg := range segs {
+			if seg == nil || seg == act || seg.used == 0 {
+				continue
+			}
+			cs := seg.colblk.Load()
+			if cs == nil {
+				continue
+			}
+			b := cs.block
+			found = true
+			for _, s := range []struct {
+				name string
+				comp []byte
+			}{
+				{"cold-numeric", b.coldNumComp},
+				{"strings     ", b.strComp},
+				{"cold-tail   ", b.coldComp},
+			} {
+				raw, err := b.codec.Decompress(nil, s.comp)
+				if err != nil {
+					t.Fatalf("%s: decompress: %v", s.name, err)
+				}
+				if len(raw) == 0 {
+					t.Logf("%s raw=0 (empty region)", s.name)
+					continue
+				}
+				noDict := plain.Compress(nil, raw)
+				t.Logf("%s raw=%6d  with-dict=%6d (%.2fx)  no-dict=%6d (%.2fx)  dict gain=%+.1f%%",
+					s.name, len(raw), len(s.comp), float64(len(raw))/float64(len(s.comp)),
+					len(noDict), float64(len(raw))/float64(len(noDict)),
+					100*(float64(len(noDict))-float64(len(s.comp)))/float64(len(noDict)))
+			}
+			// One block is enough to characterise the shapes.
+			if found {
+				return
+			}
+		}
+	}
+	if !found {
+		t.Skip("no sealed segment carried a columnar block")
+	}
+}

--- a/dbrpc/archivewide_bench_test.go
+++ b/dbrpc/archivewide_bench_test.go
@@ -1,0 +1,111 @@
+package dbrpc
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/db"
+)
+
+// wideHistoryAd is a history ad of realistic WIDTH. A real condor history record carries ~100
+// attributes; the earlier benchmarks used 5-6, which understates every cost that scales with the
+// record rather than with the one attribute being aggregated -- decompression above all.
+func wideHistoryAd(i int) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "ClusterId = %d\nProcId = %d\nOwner = \"u%d\"\nJobStatus = %d\n",
+		i/10, i%10000, i%64, 3+i%2)
+	fmt.Fprintf(&b, "RequestMemory = %d\nRequestCpus = %d\nCompletionDate = %d\nQDate = %d\n",
+		((i%16)+1)*512, 1+i%8, 1700000000+i, 1699000000+i)
+	fmt.Fprintf(&b, "Cmd = \"/home/u%d/analysis/run_%d.sh\"\nIwd = \"/home/u%d/work/job%d\"\n",
+		i%64, i%97, i%64, i)
+	fmt.Fprintf(&b, "RemoteHost = \"slot%d@node%04d.chtc.wisc.edu\"\nGlobalJobId = \"ap43#%d.%d#%d\"\n",
+		1+i%16, i%512, i/10, i%10, 1700000000+i)
+	// Filler attributes of the kind history ads actually carry: environment, requirements,
+	// resource usage, provisioning detail. Width is the point.
+	for k := 0; k < 80; k++ {
+		fmt.Fprintf(&b, "Attr%02d = \"value-%d-%d-padding-to-realistic-length\"\n", k, i%23, k)
+	}
+	return b.String()
+}
+
+// archiveMaxFixture builds an archive of exactly n wide history ads under one of three regimes and
+// returns a function that runs MAX(ProcId) against it.
+//
+//	"off"    the accelerator is never enabled -- the projected wire-native scan
+//	"full"   enabled AFTER all n are written, so every sealed segment carries a block
+//	"stale"  enabled at the halfway point, so the second half sealed blockless
+//
+// All three hold the SAME n records. An earlier version of this benchmark enabled the accelerator
+// and then appended more, so each mode measured a different dataset size -- which made a larger
+// dataset look like a slowdown. Equal data is the whole point of the comparison.
+func archiveMaxFixture(b *testing.B, n int, regime string) (func(*testing.B), func()) {
+	b.Helper()
+	cat, err := db.OpenCatalog(b.TempDir())
+	if err != nil {
+		b.Fatal(err)
+	}
+	s := NewServerCatalog(cat)
+	cconn, sconn := netPipe()
+	go func() { _ = s.ServeConnOpts(sconn, ServeOptions{Privileged: true}) }()
+	c := NewClient(cconn)
+	cleanup := func() { c.Close(); s.Close(); cat.Close() }
+	ctx := context.Background()
+	if err := c.CreateArchiveTable(ctx, "history", db.ArchiveConfig{SegmentSize: 1 << 20}); err != nil {
+		b.Fatal(err)
+	}
+	appendRange := func(from, to int) {
+		for i := from; i < to; i++ {
+			if err := c.ArchiveAppend(ctx, "history", wideHistoryAd(i)); err != nil {
+				b.Fatal(err)
+			}
+		}
+	}
+	a, ok := cat.ArchiveTable("history")
+	if !ok {
+		b.Fatal("archive missing")
+	}
+	switch regime {
+	case "off":
+		appendRange(0, n)
+	case "full":
+		appendRange(0, n)
+		if !a.BuildAndEnableSchemaScan(4000, 8) {
+			b.Skip("no sealed segments to sample")
+		}
+	case "stale":
+		appendRange(0, n/2)
+		if !a.BuildAndEnableSchemaScan(4000, 8) {
+			b.Skip("no sealed segments to sample")
+		}
+		appendRange(n/2, n)
+	}
+	info := a.SchemaScanInfo()
+	b.Logf("%s: enabled=%v coverage=%d/%d sealed, %d records",
+		regime, info.Enabled, info.CoveredSegments, info.SealedSegments, a.Count())
+	return func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			rows, err := c.ArchiveAggregate(ctx, "history", "true", nil,
+				[]db.AggSpec{{Func: db.AggMax, Arg: "ProcId"}})
+			if err != nil {
+				b.Fatal(err)
+			}
+			if len(rows) != 1 {
+				b.Fatalf("rows = %d", len(rows))
+			}
+		}
+	}, cleanup
+}
+
+// BenchmarkArchiveMaxWide compares the three regimes over identical data on the shape actually
+// deployed: an archive (ZSTD with a trained dictionary, large segments) of WIDE history ads.
+func BenchmarkArchiveMaxWide(b *testing.B) {
+	const n = 16000
+	for _, regime := range []string{"off", "full", "stale"} {
+		run, cleanup := archiveMaxFixture(b, n, regime)
+		b.Run(regime, run)
+		cleanup()
+	}
+}

--- a/dbrpc/coldcolumn_test.go
+++ b/dbrpc/coldcolumn_test.go
@@ -1,0 +1,116 @@
+package dbrpc
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/PelicanPlatform/classad/db"
+)
+
+// TestAggregateColdColumnFirstQuery explains a reported asymmetry: MAX over a large archive took
+// ~60s on the first run and ~1.6s on the second, having taken ~5s before the columnar accelerator
+// was enabled at all.
+//
+// A HOT column is read straight from each block's uncompressed prefix -- no decompression, no cache.
+// A COLD column is not: reading it calls blockCache.streams, which decompresses ALL THREE of the
+// block's streams and caches the result under a 256 MiB bound. So the first query over a cold column
+// pays decompression of essentially the whole dataset, the second is served from cache, and a working
+// set past 256 MiB thrashes and pays it every time.
+//
+// Which columns are hot is chosen by query read demand -- and until the accelerated paths recorded
+// any, a column that is only ever aggregated could not earn a slot. So the aggregated column was
+// systematically the cold one.
+func TestAggregateColdColumnFirstQuery(t *testing.T) {
+	if testing.Short() {
+		t.Skip("builds a multi-segment archive")
+	}
+	cat, err := db.OpenCatalog(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := NewServerCatalog(cat)
+	cconn, sconn := netPipe()
+	go func() { _ = s.ServeConnOpts(sconn, ServeOptions{Privileged: true}) }()
+	c := NewClient(cconn)
+	defer func() { c.Close(); s.Close(); cat.Close() }()
+	ctx := context.Background()
+
+	if err := c.CreateArchiveTable(ctx, "history", db.ArchiveConfig{SegmentSize: 1 << 20}); err != nil {
+		t.Fatal(err)
+	}
+	const n = 60000
+	for i := 0; i < n; i++ {
+		if err := c.ArchiveAppend(ctx, "history", wideHistoryAd(i)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	a, ok := cat.ArchiveTable("history")
+	if !ok {
+		t.Fatal("archive missing")
+	}
+	maxOnce := func() time.Duration {
+		start := time.Now()
+		if _, err := c.ArchiveAggregate(ctx, "history", "true", nil,
+			[]db.AggSpec{{Func: db.AggMax, Arg: "ProcId"}}); err != nil {
+			t.Fatal(err)
+		}
+		return time.Since(start)
+	}
+	hotHas := func(attr string) bool {
+		for _, f := range a.SchemaScanInfo().HotFields {
+			if strings.EqualFold(f, attr) {
+				return true
+			}
+		}
+		return false
+	}
+
+	// Squeeze ProcId out of the hot tier: demand another column, and allow only one hot slot.
+	for i := 0; i < 30; i++ {
+		if _, err := c.ArchiveAggregate(ctx, "history", "JobStatus >= 0", nil,
+			[]db.AggSpec{{Func: db.AggCount, Arg: "*"}}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if !a.BuildAndEnableSchemaScan(4000, 1) {
+		t.Skip("no sealed segments to sample")
+	}
+	if hotHas("ProcId") {
+		t.Skip("ProcId took the single hot slot; the cold-column path cannot be measured here")
+	}
+	coldFirst, coldSecond := maxOnce(), maxOnce()
+	t.Logf("ProcId COLD: first=%v second=%v  (hot: %v)",
+		coldFirst.Round(time.Millisecond), coldSecond.Round(time.Millisecond), a.SchemaScanInfo().HotFields)
+
+	// Now let the aggregate itself earn ProcId a slot, and rebuild -- which also creates a FRESH
+	// block cache, so the first query below is cold-cache too and the comparison is fair.
+	for i := 0; i < 40; i++ {
+		maxOnce()
+	}
+	if !a.ReschemaScan(4000, 1) {
+		t.Fatal("ReschemaScan failed")
+	}
+	if !hotHas("ProcId") {
+		t.Fatalf("ProcId still not hot after being aggregated repeatedly (hot: %v)",
+			a.SchemaScanInfo().HotFields)
+	}
+	hotFirst, hotSecond := maxOnce(), maxOnce()
+	t.Logf("ProcId HOT:  first=%v second=%v  (hot: %v)",
+		hotFirst.Round(time.Millisecond), hotSecond.Round(time.Millisecond), a.SchemaScanInfo().HotFields)
+
+	// The asymmetry is the finding: a cold column's first query is far slower than its second,
+	// because it is paying decompression that the cache then holds. A hot column has no such gap.
+	coldRatio := float64(coldFirst) / float64(coldSecond)
+	hotRatio := float64(hotFirst) / float64(hotSecond)
+	t.Logf("first/second ratio: cold=%.1fx hot=%.1fx", coldRatio, hotRatio)
+	if coldRatio < 2 {
+		t.Logf("NOTE: cold first/second ratio under 2x at this scale; the effect needs a working " +
+			"set large enough for decompression to dominate")
+	}
+	if hotFirst > coldFirst {
+		t.Errorf("hot column's first query (%v) slower than the cold column's (%v) -- unexpected",
+			hotFirst, coldFirst)
+	}
+}

--- a/dbrpc/escapewidth_test.go
+++ b/dbrpc/escapewidth_test.go
@@ -1,0 +1,113 @@
+package dbrpc
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/PelicanPlatform/classad/db"
+)
+
+// TestHotColumnNarrowWidthEscapes covers the case a report surfaced: `.schema` showed
+//
+//	ProcId   int (u)   1   HOT
+//
+// a HOT column, one byte wide -- while MAX(ProcId) was 15974, which does not fit in a byte. The
+// width is fitted to a high percentile of the SAMPLE, so if almost every job has a small ProcId the
+// column is one byte and the rare large ones ESCAPE to the cold tail.
+//
+// An escaped value is read via blockCache.streams, which decompresses ALL THREE of a block's
+// streams. So the cost is not proportional to the escape RATE: one escapee in a block pulls in that
+// whole block's streams. Sprinkle 0.1% of records with large values and essentially every block has
+// one, so the first query decompresses the entire dataset and the second is served from cache --
+// which is exactly the 60s-then-1.6s asymmetry reported, on a column that `.schema` calls hot.
+//
+// MAX is the worst case for this: the values it needs are precisely the escaped ones.
+func TestHotColumnNarrowWidthEscapes(t *testing.T) {
+	if testing.Short() {
+		t.Skip("builds a multi-segment archive")
+	}
+	// procId mimics a real history: nearly every job has a small ProcId, a few clusters are huge.
+	build := func(t *testing.T, procId func(int) int) (*Client, *db.ArchiveTable, func()) {
+		cat, err := db.OpenCatalog(t.TempDir())
+		if err != nil {
+			t.Fatal(err)
+		}
+		s := NewServerCatalog(cat)
+		cconn, sconn := netPipe()
+		go func() { _ = s.ServeConnOpts(sconn, ServeOptions{Privileged: true}) }()
+		c := NewClient(cconn)
+		ctx := context.Background()
+		if err := c.CreateArchiveTable(ctx, "history", db.ArchiveConfig{SegmentSize: 1 << 20}); err != nil {
+			t.Fatal(err)
+		}
+		for i := 0; i < 60000; i++ {
+			ad := strings.Replace(wideHistoryAd(i),
+				fmt.Sprintf("ProcId = %d\n", i%10000),
+				fmt.Sprintf("ProcId = %d\n", procId(i)), 1)
+			if err := c.ArchiveAppend(ctx, "history", ad); err != nil {
+				t.Fatal(err)
+			}
+		}
+		a, ok := cat.ArchiveTable("history")
+		if !ok {
+			t.Fatal("archive missing")
+		}
+		if !a.BuildAndEnableSchemaScan(4000, 8) {
+			t.Skip("no sealed segments to sample")
+		}
+		return c, a, func() { c.Close(); s.Close(); cat.Close() }
+	}
+	describe := func(t *testing.T, c *Client, a *db.ArchiveTable, label string) {
+		ctx := context.Background()
+		var width int
+		var hot bool
+		for _, f := range a.SchemaScanInfo().Schema {
+			if strings.EqualFold(f.Name, "ProcId") {
+				width, hot = f.Width, f.Hot
+			}
+		}
+		var escaped float64
+		fit, _ := a.SchemaFit(4000)
+		for _, f := range fit {
+			if strings.EqualFold(f.Name, "ProcId") {
+				escaped = f.Escaped
+			}
+		}
+		maxOnce := func() (string, time.Duration) {
+			start := time.Now()
+			rows, err := c.ArchiveAggregate(ctx, "history", "true", nil,
+				[]db.AggSpec{{Func: db.AggMax, Arg: "ProcId"}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			return rows[0].Values[0], time.Since(start)
+		}
+		v1, d1 := maxOnce()
+		_, d2 := maxOnce()
+		t.Logf("%-22s ProcId hot=%v width=%d escaped=%.2f%%  MAX=%s  first=%v second=%v (%.1fx)",
+			label, hot, width, escaped*100, v1,
+			d1.Round(time.Millisecond), d2.Round(time.Millisecond), float64(d1)/float64(d2))
+	}
+
+	// Skewed: 99.9% of jobs have ProcId < 10, one in a thousand is large. This is the reported shape.
+	t.Run("skewed", func(t *testing.T) {
+		c, a, cleanup := build(t, func(i int) int {
+			if i%1000 == 0 {
+				return 15974
+			}
+			return i % 10
+		})
+		defer cleanup()
+		describe(t, c, a, "skewed (rare large)")
+	})
+
+	// Uniform: every job's ProcId is large, so the fitted width covers them and nothing escapes.
+	t.Run("uniform", func(t *testing.T) {
+		c, a, cleanup := build(t, func(i int) int { return 1000 + i%15000 })
+		defer cleanup()
+		describe(t, c, a, "uniform (all large)")
+	})
+}

--- a/dbrpc/hottier_test.go
+++ b/dbrpc/hottier_test.go
@@ -1,0 +1,111 @@
+package dbrpc
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/PelicanPlatform/classad/db"
+)
+
+// TestAggregateHotVsColdColumn asks what the columnar aggregate costs when the aggregated
+// attribute is NOT in the hot tier.
+//
+// The hot tier holds the top-N numeric fields BY QUERY READ DEMAND, uncompressed. Everything else
+// is a cold column group that has to be decompressed to read. The tier is chosen when the schema is
+// built -- so an attribute you only ever aggregate, having never been filtered on, can easily be
+// cold, and a schema REBUILD re-derives the tier from demand accumulated since while a REWRITE
+// preserves the old one. That asymmetry would explain a rebuild making a query fast and a rewrite
+// leaving it slow.
+func TestAggregateHotVsColdColumn(t *testing.T) {
+	cat, err := db.OpenCatalog(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := NewServerCatalog(cat)
+	cconn, sconn := netPipe()
+	go func() { _ = s.ServeConnOpts(sconn, ServeOptions{Privileged: true}) }()
+	c := NewClient(cconn)
+	defer func() { c.Close(); s.Close(); cat.Close() }()
+	ctx := context.Background()
+
+	if err := c.CreateArchiveTable(ctx, "history", db.ArchiveConfig{SegmentSize: 1 << 20}); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 12000; i++ {
+		if err := c.ArchiveAppend(ctx, "history", wideHistoryAd(i)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	a, ok := cat.ArchiveTable("history")
+	if !ok {
+		t.Fatal("archive missing")
+	}
+
+	timeMax := func() time.Duration {
+		best := time.Hour
+		for i := 0; i < 3; i++ { // best of three: ignore page-cache cold starts
+			start := time.Now()
+			if _, err := c.ArchiveAggregate(ctx, "history", "true", nil,
+				[]db.AggSpec{{Func: db.AggMax, Arg: "ProcId"}}); err != nil {
+				t.Fatal(err)
+			}
+			if d := time.Since(start); d < best {
+				best = d
+			}
+		}
+		return best
+	}
+	hotHas := func(attr string) bool {
+		for _, f := range a.SchemaScanInfo().HotFields {
+			if strings.EqualFold(f, attr) {
+				return true
+			}
+		}
+		return false
+	}
+
+	// Build the schema with demand on a DIFFERENT numeric attribute, so ProcId is cold. Only a
+	// handful of hot slots exist, so the demanded ones win them.
+	for i := 0; i < 25; i++ {
+		if _, err := c.ArchiveAggregate(ctx, "history", "RequestMemory >= 0", nil,
+			[]db.AggSpec{{Func: db.AggCount, Arg: "*"}}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if !a.BuildAndEnableSchemaScan(4000, 2) { // only 2 hot slots
+		t.Skip("no sealed segments to sample")
+	}
+	coldHot := hotHas("ProcId")
+	coldTime := timeMax()
+	t.Logf("ProcId hot=%-5v  MAX best-of-3 = %v   (hot fields: %v)",
+		coldHot, coldTime.Round(time.Millisecond), a.SchemaScanInfo().HotFields)
+
+	// Now re-derive with ProcId demanded, so it takes a hot slot.
+	// Demand driven by the very query an operator runs, which is the point: aggregating ProcId has
+	// to be what teaches the hot tier that ProcId is read.
+	for i := 0; i < 60; i++ {
+		if _, err := c.ArchiveAggregate(ctx, "history", "true", nil,
+			[]db.AggSpec{{Func: db.AggMax, Arg: "ProcId"}}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if !a.ReschemaScan(4000, 2) {
+		t.Fatal("ReschemaScan failed")
+	}
+	warmHot := hotHas("ProcId")
+	warmTime := timeMax()
+	t.Logf("ProcId hot=%-5v  MAX best-of-3 = %v   (hot fields: %v)",
+		warmHot, warmTime.Round(time.Millisecond), a.SchemaScanInfo().HotFields)
+
+	// The behaviour this pins: repeatedly aggregating a column, then rebuilding, must promote it.
+	// Before the columnar paths recorded demand, no amount of aggregating could -- so the column a
+	// workload cared about most stayed cold, and which columns were hot came down to a tie-break.
+	if !warmHot {
+		t.Errorf("aggregating ProcId %d times then rebuilding did NOT promote it to the hot tier "+
+			"(hot: %v) -- the accelerated path is not feeding the demand signal that chooses the tier",
+			60, a.SchemaScanInfo().HotFields)
+	}
+	t.Logf("cold->hot timing: %v -> %v", coldTime.Round(time.Millisecond), warmTime.Round(time.Millisecond))
+}

--- a/dbrpc/rewritecoverage_test.go
+++ b/dbrpc/rewritecoverage_test.go
@@ -1,0 +1,92 @@
+package dbrpc
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/PelicanPlatform/classad/db"
+)
+
+// TestRewriteThenAggregateCoverage reproduces an operator's observation: after `.rewrite` on a
+// history table a numeric aggregate is slow, and after `.schema rebuild` it is fast again.
+//
+// A rewrite re-encodes every record into fresh segments. Any columnar block built against the old
+// records describes bytes that no longer exist, so the rewrite has to either rebuild the blocks or
+// drop them. This reports coverage and timing at each step to say which happens.
+func TestRewriteThenAggregateCoverage(t *testing.T) {
+	cat, err := db.OpenCatalog(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := NewServerCatalog(cat)
+	cconn, sconn := netPipe()
+	go func() { _ = s.ServeConnOpts(sconn, ServeOptions{Privileged: true}) }()
+	c := NewClient(cconn)
+	defer func() { c.Close(); s.Close(); cat.Close() }()
+	ctx := context.Background()
+
+	if err := c.CreateArchiveTable(ctx, "history", db.ArchiveConfig{SegmentSize: 1 << 20}); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 12000; i++ {
+		if err := c.ArchiveAppend(ctx, "history", wideHistoryAd(i)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	a, ok := cat.ArchiveTable("history")
+	if !ok {
+		t.Fatal("archive missing")
+	}
+
+	maxProcId := func() (string, time.Duration) {
+		start := time.Now()
+		rows, err := c.ArchiveAggregate(ctx, "history", "true", nil,
+			[]db.AggSpec{{Func: db.AggMax, Arg: "ProcId"}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(rows) != 1 || len(rows[0].Values) != 1 {
+			t.Fatalf("rows = %+v", rows)
+		}
+		return rows[0].Values[0], time.Since(start)
+	}
+	report := func(stage string) {
+		info := a.SchemaScanInfo()
+		val, d := maxProcId()
+		t.Logf("%-22s enabled=%-5v coverage=%d/%d  MAX=%s in %v",
+			stage, info.Enabled, info.CoveredSegments, info.SealedSegments, val, d.Round(time.Millisecond))
+	}
+
+	report("before enable")
+	if !a.BuildAndEnableSchemaScan(4000, 8) {
+		t.Skip("no sealed segments to sample")
+	}
+	report("after enable")
+
+	want, _ := maxProcId()
+
+	// The operator's sequence.
+	a.Rewrite()
+	report("after .rewrite")
+	afterRewrite := a.SchemaScanInfo()
+
+	if !a.ReschemaScan(4000, 8) {
+		t.Fatal("ReschemaScan failed")
+	}
+	report("after .schema rebuild")
+	afterRebuild := a.SchemaScanInfo()
+
+	// Correctness first: whatever the coverage, the answer must not change.
+	if got, _ := maxProcId(); got != want {
+		t.Errorf("MAX changed across rewrite/rebuild: %s -> %s", want, got)
+	}
+
+	// The finding: does a rewrite leave the accelerator covering the archive?
+	if afterRewrite.CoveredSegments < afterRewrite.SealedSegments {
+		t.Errorf("REPRODUCED: after .rewrite only %d/%d sealed segments carry a block, so the "+
+			"aggregate falls back to reading records; .schema rebuild restores %d/%d",
+			afterRewrite.CoveredSegments, afterRewrite.SealedSegments,
+			afterRebuild.CoveredSegments, afterRebuild.SealedSegments)
+	}
+}


### PR DESCRIPTION
Chasing a reported `select max(ProcId) from history` slowdown — ~60s on the first run, ~1.6s on the second, having been ~5s before the columnar accelerator was enabled. Three changes, in order of how much they matter.

### 1. Reading one block region shouldn't decompress three

A block holds three **independently compressed** regions — the cold numeric column groups, the string region, and the cold tail — and `blockCache.streams` decompressed all three on any miss. Three of its four callers want exactly one:

| caller | needs |
|---|---|
| cold column scan | cold numeric groups |
| escaped value (two readers) | cold tail |
| full-ad reconstruction | all three — the only honest caller |

So reading **one escaped integer** also inflated the block's whole string region, which on wide ads (a history record carries dozens of string attributes) is the largest of the three by far. It also spent the 256 MiB byte budget holding regions nobody read, evicting the ones they did.

Each region is now cached and decompressed separately.

### 2. Why that made a *hot* column slow

`.schema` reported `ProcId  int (u)  1  HOT` — hot, and one byte, while `MAX(ProcId)` is 15974. The width is fitted to a high percentile of a sample, so when 99.9% of jobs have a small `ProcId` the column is one byte and the rare large ones **escape** to the cold tail. Reading one escapee pulled its entire block through zstd; at 0.1% escapes essentially every block has one, so the first query decompressed the whole archive and the second came from cache.

On a 60k-record archive of wide history ads, 0.1% of `ProcId`s escaping a one-byte column:

```
before   first 108ms   second 15ms   7.4x asymmetry
after    first  15ms   second 15ms   1.0x
```

The residual gap to the no-escape case (2 ms) is the cold tail itself, which an escaped value genuinely needs. Closing that means fitting the column wide enough that nothing escapes — `hotIntFit` is deliberately 0.999 so one outlier can't widen a column for every record, but that trade was weighed against *nothing*, not against pulling a block through zstd. Worth revisiting separately.

### 3. The hot tier's feedback loop was never connected

`CountQuery` and `NumStatsQuery` recorded **no read demand**, so once the accelerator served a query it stopped telling the store which column it reads — and a column only ever *aggregated* could never earn a hot slot. Aggregating `ProcId` sixty times and rebuilding left the hot tier as `[JobStatus RequestCpus]`; with demand recorded it becomes `[JobStatus ProcId]`.

### Also: a benchmark on the shape actually deployed

`BenchmarkAggregateMax` measured a *mutable* table of six-attribute ads at *full* coverage — none of which describes a deployed archive. The new fixture uses wide history ads across three coverage regimes over identical data:

```
off (projected wire-native scan)   ~131ms
full coverage (7/7)                 ~15ms   ~9x
stale coverage (3/7)                ~80ms   ~1.6x
```

**Equal data is the point.** An earlier draft appended more records between regimes, so each measured a different dataset size; that made a bigger dataset read as a slowdown and nearly justified gating the fast path off under partial coverage — which measurement showed would have made the common case ~45% slower. The benchmark now documents the trap.

`collections`, `db`, `dbrpc` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
