### PR TITLE
collections: fix wrong columnar aggregate results — require EXACT probes before answering from them

### DIFF
--- a/collections/colagg.go
+++ b/collections/colagg.go
@@ -128,8 +128,12 @@ type colVal struct {
 // schema does not carry as a numeric field, probes spanning two fields, or a probe that is not a
 // scalar comparison (present/absent/in/isnt, or a non-numeric operand).
 func (c *Collection) numPredOnField(q *vm.Query, s *adSchema) (uint32, func(float64) bool, bool) {
-	probes := q.Probes()
-	if !q.Native() || len(probes) == 0 {
+	// ExactProbes, not Probes: this path answers from the probes and never re-verifies a record
+	// against the query, so an over-approximation would silently over-count. Probes omits any
+	// conjunct that is not `Attr OP literal`, and such a conjunct can still be NATIVE -- e.g.
+	// `ProcId >= 5 && ClusterId != ProcId` -- so Native() alone is not the guarantee it looks like.
+	probes, exact := q.ExactProbes()
+	if !q.Native() || !exact {
 		return 0, nil, false
 	}
 	fieldIdx := -1

--- a/collections/colexact_test.go
+++ b/collections/colexact_test.go
@@ -1,0 +1,112 @@
+package collections
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/collections/vm"
+)
+
+// The columnar aggregate paths answer from the query's PROBES and never re-verify a record against
+// the query. Probes is an over-approximation built for index pruning -- it omits any conjunct that is
+// not `Attr OP literal` -- so answering from it silently over-counts.
+//
+// The trap is that Native() looks like the guard for this and is not. An attribute-to-attribute
+// comparison compiles natively and is omitted from Probes, so `ProcId >= 5 && ClusterId != ProcId`
+// passed every gate and returned the count of `ProcId >= 5`: 1500 where the answer is 0.
+
+// exactFixture makes ClusterId == ProcId for every record, so `ClusterId != ProcId` excludes
+// everything and any path that ignores that conjunct is caught by a maximal margin.
+func exactFixture(t *testing.T, n int) *Collection {
+	t.Helper()
+	c := New(Options{Shards: 1, SegmentSize: 1 << 16})
+	for i := 0; i < n; i++ {
+		if err := c.Put([]byte(fmt.Sprintf("k%d", i)),
+			mustAdOld(t, fmt.Sprintf("ClusterId = %d\nProcId = %d\nOwner = \"u%d\"\nMemory = %d",
+				i%10, i%10, i%32, 1024+(i%16)*512))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if !c.BuildAndEnableSchemaScan(4000, 4) {
+		t.Skip("no sealed segments")
+	}
+	return c
+}
+
+// TestColumnarCountExactness is the regression: every query the columnar path AGREES to serve must
+// produce the row path's answer.
+func TestColumnarCountExactness(t *testing.T) {
+	c := exactFixture(t, 3000)
+	defer c.Close()
+
+	for _, expr := range []string{
+		"ProcId >= 5",                        // pure, servable
+		"ProcId >= 5 && ProcId <= 8",         // conjunction on one field, servable
+		"ProcId >= 5 && ClusterId != ProcId", // attr-to-attr conjunct: NATIVE but omitted from Probes
+		"ProcId >= 5 && Memory > ProcId",     // arithmetic-free attr-to-attr, same hole
+		"ProcId >= 5 && Owner == \"u3\"",     // two fields: declined for a different reason
+		"ProcId >= 5 || ProcId < 2",          // disjunction: not a conjunction at all
+	} {
+		q, err := vm.Parse(expr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := 0
+		for range c.Query(q) {
+			want++
+		}
+		got, served := c.CountQuery(q)
+		t.Logf("%-40s served=%-5v columnar=%-6d row=%d", expr, served, got, want)
+		if served && got != want {
+			t.Errorf("%s: columnar answered %d, row path says %d -- the columnar path served a "+
+				"query whose probes do not cover it", expr, got, want)
+		}
+	}
+}
+
+// TestColumnarStatsExactness covers the same hole in MIN/MAX/SUM, which share numPredOnField.
+func TestColumnarStatsExactness(t *testing.T) {
+	c := exactFixture(t, 3000)
+	defer c.Close()
+
+	q, err := vm.Parse("ProcId >= 5 && ClusterId != ProcId")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st, ok := c.NumStatsQuery(q, "ProcId"); ok {
+		t.Errorf("NumStatsQuery served a query with an omitted conjunct (n=%d, max=%v); no record "+
+			"matches it, so any aggregate it returns is wrong", st.N, st.Max)
+	}
+}
+
+// TestExactProbesContract pins the vm-level distinction directly, so the guarantee is testable
+// without going through a store.
+func TestExactProbesContract(t *testing.T) {
+	for _, tc := range []struct {
+		expr      string
+		wantExact bool
+	}{
+		{"ProcId >= 5", true},
+		{"ProcId >= 5 && ProcId <= 8", true},
+		{"ProcId >= 5 && Owner == \"u3\"", true},      // both conjuncts recognized
+		{"ProcId >= 5 && ClusterId != ProcId", false}, // attr-to-attr: omitted
+		{"ProcId >= 5 && Memory > ProcId", false},     // attr-to-attr: omitted
+		{"ProcId >= 5 || ProcId < 2", false},          // the whole expression is one unrecognized conjunct
+	} {
+		q, err := vm.Parse(tc.expr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		probes, exact := q.ExactProbes()
+		if exact != tc.wantExact {
+			t.Errorf("%-38s exact=%v want %v (probes=%d, Probes()=%d)",
+				tc.expr, exact, tc.wantExact, len(probes), len(q.Probes()))
+		}
+		// Whatever exactness says, the probes must remain a sound candidate filter: never more
+		// probes than Probes() would give.
+		if len(probes) > len(q.Probes()) {
+			t.Errorf("%s: ExactProbes returned more probes (%d) than Probes (%d)",
+				tc.expr, len(probes), len(q.Probes()))
+		}
+	}
+}

--- a/collections/vm/probe.go
+++ b/collections/vm/probe.go
@@ -39,6 +39,33 @@ func (q *Query) Probes() []Probe {
 	return out
 }
 
+// ExactProbes returns the query's probes together with whether they are EXACTLY equivalent to the
+// query: the top-level expression is a conjunction and EVERY conjunct was recognized as a probe.
+//
+// Probes and ProbePlan are deliberate OVER-APPROXIMATIONS, built for index pruning where the store
+// re-verifies every candidate, so an omitted conjunct only costs selectivity. A consumer that answers
+// from the probes ALONE -- a columnar COUNT/MIN/MAX that never re-verifies -- needs the opposite
+// guarantee, and using Probes for that silently over-counts: `ProcId >= 5 && ClusterId != ProcId`
+// compiles natively and yields ONE probe, because an attribute-to-attribute comparison is not
+// `Attr OP literal`, so counting from that probe alone answers `ProcId >= 5` instead of the query.
+//
+// exact=false means "do not answer from these probes"; they remain a sound candidate filter.
+func (q *Query) ExactProbes() (probes []Probe, exact bool) {
+	if q == nil || q.prog == nil || q.prog.expr == nil {
+		return nil, false
+	}
+	conj := flattenAnd(classad.FoldConstants(q.prog.expr), nil)
+	out := make([]Probe, 0, len(conj))
+	for _, c := range conj {
+		p, ok := probeFrom(c)
+		if !ok {
+			return out, false // an unrecognized conjunct: the probe set does not cover the query
+		}
+		out = append(out, p)
+	}
+	return out, len(out) > 0
+}
+
 // ProbeGroup is a conjunction of index probes -- a candidate matches the group when
 // it satisfies ALL of them. An empty Probes means the group is unconstrained (that
 // disjunct can match anything), so a plan containing one cannot prune.


### PR DESCRIPTION
Found while scoping combined-predicate support for the columnar path. **The columnar aggregates can return a wrong answer today.**

## The bug

`Probes()` is a deliberate over-approximation built for index pruning — it omits any conjunct that is not `Attr OP literal`, because the store re-verifies every candidate, so an omission only costs selectivity. The columnar aggregate paths answer **from the probes** and never re-verify, which turns that omission into a wrong result.

`Native()` looks like the guard for this and is not: an attribute-to-attribute comparison compiles entirely to native instructions *and* is omitted from `Probes()`.

Measured on a fixture where `ClusterId == ProcId` for every record:

```
count(*) where ProcId >= 5 && ClusterId != ProcId
    columnar path: 1500      <- the count of `ProcId >= 5`
    row path:         0      <- correct; no record matches
```

Same hole in `MIN`/`MAX`/`SUM`/`AVG`, which share `numPredOnField`. Shipped in v0.26.0 and earlier.

## Fix

`vm.ExactProbes()` returns the probes plus whether they are **exactly** equivalent to the query: the top level is a conjunction and *every* conjunct was recognized. `numPredOnField` now requires that, so a query with an omitted conjunct declines and falls back to the row path instead of answering a different question.

`Probes` and `ProbePlan` keep their over-approximating contract — the planner re-verifies and depends on it.

## Coverage is unchanged for legitimate queries

| query | before | after |
|---|---|---|
| `ProcId >= 5` | served, 1500 ✓ | served, 1500 ✓ |
| `ProcId >= 5 && ProcId <= 8` | served, 1200 ✓ | served, 1200 ✓ |
| `ProcId >= 5 && ClusterId != ProcId` | **served, 1500 ✗** | declines → row path, 0 ✓ |
| `ProcId >= 5 && Memory > ProcId` | **served ✗** | declines ✓ |
| `ProcId >= 5 && Owner == "u3"` | declined (two fields) | declined |
| `ProcId >= 5 \|\| ProcId < 2` | declined (no probes) | declined |

## Tests

- `TestColumnarCountExactness` — every query the columnar path agrees to serve must match the row path, over the shapes above. The fixture makes `ClusterId == ProcId` for every record so an ignored conjunct is caught by the maximum possible margin (1500 vs 0) rather than a subtle one.
- `TestColumnarStatsExactness` — the same hole in `NumStatsQuery`.
- `TestExactProbesContract` — pins the vm-level distinction directly, and that `ExactProbes` never returns more probes than `Probes`, so it stays a sound candidate filter.

`collections`, `vm`, `db`, `dbrpc` green.

Worth noting for the roadmap: a column-aware evaluator (running the *actual* query per record via `EvalResolved` against columnar storage) would make this class of bug structurally impossible, since it evaluates the query rather than a summary of it.
