### PR TITLE
collections: compress columnar block regions without the trained dictionary

### DIFF
--- a/collections/colblock.go
+++ b/collections/colblock.go
@@ -129,7 +129,7 @@ func (g colGrouping) full(rows, bytes int) bool {
 type columnarBlock struct {
 	id     uint64 // process-unique, the block-cache key
 	schema *adSchema
-	codec  Codec
+	codec  Codec // the REGION codec (dictionary id 0), not the segment's record codec
 	n      int
 
 	hot         []byte // uncompressed region, hotStride bytes per record
@@ -182,8 +182,8 @@ func layoutColumnar(b *columnarBlock, s *adSchema, hotNumFields []int, n int) {
 	}
 }
 
-func encodeColumnarBlock(s *adSchema, recs [][]byte, hotNumFields []int, codec Codec) *columnarBlock {
-	b := &columnarBlock{id: colBlockSeq.Add(1), schema: s, codec: codec, n: len(recs)}
+func encodeColumnarBlock(s *adSchema, recs [][]byte, hotNumFields []int, regionCodec Codec) *columnarBlock {
+	b := &columnarBlock{id: colBlockSeq.Add(1), schema: s, codec: regionCodec, n: len(recs)}
 	layoutColumnar(b, s, hotNumFields, len(recs))
 	cp := 0
 	for _, i := range b.coldNum {
@@ -211,9 +211,9 @@ func encodeColumnarBlock(s *adSchema, recs [][]byte, hotNumFields []int, codec C
 		b.strOff = append(b.strOff, len(strCat))
 		b.coldOff = append(b.coldOff, len(coldCat))
 	}
-	b.coldNumComp = codec.Compress(nil, coldRaw)
-	b.strComp = codec.Compress(nil, strCat)
-	b.coldComp = codec.Compress(nil, coldCat)
+	b.coldNumComp = regionCodec.Compress(nil, coldRaw)
+	b.strComp = regionCodec.Compress(nil, strCat)
+	b.coldComp = regionCodec.Compress(nil, coldCat)
 	return b
 }
 
@@ -229,10 +229,14 @@ func encodeColumnarBlock(s *adSchema, recs [][]byte, hotNumFields []int, codec C
 // records instead of the whole segment's, which for a 1 GiB segment was the same order as the
 // segment itself.
 //
+// The two codecs are deliberately different. arenaCodec decompresses the stored records and must be
+// the segment's own codec (whatever dictionary they were written under); regionCodec compresses the
+// block's regions and is the dictionary-less base codec (see Collection.regionCodec).
+//
 // toInterned canonicalizes a decompressed record into interned wire (identity for an already-
 // interned collection; a decode/re-encode for an inline/persistent one). encode reads the
 // id-keyed form, so a non-interned record must be converted first or the block would be empty.
-func buildColumnarFromSegment(data []byte, upto int, codec Codec, s *adSchema, hot []int, g colGrouping, toInterned func(dst, w []byte) ([]byte, bool)) ([]*columnarBlock, []uint32) {
+func buildColumnarFromSegment(data []byte, upto int, arenaCodec, regionCodec Codec, s *adSchema, hot []int, g colGrouping, toInterned func(dst, w []byte) ([]byte, bool)) ([]*columnarBlock, []uint32) {
 	var blocks []*columnarBlock
 	var recs [][]byte
 	var offs []uint32
@@ -245,7 +249,7 @@ func buildColumnarFromSegment(data []byte, upto int, codec Codec, s *adSchema, h
 			break
 		}
 		if !recIsMarker(data, o) {
-			if w, err := codec.Decompress(buf[:0], recAd(data, o)); err == nil {
+			if w, err := arenaCodec.Decompress(buf[:0], recAd(data, o)); err == nil {
 				buf = w
 				if iw, ok := toInterned(nil, w); ok {
 					rec := s.encode(wire.Ad(iw))
@@ -253,7 +257,7 @@ func buildColumnarFromSegment(data []byte, upto int, codec Codec, s *adSchema, h
 					offs = append(offs, o)
 					groupBytes += len(rec)
 					if g.full(len(recs), groupBytes) {
-						blocks = append(blocks, encodeColumnarBlock(s, recs, hot, codec))
+						blocks = append(blocks, encodeColumnarBlock(s, recs, hot, regionCodec))
 						recs, groupBytes = recs[:0], 0
 					}
 				}
@@ -262,13 +266,13 @@ func buildColumnarFromSegment(data []byte, upto int, codec Codec, s *adSchema, h
 		off += int(total)
 	}
 	if len(recs) > 0 {
-		blocks = append(blocks, encodeColumnarBlock(s, recs, hot, codec)) // short final group
+		blocks = append(blocks, encodeColumnarBlock(s, recs, hot, regionCodec)) // short final group
 	}
 	if len(blocks) == 0 {
 		// A segment with no encodable records still gets one empty block, so a colSegment always
 		// carries the schema it was built under (which persistence and the scan's field resolution
 		// both read from the first block).
-		blocks = append(blocks, encodeColumnarBlock(s, nil, hot, codec))
+		blocks = append(blocks, encodeColumnarBlock(s, nil, hot, regionCodec))
 	}
 	return blocks, offs
 }

--- a/collections/colblock_segment_test.go
+++ b/collections/colblock_segment_test.go
@@ -78,7 +78,7 @@ func TestBuildColumnarFromSegmentRowGroups(t *testing.T) {
 	// shape). All must produce identical per-record answers.
 	for _, groupRows := range []int{colGroupRows, 100, 1, n + 7} {
 		t.Run(fmt.Sprintf("group%d", groupRows), func(t *testing.T) {
-			blocks, offs := buildColumnarFromSegment(seg.data, seg.used, seg.codec, s, []int{memIdx}, byRows(groupRows), store.recordToInterned)
+			blocks, offs := buildColumnarFromSegment(seg.data, seg.used, seg.codec, store.regionCodec(), s, []int{memIdx}, byRows(groupRows), store.recordToInterned)
 			if len(offs) != n {
 				t.Fatalf("offs=%d, want %d", len(offs), n)
 			}

--- a/collections/colgroup_bench_test.go
+++ b/collections/colgroup_bench_test.go
@@ -83,7 +83,7 @@ func regroup(tb testing.TB, c *Collection, g colGrouping) (blocks, recs int) {
 				continue
 			}
 			d := seg.dict.Load()
-			bl, offs := buildColumnarFromSegment(seg.data, seg.used, seg.codec, st.schema, st.hot, g,
+			bl, offs := buildColumnarFromSegment(seg.data, seg.used, seg.codec, c.regionCodec(), st.schema, st.hot, g,
 				func(dst, w []byte) ([]byte, bool) { return c.recordToInternedDict(d, dst, w) })
 			seg.colblk.Store(&colSegment{blocks: bl, offs: offs})
 			blocks += len(bl)
@@ -198,7 +198,7 @@ func BenchmarkRowGroupBuild(b *testing.B) {
 		b.Run(p.name, func(b *testing.B) {
 			b.ReportAllocs()
 			for i := 0; i < b.N; i++ {
-				blocks, _ := buildColumnarFromSegment(seg.data, seg.used, seg.codec, st.schema, st.hot, p.g,
+				blocks, _ := buildColumnarFromSegment(seg.data, seg.used, seg.codec, store.regionCodec(), st.schema, st.hot, p.g,
 					func(dst, w []byte) ([]byte, bool) { return store.recordToInternedDict(d, dst, w) })
 				if len(blocks) == 0 {
 					b.Fatal("no blocks")

--- a/collections/colgroup_test.go
+++ b/collections/colgroup_test.go
@@ -359,7 +359,7 @@ func TestColSegmentRejectsGroupOffsMismatch(t *testing.T) {
 		t.Fatal("no sealed segment")
 	}
 	d := seg.dict.Load()
-	blocks, offs := buildColumnarFromSegment(seg.data, seg.used, seg.codec, st.schema, st.hot, byRows(64),
+	blocks, offs := buildColumnarFromSegment(seg.data, seg.used, seg.codec, store.regionCodec(), st.schema, st.hot, byRows(64),
 		func(dst, w []byte) ([]byte, bool) { return store.recordToInternedDict(d, dst, w) })
 	if len(blocks) < 2 {
 		t.Fatal("fixture produced a single row group; the mismatch guard would not be exercised")

--- a/collections/colpersist.go
+++ b/collections/colpersist.go
@@ -18,11 +18,16 @@ import (
 // the same "derived state, any doubt rebuilds" contract the attribute-index sidecar follows.
 const (
 	colSectionMagic = 0x434f4c58 // "COLX"
-	// colSectionVersion 2 stores a LIST of row-group blocks per segment (see colGroupRows); v1
-	// stored exactly one block covering the whole segment. A v1 section is rejected by
-	// readColSection like any other section that cannot be trusted, so the segment simply rebuilds
-	// its accelerator under the current layout -- derived state, so no migration is needed.
-	colSectionVersion = 2
+	// colSectionVersion history. v1 stored exactly one block covering the whole segment; v2 stores a
+	// LIST of row-group blocks (see colGroupRows); v3 compresses the block's regions with the
+	// dictionary-less base codec instead of the segment's dictionary codec (see
+	// Collection.regionCodec). An older section is rejected by readColSection like any other section
+	// that cannot be trusted, so the segment rebuilds its accelerator under the current rules --
+	// derived state, so no migration is needed. v3 in particular MUST be a version bump rather than
+	// a silent change: a v2 section's regions were compressed with a trained dictionary, so decoding
+	// them with the base codec would fail or, worse, be attempted against whatever dictionary the
+	// segment currently carries.
+	colSectionVersion = 3
 	colSectionHdr     = 4 + 2 + 4 + 4 // magic u32 | version u16 | upto u32 | crc u32
 )
 

--- a/collections/colscan.go
+++ b/collections/colscan.go
@@ -227,13 +227,54 @@ func (c *Collection) persistColSeg(sh *shard, seg *segment) {
 	c.installSidecar(sh, seg, path, container)
 }
 
+// regionCodec is the codec a columnar block's REGIONS are compressed with: ZSTD with NO trained
+// dictionary, created once per collection and cached.
+//
+// WHY NO DICTIONARY. The trained dictionary is an ARENA optimization and does not pay for itself on
+// the block regions. Measured on real OSPool slot ads (dictcpu_test.go, decompression throughput):
+// the dictionary costs 20% on the cold-numeric region for ZERO size benefit (it compresses that
+// region 0.0% to +0.7% WORSE), 24% on the strings region for -3.5%, and 25% on the cold tail for
+// -5.3%. Since row groups bounded the blocks, regions are only about a fifth of stored bytes, so
+// dropping the dictionary across all three costs under 1% of total stored size and returns roughly a
+// quarter of the decompression throughput on a path taken by every cold-column scan, escaped-value
+// read and full-ad reconstruct.
+//
+// WHY NOT the segment's codec (what it used to be), and why not dictionary id 0 either. A block's
+// region codec has to be recoverable at reload time without being recorded per block, so it must
+// depend only on state that never changes for the life of the collection. The segment's codec fails
+// that -- it is whatever dictionary generation the segment was written under, and a reseal changes
+// it. currentCodec fails it too, since a retrain swaps identity for ZSTD mid-life, which would leave
+// blocks written earlier in the process undecodable. Dictionary id 0 is stable, but on a store whose
+// base codec is identity (the historical default that db.chooseBaseCodec preserves for existing
+// stores) it would leave the regions UNCOMPRESSED, which for such a store is a real size regression
+// against today, where a retrain gives them dictionary compression.
+//
+// A dictionary-less ZSTD codec satisfies all of it: identical for every collection, never affected by
+// a retrain or a reseal, and compressing. Note that on an identity-base store this means the block
+// regions are compressed while the records are not. That is fine -- a block is derived state with its
+// own version stamp, and nothing assumes it shares the record encoding.
+func (c *Collection) regionCodec() Codec {
+	if h := c.regionCodecCache.Load(); h != nil {
+		return h.c
+	}
+	cd, err := NewZSTDCodec(nil)
+	if err != nil {
+		// Cannot happen for a nil dictionary; degrade to the base codec rather than fail a seal.
+		// Cached so the choice is still stable for this process.
+		cd = c.currentCodec()
+	}
+	c.regionCodecCache.CompareAndSwap(nil, &codecHolder{cd})
+	return c.regionCodecCache.Load().c
+}
+
 // buildColSegment transcodes a sealed segment into its columnar accelerator block under schema s
 // and hot tier hot (resolving an interned segment's local ids on the way). Returns nil if the
 // block cannot be built. Off the write lock (reads immutable sealed bytes).
 func (c *Collection) buildColSegment(seg *segment, s *adSchema, hot []int) *colSegment {
 	colSegmentBuilds.Add(1)
 	d := seg.dict.Load() // interned segment -> resolve its local ids during transcode
-	blocks, offs := buildColumnarFromSegment(seg.data, seg.used, seg.codec, s, hot, defaultColGrouping(),
+	blocks, offs := buildColumnarFromSegment(seg.data, seg.used, seg.codec, c.regionCodec(), s, hot,
+		defaultColGrouping(),
 		func(dst, w []byte) ([]byte, bool) { return c.recordToInternedDict(d, dst, w) })
 	if len(blocks) == 0 {
 		return nil

--- a/collections/dictgroup_test.go
+++ b/collections/dictgroup_test.go
@@ -103,7 +103,7 @@ func blocksAt(t *testing.T, c *Collection, segs []*segment, g colGrouping) []*co
 	var out []*columnarBlock
 	for _, seg := range segs {
 		d := seg.dict.Load()
-		bl, _ := buildColumnarFromSegment(seg.data, seg.used, identityCodec{}, st.schema, st.hot, g,
+		bl, _ := buildColumnarFromSegment(seg.data, seg.used, seg.codec, identityCodec{}, st.schema, st.hot, g,
 			func(dst, w []byte) ([]byte, bool) { return c.recordToInternedDict(d, dst, w) })
 		out = append(out, bl...)
 	}

--- a/collections/regioncodec_bench_test.go
+++ b/collections/regioncodec_bench_test.go
@@ -1,0 +1,102 @@
+package collections
+
+import (
+	"fmt"
+	"testing"
+)
+
+// What routing the block regions through a dictionary-less codec actually buys, end to end, on the
+// same store: the blocks are built twice over identical data, once with the collection's trained
+// dictionary codec (the old behaviour) and once with the region codec (the new one), and the same
+// aggregate query is timed against each.
+//
+// Cold, because that is the regime the block cache leaves for anything larger than it can hold and
+// the regime an escaped-value read pays repeatedly.
+func BenchmarkRegionCodecAggregate(b *testing.B) {
+	ads := realOSPoolAds(b, 20000)
+	c := New(Options{Shards: 1, SegmentSize: 1 << 21})
+	defer c.Close()
+	for i, ad := range ads {
+		if err := c.Put([]byte(fmt.Sprintf("s%d", i)), ad); err != nil {
+			b.Fatal(err)
+		}
+	}
+	if !c.BuildAndEnableSchemaScan(2000, 8) {
+		b.Skip("no sealed segments")
+	}
+	if _, err := c.RetrainDict(2000); err != nil {
+		b.Skipf("retrain declined: %v", err)
+	}
+	dictCodec := c.currentCodec()
+	if dictCodec.Name() != "zstd+dict" {
+		b.Skipf("write codec is %q, not a dictionary codec", dictCodec.Name())
+	}
+	st := c.schemaScan.Load()
+	if st == nil {
+		b.Fatal("schema scan not enabled")
+	}
+
+	// rebuild re-encodes every sealed segment's blocks with the given REGION codec, and reports the
+	// total stored region bytes so the size side of the trade is measured on the same data.
+	rebuild := func(regionCodec Codec) int {
+		bytes := 0
+		for _, sh := range c.shards {
+			sh.mu.RLock()
+			act := sh.act
+			segs := append([]*segment(nil), sh.segs...)
+			sh.mu.RUnlock()
+			for _, seg := range segs {
+				if seg == nil || seg == act || seg.used == 0 {
+					continue
+				}
+				d := seg.dict.Load()
+				bl, offs := buildColumnarFromSegment(seg.data, seg.used, seg.codec, regionCodec,
+					st.schema, st.hot, defaultColGrouping(),
+					func(dst, w []byte) ([]byte, bool) { return c.recordToInternedDict(d, dst, w) })
+				seg.colblk.Store(&colSegment{blocks: bl, offs: offs})
+				for _, blk := range bl {
+					bytes += len(blk.coldNumComp) + len(blk.strComp) + len(blk.coldComp)
+				}
+			}
+		}
+		return bytes
+	}
+
+	// Arena bytes as stored, so the region delta can be read as a fraction of what the collection
+	// actually occupies rather than of the regions alone.
+	arena := 0
+	for _, sh := range c.shards {
+		sh.mu.RLock()
+		for _, seg := range sh.segs {
+			if seg != nil {
+				arena += seg.used
+			}
+		}
+		sh.mu.RUnlock()
+	}
+	b.Logf("arena %d B stored", arena)
+
+	for _, regime := range []struct {
+		name string
+		cd   Codec
+	}{{"dictRegions", dictCodec}, {"plainRegions", c.regionCodec()}} {
+		regionBytes := rebuild(regime.cd)
+		b.Run(regime.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ReportMetric(float64(regionBytes), "regionB")
+			b.ReportMetric(100*float64(regionBytes)/float64(arena+regionBytes), "pctOfTotal")
+			for i := 0; i < b.N; i++ {
+				// Fresh cache each iteration: measure decompression, not cache hits.
+				bc, err := newBlockCache(256 << 20)
+				if err != nil {
+					b.Fatal(err)
+				}
+				c.schemaScan.Store(&schemaScanState{schema: st.schema, hot: st.hot, cache: bc})
+				got, ok := c.NumStatsQuery(nil, "Memory")
+				if !ok || got.N == 0 {
+					b.Fatal("NumStatsQuery declined or scanned nothing")
+				}
+			}
+		})
+	}
+}

--- a/collections/regioncodec_test.go
+++ b/collections/regioncodec_test.go
@@ -1,0 +1,131 @@
+package collections
+
+import (
+	"encoding/binary"
+	"fmt"
+	"hash/crc32"
+	"testing"
+)
+
+// A columnar block's regions are compressed with a dictionary-less codec (see regionCodec). The risk
+// in that change is not the compression ratio, it is DECODABILITY: a block whose regions were written
+// with one codec and are read back with another produces garbage or an error, and the codec is not
+// recorded per block -- it is re-derived at reload. So these tests pin that the derivation cannot
+// drift, across a retrain and across a reopen, and that a section written under the old rules is
+// refused rather than misread.
+
+// TestRegionCodecIsDictionaryLessAndStable pins the two properties the reload depends on: the region
+// codec carries no trained dictionary, and it does not change when the collection's codec does.
+func TestRegionCodecIsDictionaryLessAndStable(t *testing.T) {
+	c := New(Options{Shards: 1, SegmentSize: 1 << 16})
+	defer c.Close()
+	for i := 0; i < 3000; i++ {
+		if err := c.Put([]byte(fmt.Sprintf("k%d", i)),
+			mustAdOld(t, fmt.Sprintf("ClusterId = %d\nProcId = %d\nOwner = \"u%d\"\nCmd = \"/bin/x%d\"",
+				i/10, i%10, i%32, i))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	first := c.regionCodec()
+	if got := first.Name(); got != "zstd" {
+		t.Errorf("region codec is %q, want plain %q (a dictionary codec defeats the purpose)", got, "zstd")
+	}
+	// Retrain: the collection's write codec becomes zstd+dict. The region codec must not follow, or
+	// blocks built before this point would need a dictionary that the reload does not supply.
+	if _, err := c.RetrainDict(2000); err != nil {
+		t.Skipf("retrain declined: %v", err)
+	}
+	if got := c.currentCodec().Name(); got != "zstd+dict" {
+		t.Fatalf("retrain left the write codec %q; the test cannot show independence", got)
+	}
+	if second := c.regionCodec(); second != first {
+		t.Errorf("region codec changed across a retrain (%q -> %q); blocks built earlier in this "+
+			"process would no longer decode", first.Name(), second.Name())
+	}
+}
+
+// TestColumnarSurvivesRetrainWithRegionCodec is the behaviour that used to be coupled: a block was
+// compressed with its SEGMENT's codec, so a retrain (which changes that codec) meant a block had to
+// be rebuilt to stay readable. With a dictionary-less region codec the block is independent of the
+// segment's dictionary generation entirely.
+func TestColumnarSurvivesRetrainWithRegionCodec(t *testing.T) {
+	c := New(Options{Shards: 1, SegmentSize: 1 << 16})
+	defer c.Close()
+	for i := 0; i < 3000; i++ {
+		if err := c.Put([]byte(fmt.Sprintf("k%d", i)),
+			mustAdOld(t, fmt.Sprintf("ClusterId = %d\nProcId = %d\nMemory = %d\nOwner = \"u%d\"",
+				i/10, i%10, 1024+(i%64)*512, i%32))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if !c.BuildAndEnableSchemaScan(2000, 4) {
+		t.Skip("no sealed segments")
+	}
+	procID, ok := c.intern.LookupID("ProcId")
+	if !ok {
+		t.Fatal("ProcId not interned")
+	}
+	want, ok := c.NumStatsQuery(nil, "ProcId")
+	if !ok {
+		t.Fatal("NumStatsQuery declined before retrain")
+	}
+	truth := c.allBruteCount(procID, func(v int64) bool { return v >= 5 })
+
+	if _, err := c.RetrainDict(2000); err != nil {
+		t.Skipf("retrain declined: %v", err)
+	}
+
+	// Every block must still read, and agree with the row path over the same data.
+	got, ok := c.NumStatsQuery(nil, "ProcId")
+	if !ok {
+		t.Fatal("NumStatsQuery declined after retrain")
+	}
+	if got.N != want.N || got.Max != want.Max || got.IntSum != want.IntSum {
+		t.Errorf("stats changed across a retrain: (n %d, max %v, sum %d) -> (n %d, max %v, sum %d)",
+			want.N, want.Max, want.IntSum, got.N, got.Max, got.IntSum)
+	}
+	if after := c.allBruteCount(procID, func(v int64) bool { return v >= 5 }); after != truth {
+		t.Errorf("row-path truth changed across a retrain: %d -> %d", truth, after)
+	}
+}
+
+// TestColSectionRejectsOlderVersion pins the version gate. A v2 section's regions were compressed
+// with the segment's dictionary codec; decoding those bytes with the dictionary-less region codec
+// would fail or, worse, silently produce wrong values. The reload must refuse and let the segment
+// rebuild.
+func TestColSectionRejectsOlderVersion(t *testing.T) {
+	body := []byte("not really a block, but the header is what is under test")
+	const upto = 4096
+
+	// The current version round-trips.
+	if got := readColSection(wrapColSection(body, upto), upto); got == nil {
+		t.Fatal("a section at the current version was rejected")
+	}
+	// Every older version is refused.
+	for _, v := range []uint16{1, 2} {
+		old := make([]byte, 0, colSectionHdr+len(body))
+		old = appendU32(old, colSectionMagic)
+		old = appendU16(old, v)
+		old = appendU32(old, uint32(upto))
+		old = appendU32(old, crc32.ChecksumIEEE(body))
+		old = append(old, body...)
+		if got := readColSection(old, upto); got != nil {
+			t.Errorf("a v%d section was accepted; its regions were compressed with a different "+
+				"codec and would be misread", v)
+		}
+	}
+	// And a version FROM THE FUTURE is refused too, so a downgrade cannot misread a newer section.
+	future := make([]byte, 0, colSectionHdr+len(body))
+	future = appendU32(future, colSectionMagic)
+	future = appendU16(future, colSectionVersion+1)
+	future = appendU32(future, uint32(upto))
+	future = appendU32(future, crc32.ChecksumIEEE(body))
+	future = append(future, body...)
+	if got := readColSection(future, upto); got != nil {
+		t.Error("a newer-version section was accepted")
+	}
+	// Sanity: the version really is where this test writes it.
+	if v := binary.LittleEndian.Uint16(wrapColSection(body, upto)[4:]); v != colSectionVersion {
+		t.Errorf("section version at offset 4 is %d, want %d", v, colSectionVersion)
+	}
+}

--- a/collections/sealed_index.go
+++ b/collections/sealed_index.go
@@ -67,7 +67,7 @@ func (c *Collection) publishSidecar(seg *segment, path string, spec *indexSpec) 
 	// independent of this mapping.
 	var cs *colSegment
 	if body := readColSection(col, seg.used); body != nil { // rejects truncated/corrupt/stale -> row-scan
-		cs = unmarshalColSegment(body, seg.codec, c.intern.Intern)
+		cs = unmarshalColSegment(body, c.regionCodec(), c.intern.Intern)
 	}
 	// keyIdx is set exactly once per seal and is the "sealed" marker; CAS so a
 	// concurrent seal cannot leak a mapping.
@@ -234,7 +234,7 @@ func (c *Collection) installSidecar(sh *shard, seg *segment, path string, contai
 	// together by swapSidecarHook + releaseStale once scan pins drain.
 	var cs *colSegment
 	if body := readColSection(col, seg.used); body != nil {
-		cs = unmarshalColSegment(body, seg.codec, c.intern.Intern)
+		cs = unmarshalColSegment(body, c.regionCodec(), c.intern.Intern)
 	}
 	// Publish under the shard write lock: the readers that touch a sidecar without a scan pin
 	// (SidecarSizes, IndexSizes) hold the read lock while they do; pinned scan readers are handled

--- a/collections/store.go
+++ b/collections/store.go
@@ -227,10 +227,14 @@ type Collection struct {
 	shards []*shard
 	mask   uint64
 	h      Hasher
-	codec  atomic.Pointer[codecHolder]  // current codec for new writes; swapped by RetrainDict
-	intern *wire.InternTable            // shared attribute-name interning across the store
-	hotSet atomic.Pointer[hotSetHolder] // interned ids to front-load; swapped by RefreshHotSet
-	spec   atomic.Pointer[indexSpec]    // configured indexes; swapped by AddIndex/DropIndex (never nil after New)
+	codec  atomic.Pointer[codecHolder] // current codec for new writes; swapped by RetrainDict
+	// regionCodecCache holds the dictionary-less codec a columnar block's regions are compressed
+	// with (see regionCodec). Created on first use and never swapped, so a block built at any point
+	// in this collection's life decodes with the same codec.
+	regionCodecCache atomic.Pointer[codecHolder]
+	intern           *wire.InternTable            // shared attribute-name interning across the store
+	hotSet           atomic.Pointer[hotSetHolder] // interned ids to front-load; swapped by RefreshHotSet
+	spec             atomic.Pointer[indexSpec]    // configured indexes; swapped by AddIndex/DropIndex (never nil after New)
 
 	// matchRoots (case-folded) are the roots whose closure is front-loaded into the
 	// hot header for the match fast path (Options.MatchClosureRoots); nil if disabled.


### PR DESCRIPTION
The trained dictionary is an **arena** optimization. It earns its keep there — records are exactly what it was trained on — but on a block's regions it is close to free size and real CPU, and row groups (#163) changed the balance by bounding how much of the stored bytes those regions are.

## Measurements

Per region kind, decompression throughput with the dictionary vs without (`dictcpu_test.go`, medians of 3):

| region | no dict | dict | CPU cost | size benefit of dict |
|---|---|---|---|---|
| cold-numeric | 608 MB/s | 489 MB/s | −20% | **none** (0.0% to +0.7%, i.e. worse) |
| strings | 3040 MB/s | 2319 MB/s | −24% | −3.5% |
| cold-tail | 2500 MB/s | 1885 MB/s | −25% | −5.3% |

End to end on one store, blocks built twice over identical data (`BenchmarkRegionCodecAggregate`):

| regions compressed with | aggregate (cold) | region bytes | total stored |
|---|---|---|---|
| the collection's dict codec | 3.306 ms | 802,943 | 3,007,431 |
| plain ZSTD | **2.793 ms** | 851,928 | 3,056,416 |

**−15.5% query time for +1.6% total stored bytes** (arena 2,204,488 B). Note this corrects the estimate I gave when proposing it: I said +0.8%, based on a different fixture where regions were a smaller share. Measured on one store end to end it is +1.6%.

## Why plain ZSTD, and not the two more obvious choices

The region codec must be **re-derivable at reload without being recorded per block**, so it may only depend on state that never changes for the collection's life. That rules out both candidates I tried first:

- **The segment's codec** (what it used to be) — it is whatever dictionary generation the segment was written under, and a reseal changes it.
- **`currentCodec()`** — a retrain swaps identity for ZSTD mid-life, which would leave blocks built earlier in the same process undecodable.
- **Dictionary id 0** (the base codec) is stable, and was my first implementation — but on a store whose base codec is *identity*, which `db.chooseBaseCodec` deliberately preserves for pre-existing stores, it leaves the regions **uncompressed**. For exactly those stores that is a size regression against today, where a retrain gives their regions dictionary compression.

Plain ZSTD, created once per collection and cached, satisfies all of it: identical for every collection, unaffected by retrains and reseals, and compressing. On an identity-base store this does mean regions are compressed while records are not — fine, since a block is derived state with its own version stamp and nothing assumes it shares the record encoding.

**Welcome consequence:** a block no longer depends on its segment's dictionary generation at all, so a retrain cannot leave one needing a dictionary to be read.

## Format

`colSectionVersion` 2 → 3. This *must* be a version bump rather than a silent change: a v2 section's regions were compressed **with** a dictionary, so reading them under the new rule would fail or — worse — decode against whatever dictionary the segment now carries. Older sections are refused like any untrusted section and the segment rebuilds. Derived state, no migration.

`buildColumnarFromSegment` now takes the arena and region codecs separately, since it both decompresses stored records and compresses regions and those are no longer the same codec. That also fixes `dictgroup_test.go`, which passed an identity codec for *both* and worked only because its fixture's base codec happens to be identity.

## Tests

- `TestRegionCodecIsDictionaryLessAndStable` — the codec carries no dictionary, and does not change across a retrain that swaps the write codec to `zstd+dict`.
- `TestColumnarSurvivesRetrainWithRegionCodec` — blocks still read, and still agree with the row path, after a retrain. This is the coupling that used to exist.
- `TestColSectionRejectsOlderVersion` — v1 and v2 refused, current accepted, and a *future* version refused too so a downgrade cannot misread a newer section.

`collections`, `db`, `dbrpc` suites green.
