### PR TITLE
vm: build each attribute-reference node once, not once per evaluation

### DIFF
--- a/classad/vm_support.go
+++ b/classad/vm_support.go
@@ -35,6 +35,21 @@ func (e *Evaluator) ResolveRef(name string, scope ast.AttributeScope) Value {
 	return e.evaluateAttributeReference(ast.NewAttributeReference(name, scope))
 }
 
+// ResolveRefNode is ResolveRef for a reference node the caller already has, so a compiled program
+// can hold one per reference instead of building a fresh node per evaluation.
+//
+// NewAttributeReference heap-allocates and calls strings.ToLower, and ResolveRef does both on EVERY
+// resolution -- once per reference per record during a scan. That defeats the precomputed-fold
+// optimization resolveAttributeReference documents (the folded name is meant to be computed at parse
+// time), and for a custom resolver the fold is pure waste, since the resolver is handed the
+// original-cased name and never sees the folded one.
+//
+// ref must not be mutated by the caller after this returns; evaluation treats it as read-only, which
+// is what lets one node be shared by every evaluation of a program, including concurrent ones.
+func (e *Evaluator) ResolveRefNode(ref *ast.AttributeReference) Value {
+	return e.evaluateAttributeReference(ref)
+}
+
 // SetScope rebinds the evaluator to a new scope ClassAd and resets its recursion
 // depth, so one Evaluator can be reused across many evaluations (e.g. a bytecode
 // Matcher scanning a collection) instead of allocating a fresh one per ad.

--- a/collections/vm/compile.go
+++ b/collections/vm/compile.go
@@ -109,7 +109,7 @@ func (c *compiler) addOp(op string) int32 {
 }
 
 func (c *compiler) addRef(name string, scope ast.AttributeScope) int32 {
-	c.p.refs = append(c.p.refs, refInfo{name: name, scope: scope})
+	c.p.refs = append(c.p.refs, refInfo{name: name, scope: scope, node: ast.NewAttributeReference(name, scope)})
 	return int32(len(c.p.refs) - 1)
 }
 

--- a/collections/vm/interp.go
+++ b/collections/vm/interp.go
@@ -47,7 +47,7 @@ func exec(p *Program, ev *classad.Evaluator, stack []classad.Value) (classad.Val
 			ip++
 		case OpLoadRef:
 			r := p.refs[in.A]
-			stack = append(stack, ev.ResolveRef(r.name, r.scope))
+			stack = append(stack, ev.ResolveRefNode(r.node))
 			ip++
 		case OpBinop:
 			n := len(stack)

--- a/collections/vm/program.go
+++ b/collections/vm/program.go
@@ -7,7 +7,12 @@ import (
 
 // refInfo is a pooled attribute reference (name + scope) targeted by OpLoadRef.
 type refInfo struct {
-	name  string
+	name string
+	// node is the reference as an AST node, built once at compile time. The interpreter hands it
+	// straight to the evaluator, which would otherwise construct one -- heap-allocating and folding
+	// the name -- on every resolution of every record. Read-only after compilation, so one program
+	// can be evaluated concurrently by several Matchers.
+	node  *ast.AttributeReference
 	scope ast.AttributeScope
 }
 

--- a/collections/vm/refalloc_test.go
+++ b/collections/vm/refalloc_test.go
@@ -1,0 +1,46 @@
+package vm
+
+import (
+	"testing"
+
+	"github.com/PelicanPlatform/classad/ast"
+	"github.com/PelicanPlatform/classad/classad"
+)
+
+// Resolving an attribute reference must not allocate per evaluation.
+//
+// ResolveRef builds a fresh *ast.AttributeReference and folds the name with strings.ToLower on every
+// call, and the interpreter called it once per reference per RECORD -- so a scan over 20k records
+// paid 20k allocations for a name that was known at compile time. That defeated the precomputed-fold
+// optimization resolveAttributeReference documents, and for a custom resolver the fold was pure
+// waste, since the resolver receives the original-cased name.
+//
+// The program now carries one node per reference, built during compilation. This test fails if that
+// regresses, which a timing benchmark would not do reliably.
+func TestLoadRefDoesNotAllocatePerEval(t *testing.T) {
+	q, err := Parse("ProcId >= 5 && ClusterId != ProcId")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !q.Native() {
+		t.Fatal("fixture query is not native; it would not use OpLoadRef")
+	}
+	m := q.Matcher()
+	resolver := func(name string, scope ast.AttributeScope) classad.Value {
+		return classad.NewIntValue(7)
+	}
+	// Warm up, so first-call lazy work is not counted.
+	for i := 0; i < 100; i++ {
+		m.EvalResolved(resolver)
+	}
+	const n = 2000
+	allocs := testing.AllocsPerRun(n, func() {
+		m.EvalResolved(resolver)
+	})
+	// Two references per evaluation; a per-reference node build would show up as >= 2.
+	if allocs > 0.5 {
+		t.Errorf("EvalResolved allocates %.2f objects per evaluation over a 2-reference query; "+
+			"the reference node should be built once at compile time, not per evaluation", allocs)
+	}
+	t.Logf("%.2f allocs per evaluation (2 references)", allocs)
+}


### PR DESCRIPTION
Found by profiling the columnar-evaluation prototype (#172), but it is **not columnar-specific** — it is one heap allocation per attribute reference per record on every evaluation path.

## The optimization already existed and was being bypassed

`resolveAttributeReference` says so itself:

> The folded name is precomputed on the AST node at parse time (`NewAttributeReference`), so this hot path — run once per candidate per reference during matchmaking — does not allocate a fresh `strings.ToLower` result on every lookup.

But the interpreter's entry point was `ResolveRef`, which does exactly the thing that comment is guarding against:

```go
func (e *Evaluator) ResolveRef(name string, scope ast.AttributeScope) Value {
	return e.evaluateAttributeReference(ast.NewAttributeReference(name, scope))
}
```

`NewAttributeReference` heap-allocates *and* folds the name — on every resolution, for a name that `addRef` knew at compile time. And when a custom resolver is installed the fold is pure waste, because `resolveAttributeReference` hands the resolver `ref.Name` and never touches the folded form.

## Fix

The compiled program carries one `*ast.AttributeReference` per reference, built in `addRef`, and the interpreter passes it to a new `Evaluator.ResolveRefNode`.

Sharing one node is safe because evaluation treats it as read-only — `resolveAttributeReference` reads only `Name`, `Scope` and `NormalizedName()` — which matters because a `Program` is shared across concurrent `Matcher`s during a parallel scan.

## Measured, 20k records, `ProcId >= 5`

| path | before | after |
|---|---|---|
| columnar evaluation | 2.45 ms / 20,007 allocs | **1.79 ms / 7 allocs** |
| ordinary row scan | 7.83 ms / 420,225 allocs | 7.55 ms / **400,225 allocs** |
| hand-written column scan | 146 µs / 16 | 140 µs / 16 |

The columnar path loses essentially all per-record allocation (20,007 → 7 for the whole query). The row scan drops **exactly one allocation per record**, which is the clearest evidence this is a general win rather than a prototype-specific one — matchmaking and every constraint scan take the same path.

Ratios for the roadmap: columnar evaluation goes from 16.6x to **12.8x** slower than a hand-written column scan, and from 3.2x to **4.2x** faster than the row scan.

## Guard

`TestLoadRefDoesNotAllocatePerEval` asserts `EvalResolved` allocates nothing per evaluation, using `testing.AllocsPerRun` rather than a timing benchmark — one small allocation per record would not fail a timing test reliably. Verified in both directions: it reports **3.00 objects per evaluation** against the previous code.

Root module, `collections`, `collections/vm`, `db`, `dbrpc` all green.
