### PR TITLE
collections: serve `attr is undefined` from the columnar escape bitmap (9.2x)

### DIFF
--- a/collections/colblock.go
+++ b/collections/colblock.go
@@ -379,6 +379,37 @@ func (b *columnarBlock) escapedNumField(k int, fieldID uint32, bc *blockCache) (
 	return 0, false, nil
 }
 
+// escapedNode returns the raw wire node an ESCAPED field holds in record k's cold tail, without
+// interpreting it. found=false means the attribute is not in the tail at all, i.e. genuinely absent
+// from the record.
+//
+// Presence needs the node rather than a value: whether an attribute is UNDEFINED depends on which
+// literal it is (or on evaluating it, if it is an expression), and a value-returning accessor throws
+// exactly that away. Reads only this field, not the whole record.
+func (b *columnarBlock) escapedNode(k int, fieldID uint32, bc *blockCache) (node []byte, found bool, err error) {
+	tail, err := bc.stream(b, kindCold)
+	if err != nil {
+		return nil, false, err
+	}
+	cold := tail[b.coldOff[k]:b.coldOff[k+1]]
+	for len(cold) > 0 {
+		id, m := binary.Uvarint(cold)
+		if m <= 0 {
+			return nil, false, nil // malformed tail: treat fieldID as absent
+		}
+		cold = cold[m:]
+		nl, ok := wire.NodeLen(cold)
+		if !ok || nl > len(cold) {
+			return nil, false, nil
+		}
+		if uint32(id) == fieldID {
+			return cold[:nl], true, nil
+		}
+		cold = cold[nl:]
+	}
+	return nil, false, nil
+}
+
 // escapedNumVal is escapedNumField returning the value WITH its ClassAd kind. A caller that
 // renders or sums the value needs the kind, and the cold tail carries the wire node, so it is read
 // from the node rather than assumed from the segment's schema (an escaped value is by definition

--- a/collections/colpresence.go
+++ b/collections/colpresence.go
@@ -1,0 +1,216 @@
+package collections
+
+import (
+	"github.com/PelicanPlatform/classad/collections/vm"
+	"github.com/PelicanPlatform/classad/collections/wire"
+)
+
+// Presence over the columnar accelerator: `attr is undefined` and `attr isnt undefined`.
+//
+// The escape bitmap already holds the answer for the common case. A schema field's escape bit is
+// clear exactly when its value sits in the record's fixed slot, which means the attribute is present
+// AND stored as a literal of the field's kind -- so it is defined, with no decode of any sort. On a
+// fitted schema the overwhelming majority of records are in that state, so a presence count is the
+// same strided bitmap read a MIN/MAX does.
+//
+// Before this, `count(*) where ProcId is undefined` was declined by the columnar path (numPredOnField
+// wants a scalar comparison and a presence probe carries no value), so it fell back to the generic row
+// scan: decompress every record and evaluate the whole constraint against a decoded ad. Measured on a
+// production jobs table, `max(ProcId)` took 120ms and `count(*) where ProcId is undefined` took
+// 1.124s over the same records.
+//
+// WHY THIS NEEDS CARE. `X is undefined` is `X =?= UNDEFINED`, which is an EVALUATION, not a presence
+// test. Present-and-defined are not the same thing:
+//
+//   - escape bit clear -> a literal of the field's kind is in the slot -> defined.
+//   - escape bit set -> the attribute is missing, or present but not storable in the slot. Look it
+//     up in the cold tail:
+//   - not there at all -> genuinely absent -> UNDEFINED.
+//   - a literal -> defined, whatever its kind. A ProcId stored as a string escaped on TYPE, and a
+//     string is not undefined.
+//   - the UNDEFINED literal itself -> UNDEFINED. Present is not the same as defined.
+//   - the ERROR literal -> not undefined (`ERROR =?= UNDEFINED` is false).
+//   - an EXPRESSION -> its value depends on the rest of the ad, so it cannot be judged from the
+//     node. The scan DECLINES and the caller falls back to the row path.
+//
+// Declining on an expression is the whole safety argument. A wrong count here would be silent, and
+// an expression-valued numeric attribute is exceptional by construction -- it escapes -- so the
+// decline costs nothing on data that does not have any.
+
+// presencePred describes a presence predicate the columnar path can serve.
+type presencePred struct {
+	fieldID    uint32
+	wantAbsent bool // true for `is undefined`, false for `isnt undefined`
+}
+
+// presencePredOnField analyzes q as a SINGLE presence probe on one field of schema s.
+//
+// ok=false for anything else: a non-native query, no probes, more than one probe, a probe that is
+// not present/absent, or an attribute the schema does not carry. Unlike numPredOnField this accepts
+// any schema field kind, since presence does not depend on the value's type.
+func (c *Collection) presencePredOnField(q *vm.Query, s *adSchema) (presencePred, bool) {
+	probes := q.Probes()
+	if !q.Native() || len(probes) != 1 {
+		return presencePred{}, false
+	}
+	p := probes[0]
+	if p.Op != "absent" && p.Op != "present" {
+		return presencePred{}, false
+	}
+	id, ok := c.intern.LookupID(p.Attr)
+	if !ok {
+		return presencePred{}, false
+	}
+	if _, ok := s.byID[id]; !ok {
+		return presencePred{}, false
+	}
+	return presencePred{fieldID: id, wantAbsent: p.Op == "absent"}, true
+}
+
+// nodeIsUndefined reports whether a wire node is UNDEFINED for `=?= UNDEFINED` purposes.
+//
+// ok=false means the node is an expression: it cannot be judged without evaluating it against the
+// rest of the ad, so the caller must decline rather than guess.
+func nodeIsUndefined(node []byte) (undefined bool, ok bool) {
+	lit, isLit := wire.LiteralValue(node)
+	if !isLit {
+		return false, false // an expression
+	}
+	return lit.Kind == wire.LitUndef, true
+}
+
+// PresenceCountQuery counts the records matching a single `attr is undefined` / `attr isnt
+// undefined` predicate over the columnar accelerator.
+//
+// Returns ok=false when the columnar path cannot serve it -- the accelerator is off, the predicate is
+// not a lone presence probe on a schema field, or some record's value for the attribute is an
+// EXPRESSION, which needs evaluating. A caller that gets false scans instead.
+func (c *Collection) PresenceCountQuery(q *vm.Query) (int, bool) {
+	st := c.schemaScan.Load()
+	if st == nil || c.intern == nil || q == nil {
+		return 0, false
+	}
+	pred, ok := c.presencePredOnField(q, st.schema)
+	if !ok {
+		return 0, false
+	}
+	// Record the read, as the numeric paths do, so serving a column faster does not make it
+	// invisible to the hot-tier demand signal.
+	if name, ok := c.schemaFieldName(pred.fieldID); ok {
+		c.demand.recordReads([]string{name})
+	}
+	return c.schemaScanPresenceCount(pred, st.cache)
+}
+
+// schemaScanPresenceCount counts live records whose attribute is (or is not) undefined.
+//
+// Per sealed segment it resolves the field against that segment's OWN schema -- segments sealed under
+// different schemas coexist -- and reads the escape bitmap. A segment whose schema lacks the field,
+// and the active segment (which has no block), fall back to a row walk that reads only that one
+// attribute rather than decoding the whole ad. Returns ok=false if any visible record's value is an
+// expression.
+func (c *Collection) schemaScanPresenceCount(pred presencePred, bc *blockCache) (int, bool) {
+	// The row fallback must honor the collection's wire mode: inline names on a persistent store,
+	// interned ids in memory.
+	lookup := func(a wire.Ad) ([]byte, bool) { return a.Lookup(pred.fieldID) }
+	if c.inline {
+		if name, ok := c.intern.Name(pred.fieldID); ok {
+			lookup = func(a wire.Ad) ([]byte, bool) { return a.LookupByName(name) }
+		}
+	}
+	count := 0
+	tally := func(undefined bool) {
+		if undefined == pred.wantAbsent {
+			count++
+		}
+	}
+	for _, sh := range c.shards {
+		s0, wins := sh.snapshot()
+		for _, w := range wins {
+			cs := w.seg.colblk.Load()
+			idx := -1
+			if sch := cs.schema(); sch != nil {
+				if i, ok := sch.byID[pred.fieldID]; ok {
+					idx = i
+				}
+			}
+			if idx < 0 {
+				if !brutePresence(w, s0, lookup, tally) {
+					releaseWindows(wins)
+					return 0, false
+				}
+				continue
+			}
+			base := 0
+			for _, blk := range cs.blocks {
+				for k := 0; k < blk.n; k++ {
+					gk := base + k
+					if gk >= len(cs.offs) {
+						break
+					}
+					o := cs.offs[gk]
+					if !(recSeq(w.data, o) <= s0 && recSuperseded(w.data, o) > s0) {
+						continue // not visible at this snapshot
+					}
+					if !testBit(blk.escapeAt(k), idx) {
+						tally(false) // value is in its fixed slot: present and a literal
+						continue
+					}
+					// Escaped: missing, or present but not storable in the slot. Read just this
+					// field from the cold tail -- not the whole record.
+					node, found, err := blk.escapedNode(k, pred.fieldID, bc)
+					if err != nil {
+						releaseWindows(wins)
+						return 0, false
+					}
+					if !found {
+						tally(true) // genuinely absent
+						continue
+					}
+					undef, ok := nodeIsUndefined(node)
+					if !ok {
+						releaseWindows(wins) // an expression: only evaluation can answer
+						return 0, false
+					}
+					tally(undef)
+				}
+				base += blk.n
+			}
+		}
+		releaseWindows(wins)
+	}
+	return count, true
+}
+
+// brutePresence is the row fallback: walk a window's visible records and classify the attribute from
+// its wire node. It reads ONE attribute per record rather than decoding the ad. Returns false if a
+// value is an expression, which the caller must answer by evaluation.
+func brutePresence(w segWindow, s0 uint64, lookup func(wire.Ad) ([]byte, bool), tally func(bool)) bool {
+	var buf []byte
+	for off := 0; off < w.used; {
+		o := uint32(off)
+		total := recTotalLen(w.data, o)
+		if total == 0 {
+			break
+		}
+		if !recIsMarker(w.data, o) && recSeq(w.data, o) <= s0 && recSuperseded(w.data, o) > s0 {
+			ww, err := w.codec.Decompress(buf[:0], recAd(w.data, o))
+			if err != nil {
+				return false
+			}
+			buf = ww
+			node, found := lookup(wire.Ad(ww))
+			if !found {
+				tally(true)
+			} else {
+				undef, ok := nodeIsUndefined(node)
+				if !ok {
+					return false
+				}
+				tally(undef)
+			}
+		}
+		off += int(total)
+	}
+	return true
+}

--- a/collections/colpresence_bench_test.go
+++ b/collections/colpresence_bench_test.go
@@ -1,0 +1,63 @@
+package collections
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/collections/vm"
+)
+
+// What the columnar presence path is worth against the row scan it replaces, on the reported query
+// shape: count(*) where ProcId is undefined.
+func BenchmarkPresenceCount(b *testing.B) {
+	c := New(Options{Shards: 1, SegmentSize: 1 << 20})
+	defer c.Close()
+	const n = 60000
+	for i := 0; i < n; i++ {
+		src := fmt.Sprintf("ClusterId = %d\nProcId = %d\nOwner = \"user%d\"\nCmd = \"/home/user%d/run.sh\"\n"+
+			"JobStatus = %d\nRequestMemory = %d\nArgs = \"--in in%d.dat --out out%d.dat\"",
+			i/10, i%10, i%512, i%512, 1+i%5, 1024+(i%32)*512, i, i)
+		if i%997 == 0 {
+			src = fmt.Sprintf("ClusterId = %d\nOwner = \"user%d\"\nCmd = \"/home/user%d/run.sh\"", i/10, i%512, i%512)
+		}
+		if err := c.Put([]byte(fmt.Sprintf("k%d", i)), mustAdOld(b, src)); err != nil {
+			b.Fatal(err)
+		}
+	}
+	q, err := vm.Parse("ProcId >= 0")
+	if err != nil {
+		b.Fatal(err)
+	}
+	for i := 0; i < 20; i++ {
+		for range c.Query(q) {
+		}
+	}
+	if !c.BuildAndEnableSchemaScan(4000, 8) {
+		b.Skip("no sealed segments")
+	}
+	pq, err := vm.Parse("ProcId is undefined")
+	if err != nil {
+		b.Fatal(err)
+	}
+	if _, ok := c.CountQuery(pq); !ok {
+		b.Skip("columnar presence path declined")
+	}
+
+	b.Run("columnar", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			if _, ok := c.CountQuery(pq); !ok {
+				b.Fatal("declined mid-benchmark")
+			}
+		}
+	})
+	b.Run("rowScan", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			n := 0
+			for range c.Query(pq) {
+				n++
+			}
+		}
+	})
+}

--- a/collections/colpresence_test.go
+++ b/collections/colpresence_test.go
@@ -1,0 +1,192 @@
+package collections
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/collections/vm"
+)
+
+// `attr is undefined` over the columnar accelerator. The risk is not speed, it is that "present" and
+// "defined" are different things, so every shape that separates them is exercised here against the
+// row path's answer.
+
+// presenceFixture builds a store whose ProcId column exercises every classification:
+//
+//	most records   ProcId is a small int          -> in the fixed slot, not escaped
+//	i%97 == 0      ProcId missing entirely        -> escaped, absent from the cold tail  -> UNDEFINED
+//	i%101 == 0     ProcId is a string             -> escaped on TYPE, tail has a literal -> defined
+//	i%103 == 0     ProcId out of the fitted width -> escaped on WIDTH, literal           -> defined
+//	i%107 == 0     ProcId is literally undefined  -> escaped, tail holds LitUndef        -> UNDEFINED
+//
+// The exceptional rates are ~1% each on purpose. buildAdSchema only makes an attribute a schema
+// field when its dominant storable kind covers >= 90% of the sample, so a fixture that makes ProcId
+// undefined in 14% of records has no ProcId FIELD at all -- the accelerator then declines for a
+// reason that has nothing to do with presence, and the test passes vacuously or skips.
+func presenceFixture(t *testing.T, n int) *Collection {
+	t.Helper()
+	c := New(Options{Shards: 1, SegmentSize: 1 << 16})
+	for i := 0; i < n; i++ {
+		var src string
+		switch {
+		case i%97 == 0:
+			src = fmt.Sprintf("ClusterId = %d\nOwner = \"u%d\"", i/10, i%32) // no ProcId
+		case i%101 == 0:
+			src = fmt.Sprintf("ClusterId = %d\nProcId = \"notanint\"\nOwner = \"u%d\"", i/10, i%32)
+		case i%103 == 0:
+			src = fmt.Sprintf("ClusterId = %d\nProcId = %d\nOwner = \"u%d\"", i/10, 1<<40+i, i%32)
+		case i%107 == 0:
+			src = fmt.Sprintf("ClusterId = %d\nProcId = undefined\nOwner = \"u%d\"", i/10, i%32)
+		default:
+			src = fmt.Sprintf("ClusterId = %d\nProcId = %d\nOwner = \"u%d\"", i/10, i%10, i%32)
+		}
+		if err := c.Put([]byte(fmt.Sprintf("k%d", i)), mustAdOld(t, src)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	q, err := vm.Parse("ProcId >= 0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 20; i++ {
+		for range c.Query(q) {
+		}
+	}
+	if !c.BuildAndEnableSchemaScan(4000, 4) {
+		t.Skip("no sealed segments")
+	}
+	return c
+}
+
+// rowTruth counts a constraint the ordinary way, which is the reference every case is checked against.
+func rowTruth(t *testing.T, c *Collection, expr string) int {
+	t.Helper()
+	q, err := vm.Parse(expr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	n := 0
+	for range c.Query(q) {
+		n++
+	}
+	return n
+}
+
+// TestPresenceCountMatchesRowPath is the equivalence test, over data where present and defined come
+// apart in four different ways.
+func TestPresenceCountMatchesRowPath(t *testing.T) {
+	c := presenceFixture(t, 4000)
+	defer c.Close()
+
+	for _, expr := range []string{"ProcId is undefined", "ProcId isnt undefined"} {
+		want := rowTruth(t, c, expr)
+		q, err := vm.Parse(expr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got, served := c.CountQuery(q)
+		if !served {
+			t.Fatalf("%s: columnar path declined; it should serve a lone presence probe", expr)
+		}
+		if got != want {
+			t.Errorf("%s: columnar %d != row %d", expr, got, want)
+		}
+		t.Logf("%-22s columnar=%d row=%d", expr, got, want)
+	}
+	// The fixture must actually contain undefined records, or the equality above is vacuous.
+	if n := rowTruth(t, c, "ProcId is undefined"); n == 0 {
+		t.Error("fixture has no undefined ProcId; the test proves nothing")
+	}
+}
+
+// TestPresenceCountDeclinesOnExpression is the safety property. An expression's value depends on the
+// rest of the ad, so it cannot be classified from its node -- the columnar path must DECLINE and let
+// the caller evaluate, rather than guess that "present" means "defined".
+func TestPresenceCountDeclinesOnExpression(t *testing.T) {
+	c := New(Options{Shards: 1, SegmentSize: 1 << 16})
+	defer c.Close()
+	for i := 0; i < 3000; i++ {
+		src := fmt.Sprintf("ClusterId = %d\nProcId = %d\nOwner = \"u%d\"", i/10, i%10, i%32)
+		if i == 1500 {
+			// An expression that evaluates to UNDEFINED (NoSuchAttr is absent), so a
+			// presence-only reading would get the answer WRONG rather than merely imprecise.
+			src = fmt.Sprintf("ClusterId = %d\nProcId = NoSuchAttr + 1\nOwner = \"u%d\"", i/10, i%32)
+		}
+		if err := c.Put([]byte(fmt.Sprintf("k%d", i)), mustAdOld(t, src)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if !c.BuildAndEnableSchemaScan(4000, 4) {
+		t.Skip("no sealed segments")
+	}
+	q, err := vm.Parse("ProcId is undefined")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, served := c.CountQuery(q)
+	if served {
+		t.Errorf("columnar path served a query over an expression-valued attribute (returned %d); "+
+			"only evaluation can decide whether that record is undefined", got)
+	}
+	// And the ordinary path still answers correctly: the expression evaluates to undefined.
+	if want := rowTruth(t, c, "ProcId is undefined"); want != 1 {
+		t.Errorf("row path counted %d undefined, want 1 (the expression evaluates to undefined)", want)
+	}
+}
+
+// TestPresenceCountMVCC checks visibility: a superseded version must not be counted, in either
+// direction, or an update would shift the answer.
+func TestPresenceCountMVCC(t *testing.T) {
+	c := New(Options{Shards: 1, SegmentSize: 1 << 16})
+	defer c.Close()
+	const n = 2000
+	const undef = 100 // ~5%: enough to be countable, few enough that ProcId stays a schema field
+	for i := 0; i < n; i++ {
+		// Every record starts WITH a ProcId.
+		if err := c.Put([]byte(fmt.Sprintf("k%d", i)),
+			mustAdOld(t, fmt.Sprintf("ClusterId = %d\nProcId = %d\nOwner = \"u%d\"", i/10, i%10, i%32))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Supersede a few with versions that LACK ProcId. Counting a superseded (defined) version
+	// instead of its live (undefined) replacement would undercount.
+	for i := 0; i < undef; i++ {
+		if err := c.Put([]byte(fmt.Sprintf("k%d", i)),
+			mustAdOld(t, fmt.Sprintf("ClusterId = %d\nOwner = \"u%d\"", i/10, i%32))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if !c.BuildAndEnableSchemaScan(4000, 4) {
+		t.Skip("no sealed segments")
+	}
+	q, err := vm.Parse("ProcId is undefined")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, served := c.CountQuery(q)
+	if !served {
+		t.Fatal("columnar path declined; ProcId should be a schema field in this fixture")
+	}
+	want := rowTruth(t, c, "ProcId is undefined")
+	if want != undef {
+		t.Fatalf("row truth is %d, want %d: the fixture is not shaped as intended", want, undef)
+	}
+	if got != want {
+		t.Errorf("columnar %d != row %d; superseded versions are being counted", got, want)
+	}
+}
+
+// TestPresenceCountUnknownAttrDeclines pins the routing: an attribute the schema does not carry is
+// not columnar-servable, so the caller must fall back rather than get a wrong answer from a bitmap
+// that has no bit for it.
+func TestPresenceCountUnknownAttrDeclines(t *testing.T) {
+	c := presenceFixture(t, 2000)
+	defer c.Close()
+	q, err := vm.Parse("NotAnAttribute is undefined")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, served := c.CountQuery(q); served {
+		t.Errorf("served a presence query on an attribute with no schema field (returned %d)", got)
+	}
+}

--- a/collections/colscan.go
+++ b/collections/colscan.go
@@ -538,7 +538,9 @@ func (c *Collection) CountQuery(q *vm.Query) (int, bool) {
 	// resolves the field per block against each block's own schema.
 	fieldID, eval, ok := c.numPredOnField(q, st.schema)
 	if !ok {
-		return 0, false
+		// Not a scalar comparison. A lone presence probe (`attr is undefined`) is still
+		// columnar-servable straight from the escape bitmap -- see PresenceCountQuery.
+		return c.PresenceCountQuery(q)
 	}
 	// As NumStatsQuery: record the predicate's attribute so the hot tier keeps tracking the
 	// columns queries actually read, instead of freezing once the accelerator starts serving them.


### PR DESCRIPTION
Stacked on #167 (the use-after-munmap fix); both touch `colscan.go`. Base retargets to `main` once that merges.

## The reported pair

```
select max(ProcId) from jobs                            -> 120.3ms
select count(*) from jobs where ProcId is undefined     ->  1.124s
```

`MAX` routes to the columnar accelerator — a strided read of the hot column, no decode. The presence query was **declined**: `is undefined` compiles to a presence probe, `numPredOnField` wants a scalar comparison, and a presence probe carries no value ([colagg.go:152](collections/colagg.go#L152)). So it fell back to the generic row scan, which decompresses every record and evaluates the whole constraint against a decoded ad.

Nothing about the question requires that. **A schema field's escape bit is clear exactly when its value sits in the fixed slot** — present *and* stored as a literal — so for nearly every record on a fitted schema the answer is one strided bitmap read, the same read `MIN`/`MAX` does.

| | time | allocs |
|---|---|---|
| row scan | 7.14 ms | 3.41 MB |
| columnar presence | **776 µs** | **345 KB** |

60k records, ~0.1% absent, medians of 3. **9.2x** — the same ratio as the reported pair (1.124s / 120.3ms = 9.3x).

## Present and DEFINED are not the same thing

`X is undefined` is `X =?= UNDEFINED`, an *evaluation*. So escaped records are classified from their cold-tail node rather than assumed present:

| node in the cold tail | verdict | why |
|---|---|---|
| not there at all | **undefined** | genuinely missing |
| any literal | defined | a ProcId stored as a *string* escaped on type; a string is not undefined |
| the `UNDEFINED` literal | **undefined** | present ≠ defined |
| the `ERROR` literal | defined | `ERROR =?= UNDEFINED` is false |
| an **expression** | **decline** | value depends on the rest of the ad |

**Declining on an expression is the safety argument.** Only evaluation can decide, and a wrong count would be silent rather than an error. An expression-valued numeric attribute escapes by construction, so the decline costs nothing on data that has none — which is the case you described.

`escapedNode` returns the raw node for this; the existing `escapedNumVal` throws away exactly the distinction that matters.

Segments whose own schema lacks the field, and the active segment, fall back to a row walk that reads **one attribute** per record rather than decoding the ad — answering the "why does the row ever have to be fully decoded?" question: after this, for this query shape, it doesn't.

## Tests

Columnar answer checked against the row path over data where present and defined come apart four ways (missing, type exception, width exception, literal `undefined`), plus MVCC supersession, the expression decline, and an attribute with no schema field.

One fixture note worth recording: the exceptional rates are **~1% each on purpose**. `buildAdSchema` only makes an attribute a field when its dominant kind covers ≥90% of the sample, so my first fixture — 14% undefined — left ProcId with *no schema field at all*, and the accelerator then declined for a reason having nothing to do with presence. The test would have passed vacuously or skipped.

## Scope

Covers `is undefined` / `isnt undefined` where it is the **only** probe. A presence probe conjoined with other predicates still falls back; that needs the columnar path to combine predicates, which is a larger change.

`collections`, `db`, `dbrpc` green.
