### PR TITLE
db: route an archive's constrained COUNT(*) through the columnar accelerator (59-67x)

### DIFF
--- a/collections/archive.go
+++ b/collections/archive.go
@@ -220,6 +220,17 @@ func (a *Archive) Rotate(now float64) (int, error) { return a.c.Rotate(now) }
 // whole-segment steps.
 func (a *Archive) Count() int { return a.c.Len() }
 
+// CountConstraint counts the records matching constraint via the columnar accelerator, returning
+// ok=false when the columnar path cannot serve it (see Collection.CountConstraint) so the caller
+// scans instead.
+//
+// An archive is the big append-only scan target, and it is exactly where this was missing: a mutable
+// table's COUNT(*) WHERE reaches the columnar count through DB.CountConstraint, while an archive's
+// went to a wire-native scan of every record, even with an accelerator built over its segments.
+func (a *Archive) CountConstraint(constraint string) (int, bool) {
+	return a.c.CountConstraint(constraint)
+}
+
 // Truncate drops every record, resetting the archive to empty in place: all segments are
 // unmapped and their data + sidecar-index files unlinked (via the backing Collection's
 // Truncate). Segment counters keep advancing, so a fresh Append starts a new segment. This

--- a/db/archive.go
+++ b/db/archive.go
@@ -240,6 +240,18 @@ func (t *ArchiveTable) AggregateCols(constraint string, groupCols []GroupCol, ag
 	if rows, ok := t.aggregateFromIndex(constraint, groupCols, aggs); ok {
 		return rows, nil
 	}
+	// A CONSTRAINED COUNT(*) with no grouping: read the predicated columns out of the columnar
+	// blocks instead of scanning records. aggregateFromIndex above only answers the UNCONSTRAINED
+	// case (a constraint cannot be attributed to a whole segment's stored count), and
+	// ColumnarAggregate below declines a COUNT(*) because it has no attribute to aggregate -- so
+	// this shape reached neither, and fell to the scan even on an archive that carries an
+	// accelerator. It is the shape a history table is asked most.
+	if len(groupCols) == 0 && len(aggs) == 1 && aggs[0].Func == AggCount && aggs[0].Arg == "*" &&
+		aggs[0].Filter == "" {
+		if n, ok := t.a.CountConstraint(constraint); ok {
+			return []AggRow{{Values: []string{strconv.Itoa(n)}}}, nil
+		}
+	}
 	// A single MIN/MAX/COUNT(attr) over a numeric column reads that column out of the
 	// per-segment columnar blocks instead of decoding every record. Declines (and falls through
 	// to the scan) unless the archive carries an accelerator and the aggregate is in scope.
@@ -573,6 +585,12 @@ func (t *ArchiveTable) Stats() Stats { return t.a.Stats() }
 // OpStats reports cumulative operational timings. An archive has no DB-level snapshot lock,
 // so SnapshotLock is zero.
 func (t *ArchiveTable) OpStats() OpStats { return OpStats{OpStats: t.a.OpStats()} }
+
+// CountConstraint counts the rows matching constraint via the columnar accelerator, or reports
+// ok=false so the caller scans. See collections.Archive.CountConstraint.
+func (t *ArchiveTable) CountConstraint(constraint string) (int, bool) {
+	return t.a.CountConstraint(constraint)
+}
 
 // CodecStats reports the archive's compression (codec, dict size, last retrain, sampled ratio).
 func (t *ArchiveTable) CodecStats(sampleMax int) CodecStats { return t.a.CodecStats(sampleMax) }

--- a/db/archive_count_test.go
+++ b/db/archive_count_test.go
@@ -2,76 +2,171 @@ package db
 
 import (
 	"fmt"
-	"strconv"
 	"testing"
+
+	"github.com/PelicanPlatform/classad/classad"
 )
 
-// TestArchiveCountFastPath verifies an unconstrained COUNT(*) equals the archive's O(1)
-// record count (the fast path), and that constrained COUNT and SUM -- which take the
-// wire-native projected scan -- stay correct over a larger, multi-segment archive.
-func TestArchiveCountFastPath(t *testing.T) {
-	cat, err := OpenCatalog(t.TempDir())
+// A constrained COUNT(*) on an ARCHIVE reached neither index-answering (which only handles the
+// unconstrained case, since a constraint cannot be attributed to a whole segment's stored count) nor
+// ColumnarAggregate (which declines COUNT(*) for want of an attribute to aggregate). So the shape a
+// history table is asked most fell to a record scan even with an accelerator over its segments.
+
+func archiveCountFixture(tb testing.TB, n int) (*Catalog, *ArchiveTable) {
+	tb.Helper()
+	cat, err := OpenCatalogConfig(CatalogConfig{Dir: tb.TempDir()})
 	if err != nil {
-		t.Fatal(err)
+		tb.Fatal(err)
 	}
-	defer cat.Close()
-	hist, err := cat.CreateArchiveTable("history", ArchiveConfig{
-		SegmentSize: 1 << 12, // small -> several sealed segments
+	a, err := cat.CreateArchiveTable("history", ArchiveConfig{
+		SegmentSize: 1 << 16,
 		ValueAttrs:  []string{"ClusterId"},
-		ZoneAttrs:   []string{"ClusterId"},
 	})
 	if err != nil {
-		t.Fatal(err)
+		tb.Fatal(err)
 	}
-	const n = 500
-	sumOver := 0
 	for i := 0; i < n; i++ {
-		if err := hist.AppendOld(fmt.Sprintf("ClusterId = %d\nMemory = %d", i, i*2)); err != nil {
+		ad, err := classad.ParseOld(fmt.Sprintf(
+			"ClusterId = %d\nProcId = %d\nJobStatus = %d\nRequestMemory = %d\nRequestCpus = %d\n"+
+				"Owner = \"user%d\"\nCmd = \"/home/user%d/run.sh\"\nCompletionDate = %d",
+			i, i%10, 1+i%5, 1024+(i%32)*512, 1+i%8, i%512, i%512, 1700000000+i))
+		if err != nil {
+			tb.Fatal(err)
+		}
+		if err := a.Append(ad); err != nil {
+			tb.Fatal(err)
+		}
+	}
+	// Build the accelerator the way archive maintenance does.
+	if !a.BuildAndEnableSchemaScan(4000, 8) {
+		tb.Skip("no sealed segments to accelerate")
+	}
+	return cat, a
+}
+
+// scanCount is the reference: count by iterating the matching records.
+func scanCount(tb testing.TB, a *ArchiveTable, constraint string) int {
+	tb.Helper()
+	seq, err := a.Query(constraint)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	n := 0
+	for range seq {
+		n++
+	}
+	return n
+}
+
+// TestArchiveConstrainedCountMatchesScan is the equivalence gate over the shapes the columnar count
+// now serves, plus shapes it must decline and hand back to the scan.
+func TestArchiveConstrainedCountMatchesScan(t *testing.T) {
+	cat, a := archiveCountFixture(t, 5000)
+	defer cat.Close()
+
+	for _, constraint := range []string{
+		"RequestMemory > 4096",
+		"RequestMemory > 4096 && RequestCpus >= 4",
+		"JobStatus == 4 && RequestMemory > 2048 && ProcId < 5",
+		"ClusterId >= 1000 && ClusterId < 1100",
+		"ClusterId > 9999999",         // nothing matches
+		`Owner == "user3"`,            // a string field: must decline, and still be right
+		"RequestMemory > RequestCpus", // no literal: must decline
+		"true",                        // match-all: answered from the stored count
+	} {
+		want := scanCount(t, a, constraint)
+		rows, err := a.AggregateCols(constraint, nil, []AggSpec{{Func: AggCount, Arg: "*"}})
+		if err != nil {
+			t.Fatalf("%s: %v", constraint, err)
+		}
+		if len(rows) != 1 || len(rows[0].Values) != 1 {
+			t.Fatalf("%s: unexpected shape %+v", constraint, rows)
+		}
+		var got int
+		if _, err := fmt.Sscanf(rows[0].Values[0], "%d", &got); err != nil {
+			t.Fatalf("%s: unparsable count %q", constraint, rows[0].Values[0])
+		}
+		if got != want {
+			t.Errorf("%s: COUNT(*) = %d, scan = %d", constraint, got, want)
+		}
+		_, served := a.CountConstraint(constraint)
+		t.Logf("%-52s count=%-6d columnar=%v", constraint, got, served)
+	}
+}
+
+// TestArchiveCountConstraintDeclinesGracefully pins that a declined constraint still produces the
+// right answer through the scan, since the whole design rests on falling back rather than guessing.
+func TestArchiveCountConstraintDeclinesGracefully(t *testing.T) {
+	cat, a := archiveCountFixture(t, 2000)
+	defer cat.Close()
+	for _, constraint := range []string{`Owner == "user3"`, "RequestMemory > RequestCpus"} {
+		if _, served := a.CountConstraint(constraint); served {
+			t.Errorf("%s: expected the columnar count to decline", constraint)
+		}
+		rows, err := a.AggregateCols(constraint, nil, []AggSpec{{Func: AggCount, Arg: "*"}})
+		if err != nil {
 			t.Fatal(err)
 		}
-		if i >= 300 {
-			sumOver += i * 2
+		var got int
+		fmt.Sscanf(rows[0].Values[0], "%d", &got)
+		if want := scanCount(t, a, constraint); got != want {
+			t.Errorf("%s: fell back to the scan and got %d, want %d", constraint, got, want)
 		}
 	}
+}
 
-	// Unconstrained COUNT(*) -> the O(1) record count.
-	rows, err := hist.Aggregate("", nil, []AggSpec{{Func: AggCount, Arg: "*"}})
+// TestArchiveCountFilterNotServed guards the FILTER carve-out: a per-aggregate filter must not be
+// answered from a count that knows nothing about it.
+func TestArchiveCountFilterNotServed(t *testing.T) {
+	cat, a := archiveCountFixture(t, 2000)
+	defer cat.Close()
+	rows, err := a.AggregateCols("RequestMemory > 2048", nil,
+		[]AggSpec{{Func: AggCount, Arg: "*", Filter: "RequestCpus >= 4"}})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(rows) != 1 || rows[0].Values[0] != strconv.Itoa(n) {
-		t.Fatalf("COUNT(*) = %+v, want %d", rows, n)
+	var got int
+	fmt.Sscanf(rows[0].Values[0], "%d", &got)
+	want := scanCount(t, a, "RequestMemory > 2048 && RequestCpus >= 4")
+	if got != want {
+		t.Errorf("filtered COUNT(*) = %d, want %d: the filter was ignored", got, want)
 	}
-	if rows[0].Values[0] != strconv.Itoa(hist.Count()) {
-		t.Errorf("COUNT(*) %s != Count() %d", rows[0].Values[0], hist.Count())
-	}
-	// "true" is also match-all (same fast path).
-	rows, _ = hist.Aggregate("true", nil, []AggSpec{{Func: AggCount, Arg: "*"}})
-	if rows[0].Values[0] != strconv.Itoa(n) {
-		t.Errorf(`COUNT(*) WHERE true = %s, want %d`, rows[0].Values[0], n)
-	}
-	// A constant tautology folds to the SAME match-all fast path as "true", so
-	// "1 == 1" and "true" agree with COUNT() -- they must never diverge.
-	rows, _ = hist.Aggregate("1 == 1", nil, []AggSpec{{Func: AggCount, Arg: "*"}})
-	if rows[0].Values[0] != strconv.Itoa(n) {
-		t.Errorf(`COUNT(*) WHERE 1 == 1 = %s, want %d (must equal WHERE true)`, rows[0].Values[0], n)
-	}
+}
 
-	// Constrained COUNT(*) goes through the projected scan (not the fast path).
-	rows, err = hist.Aggregate("ClusterId >= 300", nil, []AggSpec{{Func: AggCount, Arg: "*"}})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if rows[0].Values[0] != strconv.Itoa(n-300) {
-		t.Errorf("COUNT(*) WHERE ClusterId>=300 = %s, want %d", rows[0].Values[0], n-300)
-	}
-
-	// SUM over a projected attribute (regression: the projected scan reads Memory correctly).
-	rows, err = hist.Aggregate("ClusterId >= 300", nil, []AggSpec{{Func: AggSum, Arg: "Memory"}})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if rows[0].Values[0] != strconv.Itoa(sumOver) {
-		t.Errorf("SUM(Memory) WHERE ClusterId>=300 = %s, want %d", rows[0].Values[0], sumOver)
+// BenchmarkArchiveConstrainedCount measures what the archive gains.
+func BenchmarkArchiveConstrainedCount(b *testing.B) {
+	cat, a := archiveCountFixture(b, 60000)
+	defer cat.Close()
+	// Multi-field conjunctions become columnar-servable with the N-conjunct column scan; on a base
+	// without it they decline, so skip rather than fail -- the point here is the archive routing, not
+	// which predicate shapes the collection can serve.
+	for _, constraint := range []string{
+		"RequestMemory > 4096",
+		"ClusterId >= 1000 && ClusterId < 1100",
+		"RequestMemory > 4096 && RequestCpus >= 4",
+	} {
+		if _, ok := a.CountConstraint(constraint); !ok {
+			b.Logf("skipping %q: the columnar count declines it on this base", constraint)
+			continue
+		}
+		b.Run("columnar/"+constraint, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				a.CountConstraint(constraint)
+			}
+		})
+		b.Run("scan/"+constraint, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				seq, err := a.Query(constraint)
+				if err != nil {
+					b.Fatal(err)
+				}
+				n := 0
+				for range seq {
+					n++
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
Stacked on #175, and **it has to be** — see the regression below.

## The gap

A history table's most common question, `COUNT(*)` with a `WHERE`, reached none of the archive's fast paths:

- `aggregateFromIndex` answers only the **unconstrained** case — a constraint can't be attributed to a whole segment's stored count.
- `ColumnarAggregate` declines `COUNT(*)` outright, since it has no attribute to aggregate (`db/colagg.go`: `Arg == "*"`).

So it fell to a record scan **even on an archive carrying a columnar accelerator**, while the identical query on a *mutable* table went through `DB.CountConstraint` and was served from columns. The archive is the big append-only scan target, so this was the wrong way round.

`ArchiveTable.CountConstraint` exposes the underlying collection's columnar count, and `AggregateCols` uses it for a single unfiltered `COUNT(*)` with no grouping, falling through to the scan when it declines.

## Why this depends on #175

Measured on a 60k-record archive whose `ClusterId` is a `ValueAttr`, so the **scan path can use its index**:

| | columnar | scan | |
|---|---|---|---|
| without block pruning | 619 µs | **216 µs** | columnar **2.9x slower** |
| with block pruning (#175) | **43.2 µs** | 250 µs | columnar **5.8x faster** |

The scan prunes an indexed selective constraint to a hundred records and reads only those; an unpruned columnar count reads every value of the column. So routing this shape without block pruning would be a **regression for exactly the queries an operator has bothered to index**. Block zones let the columnar path skip the same blocks, which inverts it.

I caught this by benchmarking the change on `main` first, where it showed 0.35x, before rebasing onto #175.

## Where a scan has nothing to help it

| constraint | columnar | scan | gain |
|---|---|---|---|
| `RequestMemory > 4096` | 1.35 ms | 90.8 ms | **67x** |
| `RequestMemory > 4096 && RequestCpus >= 4` | 1.22 ms | 72.4 ms | **59x** |

## Tests

Count checked against the scan over servable and unservable shapes: multi-field conjunctions, a same-field band, a constraint nothing matches, a **string field** and an **attribute-to-attribute** comparison (both must decline *and* still answer correctly through the scan), a match-all (answered from the stored count), and a per-aggregate `FILTER` — which must never be answered from a count that knows nothing about the filter.

## Measurement caveat

The columnar timings were taken while other suites ran concurrently and are noisier than the ratios suggest — 1.06–4.80 ms across runs for the first row. Medians are reported; the ratios are large enough that the noise doesn't change the conclusion, but the absolute numbers deserve a quiet re-run before anyone quotes them.

`collections`, `db`, `dbrpc` green.
