### PR TITLE
collections: fix use-after-munmap — pin sealed segments read off the shard lock

### DIFF
--- a/collections/colscan.go
+++ b/collections/colscan.go
@@ -175,20 +175,22 @@ func (c *Collection) EnableSchemaScan(s *adSchema, hot []int) {
 		c.schemaScan.Store(st)
 	}
 	for _, sh := range c.shards {
-		sh.mu.RLock()
-		act := sh.act
-		segs := make([]*segment, 0, len(sh.segs))
-		for _, seg := range sh.segs {
-			if seg != nil && seg != act && seg.used > 0 && seg.colblk.Load() == nil {
-				segs = append(segs, seg) // sealed ⇒ data/used immutable, safe to read off-lock
-			}
-		}
-		sh.mu.RUnlock()
-		for _, seg := range segs {
+		// PINNED: transcoding reads the segment's bytes off the shard lock, and a concurrent
+		// Compact/merge/rotation would otherwise munmap them mid-read. The pin defers the reap.
+		segs := sh.pinSealed(func(seg *segment) bool { return seg.colblk.Load() == nil })
+		// Unpin each segment as soon as its block is built, rather than holding every pin until this
+		// returns: a pin DEFERS a concurrent compaction's reap, and a whole-archive transcode takes
+		// long enough that holding them all would keep every replaced segment's file on disk for the
+		// duration. The deferred sweep is a safety net for a panic mid-loop.
+		done := 0
+		defer func() { unpinAll(segs[done:]) }()
+		for i, seg := range segs {
 			if cs := c.buildColSegment(seg, s, hot); cs != nil {
 				seg.colblk.Store(cs)
 				c.persistColSeg(sh, seg) // write it to the sidecar so a reopen reloads it (no-op for RAM)
 			}
+			seg.unpin()
+			done = i + 1
 		}
 	}
 }
@@ -267,11 +269,21 @@ func (c *Collection) regionCodec() Codec {
 	return c.regionCodecCache.Load().c
 }
 
+// colBuildStallHook is a test seam: called at the start of each segment's transcode, while the
+// caller holds that segment pinned. It lets a test force a compaction (which retires and reaps
+// sealed segments) at exactly the moment a build is reading one, which is the production race that
+// crashed -- an admin Maintain transcoding segments while the background maintenance goroutine
+// compacted them. Production leaves it nil.
+var colBuildStallHook func()
+
 // buildColSegment transcodes a sealed segment into its columnar accelerator block under schema s
 // and hot tier hot (resolving an interned segment's local ids on the way). Returns nil if the
 // block cannot be built. Off the write lock (reads immutable sealed bytes).
 func (c *Collection) buildColSegment(seg *segment, s *adSchema, hot []int) *colSegment {
 	colSegmentBuilds.Add(1)
+	if colBuildStallHook != nil {
+		colBuildStallHook()
+	}
 	d := seg.dict.Load() // interned segment -> resolve its local ids during transcode
 	blocks, offs := buildColumnarFromSegment(seg.data, seg.used, seg.codec, c.regionCodec(), s, hot,
 		defaultColGrouping(),

--- a/collections/index_query.go
+++ b/collections/index_query.go
@@ -41,6 +41,10 @@ func (c *Collection) Reindex() {
 		sh.mu.RLock()
 		act := sh.act
 		sealRAM := sh.sealRAM
+		// Pinned below, once the target list is known: reindexing decompresses every record it
+		// covers, off the shard lock, and holds only reindexMu -- which does not exclude Compact,
+		// a merge or a rotation, any of which reaps (munmaps) a sealed segment.
+		var pinned []*segment
 		window := c.backfillWindow(sh)
 		type target struct {
 			seg    *segment
@@ -89,7 +93,16 @@ func (c *Collection) Reindex() {
 				tgts = append(tgts, target{seg: seg, used: seg.used, seal: true})
 			}
 		}
+		for _, t := range tgts {
+			t.seg.pin()
+			pinned = append(pinned, t.seg)
+		}
 		sh.mu.RUnlock()
+		// Held until Reindex returns rather than released per target. A pin only DEFERS a concurrent
+		// compaction's reap, so the cost is that replaced segment files linger for the rest of this
+		// reindex; releasing them earlier would mean restructuring a loop whose body branches with
+		// continue, which is not worth doing in a correctness fix.
+		defer unpinAll(pinned)
 		for _, t := range tgts {
 			if t.reseal {
 				c.reindexSealed(sh, t.seg, spec)

--- a/collections/pinsealed_test.go
+++ b/collections/pinsealed_test.go
@@ -1,0 +1,135 @@
+package collections
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/collections/vm"
+)
+
+// A sealed segment's CONTENT is immutable; its MAPPING is not. Compact, a merge, a rotation and a
+// reseal all retire a sealed segment and reap it -- munmap + unlink -- and they hold maintMu, not the
+// shard lock. So a reader that captures a *segment under the shard read lock, releases the lock, and
+// then reads seg.data is reading address space that may already be gone.
+//
+// That is a real production crash, not a theoretical one:
+//
+//	unexpected fault address 0x7fde6772b057
+//	[signal SIGSEGV ...]
+//	huff0.(*bitReaderShifted).init ... zstd.(*Decoder).DecodeAll
+//	collections.buildColumnarFromSegment(...)   <- reading seg.data
+//	collections.(*Collection).EnableSchemaScan
+//	db.(*DB).Maintain                            <- admin RPC
+//	  ... concurrently ...
+//	collections.(*segment).reap -> unix.Munmap
+//	collections.(*Collection).compactShard
+//	db.(*DB).Compact                             <- background maintenance goroutine
+//
+// The fault address sits INSIDE a slice whose bounds are valid, which is why this reads as correct
+// code. Three call sites carried a comment asserting sealed segments were safe to read off-lock.
+
+// pinRaceFixture builds a persistent collection with several sealed segments and enough superseded
+// records that a compaction actually rewrites and reaps them.
+func pinRaceFixture(t *testing.T, n int) *Collection {
+	t.Helper()
+	c, err := Open(Options{Dir: t.TempDir(), Shards: 1, SegmentSize: 1 << 16})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < n; i++ {
+		if err := c.Put([]byte(fmt.Sprintf("k%d", i)),
+			mustAdOld(t, fmt.Sprintf("ClusterId = %d\nProcId = %d\nMemory = %d\nOwner = \"u%d\"",
+				i/10, i%10, 1024+(i%64)*512, i%32))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Supersede every key so compaction has garbage to reclaim and will retire the originals.
+	for i := 0; i < n; i++ {
+		if err := c.Put([]byte(fmt.Sprintf("k%d", i)),
+			mustAdOld(t, fmt.Sprintf("ClusterId = %d\nProcId = %d\nMemory = %d\nOwner = \"v%d\"",
+				i/10, i%10, 2048+(i%64)*512, i%32))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return c
+}
+
+// TestSchemaScanBuildSurvivesConcurrentCompaction reproduces the crash deterministically: the
+// transcode is stalled mid-build (holding the segment) while a compaction runs to completion, and
+// then the build reads the segment's bytes. Unpinned, that read is a use-after-munmap.
+func TestSchemaScanBuildSurvivesConcurrentCompaction(t *testing.T) {
+	c := pinRaceFixture(t, 4000)
+	defer c.Close()
+
+	// Fire once, and NON-REENTRANTLY. Compact itself reaches buildColSegment (via
+	// reindexAfterCompaction -> Reindex -> sealAndEvictShard -> colBlobForSeg), so a hook that held
+	// any lock while waiting for Compact would deadlock against its own nested call. The CAS is
+	// claimed before the compaction starts, so the nested call returns immediately.
+	var fired atomic.Bool
+	colBuildStallHook = func() {
+		if !fired.CompareAndSwap(false, true) {
+			return
+		}
+		// Compact takes maintMu, which the build does not hold, so it proceeds -- and retires and
+		// reaps the very segments this build is walking.
+		done := make(chan int, 1)
+		go func() { done <- c.Compact() }()
+		t.Logf("compaction reclaimed %d segment(s) while a transcode held one", <-done)
+	}
+	defer func() { colBuildStallHook = nil }()
+
+	if !c.BuildAndEnableSchemaScan(2000, 4) {
+		t.Skip("nothing to sample")
+	}
+
+	// The accelerator must still answer, and agree with the ordinary query path. Ground truth comes
+	// from Query rather than allBruteCount: this collection is PERSISTENT, so its records store
+	// attribute names inline and an interned-id lookup finds nothing.
+	q, err := vm.Parse("Memory >= 2048")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := 0
+	for range c.Query(q) {
+		want++
+	}
+	got, served := c.CountConstraint("Memory >= 2048")
+	if !served {
+		t.Skip("columnar path declined; the build produced no usable block")
+	}
+	if got != want {
+		t.Errorf("columnar count %d != row count %d after a build raced compaction", got, want)
+	}
+}
+
+// TestReindexSurvivesConcurrentCompaction covers the same hole in Reindex, which decompresses every
+// record it covers off-lock while holding only reindexMu -- which does not exclude Compact.
+func TestReindexSurvivesConcurrentCompaction(t *testing.T) {
+	c := pinRaceFixture(t, 4000)
+	defer c.Close()
+	if !c.AddIndex([]string{"Owner"}, nil) {
+		t.Skip("AddIndex declined")
+	}
+	var wg sync.WaitGroup
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() { defer wg.Done(); c.Reindex() }()
+		wg.Add(1)
+		go func() { defer wg.Done(); c.Compact() }()
+	}
+	wg.Wait()
+	// Still queryable and consistent.
+	q, err := vm.Parse("Owner =!= undefined")
+	if err != nil {
+		t.Fatal(err)
+	}
+	n := 0
+	for range c.Query(q) {
+		n++
+	}
+	if n == 0 {
+		t.Error("no records returned after concurrent reindex + compaction")
+	}
+}

--- a/collections/sealed_index.go
+++ b/collections/sealed_index.go
@@ -288,18 +288,13 @@ func (c *Collection) sealAndEvictShard(sh *shard) {
 	if c.dir == "" {
 		return // RAM collection: no file sidecars, the directory stays resident
 	}
-	// Phase A: snapshot the sealed persistent segments under the read lock. The active
-	// segment is skipped (still appended to); its keys stay resident.
-	sh.mu.RLock()
-	act := sh.act
-	var segs []*segment
-	for _, seg := range sh.segs {
-		if seg == nil || seg == act || seg.used == 0 {
-			continue
-		}
-		segs = append(segs, seg)
-	}
-	sh.mu.RUnlock()
+	// Phase A: snapshot the sealed persistent segments, PINNED. The active segment is skipped
+	// (still appended to); its keys stay resident. The pin matters because Phase B reads each
+	// segment's bytes off the shard lock to build its key index, and a concurrent compaction would
+	// otherwise munmap them mid-build; it is released only after Phase C, since unpin is what
+	// performs a deferred reap and Phase C still touches the segments.
+	segs := sh.pinSealed(nil)
+	defer unpinAll(segs)
 
 	// Phase B: build any missing key sidecars off-lock (file I/O). sealSegmentIndex is
 	// idempotent and folds in the attribute index if one is already built for the segment,

--- a/collections/shard.go
+++ b/collections/shard.go
@@ -623,6 +623,46 @@ func (sh *shard) buildWindowsLocked(s0 uint64) []segWindow {
 // releaseWindows drops the pins snapshot took, allowing any mmap segment retired
 // during the scan to be reaped. Balances snapshot; call it exactly once per
 // snapshot (typically deferred). No-op for RAM segments.
+// pinSealed snapshots sh's sealed segments -- every segment except the active append target --
+// that keep accepts, PINNED, and the caller must unpinAll the result.
+//
+// It exists because "sealed" guarantees the CONTENT will not change; it says nothing about how long
+// the MAPPING lives. Compact, a merge, a rotation and a reseal all retire a sealed segment and reap
+// it (munmap + unlink) as soon as its pin count reaches zero, and they hold maintMu rather than the
+// shard lock, so nothing stops them from doing it to a segment a reader captured and then released
+// the shard lock over.
+//
+// The failure mode is why this helper is worth having rather than open-coding the loop: reading a
+// reaped segment faults at an address INSIDE a slice whose bounds are still perfectly valid, so it
+// looks nothing like an out-of-range bug, and the code that does it reads as obviously correct --
+// three separate call sites had a comment asserting that sealed segments are safe to read off-lock.
+// A pin makes it true, by deferring the reap to unpin.
+func (sh *shard) pinSealed(keep func(seg *segment) bool) []*segment {
+	sh.mu.RLock()
+	defer sh.mu.RUnlock()
+	act := sh.act
+	var out []*segment
+	for _, seg := range sh.segs {
+		if seg == nil || seg == act || seg.used == 0 {
+			continue
+		}
+		if keep != nil && !keep(seg) {
+			continue
+		}
+		seg.pin() // documented as "called under the shard read lock"
+		out = append(out, seg)
+	}
+	return out
+}
+
+// unpinAll releases pins taken by pinSealed. Must be called with no shard lock held: the last pin
+// drop is what performs a deferred reap.
+func unpinAll(segs []*segment) {
+	for _, seg := range segs {
+		seg.unpin()
+	}
+}
+
 func releaseWindows(wins []segWindow) {
 	for i := range wins {
 		wins[i].seg.unpin()


### PR DESCRIPTION
Fixes the reported SIGSEGV. **Use-after-munmap**: a sealed segment was reaped by a concurrent compaction while a columnar transcode was reading its bytes.

```
unexpected fault address 0x7fde6772b057
[signal SIGSEGV: segmentation violation code=0x1 addr=0x7fde6772b057]

huff0.(*bitReaderShifted).init ... zstd.(*Decoder).DecodeAll
collections.buildColumnarFromSegment({0x7fde67200000, 0x800000, 0x800000}, ...)   <- reading seg.data
collections.(*Collection).EnableSchemaScan
db.(*DB).Maintain                          <- admin RPC (dbrpc admin)

  ... concurrently, same *Collection 0xc000451c08 ...

collections.(*segment).reap -> unix.Munmap
collections.(*Collection).compactShard
db.(*DB).Compact                           <- background maintenance goroutine
```

The faulting address is **inside** the segment slice (`base=0x7fde67200000, len=0x800000`), so the bounds were valid and the mapping was gone.

## Cause

"Sealed" guarantees a segment's **content** will not change. It says nothing about how long the **mapping** lives. `Compact`, a merge, a rotation and a reseal all retire a sealed segment and reap it (munmap + unlink), and they hold `maintMu` — **not** the shard lock. So a reader that captures a `*segment` under the shard read lock, releases the lock, and then reads `seg.data` is reading freed address space.

`segment.refs` — the pin count — exists for exactly this, and `retire()` defers the reap while pins are held. Only scans (via `shard.snapshot`/`releaseWindows`) and transactions were using it. **Three** call sites captured raw pointers and read off-lock, each with a comment asserting it was safe:

| site | what it reads off-lock | lock held |
|---|---|---|
| `EnableSchemaScan` | transcodes every record of every sealed segment | none |
| `Reindex` | decompresses every record it covers | `reindexMu` only |
| `sealAndEvictShard` | builds key indexes in Phase B | none |

None of those exclude `maintMu`. Reindex's comment even names the exception it doesn't handle: *"sealed (immutable until compacted)"*.

## Fix

A `shard.pinSealed(keep)` / `unpinAll` pair, used at all three sites, so the reap is deferred until the reader is done.

`EnableSchemaScan` releases each pin as soon as that segment's block is built rather than holding them all — a pin defers a reap, and a whole-archive transcode runs long enough that holding every pin would keep each replaced segment's file on disk for the duration. `Reindex` holds its shard's pins to the end: releasing per target would mean restructuring a loop that branches with `continue`, which isn't worth doing in a correctness fix.

## The test forces the race rather than hoping for it

A test seam stalls the transcode mid-build, holding a segment, while a compaction runs to completion and reaps it. Verified both directions:

- **with the fix**: passes, and the columnar count agrees with the query path
- **without the fix**: dies immediately — `slice bounds out of range [695758435:65536]`

That macOS symptom is the same use-after-reap as the production Linux SIGSEGV; the recycled mapping yields garbage lengths instead of an unmapped page.

Two things worth recording, both of which cost time here:

- The hook **must be non-reentrant**. `Compact` itself reaches `buildColSegment` (via `reindexAfterCompaction` → `Reindex` → `sealAndEvictShard` → `colBlobForSeg`), so a hook that holds a lock while awaiting `Compact` deadlocks against its own nested call.
- Ground truth must come from `Query`, not `allBruteCount`: this fixture is **persistent**, so records store attribute names inline and an interned-id lookup matches nothing. My first version compared 4000 against a silent 0.

## Why the class is hard to see

The fault lands at an address inside a slice whose bounds are still perfectly valid, so it looks nothing like an out-of-range bug, and the offending code reads as obviously correct. That's why the fix is a named helper carrying the explanation rather than three open-coded `pin()` calls.

`collections`, `db`, `dbrpc` green, plus `-race` over the concurrency-sensitive subset.
