### PR TITLE
collections: prune row groups by column range (20x on selective queries, free otherwise)

### DIFF
--- a/collections/colblock.go
+++ b/collections/colblock.go
@@ -3,6 +3,7 @@ package collections
 import (
 	"encoding/binary"
 	"errors"
+	"math"
 	"sync/atomic"
 
 	"github.com/PelicanPlatform/classad/collections/wire"
@@ -143,6 +144,26 @@ type columnarBlock struct {
 
 	strComp, coldComp []byte // per-record string regions / cold tails, concatenated + compressed
 	strOff, coldOff   []int  // per-record cumulative offsets into the decompressed streams
+
+	// zones is the per-field [min,max] of this block's NUMERIC columns, keyed by schema field index,
+	// so a scan can skip the whole block when no value in it could satisfy a predicate. It is the
+	// row-group equivalent of the per-segment zone map, and row groups are what make it worth having:
+	// a segment-wide range over a 1 GiB segment rules out almost nothing, while a ~1 MiB group's does.
+	//
+	// Computed while encoding, where the values are already in hand -- a separate pass would cost the
+	// scan it is meant to save.
+	zones map[int]blockZone
+}
+
+// blockZone is one numeric column's range within a block.
+//
+// escaped matters for correctness, not for speed: min/max cover only values stored in the column, so
+// if any record in the block has this field ESCAPED (missing, wrong type, or too wide) its value is
+// not represented here and the range cannot rule the block out. A too-wide value in particular is by
+// definition outside the column's range, so pruning on an inexact zone would drop records that match.
+type blockZone struct {
+	zoneRange
+	escaped bool
 }
 
 // encodeColumnarBlock builds a columnar block from row-form records (each the output of
@@ -211,6 +232,7 @@ func encodeColumnarBlock(s *adSchema, recs [][]byte, hotNumFields []int, regionC
 		b.strOff = append(b.strOff, len(strCat))
 		b.coldOff = append(b.coldOff, len(coldCat))
 	}
+	b.zones = numericZones(s, b, recs)
 	b.coldNumComp = regionCodec.Compress(nil, coldRaw)
 	b.strComp = regionCodec.Compress(nil, strCat)
 	b.coldComp = regionCodec.Compress(nil, coldCat)
@@ -275,6 +297,60 @@ func buildColumnarFromSegment(data []byte, upto int, arenaCodec, regionCodec Cod
 		blocks = append(blocks, encodeColumnarBlock(s, nil, hot, regionCodec))
 	}
 	return blocks, offs
+}
+
+// numericZones computes each numeric field's [min,max] over the records being encoded, and whether
+// any record escaped that field. Reads the row-form records directly, since encodeColumnarBlock has
+// them in hand.
+func numericZones(s *adSchema, b *columnarBlock, recs [][]byte) map[int]blockZone {
+	if len(recs) == 0 {
+		return nil
+	}
+	out := make(map[int]blockZone, len(b.hotNum)+len(b.coldNum))
+	for _, idx := range append(append([]int(nil), b.hotNum...), b.coldNum...) {
+		f := s.fields[idx]
+		z := blockZone{zoneRange: zoneRange{Min: math.Inf(1), Max: math.Inf(-1)}}
+		n := 0
+		for _, r := range recs {
+			if testBit(r[:s.escBytes], idx) {
+				z.escaped = true
+				continue
+			}
+			raw := readIntLE(r[s.escBytes+f.off:], f.width, f.unsigned)
+			v := float64(raw)
+			if f.kind == akReal {
+				v = math.Float64frombits(uint64(raw))
+			}
+			if v < z.Min {
+				z.Min = v
+			}
+			if v > z.Max {
+				z.Max = v
+			}
+			n++
+		}
+		if n == 0 {
+			// Every record escaped: there is no range, and the block can never be pruned on it.
+			z.Min, z.Max, z.escaped = math.Inf(-1), math.Inf(1), true
+		}
+		out[idx] = z
+	}
+	return out
+}
+
+// mayMatch reports whether this block could hold a record satisfying every test on field idx. A block
+// with no zone for the field, or an inexact one (some record escaped), is never ruled out.
+func (b *columnarBlock) mayMatch(idx int, tests []zoneTest) bool {
+	z, ok := b.zones[idx]
+	if !ok || z.escaped {
+		return true
+	}
+	for _, t := range tests {
+		if !zoneMayMatch(z.zoneRange, t.op, t.vals) {
+			return false
+		}
+	}
+	return true
 }
 
 // scanInt calls fn for each record's value of a numeric (int/real read as int bits) field: a

--- a/collections/colmulti.go
+++ b/collections/colmulti.go
@@ -27,9 +27,19 @@ import (
 // is what lets each pass simply narrow the candidate set.
 
 // fieldPred is one field's combined test: the conjunction of every probe on that field.
+//
+// tests keeps each probe's (op, values) alongside the compiled eval, because a block's zone can rule
+// the block out from the operator and bound alone -- and an eval closure cannot be reasoned about.
 type fieldPred struct {
 	fieldID uint32
 	eval    func(float64) bool
+	tests   []zoneTest
+}
+
+// zoneTest is one comparison in the form the zone map reasons about (see zoneMayMatch).
+type zoneTest struct {
+	op   string
+	vals []float64
 }
 
 // numPredsOnFields analyzes q as a conjunction of scalar numeric comparisons over ANY number of
@@ -45,6 +55,7 @@ func (c *Collection) numPredsOnFields(q *vm.Query, s *adSchema) ([]fieldPred, bo
 	}
 	order := make([]uint32, 0, len(probes))
 	cmps := make(map[uint32][]func(float64) bool, len(probes))
+	tests := make(map[uint32][]zoneTest, len(probes))
 	for _, p := range probes {
 		id, ok := c.intern.LookupID(p.Attr)
 		if !ok {
@@ -66,6 +77,7 @@ func (c *Collection) numPredsOnFields(q *vm.Query, s *adSchema) ([]fieldPred, bo
 			order = append(order, id)
 		}
 		cmps[id] = append(cmps[id], cmp)
+		tests[id] = append(tests[id], zoneTest{op: up.op, vals: up.fvals})
 	}
 	if len(order) == 0 {
 		return nil, false
@@ -74,7 +86,7 @@ func (c *Collection) numPredsOnFields(q *vm.Query, s *adSchema) ([]fieldPred, bo
 	for _, id := range order {
 		list := cmps[id]
 		if len(list) == 1 {
-			preds = append(preds, fieldPred{fieldID: id, eval: list[0]})
+			preds = append(preds, fieldPred{fieldID: id, eval: list[0], tests: tests[id]})
 			continue
 		}
 		preds = append(preds, fieldPred{fieldID: id, eval: func(v float64) bool {
@@ -84,7 +96,7 @@ func (c *Collection) numPredsOnFields(q *vm.Query, s *adSchema) ([]fieldPred, bo
 				}
 			}
 			return true
-		}})
+		}, tests: tests[id]})
 	}
 	return preds, true
 }
@@ -118,6 +130,13 @@ func (c *Collection) schemaScanCountMulti(preds []fieldPred, bc *blockCache) int
 			}
 			base := 0
 			for _, blk := range cs.blocks {
+				// Skip the whole block when its own column ranges rule it out -- no visibility
+				// walk, no column reads, no cold-tail decompression. This is where row groups pay
+				// off a second time: the finer the block, the more a selective predicate can skip.
+				if !blockMayMatch(blk, idxs, preds) {
+					base += blk.n
+					continue
+				}
 				if cap(keep) < blk.n {
 					keep = make([]bool, blk.n)
 				}
@@ -150,6 +169,16 @@ func (c *Collection) schemaScanCountMulti(preds []fieldPred, bc *blockCache) int
 		releaseWindows(wins)
 	}
 	return count
+}
+
+// blockMayMatch reports whether blk could hold a record satisfying every predicate.
+func blockMayMatch(blk *columnarBlock, idxs []int, preds []fieldPred) bool {
+	for i := range preds {
+		if !blk.mayMatch(idxs[i], preds[i].tests) {
+			return false
+		}
+	}
+	return true
 }
 
 // resolveFields maps each predicate's field to its index in this SEGMENT's schema. Segments sealed

--- a/collections/colpersist.go
+++ b/collections/colpersist.go
@@ -3,6 +3,7 @@ package collections
 import (
 	"encoding/binary"
 	"hash/crc32"
+	"math"
 )
 
 // Serialization of a sealed segment's columnar accelerator (schema + block streams + the
@@ -26,8 +27,14 @@ const (
 	// derived state, so no migration is needed. v3 in particular MUST be a version bump rather than
 	// a silent change: a v2 section's regions were compressed with a trained dictionary, so decoding
 	// them with the base codec would fail or, worse, be attempted against whatever dictionary the
-	// segment currently carries.
-	colSectionVersion = 3
+	// segment currently carries. v4 adds each block's per-field numeric zones.
+	//
+	// The zones are persisted rather than recomputed on reload because computing them costs a full
+	// pass over every column -- exactly the work they exist to skip -- so a reopened table would lose
+	// block pruning until something rebuilt its blocks. A missing zone is SAFE (mayMatch never rules
+	// a block out without one), so this is a performance property, which is precisely the kind that
+	// disappears quietly.
+	colSectionVersion = 4
 	colSectionHdr     = 4 + 2 + 4 + 4 // magic u32 | version u16 | upto u32 | crc u32
 )
 
@@ -140,6 +147,17 @@ func marshalColSegment(cs *colSegment, nameOf func(uint32) (string, bool)) []byt
 		for _, v := range b.coldOff {
 			dst = appendU32(dst, uint32(v))
 		}
+		dst = appendU32(dst, uint32(len(b.zones)))
+		for idx, z := range b.zones {
+			dst = appendU32(dst, uint32(idx))
+			dst = appendU64(dst, math.Float64bits(z.Min))
+			dst = appendU64(dst, math.Float64bits(z.Max))
+			esc := uint32(0)
+			if z.escaped {
+				esc = 1
+			}
+			dst = appendU32(dst, esc)
+		}
 	}
 	dst = appendU32(dst, uint32(len(cs.offs)))
 	for _, o := range cs.offs {
@@ -190,6 +208,24 @@ func unmarshalColSegment(data []byte, codec Codec, internName func(string) uint3
 		b.coldComp = c.bytes()
 		b.strOff = readInts(c)
 		b.coldOff = readInts(c)
+		if nz := int(c.u32()); nz > 0 {
+			if nz > len(s.fields) || !c.need(0) {
+				return nil
+			}
+			b.zones = make(map[int]blockZone, nz)
+			for j := 0; j < nz; j++ {
+				idx := int(c.u32())
+				z := blockZone{zoneRange: zoneRange{
+					Min: math.Float64frombits(c.u64()),
+					Max: math.Float64frombits(c.u64()),
+				}}
+				z.escaped = c.u32() != 0
+				if idx < 0 || idx >= len(s.fields) {
+					return nil
+				}
+				b.zones[idx] = z
+			}
+		}
 		if c.err != nil {
 			return nil
 		}

--- a/collections/colzones_test.go
+++ b/collections/colzones_test.go
@@ -1,0 +1,322 @@
+package collections
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/collections/vm"
+)
+
+// Per-block zone pruning. A block whose column range cannot satisfy a predicate is skipped whole --
+// no visibility walk, no column read, no cold-tail decompression.
+//
+// Pruning is a PERFORMANCE property enforced by a CORRECTNESS one: skipping a block that does hold a
+// match silently undercounts. So every test here compares against the same query with pruning
+// disabled, and the escape case is called out separately because it is the one that looks safe and
+// is not.
+
+// zoneFixture builds records whose ClusterId increases monotonically (so blocks are clustered by it)
+// while RequestMemory cycles (so blocks are not clustered by that). Optionally one record carries a
+// too-wide ClusterId, which ESCAPES: its value is not in the column, so the column range does not
+// describe it.
+func zoneFixture(tb testing.TB, n int, wideAt int) *Collection {
+	tb.Helper()
+	c := New(Options{Shards: 1, SegmentSize: 1 << 16})
+	for i := 0; i < n; i++ {
+		cluster := fmt.Sprintf("%d", i) // monotonic: clusters blocks
+		if wideAt >= 0 && i == wideAt {
+			cluster = fmt.Sprintf("%d", 1<<40) // too wide for the fitted slot -> escapes
+		}
+		src := fmt.Sprintf("ClusterId = %s\nProcId = %d\nRequestMemory = %d\nRequestCpus = %d\nOwner = \"u%d\"",
+			cluster, i%10, 1024+(i%32)*512, 1+i%8, i%32)
+		if err := c.Put([]byte(fmt.Sprintf("k%d", i)), mustAdOld(tb, src)); err != nil {
+			tb.Fatal(err)
+		}
+	}
+	for _, e := range []string{"ClusterId >= 0", "RequestMemory >= 0", "RequestCpus >= 0"} {
+		q, err := vm.Parse(e)
+		if err != nil {
+			tb.Fatal(err)
+		}
+		for i := 0; i < 20; i++ {
+			for range c.Query(q) {
+			}
+		}
+	}
+	if !c.BuildAndEnableSchemaScan(4000, 8) {
+		tb.Skip("no sealed segments")
+	}
+	return c
+}
+
+// stripZones removes every block's zones, disabling pruning, and reports how many it cleared.
+func stripZones(c *Collection) int {
+	n := 0
+	for _, sh := range c.shards {
+		sh.mu.RLock()
+		segs := append([]*segment(nil), sh.segs...)
+		sh.mu.RUnlock()
+		for _, seg := range segs {
+			if seg == nil {
+				continue
+			}
+			if cs := seg.colblk.Load(); cs != nil {
+				for _, blk := range cs.blocks {
+					if len(blk.zones) > 0 {
+						blk.zones = nil
+						n++
+					}
+				}
+			}
+		}
+	}
+	return n
+}
+
+// TestZonePruningPreservesAnswers is the correctness gate: pruning must not change any answer.
+func TestZonePruningPreservesAnswers(t *testing.T) {
+	queries := []string{
+		"ClusterId < 100",                         // only the earliest blocks
+		"ClusterId > 3900",                        // only the latest
+		"ClusterId >= 1000 && ClusterId < 1100",   // a narrow band in the middle
+		"ClusterId == 2500",                       // a single value
+		"ClusterId > 99999",                       // nothing: every block prunable
+		"RequestMemory > 4096",                    // unclustered: nothing prunable
+		"ClusterId < 500 && RequestMemory > 4096", // one clustered, one not
+	}
+	// With pruning.
+	c := zoneFixture(t, 4000, -1)
+	defer c.Close()
+	withPruning := map[string]int{}
+	for _, expr := range queries {
+		q, err := vm.Parse(expr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got, served := c.CountQuery(q)
+		if !served {
+			t.Fatalf("%s: declined", expr)
+		}
+		withPruning[expr] = got
+	}
+	// Same store, pruning disabled.
+	if n := stripZones(c); n == 0 {
+		t.Fatal("no block carried zones; pruning was never active and this test proves nothing")
+	}
+	for _, expr := range queries {
+		q, err := vm.Parse(expr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got, served := c.CountQuery(q)
+		if !served {
+			t.Fatalf("%s: declined without zones", expr)
+		}
+		row := 0
+		for range c.Query(q) {
+			row++
+		}
+		if got != row {
+			t.Errorf("%s: unpruned columnar %d != row %d", expr, got, row)
+		}
+		if withPruning[expr] != got {
+			t.Errorf("%s: PRUNING CHANGED THE ANSWER: %d with zones, %d without",
+				expr, withPruning[expr], got)
+		}
+		t.Logf("%-42s %d (identical with and without pruning)", expr, got)
+	}
+}
+
+// TestZonePruningRespectsEscapedValues is the case that looks safe and is not. A value too wide for
+// its slot lives in the cold tail, so the column's [min,max] does not describe it -- pruning on that
+// range would drop a record that matches.
+func TestZonePruningRespectsEscapedValues(t *testing.T) {
+	const n = 4000
+	// The wide record sits early, so its block's COLUMN range is roughly [0,128) while the record
+	// itself holds 2^40. A query for the wide value must still find it.
+	c := zoneFixture(t, n, 5)
+	defer c.Close()
+
+	q, err := vm.Parse(fmt.Sprintf("ClusterId == %d", int64(1)<<40))
+	if err != nil {
+		t.Fatal(err)
+	}
+	row := 0
+	for range c.Query(q) {
+		row++
+	}
+	if row != 1 {
+		t.Fatalf("row path found %d records with the wide ClusterId, want 1: the fixture is wrong", row)
+	}
+	got, served := c.CountQuery(q)
+	if !served {
+		t.Skip("columnar path declined")
+	}
+	if got != 1 {
+		t.Errorf("columnar count %d, want 1: a block was pruned on a column range that does not "+
+			"describe its escaped value", got)
+	}
+	// And the block holding it must be marked inexact, which is what makes that safe.
+	found := false
+	for _, sh := range c.shards {
+		sh.mu.RLock()
+		segs := append([]*segment(nil), sh.segs...)
+		sh.mu.RUnlock()
+		for _, seg := range segs {
+			if seg == nil {
+				continue
+			}
+			cs := seg.colblk.Load()
+			if cs == nil {
+				continue
+			}
+			for _, blk := range cs.blocks {
+				for _, z := range blk.zones {
+					if z.escaped {
+						found = true
+					}
+				}
+			}
+		}
+	}
+	if !found {
+		t.Error("no block zone is marked escaped; nothing would stop pruning from dropping the match")
+	}
+}
+
+// TestZonesSurviveReopen covers persistence: zones are a performance property, so losing them on
+// reload would be silent.
+func TestZonesSurviveReopen(t *testing.T) {
+	dir := t.TempDir()
+	c, err := Open(Options{Dir: dir, Shards: 1, SegmentSize: 1 << 16})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 4000; i++ {
+		if err := c.Put([]byte(fmt.Sprintf("k%d", i)),
+			mustAdOld(t, fmt.Sprintf("ClusterId = %d\nProcId = %d\nRequestMemory = %d",
+				i, i%10, 1024+(i%32)*512))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if !c.BuildAndEnableSchemaScan(4000, 8) {
+		t.Skip("no sealed segments")
+	}
+	q, err := vm.Parse("ClusterId >= 1000 && ClusterId < 1100")
+	if err != nil {
+		t.Fatal(err)
+	}
+	before, served := c.CountQuery(q)
+	if !served {
+		t.Fatal("declined before reopen")
+	}
+	if err := c.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	c2, err := Open(Options{Dir: dir, Shards: 1, SegmentSize: 1 << 16})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c2.Close()
+	zoned := 0
+	for _, sh := range c2.shards {
+		sh.mu.RLock()
+		segs := append([]*segment(nil), sh.segs...)
+		sh.mu.RUnlock()
+		for _, seg := range segs {
+			if seg == nil {
+				continue
+			}
+			if cs := seg.colblk.Load(); cs != nil {
+				for _, blk := range cs.blocks {
+					if len(blk.zones) > 0 {
+						zoned++
+					}
+				}
+			}
+		}
+	}
+	if zoned == 0 {
+		t.Error("no reloaded block carries zones; block pruning is silently off after a reopen")
+	}
+	after, served := c2.CountQuery(q)
+	if !served {
+		t.Skip("declined after reopen (accelerator not adopted)")
+	}
+	if after != before {
+		t.Errorf("count changed across reopen: %d -> %d", before, after)
+	}
+	t.Logf("%d reloaded block(s) carry zones; count %d preserved", zoned, after)
+}
+
+// BenchmarkZonePruning measures it where it can help (a clustered attribute) and where it cannot
+// (an unclustered one), because pruning that only helps clustered data is a different claim from
+// pruning that always helps.
+func BenchmarkZonePruning(b *testing.B) {
+	for _, tc := range []struct{ name, expr string }{
+		{"clustered/narrowBand", "ClusterId >= 1000 && ClusterId < 1100"},
+		{"clustered/noMatch", "ClusterId > 99999999"},
+		{"unclustered", "RequestMemory > 4096"},
+	} {
+		c := zoneFixture(b, 60000, -1)
+		q, err := vm.Parse(tc.expr)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if _, ok := c.CountQuery(q); !ok {
+			b.Fatalf("%s declined", tc.expr)
+		}
+		b.Run(tc.name+"/pruned", func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				c.CountQuery(q)
+			}
+		})
+		stripZones(c)
+		b.Run(tc.name+"/unpruned", func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				c.CountQuery(q)
+			}
+		})
+		c.Close()
+	}
+}
+
+// BenchmarkZonePruningEndToEnd is the whole stack against the path it replaces: a selective query on
+// a clustered attribute, columnar with block pruning versus the ordinary row scan.
+func BenchmarkZonePruningEndToEnd(b *testing.B) {
+	c := zoneFixture(b, 60000, -1)
+	defer c.Close()
+	q, err := vm.Parse("ClusterId >= 1000 && ClusterId < 1100")
+	if err != nil {
+		b.Fatal(err)
+	}
+	got, ok := c.CountQuery(q)
+	if !ok {
+		b.Fatal("declined")
+	}
+	row := 0
+	for range c.Query(q) {
+		row++
+	}
+	if got != row {
+		b.Fatalf("columnar %d != row %d", got, row)
+	}
+	b.Run("columnarPruned", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			c.CountQuery(q)
+		}
+	})
+	b.Run("rowScan", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			n := 0
+			for range c.Query(q) {
+				n++
+			}
+		}
+	})
+}


### PR DESCRIPTION
Stacked on #174. Composes the columnar scan with pruning, which was the remaining case where it lost to the row path.

## The gap

The multi-field column scan reads every record of every block, so a selective predicate costs the same as an unselective one. A per-block `[min,max]` per numeric column fixes that: a block whose range cannot satisfy a predicate is skipped **entirely** — no visibility walk, no column read, no cold-tail decompression.

This is the existing per-segment zone map applied one level down, and **row groups (#163) are what make it worth having**. A segment-wide range over a 1 GiB segment rules out almost nothing; a ~1 MiB group's range rules out most of a narrow band.

## Measured, 60k records, `ClusterId` monotonic so blocks are clustered by it

| case | pruned | unpruned | gain |
|---|---|---|---|
| clustered, 100 of 60k match | **30.4 µs** | 617 µs | **20.3x** |
| clustered, nothing matches | **22.2 µs** | 450 µs | **20.3x** |
| unclustered predicate | 461 µs | 463 µs | **1.00x** |

That last row is what makes it safe to leave always on — the per-block check costs nothing measurable when it can't help. Pruning that only helps clustered data is a different claim from pruning that always helps, so both are measured.

End to end against the path it replaces, the same selective query: **33.4 µs vs 13.3 ms** for the row scan (~397x), and 22.8 KB allocated against 7.7 MB.

## Correctness: the case that looks safe and isn't

A zone describes only values stored in the **column**. A value too wide for its fitted slot lives in the cold tail, so it is *by definition outside* its column's range — pruning on that range would drop a record that matches.

So a block with any escaped value for a field (missing, wrong type, or too wide) is marked **inexact** and never pruned on it. `TestZonePruningRespectsEscapedValues` stores a `2^40` ClusterId in an early block whose column range is roughly `[0,128)` and requires the query to still find it — and asserts some block zone is actually marked escaped, so the guard isn't vacuously satisfied.

Every pruning test compares against the same query with zones **stripped**, so a wrongly skipped block shows up as a *changed answer* rather than merely as a faster one.

## Why zones are computed at encode time and persisted

Computed while encoding, where the values are already in hand — a separate pass would cost exactly the scan they exist to save.

Persisted in the sidecar (section **v4**) because recomputing them means a full pass over every column, so a reopened table would otherwise lose block pruning until something rebuilt its blocks. A missing zone is *safe* (`mayMatch` never rules a block out without one), which makes that loss invisible — a performance property that fails silently. `TestZonesSurviveReopen` asserts reloaded blocks carry zones and the count is unchanged.

## Cumulative effect on the reported query shapes

| | before this series | now |
|---|---|---|
| `Memory > 4096` | 14.9 ms (row) | 797 µs |
| `Memory > 4096 && Cpus >= 4` | 16.4 ms (row) | 1.07 ms |
| selective on a clustered attr | 13.3 ms (row) | **33.4 µs** |

`collections`, `db`, `dbrpc` green.
