### PR TITLE
collections: sample recent records for the schema, hot set, fit report and index profiling

### DIFF
--- a/collections/autoindex.go
+++ b/collections/autoindex.go
@@ -134,7 +134,7 @@ func (p *attrProfile) addDistinct(k string) {
 // which carries no intern ids (the id-based ForEach would have yielded nothing).
 func (c *Collection) profileAttrs(sampleMax int) map[string]*attrProfile {
 	profiles := map[string]*attrProfile{}
-	for _, w := range c.CollectSamples(sampleMax) {
+	for _, w := range c.CollectSamplesRecentN(sampleMax) {
 		wire.Ad(w).ForEachNamed(c.intern, func(name string, node []byte) bool {
 			fold := strings.ToLower(name)
 			p := profiles[fold]

--- a/collections/colscan.go
+++ b/collections/colscan.go
@@ -344,7 +344,7 @@ func (c *Collection) BuildAndEnableSchemaScan(sampleMax, hotTopN int) bool {
 // ReschemaScan (a deliberate rebuild). Returns false if there is nothing to sample or no field
 // survived the presence threshold.
 func (c *Collection) deriveSchema(sampleMax, hotTopN int) (*adSchema, []int, bool) {
-	samples := c.CollectSamples(sampleMax)
+	samples := c.CollectSamplesRecentN(sampleMax)
 	if len(samples) == 0 {
 		return nil, nil, false
 	}

--- a/collections/hotset.go
+++ b/collections/hotset.go
@@ -28,7 +28,7 @@ func (c *Collection) RefreshHotSet(sampleMax, topN int) int {
 	//
 	// Names come via ForEachNamed (both encodings: interned ids in RAM, inline names when
 	// persistent) -- the old id-based ForEach counted nothing on a persistent collection.
-	samples := c.CollectSamples(sampleMax)
+	samples := c.CollectSamplesRecentN(sampleMax)
 	presence := make(map[string]int)
 	display := make(map[string]string) // folded -> first-seen spelling
 	for _, w := range samples {

--- a/collections/recentdecisions_test.go
+++ b/collections/recentdecisions_test.go
@@ -1,0 +1,151 @@
+package collections
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/collections/vm"
+)
+
+// The sample a decision is made from has to resemble the data the decision is applied to.
+//
+// Four maintenance decisions sample the collection: the columnar schema (deriveSchema), the hot set
+// (RefreshHotSet), the fit report (SchemaFit) and index profiling (profileAttrs). All four took the
+// ARENA PREFIX -- for an append-only table, the oldest records in it. The dictionary was the visible
+// symptom, but the schema is the expensive one: it picks each int column's fixed WIDTH, and a value
+// too wide for its slot escapes to the cold tail, which is the slow path row groups exist to bound.
+//
+// So a table whose values grew over time derived a narrow width from its ancient records and then
+// escaped on everything current. These tests pin the fix by making old and new data differ in
+// exactly the way that matters.
+
+// growingFixture builds a table whose ProcId values are small in the OLD half and large in the NEW
+// half -- the shape that punishes a prefix sample. Returns the collection and ProcId's intern id.
+func growingFixture(tb testing.TB, n int) (*Collection, uint32) {
+	tb.Helper()
+	c := New(Options{Shards: 1, SegmentSize: 1 << 16})
+	for i := 0; i < n; i++ {
+		proc := i % 10 // fits one byte
+		if i >= n/2 {
+			proc = 1000000 + i // needs four
+		}
+		ad := mustAdOld(tb, fmt.Sprintf("ClusterId = %d\nProcId = %d\nOwner = \"u%d\"\nCmd = \"/bin/j%d\"",
+			i/10, proc, i%32, i))
+		if err := c.Put([]byte(fmt.Sprintf("k%d", i)), ad); err != nil {
+			tb.Fatal(err)
+		}
+	}
+	// Drive demand so ProcId is a hot column, as a real query workload would.
+	q, err := vm.Parse("ProcId >= 0")
+	if err != nil {
+		tb.Fatal(err)
+	}
+	for i := 0; i < 20; i++ {
+		for range c.Query(q) {
+		}
+	}
+	id, ok := c.intern.LookupID("ProcId")
+	if !ok {
+		tb.Fatal("ProcId not interned")
+	}
+	return c, id
+}
+
+// widthOf returns the width the schema assigned to a field, or 0 if absent.
+func widthOf(s *adSchema, id uint32) int {
+	if idx, ok := s.byID[id]; ok {
+		return s.fields[idx].width
+	}
+	return 0
+}
+
+// TestDerivedSchemaFollowsRecentData is the payoff: the derived int width must cover the values the
+// table is CURRENTLY receiving, not the ones it received first.
+func TestDerivedSchemaFollowsRecentData(t *testing.T) {
+	c, procID := growingFixture(t, 4000)
+	defer c.Close()
+
+	// What the prefix sampler would have decided, for contrast. Built the same way deriveSchema
+	// builds it, from CollectSamples instead of the recent draw.
+	prefix := c.CollectSamples(2000)
+	if len(prefix) == 0 {
+		t.Fatal("no prefix samples")
+	}
+	prefixSchema := buildAdSchema(prefix, adSchemaOpts{Presence: 0.90, Fit: 0.95, Strings: true})
+	prefixWidth := widthOf(prefixSchema, procID)
+
+	// What the collection actually derives now.
+	s, hot, ok := c.deriveSchema(2000, 4)
+	if !ok {
+		t.Fatal("deriveSchema declined")
+	}
+	gotWidth := widthOf(s, procID)
+	if gotWidth == 0 {
+		t.Fatal("ProcId is not a field of the derived schema")
+	}
+	isHot := false
+	for _, i := range hot {
+		if s.fields[i].id == procID {
+			isHot = true
+		}
+	}
+	t.Logf("ProcId width: prefix sample would pick %d, recent sample picks %d (hot=%v)",
+		prefixWidth, gotWidth, isHot)
+
+	// The recent values need four bytes. A width that cannot hold them means every current record
+	// escapes on the column queries read most.
+	if gotWidth < 4 {
+		t.Errorf("derived width %d cannot hold current ProcId values (~1e6); recent records would "+
+			"all escape to the cold tail", gotWidth)
+	}
+	// And confirm the premise: the prefix sample really does pick a narrower width, so this test is
+	// measuring the fix rather than passing for an unrelated reason.
+	if prefixWidth >= gotWidth {
+		t.Errorf("prefix sample picked width %d, not narrower than the recent sample's %d -- the "+
+			"fixture no longer distinguishes the two samplers, so this test proves nothing",
+			prefixWidth, gotWidth)
+	}
+}
+
+// TestSchemaFitReportsRecentData covers the diagnostic: `.schema fit` exists to tell an operator
+// whether the schema still matches the data. Sampling the oldest records made it report on the wrong
+// end of the table, so a schema that had drifted badly could still look like a clean fit.
+func TestSchemaFitReportsRecentData(t *testing.T) {
+	c, procID := growingFixture(t, 4000)
+	defer c.Close()
+
+	// Enable the accelerator under a schema derived from the OLD data only, so ProcId's slot is
+	// deliberately too narrow for current records. That is the drift the report must surface.
+	oldSchema := buildAdSchema(c.CollectSamples(500), adSchemaOpts{Presence: 0.90, Fit: 0.95, Strings: true})
+	if widthOf(oldSchema, procID) >= 4 {
+		t.Skip("prefix schema already wide enough; fixture cannot create drift")
+	}
+	c.EnableSchemaScan(oldSchema, nil)
+
+	fits, sampled := c.SchemaFit(2000)
+	if sampled == 0 || len(fits) == 0 {
+		t.Fatal("SchemaFit returned nothing")
+	}
+	name, ok := c.intern.Name(procID)
+	if !ok {
+		t.Fatal("no name for ProcId")
+	}
+	var got *SchemaFieldFit
+	for i := range fits {
+		if fits[i].Name == name {
+			got = &fits[i]
+		}
+	}
+	if got == nil {
+		t.Fatalf("ProcId missing from the fit report (%d fields)", len(fits))
+	}
+	unstorable := got.Escaped - got.Missing
+	t.Logf("ProcId fit: escaped %.1f%%, missing %.1f%%, unstorable %.1f%%",
+		got.Escaped*100, got.Missing*100, unstorable*100)
+	// Half the table cannot fit the slot. Sampled from recent records the report must show a large
+	// unstorable fraction; sampled from the prefix it would show ~none.
+	if unstorable < 0.25 {
+		t.Errorf("fit reports only %.1f%% unstorable for a column that half the table overflows; "+
+			"the report is sampling the wrong end of the table", unstorable*100)
+	}
+}

--- a/collections/recentsamples.go
+++ b/collections/recentsamples.go
@@ -33,6 +33,17 @@ import (
 // dictionary size supplies both without collecting an unbounded multiple of what is used.
 const defaultSampleBytes = 4 * DefaultDictSize
 
+// statSampleBytes is the byte ceiling for a STATISTICAL sample (schema derivation, hot set, fit
+// report, index profiling) rather than a dictionary-training one.
+//
+// Those callers need sample COUNT, not sample bytes: buildAdSchema decides field presence against a
+// 0.90 threshold and chooseIntWidth picks a width at a fit percentile, and both get noisy on a few
+// dozen records. The dictionary budget (defaultSampleBytes) is sized for what TrainDictSize consumes
+// -- a few hundred KB, which on fat slot ads is only a few dozen records -- so reusing it here would
+// trade a biased sample for an underpowered one. This ceiling is set high enough that the record
+// count is what binds in practice, and exists only so a pathological table cannot read unboundedly.
+const statSampleBytes = 64 << 20
+
 // defaultLookBackBytes is how far back a training pass reaches, in segment bytes from the newest.
 // Large enough that the window holds many segments' worth of diversity rather than only the newest
 // one, and bounded so a table with years of history does not read all of it to build a 112 KB
@@ -56,6 +67,13 @@ const defaultLookBackBytes = 64 << 20
 // Returns nil when the collection holds no visible records.
 func (c *Collection) CollectSamplesRecent(maxRecords, maxBytes, lookBackBytes int) [][]byte {
 	return c.collectSamplesRecent(maxRecords, maxBytes, lookBackBytes, rand.Uint64)
+}
+
+// CollectSamplesRecentN returns up to maxRecords records drawn at random from the recent window,
+// with no meaningful byte bound -- the sampler for decisions that need a representative COUNT of
+// records rather than a fixed volume of bytes. See statSampleBytes.
+func (c *Collection) CollectSamplesRecentN(maxRecords int) [][]byte {
+	return c.CollectSamplesRecent(maxRecords, statSampleBytes, 0)
 }
 
 // collectSamplesRecent is CollectSamplesRecent with an injectable random source, so a test can pin

--- a/collections/schemafit.go
+++ b/collections/schemafit.go
@@ -47,7 +47,7 @@ func (c *Collection) SchemaFit(sampleMax int) ([]SchemaFieldFit, int) {
 	if st == nil {
 		return nil, 0
 	}
-	samples := c.CollectSamples(sampleMax)
+	samples := c.CollectSamplesRecentN(sampleMax)
 	if c.inline {
 		interned := make([][]byte, 0, len(samples))
 		for _, w := range samples {


### PR DESCRIPTION
Follows #164 (merged), which added `CollectSamplesRecent` and pointed the dictionary at it. This does the same for the four *other* decisions made from the arena prefix — they missed #164's merge window.

## The bias was not dictionary-specific

`deriveSchema`, `RefreshHotSet`, `SchemaFit` and `profileAttrs` all sampled with `CollectSamples`, which takes the first `max` visible records in arena order. On an append-only table that is the **oldest** records in it, so every one of those decisions was made from the table's infancy.

## The schema is the expensive one

It picks each int column's fixed **width**, and a value too wide for its slot escapes to the cold tail — the slow path #163 just went to the trouble of bounding. A table whose values grow over time derived a narrow width from ancient records and then escaped on everything current.

`TestDerivedSchemaFollowsRecentData`, on a fixture whose `ProcId` is one digit in its first half and seven in its second:

```
ProcId width: prefix sample would pick 1, recent sample picks 4 (hot=true)
```

That is the shape of the reported `MAX(ProcId)` case — a hot column showing `int (u) 1` against values in the thousands. The width came from the oldest records in the table.

## `SchemaFit` was reporting on the wrong end of the table

It exists to answer "does the schema still fit the data?", so sampling the oldest records meant real drift could read as a clean fit. Over the same fixture it now reports **49.5% of `ProcId` values unstorable**, where the prefix sample reported essentially none.

## Why a different sampler than the dictionary's

These four need sample **count**, not a byte volume: `buildAdSchema` thresholds presence at 0.90 and `chooseIntWidth` picks a fit percentile, and both go noisy on a few dozen records. The dictionary's budget is sized for what `TrainDictSize` consumes — a few hundred KB, which on fat slot ads is only a few dozen records — so reusing it here would trade a biased sample for an underpowered one.

`CollectSamplesRecentN` keeps the record count as the binding limit and applies only a high ceiling, so a pathological table cannot read unboundedly. The dictionary keeps its own smaller byte budget.

## Tests

Both new tests also verify the *prefix* sampler really does produce the worse answer on the same fixture, so they are measuring the fix rather than passing for an unrelated reason.

`collections`, `db`, `dbrpc` suites green.
