### PR TITLE
db: fold constant tautologies in IsMatchAll (1 == 1 now hits the COUNT fast path)

### DIFF
--- a/db/archive.go
+++ b/db/archive.go
@@ -376,7 +376,25 @@ func (t *ArchiveTable) aggregateFromIndex(constraint string, groupCols []GroupCo
 // COUNT(*) fast path in dbrpc.
 func IsMatchAll(constraint string) bool {
 	c := strings.TrimSpace(constraint)
-	return c == "" || strings.EqualFold(c, "true")
+	if c == "" || strings.EqualFold(c, "true") {
+		return true
+	}
+	// Fold a constant tautology (e.g. "1 == 1", "true && true") to the same match-all
+	// fast paths as "true": a constraint that references no attribute and evaluates to
+	// TRUE matches every record. The no-reference check is essential -- a record-
+	// dependent expression must never fold even if it happens to evaluate true against
+	// an empty ad (e.g. "JobStatus =!= 2" is TRUE when JobStatus is absent but is not
+	// match-all), so anything referencing an attribute is left to the normal scan.
+	expr, err := classad.ParseExpr(c)
+	if err != nil {
+		return false
+	}
+	empty := classad.New()
+	if len(empty.ExternalRefs(expr)) != 0 {
+		return false
+	}
+	b, err := expr.Eval(empty).BoolValue()
+	return err == nil && b
 }
 
 // CategoricalGroupCounts returns the exact per-value record counts for a categorically

--- a/db/archive_count_test.go
+++ b/db/archive_count_test.go
@@ -50,6 +50,12 @@ func TestArchiveCountFastPath(t *testing.T) {
 	if rows[0].Values[0] != strconv.Itoa(n) {
 		t.Errorf(`COUNT(*) WHERE true = %s, want %d`, rows[0].Values[0], n)
 	}
+	// A constant tautology folds to the SAME match-all fast path as "true", so
+	// "1 == 1" and "true" agree with COUNT() -- they must never diverge.
+	rows, _ = hist.Aggregate("1 == 1", nil, []AggSpec{{Func: AggCount, Arg: "*"}})
+	if rows[0].Values[0] != strconv.Itoa(n) {
+		t.Errorf(`COUNT(*) WHERE 1 == 1 = %s, want %d (must equal WHERE true)`, rows[0].Values[0], n)
+	}
 
 	// Constrained COUNT(*) goes through the projected scan (not the fast path).
 	rows, err = hist.Aggregate("ClusterId >= 300", nil, []AggSpec{{Func: AggCount, Arg: "*"}})

--- a/db/ismatchall_test.go
+++ b/db/ismatchall_test.go
@@ -1,0 +1,38 @@
+package db
+
+import "testing"
+
+func TestIsMatchAll(t *testing.T) {
+	matchAll := []string{
+		"",
+		"true",
+		"TRUE",
+		"  true  ",
+		"1 == 1",
+		"  1 == 1  ",
+		"true && true",
+		"1 == 1 && 2 == 2",
+		"1 < 2",
+		"true || false",
+	}
+	for _, c := range matchAll {
+		if !IsMatchAll(c) {
+			t.Errorf("IsMatchAll(%q) = false, want true (constant tautology matches every record)", c)
+		}
+	}
+
+	notMatchAll := []string{
+		"false",
+		"1 == 2",
+		"JobStatus == 2",         // record-dependent
+		"JobStatus =!= 2",        // TRUE against an empty ad, but NOT match-all -- must not fold
+		"true || JobStatus == 2", // always true, but references an attribute: left to the scan
+		"Owner == \"alice\"",
+		"(&*^ not parseable",
+	}
+	for _, c := range notMatchAll {
+		if IsMatchAll(c) {
+			t.Errorf("IsMatchAll(%q) = true, want false", c)
+		}
+	}
+}


### PR DESCRIPTION
## Fold constant tautologies in `IsMatchAll`

`COUNT(*) WHERE 1 == 1` did a **full scan** while `COUNT(*) WHERE true` took the
O(1) match-all fast path — two semantically identical queries with very different
plans:

```
select count(*) from jobs where 1 == 1   -> 136378   785.06ms   (full scan)
select count(*) from jobs where true      -> 136359      153µs   (Len() fast path)
```

`IsMatchAll` recognized only `""` and `"true"`. It now also folds a **constant
tautology**: a constraint that parses, **references no attribute**, and evaluates
to **TRUE** matches every record, so it takes the same match-all fast paths (COUNT
via `Len()`, the archive whole-segment path).

The no-reference check is essential — a record-dependent expression must never
fold even when it happens to evaluate true against an empty ad. For example
`JobStatus =!= 2` is TRUE when `JobStatus` is absent but is **not** match-all, so
anything referencing an attribute is left to the normal scan.

### On the count difference (136378 vs 136359)
That gap is **churn**, not a `Len()` bug: the two queries ran ~0.8s apart on a live
`jobs` table and only the fast-path one reflects a single point-in-time via `Len()`
— jobs completing/leaving between them accounts for the 19-row drop. After this
fix both queries take the **same** plan, so at a given instant they agree (a
regression test asserts `COUNT(*) WHERE 1==1 == WHERE true`). `Len()`/`sh.count`
tracks live keys exactly for a non-chained table (insert `count++`, delete
tombstone `count--`, update no-op), which is why `true` correctly hit the fast path.

### Tests
`IsMatchAll` over constant tautologies vs record-dependent / false / unparseable
constraints (including the `=!=` empty-ad trap and `true || JobStatus==2`), plus
`COUNT(*) WHERE 1==1 == WHERE true` over an archive. Full db suite green.

> Reaches the user-visible dbrpc mutable-table COUNT fast path after a `db` tag +
> dbrpc/htcondordb bumps (both call `db.IsMatchAll`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
