### PR TITLE
collections: serve N-conjunct column scans (10-19x), not just single-field

### DIFF
--- a/collections/colmulti.go
+++ b/collections/colmulti.go
@@ -1,0 +1,242 @@
+package collections
+
+import (
+	"math"
+
+	"github.com/PelicanPlatform/classad/collections/vm"
+	"github.com/PelicanPlatform/classad/collections/wire"
+)
+
+// The hand-written column scan, generalized from one attribute to N.
+//
+// numPredOnField serves a conjunction of scalar comparisons on a SINGLE numeric field, so
+// `RequestMemory > 4096` is columnar and `RequestMemory > 4096 && RequestCpus >= 4` is not -- the
+// second falls all the way back to decoding whole ads, which is a cliff rather than a slope. Nothing
+// about reading two columns instead of one requires the general evaluator: the shape is still
+// `Attr OP literal`, just repeated.
+//
+// COLUMN-AT-A-TIME, not record-at-a-time. Each field is a separate pass over the block, narrowing a
+// candidate set, so every pass is a tight strided read of one column rather than a walk that hops
+// between columns per record. A selective first predicate makes every later pass cheaper, since
+// excluded records are skipped, and a pass that empties the candidate set ends the block.
+//
+// SEMANTICS. Counting matches means counting records where the constraint is TRUE. For a conjunction
+// that is: every comparison TRUE. A missing or non-numeric value makes its comparison UNDEFINED, and
+// a conjunction with an UNDEFINED and no FALSE is UNDEFINED -- not TRUE -- so such a record is not
+// counted. Dropping a record whose value is absent is therefore correct for every combination, which
+// is what lets each pass simply narrow the candidate set.
+
+// fieldPred is one field's combined test: the conjunction of every probe on that field.
+type fieldPred struct {
+	fieldID uint32
+	eval    func(float64) bool
+}
+
+// numPredsOnFields analyzes q as a conjunction of scalar numeric comparisons over ANY number of
+// numeric schema fields, returning one combined predicate per distinct field.
+//
+// ok=false for anything else: a non-native query, probes that do not exactly cover it (see
+// ExactProbes -- this path answers from the probes and never re-verifies), an attribute the schema
+// does not carry as a numeric field, or a probe that is not a scalar comparison.
+func (c *Collection) numPredsOnFields(q *vm.Query, s *adSchema) ([]fieldPred, bool) {
+	probes, exact := q.ExactProbes()
+	if !q.Native() || !exact {
+		return nil, false
+	}
+	order := make([]uint32, 0, len(probes))
+	cmps := make(map[uint32][]func(float64) bool, len(probes))
+	for _, p := range probes {
+		id, ok := c.intern.LookupID(p.Attr)
+		if !ok {
+			return nil, false
+		}
+		idx, ok := s.byID[id]
+		if !ok || !numericKind(s.fields[idx].kind) {
+			return nil, false
+		}
+		up, ok := valUsable(id, p)
+		if !ok || len(up.fvals) != 1 {
+			return nil, false // present/absent/in/isnt or non-numeric: not a scalar comparison
+		}
+		cmp, ok := numCmp(up.op, up.fvals[0])
+		if !ok {
+			return nil, false
+		}
+		if _, seen := cmps[id]; !seen {
+			order = append(order, id)
+		}
+		cmps[id] = append(cmps[id], cmp)
+	}
+	if len(order) == 0 {
+		return nil, false
+	}
+	preds := make([]fieldPred, 0, len(order))
+	for _, id := range order {
+		list := cmps[id]
+		if len(list) == 1 {
+			preds = append(preds, fieldPred{fieldID: id, eval: list[0]})
+			continue
+		}
+		preds = append(preds, fieldPred{fieldID: id, eval: func(v float64) bool {
+			for _, cmp := range list {
+				if !cmp(v) {
+					return false
+				}
+			}
+			return true
+		}})
+	}
+	return preds, true
+}
+
+// schemaScanCountMulti counts live records satisfying every predicate, one column pass per field.
+//
+// A segment whose own schema lacks any of the fields, and the active segment (no block), are counted
+// by a row walk that reads only the predicated attributes -- not by decoding the ad. So a schema
+// change never costs more than the segments it actually affects.
+func (c *Collection) schemaScanCountMulti(preds []fieldPred, bc *blockCache) int {
+	lookups := make([]func(wire.Ad) ([]byte, bool), len(preds))
+	for i, p := range preds {
+		id := p.fieldID
+		lookups[i] = func(a wire.Ad) ([]byte, bool) { return a.Lookup(id) }
+		if c.inline {
+			if name, ok := c.intern.Name(id); ok {
+				lookups[i] = func(a wire.Ad) ([]byte, bool) { return a.LookupByName(name) }
+			}
+		}
+	}
+	count := 0
+	var keep []bool
+	for _, sh := range c.shards {
+		s0, wins := sh.snapshot()
+		for _, w := range wins {
+			cs := w.seg.colblk.Load()
+			idxs, resolved := resolveFields(cs, preds)
+			if !resolved {
+				count += bruteCountMulti(w, s0, preds, lookups)
+				continue
+			}
+			base := 0
+			for _, blk := range cs.blocks {
+				if cap(keep) < blk.n {
+					keep = make([]bool, blk.n)
+				}
+				keep = keep[:blk.n]
+				// Pass 0 establishes visibility, so later passes never touch a record no
+				// snapshot can see.
+				live := 0
+				for k := 0; k < blk.n; k++ {
+					gk := base + k
+					vis := gk < len(cs.offs)
+					if vis {
+						o := cs.offs[gk]
+						vis = recSeq(w.data, o) <= s0 && recSuperseded(w.data, o) > s0
+					}
+					keep[k] = vis
+					if vis {
+						live++
+					}
+				}
+				for i := range preds {
+					if live == 0 {
+						break // nothing left in this block; later columns would be read for nothing
+					}
+					live = narrowByField(blk, idxs[i], preds[i], bc, keep)
+				}
+				count += live
+				base += blk.n
+			}
+		}
+		releaseWindows(wins)
+	}
+	return count
+}
+
+// resolveFields maps each predicate's field to its index in this SEGMENT's schema. Segments sealed
+// under different schemas coexist, so a field present in the current schema may be absent here.
+func resolveFields(cs *colSegment, preds []fieldPred) ([]int, bool) {
+	sch := cs.schema()
+	if sch == nil {
+		return nil, false
+	}
+	idxs := make([]int, len(preds))
+	for i, p := range preds {
+		idx, ok := sch.byID[p.fieldID]
+		if !ok || !numericKind(sch.fields[idx].kind) {
+			return nil, false
+		}
+		idxs[i] = idx
+	}
+	return idxs, true
+}
+
+// narrowByField clears keep[k] for every still-candidate record failing this field's predicate, and
+// returns how many survive. A real field's slot holds math.Float64bits, so the raw value is
+// converted by kind -- reading a real as an integer would silently produce astronomical values.
+func narrowByField(blk *columnarBlock, idx int, p fieldPred, bc *blockCache, keep []bool) int {
+	isReal := blk.schema.fields[idx].kind == akReal
+	live := 0
+	_ = blk.scanInt(idx, bc, func(k int, present bool, v int64) {
+		if !keep[k] {
+			return
+		}
+		if !present {
+			// Escaped: read just this field from the cold tail. Absent or non-numeric leaves the
+			// comparison UNDEFINED, so the record cannot satisfy the conjunction.
+			nv, ok := blk.escapedNumVal(k, p.fieldID, bc)
+			if !ok || !p.eval(nv.f) {
+				keep[k] = false
+				return
+			}
+			live++
+			return
+		}
+		f := float64(v)
+		if isReal {
+			f = math.Float64frombits(uint64(v))
+		}
+		if !p.eval(f) {
+			keep[k] = false
+			return
+		}
+		live++
+	})
+	return live
+}
+
+// bruteCountMulti is the row fallback: walk a window's visible records and test the predicated
+// attributes from their wire nodes, reading only those attributes rather than decoding the ad.
+func bruteCountMulti(w segWindow, s0 uint64, preds []fieldPred, lookups []func(wire.Ad) ([]byte, bool)) int {
+	count := 0
+	var buf []byte
+	for off := 0; off < w.used; {
+		o := uint32(off)
+		total := recTotalLen(w.data, o)
+		if total == 0 {
+			break
+		}
+		if !recIsMarker(w.data, o) && recSeq(w.data, o) <= s0 && recSuperseded(w.data, o) > s0 {
+			if ww, err := w.codec.Decompress(buf[:0], recAd(w.data, o)); err == nil {
+				buf = ww
+				ok := true
+				for i := range preds {
+					node, found := lookups[i](wire.Ad(ww))
+					if !found {
+						ok = false
+						break
+					}
+					nv, isNum := nodeColVal(node)
+					if !isNum || !preds[i].eval(nv.f) {
+						ok = false
+						break
+					}
+				}
+				if ok {
+					count++
+				}
+			}
+		}
+		off += int(total)
+	}
+	return count
+}

--- a/collections/colmulti_test.go
+++ b/collections/colmulti_test.go
@@ -1,0 +1,222 @@
+package collections
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/collections/vm"
+)
+
+// multiFixture builds job-shaped ads with several numeric columns, plus the exceptional shapes that
+// make a per-field column read disagree with a naive one: a missing value, a non-numeric value, and a
+// value too wide for its fitted slot. Rates are ~1% so every attribute still clears buildAdSchema's
+// 90% presence threshold and stays a schema FIELD -- otherwise the accelerator declines for an
+// unrelated reason and the tests pass vacuously.
+func multiFixture(tb testing.TB, n int) *Collection {
+	tb.Helper()
+	c := New(Options{Shards: 1, SegmentSize: 1 << 16})
+	for i := 0; i < n; i++ {
+		mem := fmt.Sprintf("%d", 1024+(i%32)*512)
+		cpus := fmt.Sprintf("%d", 1+i%8)
+		switch {
+		case i%101 == 0:
+			mem = "" // RequestMemory missing entirely
+		case i%103 == 0:
+			mem = "\"lots\"" // non-numeric: comparison is UNDEFINED
+		case i%107 == 0:
+			mem = fmt.Sprintf("%d", 1<<40+i) // too wide for the fitted slot: escapes
+		}
+		src := fmt.Sprintf("ClusterId = %d\nProcId = %d\nJobStatus = %d\nRequestCpus = %s\n"+
+			"RemoteWallClockTime = %d.5\nOwner = \"u%d\"", i/10, i%10, 1+i%5, cpus, i%3600, i%32)
+		if mem != "" {
+			src += "\nRequestMemory = " + mem
+		}
+		if err := c.Put([]byte(fmt.Sprintf("k%d", i)), mustAdOld(tb, src)); err != nil {
+			tb.Fatal(err)
+		}
+	}
+	for _, e := range []string{"RequestMemory >= 0", "RequestCpus >= 0", "JobStatus >= 0", "ProcId >= 0"} {
+		q, err := vm.Parse(e)
+		if err != nil {
+			tb.Fatal(err)
+		}
+		for i := 0; i < 20; i++ {
+			for range c.Query(q) {
+			}
+		}
+	}
+	if !c.BuildAndEnableSchemaScan(4000, 8) {
+		tb.Skip("no sealed segments")
+	}
+	return c
+}
+
+var multiQueries = []string{
+	"RequestMemory > 4096",                                                // one field: the old fast path
+	"RequestMemory > 4096 && RequestCpus >= 4",                            // two fields
+	"JobStatus == 4 && RequestMemory > 2048 && ProcId < 5",                // three fields
+	"RequestMemory > 2048 && RequestMemory < 8192",                        // two probes, one field
+	"RequestMemory > 2048 && RequestMemory < 8192 && RequestCpus == 4",    // both at once
+	"RemoteWallClockTime > 100.0 && RequestCpus >= 2",                     // a REAL field and an int field
+	"JobStatus == 4 && RequestCpus >= 1 && RequestMemory > 1000000000000", // only wide/escaped values match
+}
+
+// TestMultiFieldCountMatchesRowPath is the equivalence test: whatever the columnar path serves must
+// equal the ordinary query path, including where a value is missing, non-numeric, or escaped.
+func TestMultiFieldCountMatchesRowPath(t *testing.T) {
+	c := multiFixture(t, 4000)
+	defer c.Close()
+	for _, expr := range multiQueries {
+		q, err := vm.Parse(expr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := 0
+		for range c.Query(q) {
+			want++
+		}
+		got, served := c.CountQuery(q)
+		if !served {
+			t.Errorf("%s: declined; a conjunction of scalar numeric comparisons should be columnar", expr)
+			continue
+		}
+		if got != want {
+			t.Errorf("%s: columnar %d != row %d", expr, got, want)
+		}
+		t.Logf("%-68s columnar=%-6d row=%d", expr, got, want)
+	}
+}
+
+// TestMultiFieldStillDeclinesWhatItMust guards the boundary. These must NOT be served: the probes do
+// not cover the query, or the shape is not a scalar comparison on a numeric field.
+func TestMultiFieldStillDeclinesWhatItMust(t *testing.T) {
+	c := multiFixture(t, 2000)
+	defer c.Close()
+	for _, expr := range []string{
+		"RequestMemory > 4096 && ClusterId != ProcId", // attr-to-attr conjunct: omitted from probes
+		"RequestMemory > 4096 && Owner == \"u3\"",     // a string field is not numeric
+		"RequestMemory > 4096 || RequestCpus >= 4",    // disjunction
+		"RequestMemory > RequestCpus",                 // no literal
+	} {
+		q, err := vm.Parse(expr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := 0
+		for range c.Query(q) {
+			want++
+		}
+		got, served := c.CountQuery(q)
+		if served && got != want {
+			t.Errorf("%s: served with a WRONG answer %d (row=%d)", expr, got, want)
+		}
+		if served {
+			t.Logf("%-46s served, and agrees (%d)", expr, got)
+		} else {
+			t.Logf("%-46s declined (row=%d)", expr, want)
+		}
+	}
+}
+
+// TestMultiFieldMVCC checks visibility: superseded versions must not be counted, and an update that
+// changes one of several predicated fields must move the answer.
+func TestMultiFieldMVCC(t *testing.T) {
+	c := multiFixture(t, 3000)
+	defer c.Close()
+	// Supersede a slice of records so they no longer satisfy RequestCpus >= 4.
+	for i := 0; i < 500; i++ {
+		if err := c.Put([]byte(fmt.Sprintf("k%d", i)),
+			mustAdOld(t, fmt.Sprintf("ClusterId = %d\nProcId = %d\nJobStatus = 4\nRequestCpus = 1\n"+
+				"RequestMemory = %d\nRemoteWallClockTime = 1.5\nOwner = \"u%d\"",
+				i/10, i%10, 1024+(i%32)*512, i%32))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	q, err := vm.Parse("RequestMemory > 4096 && RequestCpus >= 4")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := 0
+	for range c.Query(q) {
+		want++
+	}
+	got, served := c.CountQuery(q)
+	if !served {
+		t.Fatal("declined after an update")
+	}
+	if got != want {
+		t.Errorf("columnar %d != row %d after supersession", got, want)
+	}
+}
+
+// BenchmarkMultiFieldCount is the point: what the multi-field column scan is worth against the row
+// scan it replaces, and against the single-field special case on identical work.
+func BenchmarkMultiFieldCount(b *testing.B) {
+	c := multiFixture(b, 60000)
+	defer c.Close()
+	for _, expr := range []string{
+		"RequestMemory > 4096",
+		"RequestMemory > 4096 && RequestCpus >= 4",
+		"JobStatus == 4 && RequestMemory > 2048 && ProcId < 5",
+	} {
+		q, err := vm.Parse(expr)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if _, ok := c.CountQuery(q); !ok {
+			b.Fatalf("%s declined", expr)
+		}
+		b.Run("columnar/"+expr, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				c.CountQuery(q)
+			}
+		})
+		b.Run("rowScan/"+expr, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				n := 0
+				for range c.Query(q) {
+					n++
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkSingleFieldRoute guards the common case. Every single-field query now goes through the
+// multi-field scan, so it must not be slower than the path it replaced -- one narrowing pass over one
+// column against one strided pass with a direct callback.
+func BenchmarkSingleFieldRoute(b *testing.B) {
+	c := multiFixture(b, 60000)
+	defer c.Close()
+	st := c.schemaScan.Load()
+	q, err := vm.Parse("RequestMemory > 4096")
+	if err != nil {
+		b.Fatal(err)
+	}
+	preds, ok := c.numPredsOnFields(q, st.schema)
+	if !ok || len(preds) != 1 {
+		b.Fatalf("expected one combined predicate, got %d (ok=%v)", len(preds), ok)
+	}
+	fieldID, eval, ok := c.numPredOnField(q, st.schema)
+	if !ok {
+		b.Fatal("single-field analysis declined")
+	}
+	// Same answer from both, or the comparison is meaningless.
+	if a, bb := c.schemaScanCountMulti(preds, st.cache), c.schemaScanCount(fieldID, st.cache, eval); a != bb {
+		b.Fatalf("multi=%d single=%d", a, bb)
+	}
+	b.Run("multiPath", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			c.schemaScanCountMulti(preds, st.cache)
+		}
+	})
+	b.Run("oldSinglePath", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			c.schemaScanCount(fieldID, st.cache, eval)
+		}
+	})
+}

--- a/collections/colscan.go
+++ b/collections/colscan.go
@@ -536,6 +536,21 @@ func (c *Collection) CountQuery(q *vm.Query) (int, bool) {
 	// The predicate analysis is shared with NumStatsQuery (see numPredOnField). fieldID is only
 	// the routing decision -- the attr is a numeric field in the CURRENT schema; the scan
 	// resolves the field per block against each block's own schema.
+	// Multi-field first: it subsumes the single-field case (one combined predicate) and additionally
+	// serves conjunctions across several columns, which used to fall off the cliff into a full row
+	// scan even though the shape is still `Attr OP literal`, just repeated.
+	if preds, ok := c.numPredsOnFields(q, st.schema); ok {
+		names := make([]string, 0, len(preds))
+		for _, p := range preds {
+			if name, ok := c.schemaFieldName(p.fieldID); ok {
+				names = append(names, name)
+			}
+		}
+		if len(names) > 0 {
+			c.demand.recordReads(names)
+		}
+		return c.schemaScanCountMulti(preds, st.cache), true
+	}
 	fieldID, eval, ok := c.numPredOnField(q, st.schema)
 	if !ok {
 		// Not a scalar comparison. A lone presence probe (`attr is undefined`) is still

--- a/collections/colscan_countquery_test.go
+++ b/collections/colscan_countquery_test.go
@@ -74,19 +74,40 @@ func TestCountQueryAutoRoute(t *testing.T) {
 		}
 	}
 
-	// Not columnar-eligible: must decline (ok=false) so the caller uses the normal scan.
+	// A conjunction across SEVERAL numeric fields is columnar-eligible too (see numPredsOnFields):
+	// the shape is still `Attr OP literal`, just repeated, so it is served by one narrowing pass per
+	// column rather than by a full row scan.
 	for _, expr := range []string{
-		`Machine == "m0001"`,        // string field, not int schema
-		"Cpus > 2 && Memory > 4096", // two fields
-		"Memory > 4096 || Cpus > 2", // disjunction across fields
-		"Cpus > 2",                  // int field but not the hot/scanned one? still int -> eligible IF Cpus is an int schema field
+		"Cpus > 2",
+		"Cpus > 2 && Memory > 4096",
+		"Cpus > 2 && Memory > 4096 && Memory < 9000",
 	} {
 		q, _ := vm.Parse(expr)
-		if _, ok := store.CountQuery(q); ok {
-			// Cpus is a valid int schema field, so "Cpus > 2" legitimately routes; only assert
-			// the genuinely-ineligible ones decline.
-			if expr != "Cpus > 2" {
-				t.Errorf("%q: CountQuery accepted an ineligible predicate", expr)
+		got, ok := store.CountQuery(q)
+		if !ok {
+			t.Errorf("%q: CountQuery declined a multi-field conjunction of scalar comparisons", expr)
+			continue
+		}
+		if want := storeCount(expr); got != want {
+			t.Errorf("%q: CountQuery = %d, store.Query = %d", expr, got, want)
+		}
+	}
+
+	// Not columnar-eligible: must decline (ok=false) so the caller uses the normal scan.
+	for _, expr := range []string{
+		`Machine == "m0001"`,                    // string field, not a numeric schema field
+		"Memory > 4096 || Cpus > 2",             // disjunction: the probes do not cover it
+		"Memory > Cpus",                         // no literal to compare against
+		"Memory > 4096 && Machine == \"m0001\"", // one conjunct on a string field
+	} {
+		q, _ := vm.Parse(expr)
+		if got, ok := store.CountQuery(q); ok {
+			// Serving is only a bug if the answer differs; assert the stronger property.
+			if want := storeCount(expr); got != want {
+				t.Errorf("%q: CountQuery accepted an ineligible predicate AND answered %d (want %d)",
+					expr, got, want)
+			} else {
+				t.Errorf("%q: CountQuery accepted a predicate expected to be ineligible", expr)
 			}
 		}
 	}


### PR DESCRIPTION
`numPredOnField` serves a conjunction of scalar comparisons on a **single** numeric field, so `RequestMemory > 4096` was columnar and `RequestMemory > 4096 && RequestCpus >= 4` fell all the way back to decoding whole ads. That's a cliff, not a slope — and nothing about reading two columns instead of one requires the general evaluator. The shape is still `Attr OP literal`, just repeated.

## Column at a time, not record at a time

`numPredsOnFields` accepts any number of numeric fields (combining several probes on the same field into one predicate), and `schemaScanCountMulti` evaluates them as **one narrowing pass per field**: each pass is a tight strided read of a single column rather than a walk hopping between columns per record. A selective first predicate makes every later pass cheaper, and a pass that empties the candidate set ends the block early.

## Measured, 60k job-shaped records

| query | columnar | row scan | gain |
|---|---|---|---|
| `RequestMemory > 4096` | **797 µs** | 14.9 ms | **18.7x** |
| `RequestMemory > 4096 && RequestCpus >= 4` | **1.07 ms** | 16.4 ms | **15.4x** |
| `JobStatus==4 && RequestMemory>2048 && ProcId<5` | **1.07 ms** | 11.2 ms | **10.4x** |

Three fields costs no more than two, because `JobStatus == 4` cuts the candidate set to a fifth and the remaining passes only look at survivors — the narrowing design paying for itself.

For scale: the general columnar evaluator prototype (#172) reached ~2x on the two-field query. For this shape the hand-written scan is worth roughly **8x more** than the general one.

Allocations: 37–52 KB against 9.7–41 MB for the row scan.

## Semantics

Counting matches means counting records where the constraint is TRUE, and for a conjunction that is *every* comparison TRUE. A missing or non-numeric value leaves its comparison UNDEFINED, and a conjunction with an UNDEFINED and no FALSE is UNDEFINED — not TRUE. So a record whose value is absent can simply be dropped, which is what lets each pass narrow the set independently, and it holds for every combination of the other predicates.

Exercised against the row path on seven shapes including a missing value, a non-numeric value, a value too wide for its fitted slot (escaped to the cold tail), a real field, and a query only escaped values satisfy.

## No regression for the common case

Single-field queries now route through this path too, so I benchmarked it against the path it replaced on identical data: **761 µs vs 788 µs** — unchanged.

## Fallback

A segment whose own schema lacks one of the fields, and the active segment, are counted by a row walk that reads **only the predicated attributes** rather than decoding the ad. A schema change costs no more than the segments it actually affects.

## Test change worth flagging

`TestCountQueryAutoRoute` asserted that `"Cpus > 2 && Memory > 4096"` must be **declined**. That encoded the old restriction, not a correctness property. It now checks such queries are served *and* agree with the row path, and its genuinely-ineligible cases assert the stronger property that a served query must still answer correctly — so a future widening can't turn that list into silent wrong answers.

`collections`, `db`, `dbrpc` green. (One `dbrpc` run failed under concurrent load and passed on two subsequent runs; unrelated to this change, and noted rather than ignored.)

Next: composing columnar evaluation with index pruning, which is the case where the columnar path still loses to the row path.
