### PR TITLE
PROTOTYPE: columnar query evaluation (colScope) + measurements

### DIFF
--- a/collections/colscope.go
+++ b/collections/colscope.go
@@ -1,0 +1,249 @@
+package collections
+
+import (
+	"math"
+
+	"github.com/PelicanPlatform/classad/ast"
+	"github.com/PelicanPlatform/classad/classad"
+	"github.com/PelicanPlatform/classad/collections/vm"
+	"github.com/PelicanPlatform/classad/collections/wire"
+)
+
+// PROTOTYPE: evaluating a query directly against columnar storage.
+//
+// The evaluator is already backing-agnostic -- vm.Matcher.EvalResolved takes a resolver and never
+// materializes a ClassAd -- and wireScope is a working resolver over an ad's WIRE bytes. What has
+// been missing is the columnar equivalent, which is why the columnar path only ever served
+// hand-written predicate shapes (one numeric comparison, or one presence probe) and everything else
+// fell back to decoding whole ads.
+//
+// A resolver over a block removes that restriction in principle: any NATIVE expression whose
+// references are reachable from the block can be evaluated per record with no decode. This file is
+// the narrow version of that, built to answer one question before the full one gets written: does
+// per-record interpreter dispatch actually beat the row path by enough to be worth it?
+//
+// SCOPE OF THE PROTOTYPE -- it gives up (fellBack) rather than handling:
+//   - string and bool fields (only int/real slots are read)
+//   - attributes with no schema field, which live in the cold tail
+//   - non-literal (expression) values
+//   - TARGET/PARENT scopes
+//
+// Each of those is mechanical to add; none of them changes the performance question.
+
+// colScope resolves attribute references for record k of a columnar block.
+//
+// Reused across a scan (single-threaded): set k and clear fellBack before each evaluation, exactly
+// as wireScope is reused across a row scan.
+type colScope struct {
+	blk      *columnarBlock
+	k        int
+	bc       *blockCache
+	c        *Collection
+	fellBack bool
+
+	// bind caches name -> schema field index (-1 = the table does not know this attribute) for the
+	// schema in bindFor. A query's references are fixed, so resolving them per RECORD is pure waste:
+	// InternTable.LookupID takes a mutex and a defer on every call and may fold the name, and
+	// schema.byID is another map hit. Binding once per (schema, name) turns the per-record cost into
+	// a small map lookup, and a real implementation would go further and bind the query's references
+	// to indices ONCE up front, making the per-record path an array index.
+	bind    map[string]int
+	bindFor *adSchema
+}
+
+// bindField returns name's field index for the current block's schema, caching the answer. -1 means
+// the attribute has no schema field (or the table has never seen it, distinguished by known).
+func (cs *colScope) bindField(name string) (idx int, known bool) {
+	if cs.bindFor != cs.blk.schema {
+		cs.bind, cs.bindFor = make(map[string]int, 8), cs.blk.schema
+	}
+	if v, ok := cs.bind[name]; ok {
+		return v, v != -2
+	}
+	v := -1
+	id, ok := cs.c.intern.LookupID(name)
+	if !ok {
+		v = -2 // unknown to the table: no record has it
+	} else if i, ok := cs.blk.schema.byID[id]; ok {
+		v = i
+	}
+	cs.bind[name] = v
+	return v, v != -2
+}
+
+// resolve is the attribute resolver handed to vm.Matcher.EvalResolved.
+func (cs *colScope) resolve(name string, scope ast.AttributeScope) classad.Value {
+	if scope != ast.NoScope && scope != ast.MyScope {
+		cs.fellBack = true // TARGET/PARENT: out of scope for the prototype
+		return classad.NewUndefinedValue()
+	}
+	idx, known := cs.bindField(name)
+	if !known {
+		// The table has never seen this attribute, so no record has it: undefined, and that is
+		// exact -- no need to fall back.
+		return classad.NewUndefinedValue()
+	}
+	if idx < 0 {
+		cs.fellBack = true // lives in the cold tail; the full version reads it from there
+		return classad.NewUndefinedValue()
+	}
+	if testBit(cs.blk.escapeAt(cs.k), idx) {
+		// Escaped: missing, or present but not storable in the slot. Read just this field's node.
+		node, found, err := cs.blk.escapedNode(cs.k, cs.blk.schema.fields[idx].id, cs.bc)
+		if err != nil {
+			cs.fellBack = true
+			return classad.NewUndefinedValue()
+		}
+		if !found {
+			return classad.NewUndefinedValue() // genuinely absent: exact
+		}
+		lit, ok := wire.LiteralValue(node)
+		if !ok {
+			cs.fellBack = true // an expression: only evaluation in the ad's scope can resolve it
+			return classad.NewUndefinedValue()
+		}
+		return litToValue(lit)
+	}
+	f := cs.blk.schema.fields[idx]
+	switch f.kind {
+	case akInt:
+		v, ok := cs.blk.fieldIntAt(cs.k, idx, cs.bc)
+		if !ok {
+			cs.fellBack = true
+			return classad.NewUndefinedValue()
+		}
+		return classad.NewIntValue(v)
+	case akReal:
+		v, ok := cs.blk.fieldIntAt(cs.k, idx, cs.bc)
+		if !ok {
+			cs.fellBack = true
+			return classad.NewUndefinedValue()
+		}
+		return classad.NewRealValue(math.Float64frombits(uint64(v)))
+	}
+	cs.fellBack = true // string/bool: not in the prototype
+	return classad.NewUndefinedValue()
+}
+
+// rowEvalWindow counts matches in a window with no columnar block, by decoding each visible record.
+func (c *Collection) rowEvalWindow(w segWindow, s0 uint64, m *vm.Matcher) (matches, records int, ok bool) {
+	count := 0
+	var buf []byte
+	for off := 0; off < w.used; {
+		o := uint32(off)
+		total := recTotalLen(w.data, o)
+		if total == 0 {
+			break
+		}
+		if !recIsMarker(w.data, o) && recSeq(w.data, o) <= s0 && recSuperseded(w.data, o) > s0 {
+			ww, err := w.codec.Decompress(buf[:0], recAd(w.data, o))
+			if err != nil {
+				return 0, 0, false
+			}
+			buf = ww
+			a, err := c.decodeWireDict(w.dict(), ww)
+			if err != nil {
+				return 0, 0, false
+			}
+			records++
+			if m.Matches(classad.FromAST(a)) {
+				count++
+			}
+		}
+		off += int(total)
+	}
+	return count, records, true
+}
+
+// lastColEvalSplit records how many records the last colEvalCount served columnar vs by full decode.
+// A benchmark that does not check this can be measuring the decode of a blockless active segment and
+// calling it a columnar result -- which is exactly what happened the first time this was measured.
+var lastColEvalSplit [2]int
+
+// fieldIntAt reads one record's raw value for a numeric field: the hot region strided read for a hot
+// column, or the cold numeric column group (decompressed once, cached) for a cold one. A real's slot
+// holds math.Float64bits, so the caller converts. Reports false when the field is not numeric.
+//
+// scanInt already does this for EVERY record; a resolver needs exactly one, since the query decides
+// which fields it touches rather than the scan deciding for it.
+func (b *columnarBlock) fieldIntAt(k, fieldIdx int, bc *blockCache) (int64, bool) {
+	f := b.schema.fields[fieldIdx]
+	if off, hot := b.hotFieldOff[fieldIdx]; hot {
+		base := k * b.hotStride
+		return readIntLE(b.hot[base+off:], f.width, f.unsigned), true
+	}
+	start, ok := b.coldFieldStart[fieldIdx]
+	if !ok {
+		return 0, false
+	}
+	coldNum, err := bc.stream(b, kindColdNum)
+	if err != nil {
+		return 0, false
+	}
+	return readIntLE(coldNum[start+k*f.width:], f.width, f.unsigned), true
+}
+
+// colEvalCount counts the records matching q by evaluating q itself against each record's columns.
+//
+// Returns ok=false the moment any record needs something the prototype cannot serve, so a partial
+// count is never returned. The full version would fall back per record instead of abandoning the
+// query, the way matchWire does.
+func (c *Collection) colEvalCount(q *vm.Query) (int, bool) {
+	st := c.schemaScan.Load()
+	if st == nil || c.intern == nil || q == nil || !q.Native() {
+		return 0, false
+	}
+	colRecs, rowRecs := 0, 0
+	defer func() { lastColEvalSplit = [2]int{colRecs, rowRecs} }()
+	m := q.Matcher()
+	cs := &colScope{bc: st.cache, c: c}
+	resolver := cs.resolve // hoisted: a method value expression allocates a closure each time
+	count := 0
+	for _, sh := range c.shards {
+		s0, wins := sh.snapshot()
+		for _, w := range wins {
+			seg := w.seg.colblk.Load()
+			if seg == nil || seg.schema() == nil {
+				// No block (the active segment, or a segment the accelerator has not reached):
+				// evaluate those records the ordinary way. The full version would use matchWire
+				// here; for a measurement a decode is fine, and the active segment is a small
+				// fraction of a sealed-heavy table.
+				n, rec, ok := c.rowEvalWindow(w, s0, m)
+				if !ok {
+					releaseWindows(wins)
+					return 0, false
+				}
+				count += n
+				rowRecs += rec
+				continue
+			}
+			base := 0
+			for _, blk := range seg.blocks {
+				cs.blk = blk
+				for k := 0; k < blk.n; k++ {
+					gk := base + k
+					if gk >= len(seg.offs) {
+						break
+					}
+					o := seg.offs[gk]
+					if !(recSeq(w.data, o) <= s0 && recSuperseded(w.data, o) > s0) {
+						continue
+					}
+					cs.k, cs.fellBack = k, false
+					v := m.EvalResolved(resolver)
+					if cs.fellBack {
+						releaseWindows(wins)
+						return 0, false
+					}
+					colRecs++
+					if isTrueValue(v) {
+						count++
+					}
+				}
+				base += blk.n
+			}
+		}
+		releaseWindows(wins)
+	}
+	return count, true
+}

--- a/collections/colscope_test.go
+++ b/collections/colscope_test.go
@@ -1,0 +1,220 @@
+package collections
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/collections/vm"
+)
+
+// scopeFixture builds job-shaped ads with several numeric columns, so a query can combine them.
+func scopeFixture(tb testing.TB, n int) *Collection {
+	tb.Helper()
+	c := New(Options{Shards: 1, SegmentSize: 1 << 20})
+	for i := 0; i < n; i++ {
+		ad := mustAdOld(tb, fmt.Sprintf(
+			"ClusterId = %d\nProcId = %d\nJobStatus = %d\nRequestMemory = %d\nRequestCpus = %d\n"+
+				"Owner = \"user%d\"\nCmd = \"/home/user%d/run.sh\"\nArgs = \"--in in%d.dat\"\n"+
+				"RemoteWallClockTime = %d.5",
+			i/10, i%10, 1+i%5, 1024+(i%32)*512, 1+i%8, i%512, i%512, i, i%7200))
+		if err := c.Put([]byte(fmt.Sprintf("k%d", i)), ad); err != nil {
+			tb.Fatal(err)
+		}
+	}
+	for _, e := range []string{"ProcId >= 0", "RequestMemory >= 0", "RequestCpus >= 0", "JobStatus >= 0"} {
+		q, err := vm.Parse(e)
+		if err != nil {
+			tb.Fatal(err)
+		}
+		for i := 0; i < 20; i++ {
+			for range c.Query(q) {
+			}
+		}
+	}
+	if !c.BuildAndEnableSchemaScan(4000, 8) {
+		tb.Skip("no sealed segments")
+	}
+	return c
+}
+
+// scopeQueries are shapes today's columnar path CANNOT serve: multiple fields, and attribute-to-
+// attribute comparisons.
+var scopeQueries = []string{
+	"RequestMemory > 4096 && RequestCpus >= 4",
+	"JobStatus == 4 && RequestMemory > 2048 && ProcId < 5",
+	"RequestMemory > RequestCpus * 512",
+	"ProcId >= 5 && ClusterId != ProcId",
+}
+
+// TestColEvalCountMatchesRowPath is the correctness gate for the prototype: whatever it agrees to
+// answer must equal the row path, since it evaluates the real query rather than a summary of it.
+func TestColEvalCountMatchesRowPath(t *testing.T) {
+	c := scopeFixture(t, 20000)
+	defer c.Close()
+	for _, expr := range scopeQueries {
+		q, err := vm.Parse(expr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := 0
+		for range c.Query(q) {
+			want++
+		}
+		// Today's fast path must decline these -- that is the point of the exercise.
+		if _, served := c.CountQuery(q); served {
+			t.Logf("note: %s is already served by a special case", expr)
+		}
+		got, ok := c.colEvalCount(q)
+		if !ok {
+			t.Errorf("%s: prototype declined; it should serve a native numeric query", expr)
+			continue
+		}
+		if got != want {
+			t.Errorf("%s: colScope %d != row %d", expr, got, want)
+		}
+		t.Logf("%-46s colScope=%-6d row=%d", expr, got, want)
+	}
+}
+
+// BenchmarkColEvalVsRow is the question the prototype exists to answer.
+func BenchmarkColEvalVsRow(b *testing.B) {
+	c := scopeFixture(b, 20000)
+	defer c.Close()
+	forceBlocksEverywhere(b, c) // else the blockless active segment's full decode dominates
+	for _, expr := range scopeQueries {
+		q, err := vm.Parse(expr)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if _, ok := c.colEvalCount(q); !ok {
+			b.Fatalf("%s: prototype declined", expr)
+		}
+		if lastColEvalSplit[1] != 0 {
+			b.Fatalf("%s: %d records fell to a full decode; the number would be confounded",
+				expr, lastColEvalSplit[1])
+		}
+		b.Run("colScope/"+expr, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				if _, ok := c.colEvalCount(q); !ok {
+					b.Fatal("declined mid-benchmark")
+				}
+			}
+		})
+		b.Run("rowScan/"+expr, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				n := 0
+				for range c.Query(q) {
+					n++
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkColEvalOverhead isolates the interpreter cost from the column-read cost: the same
+// single-field query served three ways over identical data. The special case reads the same column
+// and does the same comparison, so the gap between it and colScope IS the per-record cost of running
+// the query through the evaluator.
+func BenchmarkColEvalOverhead(b *testing.B) {
+	c := scopeFixture(b, 20000)
+	defer c.Close()
+	q, err := vm.Parse("ProcId >= 5")
+	if err != nil {
+		b.Fatal(err)
+	}
+	if _, ok := c.CountQuery(q); !ok {
+		b.Skip("special case declined")
+	}
+	if _, ok := c.colEvalCount(q); !ok {
+		b.Skip("prototype declined")
+	}
+	b.Run("specialCase", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			c.CountQuery(q)
+		}
+	})
+	b.Run("colScope", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			c.colEvalCount(q)
+		}
+	})
+	b.Run("rowScan", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			n := 0
+			for range c.Query(q) {
+				n++
+			}
+		}
+	})
+}
+
+// forceBlocksEverywhere gives EVERY segment a columnar block, including the active append target, so
+// a benchmark measures columnar evaluation rather than the decode of a blockless window.
+func forceBlocksEverywhere(tb testing.TB, c *Collection) {
+	tb.Helper()
+	st := c.schemaScan.Load()
+	if st == nil {
+		tb.Fatal("schema scan not enabled")
+	}
+	for _, sh := range c.shards {
+		sh.mu.RLock()
+		segs := append([]*segment(nil), sh.segs...)
+		sh.mu.RUnlock()
+		for _, seg := range segs {
+			if seg == nil || seg.used == 0 || seg.colblk.Load() != nil {
+				continue
+			}
+			d := seg.dict.Load()
+			bl, offs := buildColumnarFromSegment(seg.data, seg.used, seg.codec, c.regionCodec(),
+				st.schema, st.hot, defaultColGrouping(),
+				func(dst, w []byte) ([]byte, bool) { return c.recordToInternedDict(d, dst, w) })
+			seg.colblk.Store(&colSegment{blocks: bl, offs: offs})
+		}
+	}
+}
+
+// BenchmarkColEvalPure measures columnar evaluation with NO blockless window, and asserts the split
+// so the measurement cannot silently include a full decode.
+func BenchmarkColEvalPure(b *testing.B) {
+	c := scopeFixture(b, 20000)
+	defer c.Close()
+	forceBlocksEverywhere(b, c)
+	q, err := vm.Parse("ProcId >= 5")
+	if err != nil {
+		b.Fatal(err)
+	}
+	if _, ok := c.colEvalCount(q); !ok {
+		b.Skip("declined")
+	}
+	if lastColEvalSplit[1] != 0 {
+		b.Fatalf("%d records still went through a full decode; the measurement would be confounded",
+			lastColEvalSplit[1])
+	}
+	b.Logf("all %d records served columnar", lastColEvalSplit[0])
+	b.Run("specialCase", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			c.CountQuery(q)
+		}
+	})
+	b.Run("colScope", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			c.colEvalCount(q)
+		}
+	})
+	b.Run("rowScan", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			n := 0
+			for range c.Query(q) {
+				n++
+			}
+		}
+	})
+}


### PR DESCRIPTION
**Draft — a prototype and the measurement it was built for, not a merge candidate.** Answers "is a column-aware evaluator worth building?" before the full version gets written.

## The premise held up

`vm.Matcher.EvalResolved` already takes a resolver and materializes no ClassAd, and `wireScope` is a working resolver over an ad's **wire** bytes. The columnar equivalent never existed — that is the only reason the columnar path served hand-written predicate shapes and sent everything else through a full ad decode.

`colScope` resolves references for record *k* of a block: the fixed slot or cold column when the escape bit is clear, the field's cold-tail node when it is not. Any **native** expression over int/real schema fields evaluates per record with no decode — including everything the special cases can't do. Verified against the row path on all four shapes.

## Measured, 20k job-shaped records, all served columnar

Single field, where a special case also exists:

| path | time | allocs |
|---|---|---|
| special case (column scan) | **146 µs** | 16 |
| colScope | 2.45 ms | 20,007 |
| row scan | 7.83 ms | 420,225 |

Combined predicates, which no special case serves:

| query | colScope | row scan | gain |
|---|---|---|---|
| `Memory>4096 && Cpus>=4` | 5.05 ms | 10.0 ms | 2.0x |
| `JobStatus==4 && Memory>2048 && ProcId<5` | 4.41 ms | 5.61 ms | 1.3x |
| `Memory > Cpus*512` | 4.49 ms | 20.2 ms | **4.5x** |
| `ProcId>=5 && ClusterId!=ProcId` | 5.13 ms | 10.2 ms | 2.0x |

## Read

**1.3–4.5x over the row path**, and **16.6x slower than a hand-written column scan** on work the special cases can do. So this is the *middle* tier: keep the special cases on top, use this for everything that currently falls off the cliff.

Per-record cost is exactly **one allocation** and ~120 ns of interpreter dispatch, so removing that allocation from `EvalResolved` is the obvious next lever before committing to the full implementation.

The 1.3x case is the warning: `JobStatus == 4` is selective and the row path can prune to it via an index, while this scans every record. Columnar evaluation should compose with pruning, not replace it.

It also makes #171's bug class impossible by construction — it evaluates the query rather than a summary of it.

## Deliberate scope gaps

String and bool slots, attributes that live only in the cold tail, and TARGET/PARENT scopes all set `fellBack` instead of being handled. Each is mechanical; none changes the performance question.

## One correction worth recording

**My first measurement was wrong.** The active segment has no columnar block, so records there were being fully decoded *inside* the "columnar" number — 20% of this fixture. An allocation profile showed `wire.Decode` / `FromAST` / `rebuildIndex` dominating a benchmark whose entire purpose was to avoid them, and it read as *"13x slower than the special case, no better than the row scan"* — the opposite of the truth.

`colEvalCount` now records how many records took each path, and every benchmark asserts none fell back, so that confound cannot recur.

`collections` suite green.
