### PR TITLE
collections: restore the PAX row group (bound the columnar block by bytes, not by segment)

### DIFF
--- a/collections/adschema_width6_test.go
+++ b/collections/adschema_width6_test.go
@@ -118,7 +118,7 @@ func BenchmarkIntWidth6vs8(b *testing.B) {
 	blk6 := encodeColumnarBlock(s, encodeRows(s, wires), []int{s.byID[bigID]}, codec)
 	blk8 := encodeColumnarBlock(s8, encodeRows(s8, wires), []int{s8.byID[bigID]}, codec)
 	sz := func(blk *columnarBlock) int {
-		return len(marshalColSegment(&colSegment{block: blk, offs: make([]uint32, blk.n)}, c.intern.Name))
+		return len(marshalColSegment(oneBlockColSeg(blk, make([]uint32, blk.n)), c.intern.Name))
 	}
 	b.Logf("persisted block: 6B=%d bytes  8B=%d bytes (%+d)", sz(blk6), sz(blk8), sz(blk6)-sz(blk8))
 	bc, _ := newBlockCache(64 << 20)

--- a/collections/colagg.go
+++ b/collections/colagg.go
@@ -193,10 +193,12 @@ func (c *Collection) scanNumValues(fieldID uint32, bc *blockCache, fn func(colVa
 		s0, wins := sh.snapshot()
 		for _, w := range wins {
 			cs := w.seg.colblk.Load()
+			// Every row group in a segment is built under the same schema, so the field resolves
+			// once per segment rather than once per group.
 			bidx, isReal := -1, false
-			if cs != nil {
-				if idx, ok := cs.block.schema.byID[fieldID]; ok {
-					switch cs.block.schema.fields[idx].kind {
+			if sch := cs.schema(); sch != nil {
+				if idx, ok := sch.byID[fieldID]; ok {
+					switch sch.fields[idx].kind {
 					case akInt:
 						bidx = idx
 					case akReal:
@@ -208,28 +210,39 @@ func (c *Collection) scanNumValues(fieldID uint32, bc *blockCache, fn func(colVa
 				bruteNumValues(w, s0, lookup, fn)
 				continue
 			}
-			cs.block.scanInt(bidx, bc, func(k int, present bool, v int64) {
-				o := cs.offs[k]
-				if !(recSeq(w.data, o) <= s0 && recSuperseded(w.data, o) > s0) {
-					return // not visible at this snapshot
-				}
-				if present {
-					if isReal {
-						f := math.Float64frombits(uint64(v))
-						fn(colVal{f: f, kind: akReal})
-					} else {
-						fn(colVal{f: float64(v), i: v, kind: akInt})
+			// Walk the segment's row groups in record order, tracking each group's base so a
+			// group-local record index maps back into the segment-wide offs array.
+			base := 0
+			for _, blk := range cs.blocks {
+				blk.scanInt(bidx, bc, func(k int, present bool, v int64) {
+					gk := base + k
+					if gk >= len(cs.offs) {
+						return // truncated offs: cannot establish visibility, so do not count it
 					}
-					return
-				}
-				// Escaped: read only fieldID from the cold tail, not the whole record. (A full
-				// reconstruct dominated the scan when a numeric attr has a value tail.)
-				// The cold tail carries the wire node, so its kind is read from the node
-				// itself rather than assumed from this block's schema field.
-				if nv, ok := cs.block.escapedNumVal(k, fieldID, bc); ok {
-					fn(nv)
-				}
-			})
+					o := cs.offs[gk]
+					if !(recSeq(w.data, o) <= s0 && recSuperseded(w.data, o) > s0) {
+						return // not visible at this snapshot
+					}
+					if present {
+						if isReal {
+							f := math.Float64frombits(uint64(v))
+							fn(colVal{f: f, kind: akReal})
+						} else {
+							fn(colVal{f: float64(v), i: v, kind: akInt})
+						}
+						return
+					}
+					// Escaped: read only fieldID from the cold tail, not the whole record. (A full
+					// reconstruct dominated the scan when a numeric attr has a value tail.)
+					// The cold tail carries the wire node, so its kind is read from the node
+					// itself rather than assumed from this block's schema field. With row groups
+					// this decompresses only the escaped record's OWN group's tail.
+					if nv, ok := blk.escapedNumVal(k, fieldID, bc); ok {
+						fn(nv)
+					}
+				})
+				base += blk.n
+			}
 		}
 		releaseWindows(wins)
 	}

--- a/collections/colblock.go
+++ b/collections/colblock.go
@@ -13,6 +13,107 @@ var errNotNumericField = errors.New("adschema: scanInt on a non-numeric field")
 // colBlockSeq assigns each built block a process-unique id, used as the block-cache key.
 var colBlockSeq atomic.Uint64
 
+// Row groups: a segment is split into a series of columnar blocks rather than being one block, which
+// is what makes this layout PAX (a hybrid) instead of fully columnar.
+//
+// WHY a bound is needed. Reading a value that ESCAPED its fixed slot means decompressing its
+// block's cold tail, and reconstructing a full ad means decompressing its block's string + cold
+// regions. Both costs are per-BLOCK, so they scale with the block. Measured on the OSPool slot
+// corpus (1500 ads, 561 attrs/ad; schema_fullread_test.go), point-reading one ad:
+//
+//	group  point read   vs row   full read   size
+//	row      14.4µs       1x      23.0µs/ad  4078 B/ad
+//	128       246µs      17x      11.3µs/ad   858 B/ad
+//	256       563µs      39x      11.5µs/ad   839 B/ad
+//	512      1.32ms      91x      11.3µs/ad   828 B/ad
+//	1500     4.59ms     319x      20.6µs/ad   824 B/ad
+//
+// Linear in the group size, while full-read is already saturated at 128 (and ~2x faster than the
+// row form, since a group's decompression amortizes over its records) and size barely moves -- 858
+// vs 824 B/ad is 0.8 points against the row baseline. The harder bound is the block cache: those
+// blocks' decompressed regions run ~8867 B/ad, so a block past ~30k records exceeds the cache's
+// whole 256 MiB budget, can never be admitted, and re-decompresses on EVERY read -- permanently,
+// not as a cold start. One block per segment sat exactly there: at defaultMaxSegmentBytes (1 GiB) a
+// segment holds far more than 30k ads.
+//
+// WHAT IT BUYS on the real store, over a full-column aggregate on the OSPool corpus in 8 MiB
+// segments (~800 ads per segment; colgroup_bench_test.go, medians of 3):
+//
+//	                          cold      warm    decompression (cold-warm)
+//	one block per segment    4.02ms    2.70ms      1.32ms
+//	~1 MiB groups            3.06ms    2.70ms      0.36ms
+//
+// So ~24% off the whole query and ~4x off the part the block size actually governs. That is the
+// MODEST end of the range by construction: an aggregate reads the column for every record, so a
+// block's decompression is amortized over all of it. The large end is the sparse case -- a point
+// read, or a scan where only a few records escape and each one drags in its block's whole tail --
+// which is the 17x-vs-319x in the table above, and which is what made MAX(ProcId) take 60s.
+//
+// WHY THE BOUND IS IN BYTES, not rows. 128 rows of those ads is ~1.1 MiB of regions: the row count
+// was a byte budget in disguise, and it does not travel to other ad shapes. What a block costs to
+// touch, and whether it fits the cache at all, are properties of its BYTES; rows are only a proxy,
+// and a bad one across a 300x range in ad width (a 5-attribute job ad vs a 561-attribute slot ad).
+// Budgeting the real quantity means a table of fat ads lands near the measured 128-row sweet spot on
+// its own, while a table of small ads gets thousands of rows per group instead of blocks so small
+// that splitting them accomplishes nothing.
+//
+// On that second case, note that a row-count rule is not measurably HARMFUL -- on a 5-attribute
+// fixture (~27 B/record) 128-row groups came out within ~3% of whole-segment blocks, i.e. noise, at
+// identical stored size. It is simply arbitrary there, and a bound that means nothing on half the
+// tables it applies to is one nobody can reason about later. The byte budget is the same decision
+// expressed in the units that caused it.
+//
+// Splitting is not free in principle: each block is one decompress call and one cache entry per
+// scan, and compressing groups independently gives up cross-group redundancy. Both measured small --
+// the warm column above is flat, and stored size moved 0.8 points on the corpus sweep.
+const (
+	// colGroupTargetBytes is the uncompressed record-bytes budget for one row group. ~1 MiB keeps a
+	// block's decompressed regions two orders of magnitude under the 256 MiB cache budget (so
+	// hundreds cache at once and nothing is uncacheable) while staying large enough to compress
+	// well and to amortize a decompress call.
+	colGroupTargetBytes = 1 << 20
+
+	// colGroupMaxRows caps rows per group regardless of size, so a table of very small ads still
+	// gets bounded blocks -- and bounded point reads -- rather than one block per segment by
+	// default. Well above the byte budget's reach for any ad fat enough for the byte rule to bind.
+	colGroupMaxRows = 8192
+
+	// colGroupRows is the reference point the measurements above were taken at: what
+	// colGroupTargetBytes works out to for OSPool slot ads (~8867 B/ad of regions). Kept as the
+	// documented equivalence, and used by tests that need an exact row-count grouping.
+	colGroupRows = 128
+)
+
+// colGrouping is the row-group sealing policy: seal a group once its records reach targetBytes of
+// uncompressed row form, or maxRows records, whichever comes first.
+//
+// A zero targetBytes means "no byte rule" -- group purely by row count, which is what a test
+// sweeping exact group sizes wants. A zero maxRows means colGroupMaxRows.
+type colGrouping struct {
+	targetBytes int
+	maxRows     int
+}
+
+// defaultColGrouping is the production policy.
+func defaultColGrouping() colGrouping {
+	return colGrouping{targetBytes: colGroupTargetBytes, maxRows: colGroupMaxRows}
+}
+
+// byRows is a pure row-count policy, for tests and benchmarks sweeping the group size.
+func byRows(n int) colGrouping { return colGrouping{maxRows: n} }
+
+// full reports whether a group holding rows records of bytes total should be sealed now.
+func (g colGrouping) full(rows, bytes int) bool {
+	maxRows := g.maxRows
+	if maxRows <= 0 {
+		maxRows = colGroupMaxRows
+	}
+	if rows >= maxRows {
+		return true
+	}
+	return g.targetBytes > 0 && bytes >= g.targetBytes
+}
+
 // columnarBlock is the PAX layout for a row-group of adSchema records (see adschema.go): the
 // schema's popular ("hot") numeric fields plus the escape and bool bitsets stay uncompressed
 // in a fixed-stride region (so an attribute scan reads a column with no decode), while the
@@ -116,19 +217,27 @@ func encodeColumnarBlock(s *adSchema, recs [][]byte, hotNumFields []int, codec C
 	return b
 }
 
-// buildColumnarFromSegment transcodes a segment's live-arena records in [0, upto) into a
-// columnar block, mirroring buildSegIndex: it walks the records, decompresses each (skipping
-// time-travel markers), re-encodes it in the adSchema row form, and builds the block. It
-// returns the block and offs, where offs[k] is the segment offset of block record k -- the map
-// a scan uses to recover each record's MVCC seq/sup (for visibility) and its key. Reads
-// immutable segment bytes only.
+// buildColumnarFromSegment transcodes a segment's live-arena records in [0, upto) into a series of
+// columnar ROW-GROUP blocks of groupRows records each, mirroring buildSegIndex: it walks the
+// records, decompresses each (skipping time-travel markers), re-encodes it in the adSchema row
+// form, and seals a block every groupRows records. It returns the blocks in record order and offs,
+// where offs[k] is the segment offset of the k'th record COUNTING ACROSS BLOCKS -- the map a scan
+// uses to recover each record's MVCC seq/sup (for visibility) and its key. Reads immutable segment
+// bytes only.
+//
+// Encoding a group as soon as it fills also bounds peak transcode memory at one group's row
+// records instead of the whole segment's, which for a 1 GiB segment was the same order as the
+// segment itself.
+//
 // toInterned canonicalizes a decompressed record into interned wire (identity for an already-
 // interned collection; a decode/re-encode for an inline/persistent one). encode reads the
 // id-keyed form, so a non-interned record must be converted first or the block would be empty.
-func buildColumnarFromSegment(data []byte, upto int, codec Codec, s *adSchema, hot []int, toInterned func(dst, w []byte) ([]byte, bool)) (*columnarBlock, []uint32) {
+func buildColumnarFromSegment(data []byte, upto int, codec Codec, s *adSchema, hot []int, g colGrouping, toInterned func(dst, w []byte) ([]byte, bool)) ([]*columnarBlock, []uint32) {
+	var blocks []*columnarBlock
 	var recs [][]byte
 	var offs []uint32
 	var buf []byte
+	groupBytes := 0
 	for off := 0; off < upto; {
 		o := uint32(off)
 		total := recTotalLen(data, o)
@@ -139,14 +248,29 @@ func buildColumnarFromSegment(data []byte, upto int, codec Codec, s *adSchema, h
 			if w, err := codec.Decompress(buf[:0], recAd(data, o)); err == nil {
 				buf = w
 				if iw, ok := toInterned(nil, w); ok {
-					recs = append(recs, s.encode(wire.Ad(iw)))
+					rec := s.encode(wire.Ad(iw))
+					recs = append(recs, rec)
 					offs = append(offs, o)
+					groupBytes += len(rec)
+					if g.full(len(recs), groupBytes) {
+						blocks = append(blocks, encodeColumnarBlock(s, recs, hot, codec))
+						recs, groupBytes = recs[:0], 0
+					}
 				}
 			}
 		}
 		off += int(total)
 	}
-	return encodeColumnarBlock(s, recs, hot, codec), offs
+	if len(recs) > 0 {
+		blocks = append(blocks, encodeColumnarBlock(s, recs, hot, codec)) // short final group
+	}
+	if len(blocks) == 0 {
+		// A segment with no encodable records still gets one empty block, so a colSegment always
+		// carries the schema it was built under (which persistence and the scan's field resolution
+		// both read from the first block).
+		blocks = append(blocks, encodeColumnarBlock(s, nil, hot, codec))
+	}
+	return blocks, offs
 }
 
 // scanInt calls fn for each record's value of a numeric (int/real read as int bits) field: a

--- a/collections/colblock_segment_test.go
+++ b/collections/colblock_segment_test.go
@@ -29,11 +29,24 @@ func segmentWires(t *testing.T, seg *segment) [][]byte {
 	return ws
 }
 
-// TestBuildColumnarFromSegment transcodes a real segment's records into a columnar block and
-// checks: (1) reconstruct(k) reproduces the exact ad stored at offs[k]; (2) a hot-field column
-// scan matches reading that field from the segment record; (3) offs[k] indexes a real record
-// header whose MVCC seq is readable (the map a scan uses for visibility).
-func TestBuildColumnarFromSegment(t *testing.T) {
+// oneBlockColSeg wraps a single block as a segment accelerator, for tests that build a block
+// directly rather than from a segment.
+func oneBlockColSeg(blk *columnarBlock, offs []uint32) *colSegment {
+	return &colSegment{blocks: []*columnarBlock{blk}, offs: offs}
+}
+
+// TestBuildColumnarFromSegment transcodes a real segment's records into columnar ROW-GROUP blocks
+// and checks, for several group sizes: (1) reconstruct(k) reproduces the exact ad stored at
+// offs[k]; (2) a hot-field column scan matches reading that field from the segment record; (3)
+// offs[k] indexes a real record header whose MVCC seq is readable (the map a scan uses for
+// visibility); (4) the records split into the expected groups, and every record is covered
+// exactly once.
+//
+// Sweeping the group size is the point: the group size must be transparent to every reader. A
+// bug that indexes a group-local record with a segment-wide index (or the reverse) reads another
+// record's value or another record's MVCC header, which is a wrong answer rather than a slow one,
+// and a single-group fixture cannot see it.
+func TestBuildColumnarFromSegmentRowGroups(t *testing.T) {
 	store := New(Options{Shards: 1})
 	const n = 500
 	for i := 0; i < n; i++ {
@@ -60,45 +73,82 @@ func TestBuildColumnarFromSegment(t *testing.T) {
 		t.Skip("Memory not an int schema field")
 	}
 
-	blk, offs := buildColumnarFromSegment(seg.data, seg.used, seg.codec, s, []int{memIdx}, store.recordToInterned)
-	if blk.n != n || len(offs) != n {
-		t.Fatalf("block n=%d offs=%d, want %d", blk.n, len(offs), n)
-	}
-
-	// One column-scan pass: block value per record.
-	scanned := make([]int64, n)
-	scannedPresent := make([]bool, n)
-	if err := blk.scanInt(memIdx, nil, func(k int, p bool, v int64) { scannedPresent[k], scanned[k] = p, v }); err != nil {
-		t.Fatal(err)
-	}
-
-	for k := 0; k < n; k++ {
-		// (1) reconstruct == the ad at offs[k].
-		rec, err := blk.reconstruct(k, nil)
-		if err != nil {
-			t.Fatal(err)
-		}
-		w, _ := seg.codec.Decompress(nil, recAd(seg.data, offs[k]))
-		orig := adAttrs(w)
-		dec := map[uint32][]byte{}
-		s.forEach(rec, func(id uint32, node []byte) bool { dec[id] = append([]byte(nil), node...); return true })
-		if len(dec) != len(orig) {
-			t.Fatalf("rec[%d] reconstructed %d attrs, want %d", k, len(dec), len(orig))
-		}
-		for id, on := range orig {
-			if dn, ok := dec[id]; !ok || !sameValue(on, dn) {
-				t.Errorf("rec[%d] attr %d mismatch after columnar round-trip", k, id)
+	// Group sizes: the production default, one that divides n exactly, an extreme of one record
+	// per group, and one larger than the segment (a single short group -- the old whole-segment
+	// shape). All must produce identical per-record answers.
+	for _, groupRows := range []int{colGroupRows, 100, 1, n + 7} {
+		t.Run(fmt.Sprintf("group%d", groupRows), func(t *testing.T) {
+			blocks, offs := buildColumnarFromSegment(seg.data, seg.used, seg.codec, s, []int{memIdx}, byRows(groupRows), store.recordToInterned)
+			if len(offs) != n {
+				t.Fatalf("offs=%d, want %d", len(offs), n)
 			}
-		}
-		// (2) hot column scan == the segment's Memory value.
-		mv, _ := wire.Ad(w).Lookup(memID)
-		lit, _ := wire.LiteralValue(mv)
-		if !scannedPresent[k] || scanned[k] != lit.Int {
-			t.Errorf("rec[%d] scanInt Memory=(%v,%d), segment=%d", k, scannedPresent[k], scanned[k], lit.Int)
-		}
-		// (3) offs[k] is a real record header.
-		if recSeq(seg.data, offs[k]) == 0 {
-			t.Errorf("rec[%d] at offs %d has zero seq", k, offs[k])
-		}
+			// (4) expected group split, and the counts sum to every record exactly once.
+			wantBlocks := (n + groupRows - 1) / groupRows
+			if len(blocks) != wantBlocks {
+				t.Fatalf("got %d row groups, want %d at groupRows=%d", len(blocks), wantBlocks, groupRows)
+			}
+			total := 0
+			for i, b := range blocks {
+				if b.n > groupRows {
+					t.Errorf("group %d holds %d records, over the %d limit", i, b.n, groupRows)
+				}
+				if i < len(blocks)-1 && b.n != groupRows {
+					t.Errorf("group %d holds %d records; only the last group may be short", i, b.n)
+				}
+				total += b.n
+			}
+			if total != n {
+				t.Fatalf("row groups cover %d records, want %d", total, n)
+			}
+
+			// One column-scan pass per group, gathered into segment-wide order.
+			scanned := make([]int64, n)
+			scannedPresent := make([]bool, n)
+			base := 0
+			for _, b := range blocks {
+				bb := base
+				if err := b.scanInt(memIdx, nil, func(k int, p bool, v int64) {
+					scannedPresent[bb+k], scanned[bb+k] = p, v
+				}); err != nil {
+					t.Fatal(err)
+				}
+				base += b.n
+			}
+
+			base = 0
+			for bi, b := range blocks {
+				for k := 0; k < b.n; k++ {
+					gk := base + k
+					// (1) reconstruct == the ad at offs[gk].
+					rec, err := b.reconstruct(k, nil)
+					if err != nil {
+						t.Fatal(err)
+					}
+					w, _ := seg.codec.Decompress(nil, recAd(seg.data, offs[gk]))
+					orig := adAttrs(w)
+					dec := map[uint32][]byte{}
+					s.forEach(rec, func(id uint32, node []byte) bool { dec[id] = append([]byte(nil), node...); return true })
+					if len(dec) != len(orig) {
+						t.Fatalf("group %d rec[%d] reconstructed %d attrs, want %d", bi, k, len(dec), len(orig))
+					}
+					for id, on := range orig {
+						if dn, ok := dec[id]; !ok || !sameValue(on, dn) {
+							t.Errorf("group %d rec[%d] attr %d mismatch after columnar round-trip", bi, k, id)
+						}
+					}
+					// (2) hot column scan == the segment's Memory value.
+					mv, _ := wire.Ad(w).Lookup(memID)
+					lit, _ := wire.LiteralValue(mv)
+					if !scannedPresent[gk] || scanned[gk] != lit.Int {
+						t.Errorf("rec[%d] scanInt Memory=(%v,%d), segment=%d", gk, scannedPresent[gk], scanned[gk], lit.Int)
+					}
+					// (3) offs[gk] is a real record header.
+					if recSeq(seg.data, offs[gk]) == 0 {
+						t.Errorf("rec[%d] at offs %d has zero seq", gk, offs[gk])
+					}
+				}
+				base += b.n
+			}
+		})
 	}
 }

--- a/collections/colblock_test.go
+++ b/collections/colblock_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/PelicanPlatform/classad/collections/wire"
 )
 
-func mustAdOld(t *testing.T, src string) *classad.ClassAd {
+func mustAdOld(t testing.TB, src string) *classad.ClassAd {
 	t.Helper()
 	ad, err := classad.ParseOld(src)
 	if err != nil {

--- a/collections/colgroup_bench_test.go
+++ b/collections/colgroup_bench_test.go
@@ -1,0 +1,257 @@
+package collections
+
+import (
+	"fmt"
+	"testing"
+)
+
+// What the row-group policy costs on the REAL store aggregate path, over TWO ad shapes.
+//
+// The mechanism: reading a value that ESCAPED its fixed slot means decompressing its block's cold
+// tail. With one block per segment that is the whole segment's tail to read one record; with row
+// groups it is only that record's group. So the cost scales with the block, and bounding the block
+// bounds the cost.
+//
+// Splitting is not free: each block is one decompress call and one cache entry per scan. So BOTH ad
+// shapes are measured -- fat ads (real OSPool slot ads, ~561 attributes, ~10 KB) and small ads (5
+// attributes, tens of bytes) -- because the same row count means ~1 MiB of block on one and a few
+// kilobytes on the other, a 300x spread in what a "128-row group" actually is.
+//
+// MEASURED (medians of 3, 8 MiB segments): on fat ads, bounding the block takes a cold aggregate
+// from 4.02ms to 3.06ms and the decompression component (cold minus warm) from 1.32ms to 0.36ms.
+// On small ads the group size is a NON-EFFECT: 128-row groups land within ~3% of whole-segment
+// blocks, which is inside the run-to-run noise. Warm is flat on both.
+//
+// Beware two traps here, both of which produced wrong conclusions during this work. (1) ORDER: the
+// regimes run sequentially against one store, and the first one measured absorbs warmup -- an
+// earlier version of this benchmark reported a 57% small-ad regression that was entirely the cost
+// of running first, and vanished under -count. Compare medians across -count>=3, never single runs.
+// (2) SEGMENT SIZE: if a segment holds fewer records than the group size being measured, that
+// regime silently equals whole-segment, and two "different" rows of the table are the same
+// measurement. Check the rec/blk metric before believing any comparison.
+//
+// The cold variants build a FRESH cache per iteration. That is not pessimism, it is the regime a
+// segment-sized block actually lives in: at ~8867 B/ad of regions a block past ~30k records exceeds
+// the cache's entire 256 MiB budget, is never admitted, and re-decompresses on every read forever.
+// Always-cold IS its steady state.
+
+// groupPolicy is one measured regime.
+type groupPolicy struct {
+	name string
+	g    colGrouping
+}
+
+// benchPolicies spans the production default, a row-count sweep, and a group larger than any
+// segment in these fixtures -- which reproduces the old one-block-per-segment shape.
+var benchPolicies = []groupPolicy{
+	{"default", defaultColGrouping()},
+	{"rows128", byRows(128)},
+	{"rows512", byRows(512)},
+	{"wholeSegment", byRows(1 << 20)},
+}
+
+// coldCache swaps in a fresh block cache, so the next query pays full decompression.
+func coldCache(tb testing.TB, c *Collection) {
+	tb.Helper()
+	st := c.schemaScan.Load()
+	if st == nil {
+		tb.Fatal("schema scan not enabled")
+	}
+	bc, err := newBlockCache(256 << 20)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	c.schemaScan.Store(&schemaScanState{schema: st.schema, hot: st.hot, cache: bc})
+}
+
+// regroup rebuilds every sealed segment's accelerator under g, and reports the resulting block
+// count and mean records per block -- so a regime that produced only one block per segment cannot be
+// mistaken for one that split.
+func regroup(tb testing.TB, c *Collection, g colGrouping) (blocks, recs int) {
+	tb.Helper()
+	st := c.schemaScan.Load()
+	if st == nil {
+		tb.Fatal("schema scan not enabled")
+	}
+	for _, sh := range c.shards {
+		sh.mu.RLock()
+		act := sh.act
+		segs := append([]*segment(nil), sh.segs...)
+		sh.mu.RUnlock()
+		for _, seg := range segs {
+			if seg == nil || seg == act || seg.used == 0 {
+				continue
+			}
+			d := seg.dict.Load()
+			bl, offs := buildColumnarFromSegment(seg.data, seg.used, seg.codec, st.schema, st.hot, g,
+				func(dst, w []byte) ([]byte, bool) { return c.recordToInternedDict(d, dst, w) })
+			seg.colblk.Store(&colSegment{blocks: bl, offs: offs})
+			blocks += len(bl)
+			recs += len(offs)
+		}
+	}
+	if blocks == 0 {
+		tb.Fatal("regrouped no segment: there is no columnar path to measure")
+	}
+	return blocks, recs
+}
+
+// ospoolFixture loads the real OSPool slot corpus into a store with sealed segments -- ~561
+// attributes per ad, which is the shape the row-group measurements were taken on.
+func ospoolFixture(tb testing.TB) (*Collection, string) {
+	tb.Helper()
+	ads, _ := loadOSPoolAds(tb)
+	if len(ads) == 0 {
+		tb.Skip("no OSPool ads")
+	}
+	// 8 MiB segments over ~10 KB ads: ~800 records per segment, so a whole-segment block holds
+	// several times the byte budget and the policies are far apart. (At 2 MiB a segment is only
+	// ~208 records, which already caps the row-count regimes and understates the difference.)
+	store := New(Options{Shards: 1, SegmentSize: 1 << 23})
+	for i, ad := range ads {
+		if err := store.Put([]byte(fmt.Sprintf("s%d", i)), ad); err != nil {
+			tb.Fatal(err)
+		}
+	}
+	// Drive demand on Memory so it lands in the hot tier, as a maintenance pass would.
+	if !store.BuildAndEnableSchemaScan(2000, 8) {
+		tb.Skip("no schema derived from the OSPool corpus")
+	}
+	if info := store.SchemaScanInfo(); info.CoveredSegments == 0 {
+		tb.Skipf("accelerator covers no sealed segment (%d sealed)", info.SealedSegments)
+	}
+	return store, "Memory"
+}
+
+// benchAggregate runs the aggregate query over each policy, cold and warm.
+func benchAggregate(b *testing.B, newStore func(testing.TB) (*Collection, string)) {
+	store, attr := newStore(b)
+	if _, ok := store.NumStatsQuery(nil, attr); !ok {
+		b.Skipf("NumStatsQuery declined for %s; the columnar path is not serving it", attr)
+	}
+	for _, p := range benchPolicies {
+		blocks, recs := regroup(b, store, p.g)
+		perBlock := float64(recs) / float64(blocks)
+		b.Run(p.name+"/cold", func(b *testing.B) {
+			b.ReportAllocs()
+			b.ReportMetric(float64(blocks), "blocks")
+			b.ReportMetric(perBlock, "rec/blk")
+			for i := 0; i < b.N; i++ {
+				coldCache(b, store)
+				st, ok := store.NumStatsQuery(nil, attr)
+				if !ok {
+					b.Fatal("NumStatsQuery declined mid-benchmark")
+				}
+				if st.N == 0 {
+					b.Fatal("no values scanned")
+				}
+			}
+		})
+		coldCache(b, store) // one fresh cache, then let it warm
+		b.Run(p.name+"/warm", func(b *testing.B) {
+			b.ReportAllocs()
+			b.ReportMetric(perBlock, "rec/blk")
+			for i := 0; i < b.N; i++ {
+				if _, ok := store.NumStatsQuery(nil, attr); !ok {
+					b.Fatal("NumStatsQuery declined mid-benchmark")
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkRowGroupOSPool is the fat-ad case: real slot ads, where bounding the block is the win.
+func BenchmarkRowGroupOSPool(b *testing.B) {
+	benchAggregate(b, func(tb testing.TB) (*Collection, string) { return ospoolFixture(tb) })
+}
+
+// BenchmarkRowGroupSmallAds is the small-ad case: blocks so small that splitting them changes
+// nothing measurable, which is why the budget is in bytes rather than rows -- not because rows are
+// slower here, but because a row count means something entirely different at this ad width.
+func BenchmarkRowGroupSmallAds(b *testing.B) {
+	benchAggregate(b, func(tb testing.TB) (*Collection, string) {
+		c, _ := groupFixture(tb, 8000)
+		return c, "ProcId"
+	})
+}
+
+// BenchmarkRowGroupBuild measures the transcode: each group compresses independently, so it is
+// worth knowing whether seal-time cost moved.
+func BenchmarkRowGroupBuild(b *testing.B) {
+	store, _ := ospoolFixture(b)
+	st := store.schemaScan.Load()
+	var seg *segment
+	for _, sh := range store.shards {
+		sh.mu.RLock()
+		for _, s := range sh.segs {
+			if s != nil && s != sh.act && s.used > 0 {
+				seg = s
+			}
+		}
+		sh.mu.RUnlock()
+	}
+	if seg == nil {
+		b.Fatal("no sealed segment")
+	}
+	d := seg.dict.Load()
+	for _, p := range benchPolicies {
+		b.Run(p.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				blocks, _ := buildColumnarFromSegment(seg.data, seg.used, seg.codec, st.schema, st.hot, p.g,
+					func(dst, w []byte) ([]byte, bool) { return store.recordToInternedDict(d, dst, w) })
+				if len(blocks) == 0 {
+					b.Fatal("no blocks")
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkRowGroupBlockBytes is a size report, not a timing: what splitting costs on disk.
+// Compressing each group independently gives up cross-group redundancy, the one axis where a
+// smaller group is genuinely worse.
+func BenchmarkRowGroupBlockBytes(b *testing.B) {
+	for _, fx := range []struct {
+		name  string
+		build func(testing.TB) (*Collection, string)
+	}{
+		{"ospool", func(tb testing.TB) (*Collection, string) { return ospoolFixture(tb) }},
+		{"smallAds", func(tb testing.TB) (*Collection, string) {
+			c, _ := groupFixture(tb, 8000)
+			return c, "ProcId"
+		}},
+	} {
+		store, _ := fx.build(b)
+		for _, p := range benchPolicies {
+			regroup(b, store, p.g)
+			bytes, blocks, recs := 0, 0, 0
+			for _, sh := range store.shards {
+				sh.mu.RLock()
+				segs := append([]*segment(nil), sh.segs...)
+				act := sh.act
+				sh.mu.RUnlock()
+				for _, seg := range segs {
+					if seg == nil || seg == act || seg.used == 0 {
+						continue
+					}
+					cs := seg.colblk.Load()
+					if cs == nil {
+						continue
+					}
+					for _, blk := range cs.blocks {
+						bytes += len(blk.hot) + len(blk.coldNumComp) + len(blk.strComp) + len(blk.coldComp)
+						blocks++
+						recs += blk.n
+					}
+				}
+			}
+			if recs == 0 {
+				b.Fatal("no records")
+			}
+			b.Logf("%-9s %-13s blocks=%-4d %5d records  %9d B  %.1f B/record  %.0f rec/blk",
+				fx.name, p.name, blocks, recs, bytes, float64(bytes)/float64(recs),
+				float64(recs)/float64(blocks))
+		}
+	}
+}

--- a/collections/colgroup_test.go
+++ b/collections/colgroup_test.go
@@ -1,0 +1,379 @@
+package collections
+
+import (
+	"fmt"
+	"testing"
+)
+
+// Row groups (see colGroupRows): a segment's columnar accelerator is a SERIES of blocks, not one
+// block covering the whole segment. These tests hold that line, because the failure mode of losing
+// it is invisible: a segment-sized block is still correct, still passes every equivalence test, and
+// only shows up as a query that got slower on big data. The design carried the row group from the
+// start (the layout is documented as PAX, and the block comment still says "row-group"), and the
+// production build silently handed the encoder every record in the segment.
+
+// regroupSegments rebuilds every sealed segment's accelerator at an exact row-group size (see
+// regroup in the benchmarks, which this wraps), for tests sweeping the group size.
+func regroupSegments(tb testing.TB, c *Collection, groupRows int) {
+	tb.Helper()
+	regroup(tb, c, byRows(groupRows))
+}
+
+// groupFixture builds a store whose sealed segments hold many more than colGroupRows records each,
+// so a segment-sized block and a row-grouped one are actually distinguishable.
+func groupFixture(tb testing.TB, n int) (*Collection, uint32) {
+	tb.Helper()
+	// The segment size has to seal segments (a segment that never seals gets no columnar block at
+	// all, and every assertion below would pass against the row fallback) while still holding many
+	// more than colGroupRows records each -- which is the case row groups exist for. At ~200 bytes
+	// a record, 64 KiB is a few hundred records per segment, so a segment spans several groups.
+	store := New(Options{Shards: 1, SegmentSize: 1 << 16})
+	for i := 0; i < n; i++ {
+		src := fmt.Sprintf("Cpus = %d\nMemory = %d\nProcId = %d\nOwner = \"u%d\"\nMachine = \"m%04d.example.org\"",
+			1+i%16, 1024+(i%64)*512, i%10, i%32, i)
+		// Every 997th record carries an out-of-width ProcId, so the escaped cold-tail path is
+		// exercised too -- that is the path the group size affects most.
+		if i%997 == 996 {
+			src = fmt.Sprintf("Cpus = %d\nMemory = %d\nProcId = %d\nOwner = \"u%d\"\nMachine = \"m%04d.example.org\"",
+				1+i%16, 1024+(i%64)*512, 900000+i, i%32, i)
+		}
+		if err := store.Put([]byte(fmt.Sprintf("k%d", i)), mustAdOld(tb, src)); err != nil {
+			tb.Fatal(err)
+		}
+	}
+	if !store.BuildAndEnableSchemaScan(4000, 4) {
+		tb.Fatal("BuildAndEnableSchemaScan returned false")
+	}
+	id, ok := store.intern.LookupID("ProcId")
+	if !ok {
+		tb.Fatal("ProcId not interned")
+	}
+	return store, id
+}
+
+// fatFixture builds a store of FAT ads -- ~4 KB of record each, the shape the byte budget is meant
+// to bind on. Synthetic rather than the real OSPool corpus so this runs in CI, where the 38 MB
+// testdata is not present.
+func fatFixture(tb testing.TB, n int) (*Collection, uint32) {
+	tb.Helper()
+	store := New(Options{Shards: 1, SegmentSize: 1 << 22})
+	for i := 0; i < n; i++ {
+		var b []byte
+		b = append(b, fmt.Sprintf("Cpus = %d\nMemory = %d\nProcId = %d\n", 1+i%16, 1024+(i%64)*512, i%10)...)
+		// Enough distinct string attributes to make a record kilobytes wide, as a real slot ad's
+		// several hundred attributes do.
+		for j := 0; j < 60; j++ {
+			b = append(b, fmt.Sprintf("Attr%02d = \"value-%d-%02d-%s\"\n", j, i, j, "padpadpadpadpadpadpadpadpadpadpadpadpadpadpadpad")...)
+		}
+		if i%97 == 96 {
+			b = append(b, fmt.Sprintf("ProcId = %d\n", 900000+i)...) // out-of-width: escapes
+		}
+		if err := store.Put([]byte(fmt.Sprintf("f%d", i)), mustAdOld(tb, string(b))); err != nil {
+			tb.Fatal(err)
+		}
+	}
+	if !store.BuildAndEnableSchemaScan(4000, 4) {
+		tb.Fatal("BuildAndEnableSchemaScan returned false")
+	}
+	id, ok := store.intern.LookupID("ProcId")
+	if !ok {
+		tb.Fatal("ProcId not interned")
+	}
+	return store, id
+}
+
+// blockRecordBytes is a block's uncompressed record footprint: the hot region plus its decompressed
+// string and cold-tail regions. This is the quantity the block cache is budgeted in, so it is the
+// quantity the group policy has to bound.
+func blockRecordBytes(tb testing.TB, b *columnarBlock) int {
+	tb.Helper()
+	total := len(b.hot)
+	for _, kind := range []streamKind{kindColdNum, kindStr, kindCold} {
+		raw, err := b.regionRaw(kind)
+		if err != nil {
+			tb.Fatal(err)
+		}
+		total += len(raw)
+	}
+	return total
+}
+
+// TestRowGroupsBoundedByBytes is the regression gate against the cache cliff: under the default
+// policy a fat-ad segment must be split into several groups, and no group may exceed the byte budget
+// (plus one record, since a group is sealed after the record that crosses it).
+//
+// This is what a return to one-block-per-segment would break, and nothing else would notice: a
+// segment-sized block is still CORRECT, still passes every equivalence test, and shows up only as a
+// query that got slower on data larger than any test fixture.
+func TestRowGroupsBoundedByBytes(t *testing.T) {
+	store, _ := fatFixture(t, 1200)
+	sealed, blocks, multi, biggest := 0, 0, 0, 0
+	for _, sh := range store.shards {
+		sh.mu.RLock()
+		act := sh.act
+		segs := append([]*segment(nil), sh.segs...)
+		sh.mu.RUnlock()
+		for _, seg := range segs {
+			if seg == nil || seg == act || seg.used == 0 {
+				continue
+			}
+			cs := seg.colblk.Load()
+			if cs == nil {
+				continue
+			}
+			sealed++
+			blocks += len(cs.blocks)
+			if len(cs.blocks) > 1 {
+				multi++
+			}
+			total := 0
+			for _, b := range cs.blocks {
+				if b.n > colGroupMaxRows {
+					t.Errorf("a block holds %d records, over the %d row backstop", b.n, colGroupMaxRows)
+				}
+				by := blockRecordBytes(t, b)
+				if by > biggest {
+					biggest = by
+				}
+				// One record of slack: the group seals AFTER the record that crosses the budget.
+				if b.n > 1 && by > colGroupTargetBytes+by/b.n {
+					t.Errorf("a block holds %d B of records (%d records), over the %d B budget",
+						by, b.n, colGroupTargetBytes)
+				}
+				total += b.n
+			}
+			if total != len(cs.offs) {
+				t.Errorf("blocks cover %d records but offs has %d", total, len(cs.offs))
+			}
+		}
+	}
+	if sealed == 0 {
+		t.Fatal("no sealed segment carried a columnar block: the fixture never sealed, so this " +
+			"test would pass against any block size at all")
+	}
+	if multi == 0 {
+		t.Fatalf("no fat-ad segment was split into row groups (%d sealed, %d blocks, biggest %d B) -- "+
+			"either the fixture is too small or the segment is one block again", sealed, blocks, biggest)
+	}
+	t.Logf("%d sealed segment(s), %d row groups, biggest %d B (budget %d B)", sealed, blocks, biggest, colGroupTargetBytes)
+}
+
+// TestRowGroupsBoundedByRows covers the other half of the policy: a table of SMALL ads never
+// reaches the byte budget, so the row backstop is what bounds its blocks. It also pins the
+// intended behaviour that small ads get MANY rows per group: at ~27 B a record, 128 rows would be a
+// 3 KB block, a bound that governs nothing (measured within ~3% of whole-segment blocks, i.e.
+// noise). The byte budget is what makes the same policy mean something at both ad widths.
+func TestRowGroupsBoundedByRows(t *testing.T) {
+	store, _ := groupFixture(t, 4000)
+	sealed, blocks, biggest := 0, 0, 0
+	multi := 0
+	for _, sh := range store.shards {
+		sh.mu.RLock()
+		act := sh.act
+		segs := append([]*segment(nil), sh.segs...)
+		sh.mu.RUnlock()
+		for _, seg := range segs {
+			if seg == nil || seg == act || seg.used == 0 {
+				continue
+			}
+			cs := seg.colblk.Load()
+			if cs == nil {
+				continue
+			}
+			sealed++
+			blocks += len(cs.blocks)
+			total := 0
+			for _, b := range cs.blocks {
+				if b.n > colGroupMaxRows {
+					t.Errorf("a block covers %d records, over the %d row backstop", b.n, colGroupMaxRows)
+				}
+				if b.n > biggest {
+					biggest = b.n
+				}
+				total += b.n
+			}
+			if len(cs.blocks) > 1 {
+				multi++
+			}
+			// Every record in the segment is covered exactly once by the groups.
+			if total != len(cs.offs) {
+				t.Errorf("blocks cover %d records but offs has %d", total, len(cs.offs))
+			}
+		}
+	}
+	if sealed == 0 {
+		t.Fatal("no sealed segment carried a columnar block: the fixture never sealed, so this " +
+			"test would pass against any block size at all")
+	}
+	// Small ads are EXPECTED to fit one group per segment here; what matters is that the backstop
+	// holds and that a block never grows unbounded.
+	t.Logf("%d sealed segment(s), %d row groups, biggest %d records (backstop %d, %d multi-group)",
+		sealed, blocks, biggest, colGroupMaxRows, multi)
+}
+
+// TestRowGroupSizeIsTransparent sweeps the group size over the REAL store aggregate path and
+// requires an identical answer every time, including the extremes. The group size is a performance
+// dial; if it can change an answer, the record indexing is wrong somewhere.
+func TestRowGroupSizeIsTransparent(t *testing.T) {
+	store, procID := groupFixture(t, 3000)
+
+	// Ground truth from the row path, ignoring the columnar blocks entirely.
+	wantCount := store.allBruteCount(procID, func(v int64) bool { return v >= 5 })
+	stats, ok := store.NumStatsQuery(nil, "ProcId")
+	if !ok {
+		t.Fatal("NumStatsQuery declined")
+	}
+	wantMax, wantN, wantSum := stats.Max, stats.N, stats.IntSum
+	if info := store.SchemaScanInfo(); info.CoveredSegments == 0 {
+		t.Fatalf("no sealed segment is covered by the accelerator (%d sealed): the sweep below "+
+			"would compare the row fallback against itself", info.SealedSegments)
+	}
+
+	for _, groupRows := range []int{1, 7, colGroupRows, 512, 1 << 20} {
+		t.Run(fmt.Sprintf("group%d", groupRows), func(t *testing.T) {
+			regroupSegments(t, store, groupRows)
+			if got := store.schemaScanIntCount(store.schemaScan.Load().schema,
+				store.schemaScan.Load().schema.byID[procID], func(v int64) bool { return v >= 5 }); got != wantCount {
+				t.Errorf("count = %d, want %d", got, wantCount)
+			}
+			got, ok := store.NumStatsQuery(nil, "ProcId")
+			if !ok {
+				t.Fatal("NumStatsQuery declined")
+			}
+			if got.Max != wantMax || got.N != wantN || got.IntSum != wantSum {
+				t.Errorf("stats = (max %v, n %d, sum %d), want (max %v, n %d, sum %d)",
+					got.Max, got.N, got.IntSum, wantMax, wantN, wantSum)
+			}
+		})
+	}
+	// The escaped values must actually be in the data, or the sweep proves less than it looks.
+	if wantMax < 900000 {
+		t.Errorf("fixture MAX(ProcId) = %v; the out-of-width escaped values are missing, so the "+
+			"cold-tail path was never exercised", wantMax)
+	}
+}
+
+// TestColSegmentPersistMultiGroup round-trips a MULTI-group accelerator through the sidecar
+// serialization. v1 stored exactly one block, so the block count, the per-block streams and the
+// segment-wide offs array are all new framing, and a reload that mis-parses any of them hands the
+// scan another record's bytes.
+func TestColSegmentPersistMultiGroup(t *testing.T) {
+	store, procID := groupFixture(t, 2000)
+	st := store.schemaScan.Load()
+	// Group by an explicit small row count so there are definitely several groups to serialize,
+	// independent of whether this fixture's ads reach the byte budget.
+	regroupSegments(t, store, 64)
+
+	var cs *colSegment
+	for _, sh := range store.shards {
+		sh.mu.RLock()
+		act := sh.act
+		segs := append([]*segment(nil), sh.segs...)
+		sh.mu.RUnlock()
+		for _, seg := range segs {
+			if seg != nil && seg != act && seg.used > 0 {
+				if got := seg.colblk.Load(); got != nil && len(got.blocks) > 1 {
+					cs = got
+				}
+			}
+		}
+	}
+	if cs == nil {
+		t.Fatal("no sealed segment with more than one row group: nothing multi-group to round-trip")
+	}
+
+	blob := marshalColSegment(cs, store.intern.Name)
+	if blob == nil {
+		t.Fatal("marshalColSegment returned nil")
+	}
+	got := unmarshalColSegment(blob, identityCodec{}, store.intern.Intern)
+	if got == nil {
+		t.Fatal("unmarshalColSegment returned nil for a multi-group segment")
+	}
+	if len(got.blocks) != len(cs.blocks) {
+		t.Fatalf("reloaded %d row groups, want %d", len(got.blocks), len(cs.blocks))
+	}
+	if len(got.offs) != len(cs.offs) {
+		t.Fatalf("reloaded %d offs, want %d", len(got.offs), len(cs.offs))
+	}
+	for i := range cs.blocks {
+		a, b := cs.blocks[i], got.blocks[i]
+		if a.n != b.n || a.hotStride != b.hotStride {
+			t.Errorf("group %d: n/stride = %d/%d, want %d/%d", i, b.n, b.hotStride, a.n, a.hotStride)
+		}
+		if string(a.hot) != string(b.hot) {
+			t.Errorf("group %d: hot region differs after round-trip", i)
+		}
+		if string(a.strComp) != string(b.strComp) || string(a.coldComp) != string(b.coldComp) ||
+			string(a.coldNumComp) != string(b.coldNumComp) {
+			t.Errorf("group %d: a compressed stream differs after round-trip", i)
+		}
+	}
+	// And the reloaded blocks read the same values: scan the schema's ProcId column across both.
+	idx, ok := st.schema.byID[procID]
+	if !ok {
+		t.Skip("ProcId not a schema field")
+	}
+	read := func(cs *colSegment) []int64 {
+		var out []int64
+		for _, b := range cs.blocks {
+			if err := b.scanInt(idx, nil, func(_ int, present bool, v int64) {
+				if present {
+					out = append(out, v)
+				}
+			}); err != nil {
+				t.Fatal(err)
+			}
+		}
+		return out
+	}
+	origVals, gotVals := read(cs), read(got)
+	if len(origVals) != len(gotVals) {
+		t.Fatalf("reloaded %d column values, want %d", len(gotVals), len(origVals))
+	}
+	for i := range origVals {
+		if origVals[i] != gotVals[i] {
+			t.Fatalf("reloaded value %d = %d, want %d", i, gotVals[i], origVals[i])
+		}
+	}
+}
+
+// TestColSegmentRejectsGroupOffsMismatch pins the reload guard: if the blocks' record counts do not
+// sum to the offs length, a scan would map a record to another record's arena offset and read the
+// wrong MVCC header -- a wrong answer. The reload must refuse and let the segment rebuild.
+func TestColSegmentRejectsGroupOffsMismatch(t *testing.T) {
+	store, _ := groupFixture(t, 2000)
+	st := store.schemaScan.Load()
+	var seg *segment
+	for _, sh := range store.shards {
+		sh.mu.RLock()
+		act := sh.act
+		for _, s := range sh.segs {
+			if s != nil && s != act && s.used > 0 {
+				seg = s
+			}
+		}
+		sh.mu.RUnlock()
+	}
+	if seg == nil {
+		t.Fatal("no sealed segment")
+	}
+	d := seg.dict.Load()
+	blocks, offs := buildColumnarFromSegment(seg.data, seg.used, seg.codec, st.schema, st.hot, byRows(64),
+		func(dst, w []byte) ([]byte, bool) { return store.recordToInternedDict(d, dst, w) })
+	if len(blocks) < 2 {
+		t.Fatal("fixture produced a single row group; the mismatch guard would not be exercised")
+	}
+	// A truthful blob reloads.
+	if unmarshalColSegment(marshalColSegment(&colSegment{blocks: blocks, offs: offs}, store.intern.Name),
+		identityCodec{}, store.intern.Intern) == nil {
+		t.Fatal("a well-formed multi-group blob failed to reload")
+	}
+	// Drop one record from offs: the counts no longer sum, and the reload must refuse.
+	short := &colSegment{blocks: blocks, offs: offs[:len(offs)-1]}
+	if got := unmarshalColSegment(marshalColSegment(short, store.intern.Name),
+		identityCodec{}, store.intern.Intern); got != nil {
+		t.Error("a blob whose block counts do not sum to its offs length was accepted; a scan " +
+			"would read the wrong record's MVCC header")
+	}
+}

--- a/collections/colpersist.go
+++ b/collections/colpersist.go
@@ -17,8 +17,12 @@ import (
 // built from a different segment byte length) and rebuilds instead of trusting corrupt bytes --
 // the same "derived state, any doubt rebuilds" contract the attribute-index sidecar follows.
 const (
-	colSectionMagic   = 0x434f4c58 // "COLX"
-	colSectionVersion = 1
+	colSectionMagic = 0x434f4c58 // "COLX"
+	// colSectionVersion 2 stores a LIST of row-group blocks per segment (see colGroupRows); v1
+	// stored exactly one block covering the whole segment. A v1 section is rejected by
+	// readColSection like any other section that cannot be trusted, so the segment simply rebuilds
+	// its accelerator under the current layout -- derived state, so no migration is needed.
+	colSectionVersion = 2
 	colSectionHdr     = 4 + 2 + 4 + 4 // magic u32 | version u16 | upto u32 | crc u32
 )
 
@@ -101,27 +105,36 @@ func readAdSchema(c *cursor, internName func(string) uint32) *adSchema {
 	return layoutSchema(fields)
 }
 
-// marshalColSegment serializes cs (its block's schema, hot set, record count, byte streams, and
-// per-record offsets, plus offs -- the block->arena map for MVCC visibility).
+// marshalColSegment serializes cs: the schema and hot set ONCE (every row group in a segment shares
+// them, so storing them per group would multiply a ~kB blob by the group count), then each block's
+// record count, byte streams and per-record offsets, then offs -- the segment-wide record->arena map
+// for MVCC visibility. Returns nil for a colSegment carrying no schema, which cannot be reloaded.
 func marshalColSegment(cs *colSegment, nameOf func(uint32) (string, bool)) []byte {
-	b := cs.block
-	dst := marshalAdSchema(nil, b.schema, nameOf)
-	dst = appendU32(dst, uint32(len(b.hotNum)))
-	for _, i := range b.hotNum {
+	sch := cs.schema()
+	if sch == nil {
+		return nil
+	}
+	hotNum := cs.hotNum()
+	dst := marshalAdSchema(nil, sch, nameOf)
+	dst = appendU32(dst, uint32(len(hotNum)))
+	for _, i := range hotNum {
 		dst = appendU32(dst, uint32(i))
 	}
-	dst = appendU32(dst, uint32(b.n))
-	dst = appendBytes(dst, b.hot)
-	dst = appendBytes(dst, b.coldNumComp)
-	dst = appendBytes(dst, b.strComp)
-	dst = appendBytes(dst, b.coldComp)
-	dst = appendU32(dst, uint32(len(b.strOff)))
-	for _, v := range b.strOff {
-		dst = appendU32(dst, uint32(v))
-	}
-	dst = appendU32(dst, uint32(len(b.coldOff)))
-	for _, v := range b.coldOff {
-		dst = appendU32(dst, uint32(v))
+	dst = appendU32(dst, uint32(len(cs.blocks)))
+	for _, b := range cs.blocks {
+		dst = appendU32(dst, uint32(b.n))
+		dst = appendBytes(dst, b.hot)
+		dst = appendBytes(dst, b.coldNumComp)
+		dst = appendBytes(dst, b.strComp)
+		dst = appendBytes(dst, b.coldComp)
+		dst = appendU32(dst, uint32(len(b.strOff)))
+		for _, v := range b.strOff {
+			dst = appendU32(dst, uint32(v))
+		}
+		dst = appendU32(dst, uint32(len(b.coldOff)))
+		for _, v := range b.coldOff {
+			dst = appendU32(dst, uint32(v))
+		}
 	}
 	dst = appendU32(dst, uint32(len(cs.offs)))
 	for _, o := range cs.offs {
@@ -154,20 +167,42 @@ func unmarshalColSegment(data []byte, codec Codec, internName func(string) uint3
 	for i := range hotNum {
 		hotNum[i] = int(c.u32())
 	}
-	n := int(c.u32())
-	b := &columnarBlock{id: colBlockSeq.Add(1), schema: s, codec: codec, n: n}
-	b.hot = c.bytes() // aliases data (the mmap); read-only, scanned in place
-	b.coldNumComp = c.bytes()
-	b.strComp = c.bytes()
-	b.coldComp = c.bytes()
-	b.strOff = readInts(c)
-	b.coldOff = readInts(c)
-	offs := readU32s(c)
-	if c.err != nil || n < 0 {
+	nb := int(c.u32())
+	if nb < 0 || !c.need(0) {
 		return nil
 	}
-	layoutColumnar(b, s, hotNum, n)
-	return &colSegment{block: b, offs: offs}
+	blocks := make([]*columnarBlock, 0, nb)
+	total := 0
+	for i := 0; i < nb; i++ {
+		n := int(c.u32())
+		if n < 0 || c.err != nil {
+			return nil
+		}
+		b := &columnarBlock{id: colBlockSeq.Add(1), schema: s, codec: codec, n: n}
+		b.hot = c.bytes() // aliases data (the mmap); read-only, scanned in place
+		b.coldNumComp = c.bytes()
+		b.strComp = c.bytes()
+		b.coldComp = c.bytes()
+		b.strOff = readInts(c)
+		b.coldOff = readInts(c)
+		if c.err != nil {
+			return nil
+		}
+		layoutColumnar(b, s, hotNum, n)
+		blocks = append(blocks, b)
+		total += n
+	}
+	offs := readU32s(c)
+	if c.err != nil {
+		return nil
+	}
+	// The blocks' record counts must sum to the offs length, or a scan would map a record to the
+	// wrong arena offset and read another record's MVCC seq -- a wrong answer rather than a slow
+	// one. Reject instead, and let the segment rebuild.
+	if total != len(offs) {
+		return nil
+	}
+	return &colSegment{blocks: blocks, offs: offs}
 }
 
 func readInts(c *cursor) []int {

--- a/collections/colpersist_test.go
+++ b/collections/colpersist_test.go
@@ -28,13 +28,13 @@ func TestColSegmentMarshalRoundTrip(t *testing.T) {
 		for i := range offs {
 			offs[i] = uint32(i * 7) // arbitrary stand-in arena offsets
 		}
-		orig := &colSegment{block: blk, offs: offs}
+		orig := oneBlockColSeg(blk, offs)
 
 		got := unmarshalColSegment(marshalColSegment(orig, c.intern.Name), codec, c.intern.Intern)
 		if got == nil {
 			t.Fatalf("%s: unmarshal returned nil", codec.Name())
 		}
-		gb := got.block
+		gb := got.blocks[0]
 		if gb.n != blk.n || gb.hotStride != blk.hotStride || len(gb.hotNum) != len(blk.hotNum) || len(gb.coldNum) != len(blk.coldNum) {
 			t.Fatalf("%s: layout mismatch: n=%d/%d stride=%d/%d hot=%d/%d cold=%d/%d",
 				codec.Name(), gb.n, blk.n, gb.hotStride, blk.hotStride, len(gb.hotNum), len(blk.hotNum), len(gb.coldNum), len(blk.coldNum))
@@ -88,7 +88,7 @@ func TestUnmarshalColSegmentTruncated(t *testing.T) {
 	}
 	s := buildAdSchema(wires, adSchemaOpts{Presence: 0.5, Fit: 0.95})
 	blk := encodeColumnarBlock(s, encodeRows(s, wires), nil, identityCodec{})
-	full := marshalColSegment(&colSegment{block: blk, offs: make([]uint32, blk.n)}, c.intern.Name)
+	full := marshalColSegment(oneBlockColSeg(blk, make([]uint32, blk.n)), c.intern.Name)
 	for _, cut := range []int{0, 1, len(full) / 2, len(full) - 1} {
 		if got := unmarshalColSegment(full[:cut], identityCodec{}, c.intern.Intern); got != nil {
 			t.Errorf("truncated to %d bytes: expected nil, got a block", cut)
@@ -110,7 +110,7 @@ func TestColSegmentSchemaNameAnchored(t *testing.T) {
 	}
 	s := buildAdSchema(wires, adSchemaOpts{Presence: 0.8, Fit: 0.95})
 	blk := encodeColumnarBlock(s, encodeRows(s, wires), hotHalf(s), identityCodec{})
-	data := marshalColSegment(&colSegment{block: blk, offs: make([]uint32, blk.n)}, c.intern.Name)
+	data := marshalColSegment(oneBlockColSeg(blk, make([]uint32, blk.n)), c.intern.Name)
 
 	// Simulate a reopen: a fresh intern table that assigns DIFFERENT ids to the same names
 	// (decoys shift first-seen order so Memory/Cpus/Disk do not land on their original ids).
@@ -130,26 +130,26 @@ func TestColSegmentSchemaNameAnchored(t *testing.T) {
 		t.Fatal("unmarshal returned nil")
 	}
 	// Every field re-bound to the REOPENED table's id, and byID indexes it under that id.
-	for _, f := range got.block.schema.fields {
+	for _, f := range got.blocks[0].schema.fields {
 		name, ok := reopened.Name(f.id)
 		if !ok {
 			t.Fatalf("field id %d not resolvable in the reopened table", f.id)
 		}
-		if idx, ok := got.block.schema.byID[f.id]; !ok || got.block.schema.fields[idx].id != f.id {
+		if idx, ok := got.blocks[0].schema.byID[f.id]; !ok || got.blocks[0].schema.fields[idx].id != f.id {
 			t.Fatalf("byID does not index field %q (id %d)", name, f.id)
 		}
 	}
 	// Routing by name through the reopened table lands on the Memory int field...
 	memID := reopened.Intern("Memory")
-	idx, ok := got.block.schema.byID[memID]
-	if !ok || got.block.schema.fields[idx].kind != akInt {
+	idx, ok := got.blocks[0].schema.byID[memID]
+	if !ok || got.blocks[0].schema.fields[idx].kind != akInt {
 		t.Fatalf("Memory (reopened id %d) not resolvable as an int field", memID)
 	}
 	// ...and the block still scans that field's values correctly (records are positional, so the
 	// scan is independent of the intern id -- but the field is FOUND only because it is name-keyed).
 	origMemID, _ := c.intern.LookupID("Memory")
 	mismatch := 0
-	got.block.scanInt(idx, nil, func(k int, p bool, v int64) {
+	got.blocks[0].scanInt(idx, nil, func(k int, p bool, v int64) {
 		if node, ok := wire.Ad(wires[k]).Lookup(origMemID); ok {
 			if lit, _ := wire.LiteralValue(node); p && lit.Kind == wire.LitInt && v != lit.Int {
 				mismatch++

--- a/collections/colscan.go
+++ b/collections/colscan.go
@@ -14,11 +14,32 @@ import (
 // Open -- proving the accelerator came off disk rather than being re-transcoded.
 var colSegmentBuilds atomic.Int64
 
-// colSegment is a sealed segment's columnar accelerator: the PAX block plus offs, mapping each
-// block record k to its arena offset so a scan can read the record's live MVCC seq/sup.
+// colSegment is a sealed segment's columnar accelerator: the segment's PAX row-group blocks (see
+// colGroupRows) in record order, plus offs, mapping each record to its arena offset so a scan can
+// read the record's live MVCC seq/sup.
+//
+// offs is FLAT across the blocks: block j's local record k is offs[base_j+k], where base_j is the
+// sum of the preceding blocks' record counts. Every block in a segment is built under the same
+// schema and hot set, so those are read from the first block.
 type colSegment struct {
-	block *columnarBlock
-	offs  []uint32
+	blocks []*columnarBlock
+	offs   []uint32
+}
+
+// schema returns the schema all of cs's blocks were built under, or nil if it carries none.
+func (cs *colSegment) schema() *adSchema {
+	if cs == nil || len(cs.blocks) == 0 {
+		return nil
+	}
+	return cs.blocks[0].schema
+}
+
+// hotNum returns the hot numeric field set all of cs's blocks were built under.
+func (cs *colSegment) hotNum() []int {
+	if cs == nil || len(cs.blocks) == 0 {
+		return nil
+	}
+	return cs.blocks[0].hotNum
 }
 
 // schemaScanState is a collection's resolved adschema columnar scan configuration.
@@ -212,12 +233,12 @@ func (c *Collection) persistColSeg(sh *shard, seg *segment) {
 func (c *Collection) buildColSegment(seg *segment, s *adSchema, hot []int) *colSegment {
 	colSegmentBuilds.Add(1)
 	d := seg.dict.Load() // interned segment -> resolve its local ids during transcode
-	blk, offs := buildColumnarFromSegment(seg.data, seg.used, seg.codec, s, hot,
+	blocks, offs := buildColumnarFromSegment(seg.data, seg.used, seg.codec, s, hot, defaultColGrouping(),
 		func(dst, w []byte) ([]byte, bool) { return c.recordToInternedDict(d, dst, w) })
-	if blk == nil {
+	if len(blocks) == 0 {
 		return nil
 	}
-	return &colSegment{block: blk, offs: offs}
+	return &colSegment{blocks: blocks, offs: offs}
 }
 
 // colBlobForSeg builds and marshals seg's columnar block under the collection's CURRENT schema-scan
@@ -234,7 +255,11 @@ func (c *Collection) colBlobForSeg(seg *segment) []byte {
 	if cs == nil {
 		return nil
 	}
-	return wrapColSection(marshalColSegment(cs, c.intern.Name), seg.used)
+	body := marshalColSegment(cs, c.intern.Name)
+	if body == nil {
+		return nil
+	}
+	return wrapColSection(body, seg.used)
 }
 
 // colBlobPreserve returns the sidecar columnar section for seg on a REINDEX (sidecar rewrite),
@@ -247,7 +272,11 @@ func (c *Collection) colBlobPreserve(seg *segment) []byte {
 	if cs == nil {
 		return c.colBlobForSeg(seg)
 	}
-	return wrapColSection(marshalColSegment(cs, c.intern.Name), seg.used)
+	body := marshalColSegment(cs, c.intern.Name)
+	if body == nil {
+		return nil
+	}
+	return wrapColSection(body, seg.used)
 }
 
 // adoptPersistedSchemaScan enables schema-scan on reopen from persisted columnar blocks: if any
@@ -266,8 +295,8 @@ func (c *Collection) adoptPersistedSchemaScan() {
 		sh.mu.RLock()
 		for _, seg := range sh.segs {
 			if seg != nil {
-				if cs := seg.colblk.Load(); cs != nil {
-					adopt = cs // last recovered block wins; any block's schema is a valid seed
+				if cs := seg.colblk.Load(); cs != nil && cs.schema() != nil {
+					adopt = cs // last recovered segment wins; any segment's schema is a valid seed
 				}
 			}
 		}
@@ -280,7 +309,7 @@ func (c *Collection) adoptPersistedSchemaScan() {
 	if err != nil {
 		return
 	}
-	c.schemaScan.Store(&schemaScanState{schema: adopt.block.schema, hot: adopt.block.hotNum, cache: bc})
+	c.schemaScan.Store(&schemaScanState{schema: adopt.schema(), hot: adopt.hotNum(), cache: bc})
 }
 
 // BuildAndEnableSchemaScan samples the collection, builds an adschema, chooses the hot numeric

--- a/collections/colscan_refresh_test.go
+++ b/collections/colscan_refresh_test.go
@@ -107,7 +107,7 @@ func TestBuildAndEnableSchemaScanRefreshSafe(t *testing.T) {
 			}
 			sealed++
 			cs := seg.colblk.Load()
-			if cs == nil || cs.block.schema != second.schema {
+			if cs == nil || cs.schema() != second.schema {
 				orphaned++
 			}
 		}

--- a/collections/regionsamples.go
+++ b/collections/regionsamples.go
@@ -52,11 +52,13 @@ func (c *Collection) CollectRegionSamples(maxBytes, lookBackBytes int) [][]byte 
 	return out
 }
 
-// sampleableBlocks returns the blocks to draw from, newest first, honoring the look-back budget.
+// sampleableBlocks returns the row-group blocks to draw from, newest segment first, honoring the
+// look-back budget. A segment contributes ALL of its row groups, and is charged its segment bytes
+// once -- the budget bounds how far back in history the draw reaches, not how many blocks it sees.
 func (c *Collection) sampleableBlocks(lookBackBytes int) []*columnarBlock {
 	type seg struct {
-		b    *columnarBlock
-		used int
+		blocks []*columnarBlock
+		used   int
 	}
 	var segs []seg
 	for _, sh := range c.shards {
@@ -68,16 +70,16 @@ func (c *Collection) sampleableBlocks(lookBackBytes int) []*columnarBlock {
 			if s == nil || s == act || s.used == 0 {
 				continue
 			}
-			if cs := s.colblk.Load(); cs != nil {
-				segs = append(segs, seg{cs.block, s.used})
+			if cs := s.colblk.Load(); cs != nil && len(cs.blocks) > 0 {
+				segs = append(segs, seg{cs.blocks, s.used})
 			}
 		}
 		sh.mu.RUnlock()
 	}
-	out := make([]*columnarBlock, 0, len(segs))
+	var out []*columnarBlock
 	bytes := 0
 	for _, s := range segs {
-		out = append(out, s.b)
+		out = append(out, s.blocks...)
 		bytes += s.used
 		if lookBackBytes > 0 && bytes >= lookBackBytes {
 			break // far enough back: older segments predate what future writes will look like

--- a/collections/streamdict_test.go
+++ b/collections/streamdict_test.go
@@ -75,7 +75,7 @@ func TestStreamDictionaryFit(t *testing.T) {
 			if cs == nil {
 				continue
 			}
-			b := cs.block
+			b := cs.blocks[0]
 			found = true
 			for _, s := range []struct {
 				name string


### PR DESCRIPTION
Builds on #162 (merged) for the per-stream `bc.stream` reads.

## The bug

The columnar layout was designed as PAX — a hybrid, with schema attributes column-major inside a **bounded row group** — and the code still describes itself that way (`colblock.go`: "the PAX layout for a row-group of adSchema records"; `blockcache.go`: "escaped-record lookups within a row-group"). The row group was never implemented. `buildColumnarFromSegment` walked the whole segment into one `recs` slice and encoded one block from it, so a block *was* a segment and the layout was fully columnar in practice.

Nothing failed, which is why it survived: a segment-sized block is correct, and passes every equivalence test. It only shows up as a query that got slower on data bigger than any fixture.

## Why it matters

The costs it makes unbounded are per-block:

- reading a value that **escaped** its fixed slot decompresses that block's cold tail
- reconstructing a full ad decompresses that block's string + cold regions

At `defaultMaxSegmentBytes` (1 GiB) one escaped read drags in a segment's worth of tail. And a block's decompressed regions run **~8867 B/ad** on OSPool slot ads, so past **~30k records** they exceed the block cache's entire 256 MiB budget — never admitted, re-decompressed on *every* read, permanently rather than as a cold start. That is the `MAX(ProcId)` 60s regression: a hot column too narrow for its values, so ~0.1% of records escaped and each one paid a full segment decompression that could never be cached.

## The fix, and why the bound is in bytes

Seal a group on a **~1 MiB record-byte budget** with an 8192-row backstop, rather than a fixed row count.

128 rows of slot ads is ~1.1 MiB of regions — the row count from the original sweep was a byte budget in disguise. What a block costs to touch, and whether it fits the cache at all, are properties of its bytes; rows are a proxy that does not survive a 300x range in ad width (a 5-attribute job ad vs a 561-attribute slot ad). Budgeting the real quantity lands fat ads near the measured 128-row sweet spot on their own and gives small-ad tables thousands of rows per group instead of 3 KB blocks.

Encoding each group as it fills also bounds peak transcode memory at one group rather than the whole segment.

## Measurements

Store-level, OSPool corpus in 8 MiB segments (~800 ads/segment), full-column aggregate, medians of 3:

| | cold | warm | decompression (cold−warm) |
|---|---|---|---|
| one block per segment | 4.02 ms | 2.70 ms | 1.32 ms |
| ~1 MiB row groups | **3.06 ms** | 2.70 ms | **0.36 ms** |

~24% off the query, ~4x off the part the block size governs. That is the *modest* end by construction — an aggregate reads the column for every record, so decompression amortizes. The large end is the sparse case, from the corpus sweep in `schema_fullread_test.go`: point-reading one ad is 17x the row form at 128 rows against **319x** unbounded, linear in group size.

Small ads (5 attributes, ~27 B/record): group size is a **non-effect**, 128-row groups within ~3% of whole-segment blocks. Stored size moved 0.8 points across the sweep.

## Shape and persistence

`colSegment` holds `blocks []*columnarBlock` with a segment-wide `offs` array (block *j*'s local record *k* is `offs[base_j+k]`). Schema and hot set are read from the first block — all groups in a segment share them, so the sidecar stores them **once per segment, not per group**.

Sidecar section goes to **v2**. A v1 section is rejected like any section that cannot be trusted and the segment rebuilds — derived state, no migration. A reload whose group record counts do not sum to its `offs` length is refused rather than mapping records onto the wrong MVCC headers.

## Tests

- `TestRowGroupSizeIsTransparent` — sweeps the group size (1, 7, 128, 512, 2^20) over the real store aggregate path and requires an identical answer every time. The group size is a performance dial; if it can change an answer, a record index is wrong somewhere.
- `TestBuildColumnarFromSegmentRowGroups` — per-group reconstruct, column scan and MVCC offset against the segment truth, at four group sizes.
- `TestRowGroupsBoundedByBytes` — the gate: fat ads must split, and no group may exceed the byte budget (+1 record of slack). Synthetic fat ads, so it runs in CI without the 38 MB corpus.
- `TestRowGroupsBoundedByRows` — small ads stay under the row backstop.
- `TestColSegmentPersistMultiGroup` / `TestColSegmentRejectsGroupOffsMismatch` — multi-group round-trip, and the sum guard.

Every fixture asserts the accelerator is actually covering sealed segments first. Two earlier versions of this work passed **vacuously** — a 4 MiB segment size never sealed, so the sweep compared the row fallback against itself — so `regroupSegments` now fails if it regrouped nothing, and the guards `Fatal` where they used to `Skip`.

The benchmark file documents two traps that each produced a wrong conclusion here: regime **order** (the first regime absorbs warmup — an earlier run reported a 57% small-ad regression that was entirely that, and vanished under `-count`), and **segment size** (a segment smaller than the group size makes that regime silently identical to whole-segment).

`collections`, `db`, `dbrpc` suites green.
