### PR TITLE
collections: estimate the presence probes instead of falling through

### DIFF
--- a/collections/archive_mmapindex.go
+++ b/collections/archive_mmapindex.go
@@ -534,3 +534,10 @@ func cmpStrBytes(s string, b []byte) int {
 	}
 	return 0
 }
+
+// recordCount is the number of records this segment's index covers. Unlike the per-attribute
+// summaries -- parsed eagerly so the planner never pages the postings -- this reads the
+// all-records bitmap out of the mapping, which is why indexEstCandidates calls it only for the
+// presence probes. An `absent` probe's execution clones the same bitmap, so a probe that is
+// estimated and then run pays for it once either way.
+func (si *mmapSegIndex) recordCount() uint64 { return si.allBitmap().GetCardinality() }

--- a/collections/index_query.go
+++ b/collections/index_query.go
@@ -1462,3 +1462,7 @@ func (c *Collection) backfillWindow(sh *shard) map[*segment]bool {
 	}
 	return window
 }
+
+// recordCount is the number of records this segment's index covers. The all-records bitmap is
+// already materialized for this tier, so it is a cardinality read.
+func (si *segIndex) recordCount() uint64 { return si.all.GetCardinality() }

--- a/collections/match_index.go
+++ b/collections/match_index.go
@@ -176,7 +176,7 @@ func (c *Collection) ExplainMatch(job *classad.ClassAd, targetConstraint string)
 				ex.IndexUsable++
 				if cand, covered := c.estimateCandidates(up); covered {
 					pe.HasSelectivity = true
-					pe.EstCandidates = int64(cand + 0.5)
+					pe.EstCandidates = clampEst(cand, total)
 					if total > 0 {
 						pe.Selectivity = math.Min(1, cand/float64(total))
 					}
@@ -258,7 +258,7 @@ func (c *Collection) meldTargetConstraint(ex *MatchExplain, targetConstraint str
 			ex.IndexUsable++
 			if cand, covered := c.estimateCandidates(up); covered {
 				pe.HasSelectivity = true
-				pe.EstCandidates = int64(cand + 0.5)
+				pe.EstCandidates = clampEst(cand, total)
 				if total > 0 {
 					pe.Selectivity = math.Min(1, cand/float64(total))
 				}
@@ -953,4 +953,20 @@ func (c *Collection) indexedMatches(job *classad.ClassAd, groups [][]usableProbe
 func overSelectivityGate(c *Collection, groups [][]usableProbe) bool {
 	frac, ok := c.planFrac(groups)
 	return ok && frac > maxPushdownFrac
+}
+
+// clampEst caps a reported candidate estimate at the collection's live count.
+//
+// The estimate is summed over segment indexes, which cover every record the index visits --
+// including versions later superseded and not yet compacted away. That is the right quantity
+// for ORDERING probes, since the index really does visit them, but it is not a number of ads:
+// on a table with churn it exceeds the live count, and reporting "~157455 of 135814" reads as
+// impossible rather than as "expect no pruning". Selectivity is already clamped the same way,
+// so this only stops the two halves of one line disagreeing.
+func clampEst(cand float64, total int) int64 {
+	n := int64(cand + 0.5)
+	if total > 0 && n > int64(total) {
+		return int64(total)
+	}
+	return n
 }

--- a/collections/presence_selectivity_test.go
+++ b/collections/presence_selectivity_test.go
@@ -1,0 +1,116 @@
+package collections
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/classad"
+)
+
+// presenceEstimates returns the estimated candidates for `attr is undefined` and
+// `attr isnt undefined` over c, summed across segments the way the planner sees them.
+func presenceEstimates(t *testing.T, c *Collection, attr string, cat bool) (absent, present float64) {
+	t.Helper()
+	spec := c.spec.Load()
+	var id uint32
+	var ok bool
+	if spec.inline {
+		id, ok = spec.nameToID[attr]
+	} else {
+		id, ok = c.intern.LookupID(attr)
+	}
+	if !ok {
+		t.Fatalf("%s is not indexed; the estimator would not be consulted", attr)
+	}
+	mk := func(op string) usableProbe { return usableProbe{attrID: id, op: op, cat: cat} }
+	for _, sh := range c.shards {
+		for _, seg := range sh.segs {
+			if seg == nil {
+				continue
+			}
+			si := seg.idx.Load()
+			if si == nil {
+				continue
+			}
+			absent += indexEstCandidates(si, mk("absent"))
+			present += indexEstCandidates(si, mk("present"))
+		}
+	}
+	return absent, present
+}
+
+// TestPresenceEstimatesAreComplementary is the reported symptom: `attr is undefined` and
+// `attr isnt undefined` are complements, so their estimates must partition the indexed
+// records. Both were previously estimated at the count of records that HAVE the attribute,
+// so a probe matching nothing and a probe matching everything scored the same -- and
+// selectivity exists precisely to tell those apart.
+func TestPresenceEstimatesAreComplementary(t *testing.T) {
+	c := New(Options{Shards: 1, ValueAttrs: []string{"JobStatus"}})
+	defer c.Close()
+	const n = 400
+	for i := range n {
+		ad, err := classad.Parse(fmt.Sprintf(`[ ClusterId=%d; JobStatus=%d ]`, i, i%6))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := c.Put([]byte(fmt.Sprintf("%d.0", i)), ad); err != nil {
+			t.Fatal(err)
+		}
+	}
+	c.Reindex() // segment indexes (and their stats) are what the estimator reads
+	absent, present := presenceEstimates(t, c, "jobstatus", false)
+
+	// Every ad carries JobStatus, so `is undefined` matches nothing.
+	if absent > float64(n)*0.01 {
+		t.Errorf("`JobStatus is undefined` estimated %.0f of %d; every ad has JobStatus", absent, n)
+	}
+	if present < float64(n)*0.99 {
+		t.Errorf("`JobStatus isnt undefined` estimated %.0f of %d; every ad has JobStatus", present, n)
+	}
+	// The two partition the records: neither may exceed the total, and they must not both
+	// claim (nearly) all of them.
+	if sum := absent + present; sum > float64(n)*1.01 {
+		t.Errorf("absent(%.0f) + present(%.0f) = %.0f, exceeds %d indexed records",
+			absent, present, sum, n)
+	}
+}
+
+// TestPresenceEstimatesWithMixedPresence: with the attribute on only some ads, each estimate
+// must track its own side rather than both reporting the same number.
+func TestPresenceEstimatesWithMixedPresence(t *testing.T) {
+	c := New(Options{Shards: 1, ValueAttrs: []string{"JobStatus"}})
+	defer c.Close()
+	const n = 400
+	withAttr := 0
+	for i := range n {
+		text := fmt.Sprintf(`[ ClusterId=%d ]`, i)
+		if i%4 == 0 { // a quarter carry JobStatus
+			text = fmt.Sprintf(`[ ClusterId=%d; JobStatus=%d ]`, i, i%6)
+			withAttr++
+		}
+		ad, err := classad.Parse(text)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := c.Put([]byte(fmt.Sprintf("%d.0", i)), ad); err != nil {
+			t.Fatal(err)
+		}
+	}
+	c.Reindex() // segment indexes (and their stats) are what the estimator reads
+	absent, present := presenceEstimates(t, c, "jobstatus", false)
+
+	wantAbsent, wantPresent := float64(n-withAttr), float64(withAttr)
+	if absent < wantAbsent*0.9 || absent > wantAbsent*1.1 {
+		t.Errorf("absent estimate %.0f, want ~%.0f", absent, wantAbsent)
+	}
+	if present < wantPresent*0.9 || present > wantPresent*1.1 {
+		t.Errorf("present estimate %.0f, want ~%.0f", present, wantPresent)
+	}
+	// The bug made the absent estimate track the PRESENT count, so this is the ordering
+	// that actually mattered: with a quarter of ads carrying the attribute, `absent` must
+	// be the larger of the two.
+	if absent <= present {
+		t.Errorf("absent(%.0f) <= present(%.0f) when only %d of %d ads carry the attribute",
+			absent, present, withAttr, n)
+	}
+}

--- a/collections/readindex.go
+++ b/collections/readindex.go
@@ -42,6 +42,11 @@ type indexPrimitives interface {
 	probeOffsets(up usableProbe) *roaring.Bitmap
 	// coversProbe reports whether this segment indexes the probe's attribute.
 	coversProbe(up usableProbe) bool
+	// recordCount is how many records this segment's index covers -- the size of the set an
+	// `absent` probe subtracts from. Called ONLY for present/absent estimates: on the mmap
+	// tier it reads the all-records bitmap, which the planner otherwise deliberately avoids
+	// paging in, and which an absent probe's execution clones anyway.
+	recordCount() uint64
 	// bloomAbsent reports whether a categorical ==/in probe's values are ALL provably absent
 	// (via the per-segment bloom). false when undeterminable: no bloom, a value might be
 	// present, or the probe is not a categorical equality. The tiers differ only here (the
@@ -202,10 +207,17 @@ func indexSkipsPrefix(ix indexPrimitives, usable []usableProbe) bool {
 // indexEstCandidates estimates how many records a probe admits, for ordering only (never
 // correctness). estCandidatesFromStats holds the logic so it is testable on a bare segStats.
 func indexEstCandidates(ix indexPrimitives, up usableProbe) float64 {
-	return estCandidatesFromStats(ix.statsFor(up), up)
+	var total float64
+	// Only the presence probes need the segment's record count, and only they pay for it.
+	if up.op == "present" || up.op == "absent" {
+		total = float64(ix.recordCount())
+	}
+	return estCandidatesFromStats(ix.statsFor(up), total, up)
 }
 
-func estCandidatesFromStats(s *segStats, up usableProbe) float64 {
+// estCandidatesFromStats estimates the candidates one probe admits. total is the segment's
+// covered record count, needed only by the presence probes (0 otherwise).
+func estCandidatesFromStats(s *segStats, total float64, up usableProbe) float64 {
 	if s == nil {
 		return math.MaxFloat64 // unknown: apply last
 	}
@@ -233,6 +245,25 @@ func estCandidatesFromStats(s *segStats, up usableProbe) float64 {
 			return indexable - s.estEqualStr(strings.ToLower(up.svals[0])) + float64(s.exc)
 		}
 		return indexable
+	case "present":
+		// Executes as posted|exc, so every record carrying the attribute in any form is a
+		// candidate -- that is exactly `covered`.
+		return float64(s.covered)
+	case "absent":
+		// Executes as all AND NOT posted: the records with no indexed value, which includes
+		// the exceptional ones (present but not the indexed literal type) because those are
+		// re-verified rather than trusted.
+		//
+		// Without this case both presence probes fell through to the default below and were
+		// estimated at `indexable` -- so `attr is undefined` was estimated at the count of
+		// records that HAVE the attribute, and the two complementary probes scored
+		// identically instead of summing to the segment. On a table where every ad carries
+		// the attribute that is the difference between "matches nothing" and "matches
+		// everything", which is the whole of what selectivity decides.
+		if e := total - indexable; e > 0 {
+			return e
+		}
+		return 0
 	case "<", "<=", ">", ">=":
 		frac := s.estRange(up.op, up.fvals[0])
 		if up.twoSided() {


### PR DESCRIPTION
Reported from `.explain`: two complementary predicates each estimated at ~100%, and both claiming more candidates than the table has rows.

```
.explain JobStatus is undefined     -> est ~100.0% (~157455 of 135814)
.explain JobStatus isnt undefined   -> est ~100.0% (~157430 of 135814)
```

## Cause

`estCandidatesFromStats` switches on `==`, `in`, `!=`, `isnt` and the range ops. There was **no case for `present` or `absent`**, so both fell through to the default and were estimated at `indexable` — the count of records that **have** the attribute. For `absent` that is the complement of the right answer.

On a table where every ad carries `JobStatus`, `is undefined` matches nothing and was estimated to match everything, so it sorted **last** among the probes instead of first. That is the whole of what selectivity decides.

**Results were never wrong.** Both execution paths were already correct (`posted|exc`, and `all AND NOT posted`) — only the estimate was missing, so this is plan ordering, not correctness.

## Fix

- `present` → `covered`, matching what it executes.
- `absent` → the segment's record count minus the indexable ones, which keeps the exceptional records it re-verifies.

`absent` needs a per-segment record count, which `indexPrimitives` did not expose — `statsFor` is per-attribute. So it gains `recordCount()`, implemented on both tiers. It is called **only** for the presence probes: on the mmap tier it reads the all-records bitmap, which the planner otherwise deliberately avoids paging in ([v7 parses the per-attribute summaries eagerly for exactly that reason](collections/archive_mmapindex.go#L26)), and which an `absent` probe's execution clones anyway — so a probe that is estimated and then run pays for it once either way.

## The second number

The estimate sums over segment indexes, which cover every record the index visits — **including versions later superseded and not yet compacted**. That is the right quantity for ordering, but it is not a number of ads, so a churning table reported more candidates than it has rows. `Selectivity` was already clamped to 1; the raw count was not, which is why one line could read `~157455 of 135814`. Now clamped the same way.

The ~25 difference between the two runs in the report is just the table moving between commands.

## Testing

`TestPresenceEstimatesAreComplementary` reproduces the report directly — under the old behaviour it fails with `absent(400) + present(400) = 800, exceeds 400 indexed records`. `TestPresenceEstimatesWithMixedPresence` covers the ordering that actually matters: with a quarter of ads carrying the attribute, `absent` must be the larger estimate; the old code had them equal.

I verified both fail when the fix is reverted.

`go vet` and all five module suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
