### PR TITLE
collections: re-measure dictionary training against row groups; train on random recent records

### DIFF
--- a/collections/compact.go
+++ b/collections/compact.go
@@ -242,7 +242,12 @@ func (c *Collection) RetrainDict(sampleMax int) (int, error) {
 	defer c.maintMu.Unlock()
 	start := time.Now()
 	defer func() { c.opm.retrain.observe(time.Since(start)) }()
-	dict, err := TrainDict(c.CollectSamples(sampleMax))
+	// Recent random records, not the oldest sampleMax of them: for an append-only table
+	// CollectSamples returns the first records ever stored, which is the least representative
+	// sample of what is arriving next (see CollectSamplesRecent). sampleMax keeps its meaning as a
+	// record count; the sampler additionally applies its own byte budget, so a table of very fat
+	// ads no longer decompresses tens of megabytes to build a 112 KB dictionary.
+	dict, err := TrainDict(c.CollectSamplesRecent(sampleMax, 0, 0))
 	if err != nil {
 		return 0, err
 	}

--- a/collections/dictcpu_test.go
+++ b/collections/dictcpu_test.go
@@ -1,0 +1,139 @@
+package collections
+
+import (
+	"fmt"
+	"testing"
+)
+
+// Does the trained dictionary cost CPU on the streams it does not help?
+//
+// The size argument against a dictionary-less codec for the cold-numeric region was that the region
+// gains nothing from a dictionary (0.0% to +0.7%), which is ~100 bytes per 2.7 MB -- not worth a
+// second encoder. That argument only weighed BYTES. A dictionary is not free at runtime: the encoder
+// has to seed its window with the dictionary content on every EncodeAll, and the decoder has to
+// reference it on every DecodeAll. Cold-numeric is decompressed on every cold-column scan, so if
+// that per-call cost is real it lands on a hot path, and the trade is different.
+//
+// Measured per REGION KIND so the comparison is not confounded: a dictionary that costs CPU on
+// cold-numeric while saving 5-7% on the cold tail is two separate decisions.
+
+// dictCPUFixture returns raw regions by kind, plus a dictionary trained on records.
+func dictCPUFixture(tb testing.TB) (map[streamKind][][]byte, []byte) {
+	tb.Helper()
+	ads := realOSPoolAds(tb, 20000)
+	c := New(Options{Shards: 1, SegmentSize: 1 << 20})
+	for i, ad := range ads {
+		if err := c.Put([]byte(fmt.Sprintf("slot%d", i)), ad); err != nil {
+			tb.Fatal(err)
+		}
+	}
+	if !c.BuildAndEnableSchemaScan(4000, 8) {
+		tb.Skip("no sealed segments")
+	}
+	dict, err := TrainDict(c.CollectSamples(2000))
+	if err != nil {
+		tb.Fatal(err)
+	}
+	out := map[streamKind][][]byte{}
+	for _, b := range c.sampleableBlocks(0) {
+		for _, k := range []streamKind{kindColdNum, kindStr, kindCold} {
+			if raw, err := b.regionRaw(k); err == nil && len(raw) > 0 {
+				out[k] = append(out[k], raw)
+			}
+		}
+	}
+	return out, dict
+}
+
+var dictCPUKinds = []struct {
+	kind streamKind
+	name string
+}{{kindColdNum, "coldNumeric"}, {kindStr, "strings"}, {kindCold, "coldTail"}}
+
+// BenchmarkRegionCompressDict measures compression CPU per region kind, with and without the
+// dictionary.
+func BenchmarkRegionCompressDict(b *testing.B) {
+	regions, dict := dictCPUFixture(b)
+	plain, err := NewZSTDCodec(nil)
+	if err != nil {
+		b.Fatal(err)
+	}
+	trained, err := NewZSTDCodec(dict)
+	if err != nil {
+		b.Fatal(err)
+	}
+	for _, kv := range dictCPUKinds {
+		payloads := regions[kv.kind]
+		if len(payloads) == 0 {
+			continue
+		}
+		bytes := 0
+		for _, p := range payloads {
+			bytes += len(p)
+		}
+		for _, cs := range []struct {
+			name string
+			cd   Codec
+		}{{"noDict", plain}, {"dict", trained}} {
+			b.Run(kv.name+"/"+cs.name, func(b *testing.B) {
+				b.ReportAllocs()
+				b.SetBytes(int64(bytes))
+				var dst []byte
+				for i := 0; i < b.N; i++ {
+					for _, p := range payloads {
+						dst = cs.cd.Compress(dst[:0], p)
+					}
+				}
+			})
+		}
+	}
+}
+
+// BenchmarkRegionDecompressDict measures DECOMPRESSION CPU per region kind. This is the one that
+// matters: a cold-column scan decompresses the cold-numeric region, and a reconstruct or an escaped
+// read decompresses the string and cold-tail regions. Each payload is compressed by the SAME codec
+// that decompresses it, which is how it works in the store.
+func BenchmarkRegionDecompressDict(b *testing.B) {
+	regions, dict := dictCPUFixture(b)
+	plain, err := NewZSTDCodec(nil)
+	if err != nil {
+		b.Fatal(err)
+	}
+	trained, err := NewZSTDCodec(dict)
+	if err != nil {
+		b.Fatal(err)
+	}
+	for _, kv := range dictCPUKinds {
+		payloads := regions[kv.kind]
+		if len(payloads) == 0 {
+			continue
+		}
+		rawBytes := 0
+		for _, p := range payloads {
+			rawBytes += len(p)
+		}
+		for _, cs := range []struct {
+			name string
+			cd   Codec
+		}{{"noDict", plain}, {"dict", trained}} {
+			comp := make([][]byte, len(payloads))
+			for i, p := range payloads {
+				comp[i] = cs.cd.Compress(nil, p)
+			}
+			b.Run(kv.name+"/"+cs.name, func(b *testing.B) {
+				b.ReportAllocs()
+				b.SetBytes(int64(rawBytes))
+				var dst []byte
+				for i := 0; i < b.N; i++ {
+					for _, c := range comp {
+						var err error
+						dst, err = cs.cd.Decompress(dst[:0], c)
+						if err != nil {
+							b.Fatal(err)
+						}
+					}
+				}
+			})
+		}
+	}
+}

--- a/collections/dictgroup_test.go
+++ b/collections/dictgroup_test.go
@@ -1,0 +1,349 @@
+package collections
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/collections/vm"
+)
+
+// Dictionary training, revisited now that a block is a bounded ROW GROUP rather than a whole
+// segment (see colGroupRows / colGroupTargetBytes).
+//
+// The block size is exactly what decides whether a dictionary can earn anything. A dictionary
+// supplies the redundancy a payload cannot supply itself, so a big block -- which carries hundreds
+// of similar records and compresses well unaided -- has little left for a dictionary to add, while a
+// small one has plenty. Every earlier dictionary measurement here was taken when a block was a whole
+// segment, so it answered the question for a block size that no longer exists.
+//
+// TWO METHODOLOGY FIXES over the earlier comparison (TestDictStrategiesRealOSPool), both of which
+// flattered the dictionaries:
+//
+//  1. TRAIN/MEASURE SPLIT. That test trained on samples drawn from every block and then measured on
+//     every block -- and for the "records" row, measured on the training samples themselves. A
+//     dictionary scored against its own training bytes is not measuring compression, it is measuring
+//     memorization. Here the OLDEST half of the segments trains and the NEWEST half is measured,
+//     which is also what production actually does: train on history, apply to what arrives next.
+//
+//  2. GROUP SIZE SWEPT. Region samples are drawn from blocks at the SAME group size being measured,
+//     so each row is self-consistent rather than sampling production-shaped blocks and applying the
+//     result to a different shape.
+
+// dictRegimes are the block shapes measured: two small row-count groups, the production byte budget,
+// and one group per segment (the pre-row-group shape).
+var dictRegimes = []struct {
+	name string
+	g    colGrouping
+}{
+	{"rows8", byRows(8)},
+	{"rows32", byRows(32)},
+	{"rows64", byRows(64)},
+	{"default(~1MiB)", defaultColGrouping()},
+}
+
+// dictCorpus loads real OSPool ads into a store with many sealed segments.
+//
+// CORPUS LIMIT: the committed corpus is 1500 slot ads at ~10 KB, so ~15 MB total. Getting enough
+// segments to hold out half for training caps a segment at ~1 MiB, i.e. ~100 ads -- which is
+// coincidentally the production row-group size, since the byte budget is 1 MiB. So this sweep covers
+// production-shaped blocks and SMALLER. The multi-megabyte block that one-block-per-segment used to
+// produce cannot be reproduced on this corpus without duplicating ads, and duplication would
+// manufacture exactly the cross-block redundancy the measurement is about.
+func dictCorpus(t *testing.T) *Collection {
+	t.Helper()
+	ads := realOSPoolAds(t, 20000)
+	c := New(Options{Shards: 1, SegmentSize: 1 << 20})
+	for i, ad := range ads {
+		if err := c.Put([]byte(fmt.Sprintf("slot%d", i)), ad); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, e := range []string{"Memory >= 0", "Cpus >= 0"} {
+		q, err := vm.Parse(e)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i := 0; i < 20; i++ {
+			for range c.Query(q) {
+			}
+		}
+	}
+	if !c.BuildAndEnableSchemaScan(4000, 8) {
+		t.Skip("no sealed segments to sample")
+	}
+	t.Logf("corpus: %d ads, %d sealed segments", len(ads), c.SchemaScanInfo().SealedSegments)
+	return c
+}
+
+// sealedSegs returns the sealed segments oldest-first.
+func sealedSegs(c *Collection) []*segment {
+	var out []*segment
+	for _, sh := range c.shards {
+		sh.mu.RLock()
+		act := sh.act
+		for _, s := range sh.segs {
+			if s != nil && s != act && s.used > 0 {
+				out = append(out, s)
+			}
+		}
+		sh.mu.RUnlock()
+	}
+	return out
+}
+
+// blocksAt builds the columnar blocks for segs at group size g, with an IDENTITY codec so the
+// regions are stored raw -- the comparison then compresses those raw bytes with each candidate
+// dictionary, instead of measuring a compression of a compression.
+func blocksAt(t *testing.T, c *Collection, segs []*segment, g colGrouping) []*columnarBlock {
+	t.Helper()
+	st := c.schemaScan.Load()
+	if st == nil {
+		t.Fatal("schema scan not enabled")
+	}
+	var out []*columnarBlock
+	for _, seg := range segs {
+		d := seg.dict.Load()
+		bl, _ := buildColumnarFromSegment(seg.data, seg.used, identityCodec{}, st.schema, st.hot, g,
+			func(dst, w []byte) ([]byte, bool) { return c.recordToInternedDict(d, dst, w) })
+		out = append(out, bl...)
+	}
+	return out
+}
+
+// regionsOf gathers one kind's raw regions from blocks.
+func regionsOf(blocks []*columnarBlock, kind streamKind) [][]byte {
+	var out [][]byte
+	for _, b := range blocks {
+		if raw, err := b.regionRaw(kind); err == nil && len(raw) > 0 {
+			out = append(out, raw)
+		}
+	}
+	return out
+}
+
+// TestDictStrategyNetBytes is the decision: TOTAL stored bytes under each training strategy, at the
+// production group size, counting BOTH things the collection stores -- the per-record arena (the
+// source of truth, compressed per record at ingest) and the columnar block regions (the derived
+// accelerator in the sidecar).
+//
+// It exists because the per-region percentages alone point the wrong way. Region-trained
+// dictionaries beat ad-trained ones on every region kind, so a per-region table reads as an
+// argument for switching what production trains on. But one codec serves the whole collection, the
+// arena is several times the bytes of the regions, and records ARE ads -- so an ad-trained
+// dictionary is matched to the payload that dominates. Netting it out reverses the ranking.
+func TestDictStrategyNetBytes(t *testing.T) {
+	c := dictCorpus(t)
+	defer c.Close()
+	segs := sealedSegs(c)
+	if len(segs) < 4 {
+		t.Skipf("need several sealed segments, have %d", len(segs))
+	}
+	half := len(segs) / 2
+	trainSegs, measSegs := segs[:half], segs[half:]
+
+	mk := func(d []byte) Codec {
+		cd, err := NewZSTDCodec(d)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return cd
+	}
+	adDict, err := TrainDict(segmentRecordSamples(t, c, trainSegs, 2000))
+	if err != nil {
+		t.Fatal(err)
+	}
+	kinds := []streamKind{kindColdNum, kindStr, kindCold}
+	trainBlocks := blocksAt(t, c, trainSegs, defaultColGrouping())
+	var mixed [][]byte
+	for _, k := range kinds {
+		mixed = append(mixed, sampleKind(trainBlocks, k, DefaultDictSize/regionKinds)...)
+	}
+	regionDict, rerr := TrainDict(mixed)
+	if rerr != nil {
+		t.Skipf("region dict did not train: %v", rerr)
+	}
+
+	measBlocks := blocksAt(t, c, measSegs, defaultColGrouping())
+	measRecs := segmentRecordSamples(t, c, measSegs, 2000)
+
+	for _, strat := range []struct {
+		name string
+		cd   Codec
+	}{{"none", mk(nil)}, {"ad-trained", mk(adDict)}, {"region-trained", mk(regionDict)}} {
+		arena := 0
+		for _, p := range measRecs {
+			arena += len(strat.cd.Compress(nil, p))
+		}
+		regions := 0
+		for _, k := range kinds {
+			for _, p := range regionsOf(measBlocks, k) {
+				regions += len(strat.cd.Compress(nil, p))
+			}
+		}
+		t.Logf("%-15s arena=%9d  regions=%8d  TOTAL=%9d", strat.name, arena, regions, arena+regions)
+	}
+}
+
+// TestDictStrategyByGroupSize is the measurement: for each block shape, how much does each
+// dictionary-training strategy save on each region kind, trained on held-out data?
+//
+// Strategies:
+//
+//	none        no dictionary (the baseline every percentage is against)
+//	ad          trained on whole ClassAd records -- what production trains on today
+//	region      trained on region bytes, all three kinds mixed (CollectRegionSamples)
+//	per-kind    trained on ONLY the kind being compressed -- the candidate improvement, which needs
+//	            a codec per stream kind rather than one codec per collection
+func TestDictStrategyByGroupSize(t *testing.T) {
+	c := dictCorpus(t)
+	defer c.Close()
+
+	segs := sealedSegs(c)
+	if len(segs) < 4 {
+		t.Skipf("need several sealed segments to split train/measure, have %d", len(segs))
+	}
+	half := len(segs) / 2
+	trainSegs, measSegs := segs[:half], segs[half:]
+	t.Logf("train on %d oldest segment(s), measure on %d newest", len(trainSegs), len(measSegs))
+
+	// Ad-record samples come from the TRAIN segments only, for the same held-out reason.
+	adSamples := segmentRecordSamples(t, c, trainSegs, 2000)
+	adDict, err := TrainDict(adSamples)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("ad-trained dictionary: %d samples, %d B dict", len(adSamples), len(adDict))
+
+	mk := func(d []byte) Codec {
+		cd, err := NewZSTDCodec(d)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return cd
+	}
+	none, adTrained := mk(nil), mk(adDict)
+
+	kinds := []struct {
+		kind streamKind
+		name string
+	}{{kindColdNum, "cold-numeric"}, {kindStr, "strings"}, {kindCold, "cold-tail"}}
+
+	// THE PER-RECORD ARENA. One codec serves the whole collection, so the same dictionary that
+	// compresses a block's regions also compresses every record written to the arena (ingest
+	// compresses per record). A training strategy that wins on regions and loses here may be a net
+	// loss, since a columnar collection stores both. Measured on held-out records.
+	measRecs := segmentRecordSamples(t, c, measSegs, 2000)
+	t.Run("records", func(t *testing.T) {
+		var mixedAll [][]byte
+		for i := range kinds {
+			blocks := blocksAt(t, c, trainSegs, defaultColGrouping())
+			mixedAll = append(mixedAll, sampleKind(blocks, kinds[i].kind, DefaultDictSize/regionKinds)...)
+		}
+		regionDict, rerr := TrainDict(mixedAll)
+		var raw, bn, ba, br int
+		for _, p := range measRecs {
+			raw += len(p)
+			bn += len(none.Compress(nil, p))
+			ba += len(adTrained.Compress(nil, p))
+		}
+		msg := "   n/a"
+		if rerr == nil {
+			rc := mk(regionDict)
+			for _, p := range measRecs {
+				br += len(rc.Compress(nil, p))
+			}
+			msg = fmt.Sprintf("%+6.1f%%", 100*float64(br-bn)/float64(bn))
+		}
+		t.Logf("records(%d held-out)  raw=%9d  none=%8d  ad=%+6.1f%%  region=%s",
+			len(measRecs), raw, bn, 100*float64(ba-bn)/float64(bn), msg)
+	})
+
+	for _, regime := range dictRegimes {
+		trainBlocks := blocksAt(t, c, trainSegs, regime.g)
+		measBlocks := blocksAt(t, c, measSegs, regime.g)
+		if len(measBlocks) == 0 {
+			t.Fatalf("%s: no blocks to measure", regime.name)
+		}
+		recs := 0
+		for _, b := range measBlocks {
+			recs += b.n
+		}
+		t.Logf("--- %s: %d train blocks, %d measure blocks, %.0f rec/blk ---",
+			regime.name, len(trainBlocks), len(measBlocks), float64(recs)/float64(len(measBlocks)))
+
+		// region dict: all kinds mixed, from the TRAIN blocks at this group size.
+		var mixed [][]byte
+		for i := range kinds {
+			mixed = append(mixed, sampleKind(trainBlocks, kinds[i].kind, DefaultDictSize/regionKinds)...)
+		}
+		// A dictionary can fail to train: zstd's BuildDict panics on some degenerate sample
+		// distributions and TrainDict contains that as an error. Report it as a missing number
+		// rather than failing the sweep -- it is itself a result about the strategy.
+		regionTrained, regionOK := none, false
+		if len(mixed) > 0 {
+			if d, err := TrainDict(mixed); err != nil {
+				t.Logf("  %s: region dict did not train: %v", regime.name, err)
+			} else {
+				regionTrained, regionOK = mk(d), true
+			}
+		}
+
+		for _, kv := range kinds {
+			payloads := regionsOf(measBlocks, kv.kind)
+			if len(payloads) == 0 {
+				continue
+			}
+			// per-kind dict: trained on this kind alone, at this group size.
+			perKind, perKindOK := none, false
+			if s := sampleKind(trainBlocks, kv.kind, DefaultDictSize); len(s) > 0 {
+				if d, err := TrainDict(s); err != nil {
+					t.Logf("  %s/%s: per-kind dict did not train: %v", regime.name, kv.name, err)
+				} else {
+					perKind, perKindOK = mk(d), true
+				}
+			}
+			var raw, bn, ba, br, bp int
+			for _, p := range payloads {
+				raw += len(p)
+				bn += len(none.Compress(nil, p))
+				ba += len(adTrained.Compress(nil, p))
+				br += len(regionTrained.Compress(nil, p))
+				bp += len(perKind.Compress(nil, p))
+			}
+			pct := func(v int, ok bool) string {
+				if !ok {
+					return "   n/a"
+				}
+				return fmt.Sprintf("%+6.1f%%", 100*float64(v-bn)/float64(bn))
+			}
+			t.Logf("  %-13s raw=%9d  none=%8d  ad=%s  region=%s  perKind=%s",
+				kv.name, raw, bn, pct(ba, true), pct(br, regionOK), pct(bp, perKindOK))
+		}
+	}
+}
+
+// segmentRecordSamples collects whole-record wire samples from specific segments -- the held-out
+// equivalent of CollectSamples, which draws from the entire collection.
+func segmentRecordSamples(t *testing.T, c *Collection, segs []*segment, max int) [][]byte {
+	t.Helper()
+	var out [][]byte
+	for _, seg := range segs {
+		d := seg.dict.Load()
+		for off := 0; off < seg.used && len(out) < max; {
+			o := uint32(off)
+			total := recTotalLen(seg.data, o)
+			if total == 0 {
+				break
+			}
+			if !recIsMarker(seg.data, o) {
+				if w, err := seg.codec.Decompress(nil, recAd(seg.data, o)); err == nil {
+					if iw, ok := c.recordToInternedDict(d, nil, w); ok {
+						out = append(out, iw)
+					}
+				}
+			}
+			off += int(total)
+		}
+	}
+	return out
+}

--- a/collections/dictreal_test.go
+++ b/collections/dictreal_test.go
@@ -40,6 +40,11 @@ func realOSPoolAds(tb testing.TB, max int) []*classad.ClassAd {
 // TestDictStrategiesRealOSPool repeats the dictionary comparison on REAL OSPool ads rather than a
 // synthetic fixture whose numeric columns were regular enough to flatter a region-trained
 // dictionary. These ads carry ~568 attributes apiece, so all three regions are populated naturally.
+//
+// NOT HELD OUT, and the "records" row is measured on the training samples themselves, so every
+// figure it logs is optimistic. Superseded for decision-making by TestDictStrategyByGroupSize and
+// TestDictStrategyNetBytes (dictgroup_test.go); kept because it exercises the strategies over the
+// real corpus at one segment size with no group-size machinery.
 func TestDictStrategiesRealOSPool(t *testing.T) {
 	ads := realOSPoolAds(t, 20000)
 	t.Logf("corpus: %d real OSPool ads, %d attributes in the first",

--- a/collections/recentsamples.go
+++ b/collections/recentsamples.go
@@ -1,0 +1,155 @@
+package collections
+
+import (
+	"math/rand/v2"
+)
+
+// Dictionary training samples: RANDOM records drawn from RECENT segments, budgeted in bytes.
+//
+// CollectSamples takes the first max visible records in arena order, which for an append-only table
+// means the OLDEST records in it. A history table with millions of ads trains its dictionary on the
+// first two thousand it ever stored -- the least representative sample of what is arriving next, and
+// the one most likely to predate whatever changed the ads' shape. It is also budgeted in RECORD
+// COUNT, so what it actually costs depends on how fat the ads happen to be: 2000 real slot ads is
+// ~15 MB decompressed and copied, of which TrainDictSize uses the first 112 KB as dictionary content
+// (the remainder only trains entropy tables).
+//
+// Three properties fix that, and they compose:
+//
+//   - BYTE BUDGET. Stop at the bytes the dictionary can actually consume, rather than at a record
+//     count that means a different amount of work per table.
+//   - RECENCY WINDOW. Draw only from the newest lookBackBytes of segments. Future writes resemble
+//     recent history; an archive's oldest segments may predate the current schema or workload.
+//   - RANDOM SELECTION. Within that window, pick records at random rather than taking a prefix, so
+//     the sample is representative of the window instead of of whichever segment sorts first.
+//
+// The pass walks record HEADERS to build its candidate list and decompresses only the records it
+// keeps, so the bytes it touches are bounded by the budget rather than by the window. That is what
+// keeps a random draw from being the expensive option: random selection is cheap, random
+// DECOMPRESSION would not be.
+
+// defaultSampleBytes is the byte budget for a training pass. TrainDictSize uses DefaultDictSize of
+// dictionary content and trains entropy tables on everything it is given, so a few times the
+// dictionary size supplies both without collecting an unbounded multiple of what is used.
+const defaultSampleBytes = 4 * DefaultDictSize
+
+// defaultLookBackBytes is how far back a training pass reaches, in segment bytes from the newest.
+// Large enough that the window holds many segments' worth of diversity rather than only the newest
+// one, and bounded so a table with years of history does not read all of it to build a 112 KB
+// dictionary.
+const defaultLookBackBytes = 64 << 20
+
+// CollectSamplesRecent returns record samples drawn at random from the newest lookBackBytes of
+// segment data, honoring MVCC visibility, bounded by BOTH a record count and a byte budget --
+// whichever binds first.
+//
+// Both bounds exist because they answer different questions and callers supply different ones.
+// maxRecords is what every existing caller has (RetrainDict's sampleMax), and keeping it a count
+// means switching to this sampler cannot change what an existing call collects by reinterpreting its
+// units. maxBytes is what the work actually scales with, since a record's size varies by two orders
+// of magnitude across tables.
+//
+// maxRecords <= 0 means no count bound; maxBytes <= 0 uses defaultSampleBytes; lookBackBytes <= 0
+// uses defaultLookBackBytes. Samples are flattened to inline wire exactly as CollectSamples does, so
+// the two are interchangeable as TrainDict input.
+//
+// Returns nil when the collection holds no visible records.
+func (c *Collection) CollectSamplesRecent(maxRecords, maxBytes, lookBackBytes int) [][]byte {
+	return c.collectSamplesRecent(maxRecords, maxBytes, lookBackBytes, rand.Uint64)
+}
+
+// collectSamplesRecent is CollectSamplesRecent with an injectable random source, so a test can pin
+// the draw. rnd returns a uniformly distributed uint64.
+func (c *Collection) collectSamplesRecent(maxRecords, maxBytes, lookBackBytes int, rnd func() uint64) [][]byte {
+	if maxBytes <= 0 {
+		maxBytes = defaultSampleBytes
+	}
+	if lookBackBytes <= 0 {
+		lookBackBytes = defaultLookBackBytes
+	}
+	if len(c.shards) == 0 {
+		return nil
+	}
+	// Split the budget across shards so one shard cannot spend all of it; a shard that cannot fill
+	// its share simply contributes less.
+	share := maxBytes / len(c.shards)
+	if share <= 0 {
+		share = maxBytes
+	}
+	recShare := maxRecords / len(c.shards)
+	if maxRecords > 0 && recShare <= 0 {
+		recShare = 1
+	}
+	var out [][]byte
+	for _, sh := range c.shards {
+		out = append(out, sh.recentRecordSamples(c, recShare, share, lookBackBytes, rnd)...)
+	}
+	return out
+}
+
+// recordSite is one candidate record: which window it lives in and where.
+type recordSite struct {
+	win int
+	off uint32
+}
+
+// recentRecordSamples draws random visible records from this shard's newest segments, up to
+// maxBytes of flattened content.
+func (sh *shard) recentRecordSamples(c *Collection, maxRecords, maxBytes, lookBackBytes int, rnd func() uint64) [][]byte {
+	s0, wins := sh.snapshot()
+	defer releaseWindows(wins)
+
+	// Candidate sites, newest window first, until the look-back budget is spent. Only headers are
+	// read here -- no decompression -- so building the list is cheap even over a large window.
+	var sites []recordSite
+	seen := 0
+	for i := len(wins) - 1; i >= 0; i-- {
+		w := wins[i]
+		if w.used == 0 {
+			continue
+		}
+		for off := 0; off < w.used; {
+			o := uint32(off)
+			total := recTotalLen(w.data, o)
+			if total == 0 {
+				break
+			}
+			if !recIsMarker(w.data, o) && recSeq(w.data, o) <= s0 && recSuperseded(w.data, o) > s0 {
+				sites = append(sites, recordSite{i, o})
+			}
+			off += int(total)
+		}
+		seen += w.used
+		if seen >= lookBackBytes {
+			break // far enough back: older segments predate what future writes will look like
+		}
+	}
+	if len(sites) == 0 {
+		return nil
+	}
+	// Partial Fisher-Yates: draw distinct sites at random and decompress each as it is drawn,
+	// stopping at the byte budget. Only the drawn records are decompressed.
+	var out [][]byte
+	var buf []byte
+	bytes := 0
+	for n := len(sites); n > 0 && bytes < maxBytes; n-- {
+		if maxRecords > 0 && len(out) >= maxRecords {
+			break
+		}
+		j := int(rnd() % uint64(n))
+		sites[j], sites[n-1] = sites[n-1], sites[j]
+		s := sites[n-1]
+		w := wins[s.win]
+		ww, err := w.codec.Decompress(buf[:0], recAd(w.data, s.off))
+		if err != nil {
+			continue
+		}
+		buf = ww
+		iw := c.wireToInline(w.dict(), ww)
+		cp := make([]byte, len(iw))
+		copy(cp, iw)
+		out = append(out, cp)
+		bytes += len(cp)
+	}
+	return out
+}

--- a/collections/recentsamples_test.go
+++ b/collections/recentsamples_test.go
@@ -1,0 +1,261 @@
+package collections
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// seqRand is a deterministic stand-in for the random source, so a test can pin which records the
+// draw selects.
+func seqRand(vals ...uint64) func() uint64 {
+	i := 0
+	return func() uint64 {
+		v := vals[i%len(vals)]
+		i++
+		return v
+	}
+}
+
+// TestCollectSamplesRecentBounds pins both bounds and that they are independent: whichever binds
+// first stops the draw. Reinterpreting the existing record count as a byte budget would have
+// silently starved every current caller's dictionary, so the count bound has to keep working.
+func TestCollectSamplesRecentBounds(t *testing.T) {
+	c := New(Options{Shards: 1, SegmentSize: 1 << 16})
+	defer c.Close()
+	for i := 0; i < 2000; i++ {
+		ad := mustAdOld(t, fmt.Sprintf("ClusterId = %d\nProcId = %d\nOwner = \"u%d\"\nCmd = \"/bin/run%d\"",
+			i/10, i%10, i%32, i))
+		if err := c.Put([]byte(fmt.Sprintf("k%d", i)), ad); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Record bound binds: 5 records, huge byte budget.
+	got := c.CollectSamplesRecent(5, 1<<30, 0)
+	if len(got) != 5 {
+		t.Errorf("record bound: got %d samples, want 5", len(got))
+	}
+	// Byte bound binds: no record cap, tiny byte budget. One record may exceed the budget, since the
+	// budget is checked before each draw, so allow the overshoot of a single sample.
+	got = c.CollectSamplesRecent(0, 300, 0)
+	total := 0
+	for _, s := range got {
+		total += len(s)
+	}
+	if len(got) == 0 {
+		t.Fatal("byte bound: got no samples")
+	}
+	if total > 300+len(got[len(got)-1]) {
+		t.Errorf("byte bound: collected %d B, over the 300 B budget by more than one sample", total)
+	}
+	if len(got) > 50 {
+		t.Errorf("byte bound: %d samples for a 300 B budget; the budget is not binding", len(got))
+	}
+	// Defaults produce something usable.
+	if got = c.CollectSamplesRecent(0, 0, 0); len(got) == 0 {
+		t.Error("defaults produced no samples")
+	}
+}
+
+// TestCollectSamplesRecentPrefersRecent is the point of the change: an append-only table must not
+// train its dictionary on the oldest records it ever stored. The two halves here are
+// distinguishable by content, so the sample's composition is checkable.
+func TestCollectSamplesRecentPrefersRecent(t *testing.T) {
+	c := New(Options{Shards: 1, SegmentSize: 1 << 16})
+	defer c.Close()
+	const n = 4000
+	for i := 0; i < n; i++ {
+		era := "OLD"
+		if i >= n/2 {
+			era = "NEW"
+		}
+		ad := mustAdOld(t, fmt.Sprintf("ClusterId = %d\nEra = \"%s\"\nPad = \"%s\"", i, era, strings.Repeat("x", 200)))
+		if err := c.Put([]byte(fmt.Sprintf("k%d", i)), ad); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// A look-back of roughly a quarter of the data must draw only from the newest records.
+	var used int
+	for _, sh := range c.shards {
+		sh.mu.RLock()
+		for _, s := range sh.segs {
+			if s != nil {
+				used += s.used
+			}
+		}
+		sh.mu.RUnlock()
+	}
+	samples := c.CollectSamplesRecent(0, 64<<10, used/4)
+	if len(samples) == 0 {
+		t.Fatal("no samples")
+	}
+	old, recent := 0, 0
+	for _, s := range samples {
+		if strings.Contains(string(s), "OLD") {
+			old++
+		}
+		if strings.Contains(string(s), "NEW") {
+			recent++
+		}
+	}
+	if old != 0 {
+		t.Errorf("%d/%d samples came from the OLD half despite a quarter-of-the-table look-back",
+			old, len(samples))
+	}
+	if recent == 0 {
+		t.Fatal("no samples from the NEW half; the look-back window found nothing")
+	}
+
+	// And the OLD prefix is exactly what the existing sampler returns, which is the bug being fixed.
+	prefix := c.CollectSamples(50)
+	oldPrefix := 0
+	for _, s := range prefix {
+		if strings.Contains(string(s), "OLD") {
+			oldPrefix++
+		}
+	}
+	if oldPrefix != len(prefix) {
+		t.Logf("CollectSamples returned %d/%d OLD records", oldPrefix, len(prefix))
+	}
+	if oldPrefix == 0 {
+		t.Error("CollectSamples returned no OLD records; the premise of this change is that it " +
+			"returns the arena prefix, so verify that before trusting the comparison")
+	}
+}
+
+// TestCollectSamplesRecentRandomizes checks the draw actually varies rather than returning a prefix
+// under a different name, and that it is reproducible for a fixed random source.
+func TestCollectSamplesRecentRandomizes(t *testing.T) {
+	c := New(Options{Shards: 1, SegmentSize: 1 << 16})
+	defer c.Close()
+	for i := 0; i < 1000; i++ {
+		ad := mustAdOld(t, fmt.Sprintf("ClusterId = %d\nOwner = \"u%d\"", i, i))
+		if err := c.Put([]byte(fmt.Sprintf("k%d", i)), ad); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Same source, same draw.
+	a := c.collectSamplesRecent(20, 1<<30, 0, seqRand(3, 11, 7, 29, 5))
+	b := c.collectSamplesRecent(20, 1<<30, 0, seqRand(3, 11, 7, 29, 5))
+	if len(a) != len(b) || len(a) == 0 {
+		t.Fatalf("pinned draws differ in length: %d vs %d", len(a), len(b))
+	}
+	for i := range a {
+		if string(a[i]) != string(b[i]) {
+			t.Fatalf("pinned draw is not reproducible at sample %d", i)
+		}
+	}
+	// Different source, different draw. (A prefix-taking implementation would return the same
+	// records regardless of the random source.)
+	d := c.collectSamplesRecent(20, 1<<30, 0, seqRand(1, 2, 3, 4, 5))
+	same := 0
+	for i := range a {
+		if i < len(d) && string(a[i]) == string(d[i]) {
+			same++
+		}
+	}
+	if same == len(a) {
+		t.Error("two different random sources produced identical draws; selection is not random")
+	}
+}
+
+// TestCollectSamplesRecentMVCC checks the draw honors visibility: an overwritten record must not
+// appear, or the dictionary would be trained partly on data no query can see.
+func TestCollectSamplesRecentMVCC(t *testing.T) {
+	c := New(Options{Shards: 1, SegmentSize: 1 << 16})
+	defer c.Close()
+	for i := 0; i < 500; i++ {
+		if err := c.Put([]byte(fmt.Sprintf("k%d", i)),
+			mustAdOld(t, fmt.Sprintf("ClusterId = %d\nState = \"ORIGINAL\"", i))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Supersede every key.
+	for i := 0; i < 500; i++ {
+		if err := c.Put([]byte(fmt.Sprintf("k%d", i)),
+			mustAdOld(t, fmt.Sprintf("ClusterId = %d\nState = \"REPLACED\"", i))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	samples := c.CollectSamplesRecent(0, 1<<20, 0)
+	if len(samples) == 0 {
+		t.Fatal("no samples")
+	}
+	for _, s := range samples {
+		if strings.Contains(string(s), "ORIGINAL") {
+			t.Fatalf("a superseded record was sampled; %d samples", len(samples))
+		}
+	}
+}
+
+// TestRecentSamplerDictQuality is the check that the cheaper sampler is not a worse sampler.
+//
+// The byte budget collects far less than CollectSamples does (a few hundred KB against ~15 MB of
+// real slot ads), and TrainDictSize trains entropy tables on everything it is handed, so a smaller
+// sample could in principle produce a weaker dictionary. Measured on a SEPARATE collection's records
+// -- built from different ads than either sampler ever saw -- so neither is scored against its own
+// training bytes.
+func TestRecentSamplerDictQuality(t *testing.T) {
+	ads := realOSPoolAds(t, 20000)
+	if len(ads) < 200 {
+		t.Skip("corpus too small to split")
+	}
+	half := len(ads) / 2
+	trainAds, measAds := ads[:half], ads[half:]
+	trainC := New(Options{Shards: 1, SegmentSize: 1 << 20})
+	defer trainC.Close()
+	for i, ad := range trainAds {
+		if err := trainC.Put([]byte(fmt.Sprintf("t%d", i)), ad); err != nil {
+			t.Fatal(err)
+		}
+	}
+	measC := New(Options{Shards: 1, SegmentSize: 1 << 20})
+	defer measC.Close()
+	for i, ad := range measAds {
+		if err := measC.Put([]byte(fmt.Sprintf("m%d", i)), ad); err != nil {
+			t.Fatal(err)
+		}
+	}
+	held := measC.CollectSamples(2000)
+	if len(held) == 0 {
+		t.Skip("no held-out records")
+	}
+
+	mk := func(samples [][]byte, label string) (Codec, int, int) {
+		bytes := 0
+		for _, s := range samples {
+			bytes += len(s)
+		}
+		d, err := TrainDict(samples)
+		if err != nil {
+			t.Fatalf("%s: %v", label, err)
+		}
+		cd, err := NewZSTDCodec(d)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return cd, len(samples), bytes
+	}
+	plain, err := NewZSTDCodec(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	size := func(cd Codec) int {
+		n := 0
+		for _, p := range held {
+			n += len(cd.Compress(nil, p))
+		}
+		return n
+	}
+	base := size(plain)
+
+	oldCd, oldN, oldB := mk(trainC.CollectSamples(2000), "CollectSamples")
+	t.Logf("CollectSamples(2000):        %5d samples, %9d B collected -> held-out %+.1f%%",
+		oldN, oldB, 100*float64(size(oldCd)-base)/float64(base))
+
+	for _, budget := range []int{DefaultDictSize, 2 * DefaultDictSize, defaultSampleBytes, 16 * DefaultDictSize} {
+		cd, n, b := mk(trainC.CollectSamplesRecent(0, budget, 0), fmt.Sprintf("recent/%d", budget))
+		t.Logf("CollectSamplesRecent(%7d): %5d samples, %9d B collected -> held-out %+.1f%%",
+			budget, n, b, 100*float64(size(cd)-base)/float64(base))
+	}
+}

--- a/collections/regionsamples.go
+++ b/collections/regionsamples.go
@@ -2,18 +2,46 @@ package collections
 
 // Dictionary training samples drawn from columnar block REGIONS rather than whole ads.
 //
-// The dictionary is trained from CollectSamples: whole ClassAd records. That content is a good
-// match for compressing a record -- small, independent, and full of the attribute names and values
-// the dictionary carries. It is a poor match for a block's three regions, which are aggregates over
-// a whole segment: column-major fixed-width integers, concatenated string values, and the
-// record-shaped cold tail. Measured on a 4000-record fixture, an ad-trained dictionary gained
-// -0.1% on the cold numeric region, -14.7% on the strings, and -3.7% on the cold tail -- it helped
-// none of them.
+// NOT WIRED INTO RETRAINING, DELIBERATELY -- see the measurement below. Retraining trains on whole
+// records (CollectSamples, via compact.go), and that is the right choice. This exists because it is
+// the right choice for a regime that is reachable but not the default, and because the reasoning is
+// worth keeping next to the code rather than in a pull request.
 //
-// Sampling the regions themselves gives training content drawn from what is actually being
-// compressed. The interesting case is a SMALL block, which has little internal redundancy of its
-// own to exploit and is therefore where a dictionary can still earn something; a large block
-// compresses well unaided either way.
+// The premise is sound: a dictionary trained on whole ClassAd records is matched to compressing a
+// record and mismatched to a block's three regions, which are a different shape entirely
+// (column-major fixed-width integers, concatenated string values, and the record-shaped cold tail).
+// Sampling the regions themselves gives training content drawn from what is actually compressed, and
+// it does win per region. MEASURED HELD-OUT on the real OSPool corpus, oldest half of segments
+// training and newest half measured (TestDictStrategyByGroupSize), at the production ~1 MiB row
+// group: strings -4.5% vs the ad dictionary's -3.5%, cold tail -7.0% vs -5.3%.
+//
+// It still loses, because ONE codec serves the whole collection. The same dictionary compresses
+// every record written to the arena, the arena is several times the bytes of the block regions, and
+// records are exactly what an ad-trained dictionary is good at. Net stored bytes over the same
+// held-out data (TestDictStrategyNetBytes):
+//
+//	strategy         arena      regions     total
+//	none           3514376      481643    3996019
+//	ad-trained     1640224      464535    2104759   <- production
+//	region-trained 1853546      459125    2312671   (+9.9%)
+//
+// Region training saves 5.4 KB on the regions and gives back 213 KB on the arena. Per-region
+// percentages alone point the other way, which is the trap this comment exists to close.
+//
+// WHEN IT WOULD PAY. Dictionary value on a region falls off fast as the block grows, because a
+// dictionary supplies redundancy the payload cannot supply itself. Same measurement, by block size,
+// strings / cold tail with a region dictionary: 8 records -26.1%/-32.4%, 27 records -12.6%/-16.2%,
+// 53 records -7.3%/-10.3%, 107 records (the ~1 MiB default) -4.5%/-7.0%. So a deployment that
+// configured much smaller row groups than colGroupTargetBytes, or one that stopped storing the row
+// arena, could reach the regime where this wins -- and should re-run both tests rather than trust
+// these numbers, which are for one corpus.
+//
+// Two things that are NOT worth building, measured: a per-region-kind dictionary adds nothing over
+// one mixed region dictionary (-4.2% vs -4.5% on strings) and fails to train at all on the cold tail
+// at every group size at or above 32 records (zstd BuildDict divides by zero on that sample
+// distribution). And the cold-numeric region gains nothing from any dictionary -- between 0.0% and
+// +0.7%, i.e. slightly worse -- so a dictionary-less codec for that one stream would buy about 100
+// bytes per 2.7 MB, which does not pay for a second zstd encoder's resident memory.
 
 // regionKinds is the number of region kinds sampled, and the number of equal shares the byte budget
 // is split into.

--- a/collections/regionsamples_test.go
+++ b/collections/regionsamples_test.go
@@ -89,13 +89,20 @@ func TestRegionSamplesLookBack(t *testing.T) {
 	}
 }
 
-// TestDictStrategies is the decision: for each of the three regions AND for whole records, compare
+// NOT HELD OUT: this harness trains and measures on the same bytes, so its savings are optimistic
+// -- a dictionary scored against its own training samples is partly measuring memorization. It
+// survives as a synthetic smoke test that the strategies are wired up and comparable. For numbers to
+// reason about, use TestDictStrategyByGroupSize / TestDictStrategyNetBytes (dictgroup_test.go), which
+// train on the oldest half of the segments and measure on the newest, sweep the row-group size, and
+// net the arena against the regions.
+//
+// TestDictStrategies compares, for each of the three regions AND for whole records, compare
 // no dictionary, the ad-trained dictionary (status quo), and a region-trained one.
 //
 // The two uses pull in opposite directions. A record is small and independent, which is exactly what
-// a dictionary is for. A block region is a large aggregate with its own redundancy, where a
-// dictionary has little to add. Since ONE codec compresses both, the numbers below decide whether
-// training on regions is an improvement or a trade.
+// a dictionary is for. A block region is a larger aggregate with its own redundancy, where a
+// dictionary has less to add. Since ONE codec compresses both, the trade has to be netted -- see
+// TestDictStrategyNetBytes, which does that on held-out data and finds ad training ahead.
 func TestDictStrategies(t *testing.T) {
 	c := dictFixture(t, 4000)
 	defer c.Close()

--- a/collections/sampcost_test.go
+++ b/collections/sampcost_test.go
@@ -1,0 +1,76 @@
+package collections
+
+import (
+	"fmt"
+	"testing"
+)
+
+// What does each sampling strategy COST to run? Training content quality is one axis; the sampling
+// pass is a periodic maintenance operation with its own price, and the two get conflated.
+//
+// The asymmetry that matters: region sampling must DECOMPRESS a whole region to take a chunk out of
+// it. At the production ~1 MiB group a region is several hundred KB and regionChunk is 4 KB, so the
+// read amplification is large. Record sampling decompresses only the records it keeps.
+func sampCostFixture(tb testing.TB) *Collection {
+	tb.Helper()
+	ads := realOSPoolAds(tb, 20000)
+	c := New(Options{Shards: 1, SegmentSize: 1 << 20})
+	for i, ad := range ads {
+		if err := c.Put([]byte(fmt.Sprintf("slot%d", i)), ad); err != nil {
+			tb.Fatal(err)
+		}
+	}
+	if !c.BuildAndEnableSchemaScan(4000, 8) {
+		tb.Skip("no sealed segments")
+	}
+	return c
+}
+
+func BenchmarkSampleCost(b *testing.B) {
+	c := sampCostFixture(b)
+	b.Run("records/CollectSamples2000", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			if s := c.CollectSamples(2000); len(s) == 0 {
+				b.Fatal("no samples")
+			}
+		}
+	})
+	b.Run("records/CollectSamplesRecent", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			if s := c.CollectSamplesRecent(0, 0, 0); len(s) == 0 {
+				b.Fatal("no samples")
+			}
+		}
+	})
+	b.Run("regions/CollectRegionSamples112K", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			if s := c.CollectRegionSamples(DefaultDictSize, 0); len(s) == 0 {
+				b.Fatal("no samples")
+			}
+		}
+	})
+	// How many bytes does each actually deliver as training content, and at what decompression cost?
+	recs := c.CollectSamples(2000)
+	regs := c.CollectRegionSamples(DefaultDictSize, 0)
+	rb, gb := 0, 0
+	for _, s := range recs {
+		rb += len(s)
+	}
+	for _, s := range regs {
+		gb += len(s)
+	}
+	decompressed := 0
+	for _, blk := range c.sampleableBlocks(0) {
+		for _, k := range []streamKind{kindColdNum, kindStr, kindCold} {
+			if raw, err := blk.regionRaw(k); err == nil {
+				decompressed += len(raw)
+			}
+		}
+	}
+	b.Logf("records: %d samples, %d B content", len(recs), rb)
+	b.Logf("regions: %d samples, %d B content, but ~%d B decompressed to produce it (%.0fx amplification)",
+		len(regs), gb, decompressed, float64(decompressed)/float64(gb))
+}


### PR DESCRIPTION
Follows #163. Two commits: re-measure the training strategy against row groups (held out), then fix the sampler that measurement exposed.

# Part 1 — re-measuring the strategy
 A dictionary supplies the redundancy a payload cannot supply itself, so its value on a block region is a function of the block size — and every earlier dictionary measurement here was taken when a block was a whole segment. Row groups changed the input, so the question was worth re-asking.

## Two methodology problems in the old harnesses

Both made the dictionaries look better than they are, and both are fixed here:

1. **Not held out.** `TestDictStrategies` and `TestDictStrategiesRealOSPool` trained on samples drawn from every block, then measured on every block. The `records` row measured on the *training samples themselves*. A dictionary scored against its own training bytes is measuring memorization, not compression.
2. **Group size not swept.** Region samples came from production-shaped blocks while the conclusion was applied generally.

The new harness (`dictgroup_test.go`) trains on the **oldest half** of the segments and measures on the **newest half** — which is also what production does: train on history, apply to what arrives next — and samples regions at the same group size it measures.

## Per region, region training wins, and block size dominates

Held out, real OSPool corpus, savings vs no dictionary:

| block | strings (ad / region) | cold-tail (ad / region) | cold-numeric |
|---|---|---|---|
| 8 records | −23.6% / **−26.1%** | −30.7% / **−32.4%** | ~0% |
| 27 records | −11.1% / **−12.6%** | −15.5% / **−16.2%** | ~0% |
| 53 records | −6.5% / **−7.3%** | −9.4% / **−10.3%** | ~0% |
| 107 records (~1 MiB default) | −3.5% / **−4.5%** | −5.3% / **−7.0%** | ~0% |

Region training beats ad training everywhere, and the value of *any* dictionary falls off fast as the block grows — 24–31% at 8 records down to 3.5–5.3% at the production group.

## Net, it loses — which reverses the recommendation

One codec serves the whole collection. The same dictionary compresses every record written to the arena, the arena is several times the bytes of the block regions, and records are exactly what an ad-trained dictionary is good at. Same held-out data, total stored bytes:

| strategy | arena | regions | total |
|---|---|---|---|
| none | 3,514,376 | 481,643 | 3,996,019 |
| **ad-trained** (production) | 1,640,224 | 464,535 | **2,104,759** |
| region-trained | 1,853,546 | 459,125 | 2,312,671 (+9.9%) |

Region training saves 5.4 KB on the regions and gives back 213 KB on the arena. So **retraining keeps training on records** — now measured rather than assumed. The per-region table alone points the other way, which is the trap `TestDictStrategyNetBytes` exists to close.

## Also ruled out, measured

- **Per-region-kind dictionaries** add nothing over one mixed region dictionary (−4.2% vs −4.5% on strings) and **fail to train at all** on the cold tail at every group size ≥32 records — zstd's `BuildDict` divides by zero on that sample distribution. (`TrainDictSize` already contains that panic as an error by design, so this is a known failure mode, not a new bug.)
## The dictionary's CPU cost, which changes one of the above conclusions

I first dismissed a dictionary-less codec for the cold-numeric stream on size grounds (~100 bytes per 2.7 MB). That weighed only bytes. `dictcpu_test.go` measures the runtime cost per region kind — decompression throughput, medians of 3:

| region | no dict | dict | cost | size benefit of dict |
|---|---|---|---|---|
| cold-numeric | 608 MB/s | 489 MB/s | **−20%** | **none** (0 to +0.7%) |
| strings | 3040 MB/s | 2319 MB/s | −24% | −3.5% |
| cold-tail | 2500 MB/s | 1885 MB/s | −25% | −5.3% |

Compression on cold-numeric is worse: 191 → 135 MB/s (−29%). Cold-numeric is decompressed by every cold-column scan, so that is ~20% of the throughput on a hot path in exchange for zero bytes — a pure loss, and the earlier "does not pay" conclusion was wrong because it only counted size.

The generalization is more interesting: strings and cold-tail pay the same ~25% tax for 3.5–5.3%, and since row groups bounded the blocks, regions are only ~22% of stored bytes. So the coherent design is a **dictionary for the arena and a plain codec for all three block regions**: +17 KB (+0.8% of total stored) for ~25% faster region decompression everywhere, two codecs, a deterministic rule so a block need not record which codec built it, and `colSectionVersion` 2→3 so existing blocks rebuild.

**Not implemented here** — it is a storage-format change trading bytes for CPU, so it wants an explicit decision rather than being smuggled in with a measurement PR. Note it is *not* a memory saving: a plain region codec is an additional codec instance, not a removed one (one extra encoder state, since concurrency is capped at 1).

## What changed in the tree

No production behaviour change. `CollectRegionSamples` stays **unwired** — it has no production caller and is unreleased (absent from every tag through v0.25.3) — but keeps its place with the measurement, the conditions under which it *would* win (much smaller row groups, or a deployment not storing the row arena), and its **stale doc comment corrected**: it claimed an ad-trained dictionary "helped none of" the regions, which held-out data contradicts.

The two non-held-out harnesses are annotated as such so their logged figures aren't mistaken for decision inputs.

Happy to delete `CollectRegionSamples` outright instead of keeping it unwired — it's exported but unreleased, so removing it is still free. Kept it on the grounds that the small-block regime is reachable and the reasoning is worth having next to the code.

# Part 2 — the sampler

Measuring the above exposed a worse bug than the one I set out to check. `CollectSamples` takes the first `max` visible records in arena order — for an append-only table, the **oldest** records in it. And `TrainDictSize` builds its dictionary content from the first `DefaultDictSize` bytes of whatever it is handed, so the whole dictionary was effectively decided by the **first ~11 adjacent ads** in the table.

`CollectSamplesRecent` does three things that compose:

- **recency window** — draw only from the newest `lookBackBytes` of segment data
- **random selection** — pick records at random within that window, not a prefix
- **byte budget** — stop at bytes the dictionary can consume, not at a record count that means a different amount of work per table

It walks record *headers* to build the candidate list and decompresses only the records it draws, so the bytes touched are bounded by the budget rather than by the window. That is what keeps a random draw from being the expensive option — random selection is cheap, random *decompression* would not be.

## Quality: better dictionary from 1/16th the data

Trained on one collection, scored on a **separate** collection's records, so neither sampler is measured against its own training bytes:

| sampler | collected | samples | held-out |
|---|---|---|---|
| `CollectSamples(2000)` | 7,681,537 B | 750 | −27.8% |
| `CollectSamplesRecent` (default) | 462,434 B | 47 | **−33.5%** |

5.7 points better on 1/16th of the data, because the dictionary content now comes from across the window instead of from eleven neighbours. Quality is flat from 112 KB of budget upward, so `defaultSampleBytes` is set for slack rather than for gains.

## Cost: 21x

| sampler | time | allocated |
|---|---|---|
| `CollectSamples(2000)` | 2.27 ms | 15.8 MB |
| `CollectRegionSamples` | 0.444 ms | 8.8 MB |
| `CollectSamplesRecent` | **0.108 ms** | **0.60 MB** |

This also settles the sampling-cost case for training on regions instead of records. Region sampling looked cheaper only because `CollectSamples` was budgeted in record count (2000 fat slot ads ≈ 15 MB) while regions were budgeted in bytes. Budget records in bytes and they are the cheapest option *and* the content that wins on net stored bytes.

## API safety

`RetrainDict` keeps `sampleMax` as a **record count**. Every caller passes counts (2000, 4000), so reinterpreting it as a byte budget would have silently starved their dictionaries — the exact class of change that produces a quiet regression rather than an error. The byte budget is applied as a second, independent bound, and `TestCollectSamplesRecentBounds` pins both.

Tests: both bounds, recency composition (samples must not come from the OLD half, and the test verifies `CollectSamples` *does* return the old prefix before trusting the comparison), reproducibility under a pinned random source plus divergence under a different one, MVCC (a superseded record must never be sampled), and the held-out quality comparison above.

# Part 3 — the same bias in four other decisions

The dictionary was not the only thing decided from the arena prefix. `deriveSchema`, `RefreshHotSet`, `SchemaFit` and `profileAttrs` all sampled with `CollectSamples`, so on an append-only table every one of them was decided by the oldest records in it.

**The schema is the expensive one.** It picks each int column's fixed WIDTH, and a value too wide for its slot escapes to the cold tail — the slow path #163 just went to the trouble of bounding. A table whose values grow over time therefore derived a narrow width from ancient records and escaped on everything current.

`TestDerivedSchemaFollowsRecentData`, on a fixture whose `ProcId` is one digit in its first half and seven in its second:

```
ProcId width: prefix sample would pick 1, recent sample picks 4 (hot=true)
```

That is the shape of the reported `MAX(ProcId)` case — a hot column showing `int (u) 1` against values in the thousands. The width came from the oldest records.

**`SchemaFit` is the other pointed one.** It exists to tell an operator whether the schema still fits the data, and sampling the oldest records meant it reported on the wrong end of the table, so real drift could look like a clean fit. Over the same fixture it now reports **49.5% of `ProcId` values unstorable**, where the prefix sample reported essentially none.

These four use `CollectSamplesRecentN`, not the dictionary's sampler, because they need sample **count**: `buildAdSchema` thresholds presence at 0.90 and `chooseIntWidth` picks a fit percentile, and both go noisy on a few dozen records. So the record count stays the binding limit and only a high ceiling applies, to stop a pathological table reading unboundedly. The dictionary keeps its own smaller byte budget, sized for what `TrainDictSize` actually consumes.

Each test also verifies the *prefix* sampler really does produce the worse answer, so it is measuring the fix rather than passing for an unrelated reason.

---

`collections`, `db`, `dbrpc` suites green.

Paired with bbockelm/htcondordb#143, which makes archives retrain automatically — until now nothing retrained an append-only table's dictionary at all, which is the case this sampling bias hurt most.
