### PR TITLE
collections: evaluate any native query against the columns (colScope) — 2.1-2.7x on shapes nothing served

### DIFF
--- a/collections/colpresence_test.go
+++ b/collections/colpresence_test.go
@@ -123,10 +123,15 @@ func TestPresenceCountDeclinesOnExpression(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	got, served := c.CountQuery(q)
-	if served {
-		t.Errorf("columnar path served a query over an expression-valued attribute (returned %d); "+
-			"only evaluation can decide whether that record is undefined", got)
+	// The BITMAP path must decline -- only evaluation can judge an expression.
+	if _, served := c.PresenceCountQuery(q); served {
+		t.Error("the escape-bitmap presence path served a query over an expression-valued attribute; " +
+			"only evaluation can decide whether that record is undefined")
+	}
+	// CountQuery as a whole may still serve it, via the columnar EVALUATOR, which re-evaluates that
+	// one record the ordinary way -- so the requirement is a correct answer, not a refusal.
+	if got, served := c.CountQuery(q); served && got != rowTruth(t, c, "ProcId is undefined") {
+		t.Errorf("CountQuery answered %d, row path says %d", got, rowTruth(t, c, "ProcId is undefined"))
 	}
 	// And the ordinary path still answers correctly: the expression evaluates to undefined.
 	if want := rowTruth(t, c, "ProcId is undefined"); want != 1 {
@@ -186,7 +191,14 @@ func TestPresenceCountUnknownAttrDeclines(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got, served := c.CountQuery(q); served {
-		t.Errorf("served a presence query on an attribute with no schema field (returned %d)", got)
+	// The bitmap path has no bit for an attribute the schema does not carry, so it must decline.
+	if _, served := c.PresenceCountQuery(q); served {
+		t.Error("the escape-bitmap path served a presence query on an attribute with no schema field")
+	}
+	// The columnar evaluator can answer it (an un-interned name is undefined in every record), so
+	// CountQuery may serve it -- correctly.
+	if got, served := c.CountQuery(q); served && got != rowTruth(t, c, "NotAnAttribute is undefined") {
+		t.Errorf("CountQuery answered %d, row path says %d",
+			got, rowTruth(t, c, "NotAnAttribute is undefined"))
 	}
 }

--- a/collections/colscan.go
+++ b/collections/colscan.go
@@ -555,7 +555,22 @@ func (c *Collection) CountQuery(q *vm.Query) (int, bool) {
 	if !ok {
 		// Not a scalar comparison. A lone presence probe (`attr is undefined`) is still
 		// columnar-servable straight from the escape bitmap -- see PresenceCountQuery.
-		return c.PresenceCountQuery(q)
+		if n, served := c.PresenceCountQuery(q); served {
+			return n, true
+		}
+		// Last tier: evaluate the query itself against the columns (see ColumnarEvalCount). It serves
+		// any NATIVE query -- string comparisons, attribute-to-attribute, arithmetic, disjunctions --
+		// at roughly an order of magnitude less than the hand-written scans but several times better
+		// than decoding ads.
+		//
+		// Skipped when an index could prune the row path instead: this evaluates EVERY visible record,
+		// so against a selective indexed constraint the scan wins, and a routing that ignored that was
+		// measured 2.9x slower on exactly such a query.
+		// Skipped only when an index could prune the row path instead.
+		if !c.indexCanPrune(q) {
+			return c.ColumnarEvalCount(q)
+		}
+		return 0, false
 	}
 	// As NumStatsQuery: record the predicate's attribute so the hot tier keeps tracking the
 	// columns queries actually read, instead of freezing once the accelerator starts serving them.

--- a/collections/colscan_countquery_test.go
+++ b/collections/colscan_countquery_test.go
@@ -93,7 +93,10 @@ func TestCountQueryAutoRoute(t *testing.T) {
 		}
 	}
 
-	// Not columnar-eligible: must decline (ok=false) so the caller uses the normal scan.
+	// These reach no HAND-WRITTEN column scan. The columnar evaluator may still serve them (it
+	// evaluates the query itself), so the requirement is that whatever answers is correct -- which is
+	// the property that actually matters, and the one that keeps holding as more shapes become
+	// servable.
 	for _, expr := range []string{
 		`Machine == "m0001"`,                    // string field, not a numeric schema field
 		"Memory > 4096 || Cpus > 2",             // disjunction: the probes do not cover it
@@ -102,12 +105,8 @@ func TestCountQueryAutoRoute(t *testing.T) {
 	} {
 		q, _ := vm.Parse(expr)
 		if got, ok := store.CountQuery(q); ok {
-			// Serving is only a bug if the answer differs; assert the stronger property.
 			if want := storeCount(expr); got != want {
-				t.Errorf("%q: CountQuery accepted an ineligible predicate AND answered %d (want %d)",
-					expr, got, want)
-			} else {
-				t.Errorf("%q: CountQuery accepted a predicate expected to be ineligible", expr)
+				t.Errorf("%q: CountQuery answered %d, store.Query = %d", expr, got, want)
 			}
 		}
 	}

--- a/collections/colscope.go
+++ b/collections/colscope.go
@@ -1,0 +1,392 @@
+package collections
+
+import (
+	"encoding/binary"
+	"math"
+	"unsafe"
+
+	"github.com/PelicanPlatform/classad/ast"
+	"github.com/PelicanPlatform/classad/classad"
+	"github.com/PelicanPlatform/classad/collections/vm"
+	"github.com/PelicanPlatform/classad/collections/wire"
+)
+
+// Evaluating a query directly against columnar storage.
+//
+// The hand-written column scans serve `Attr OP literal` conjunctions on numeric fields, which is the
+// common case and is 10-500x. Everything else -- a string comparison, an attribute-to-attribute
+// comparison, arithmetic between attributes, a disjunction -- reached no columnar path at all and
+// decoded whole ads, even though all of it compiles to NATIVE instructions:
+//
+//	Owner == "user3"                        native, not served
+//	Owner == "user3" && RequestMemory > 4096 native, not served
+//	RequestMemory > RequestCpus * 512        native, not served
+//	ProcId >= 5 && ClusterId != ProcId       native, not served
+//	RequestMemory > 4096 || RequestCpus >= 4 native, not served
+//
+// Those are four different shapes, and extending the narrowing scan to each would be four special
+// cases -- disjunction does not fit a narrowing design at all. One resolver covers them, because the
+// evaluator is already backing-agnostic: vm.Matcher.EvalResolved takes a resolver and materializes no
+// ClassAd, and wireScope is the same idea over an ad's WIRE bytes. colScope is that resolver over a
+// block.
+//
+// It is the LAST tier, not the first. Per-record interpreter dispatch costs roughly an order of
+// magnitude more than a strided column read, so the hand-written paths run ahead of it and this
+// catches what they decline.
+
+// colScope resolves attribute references for record k of a columnar block.
+//
+// Reused across a scan (single-threaded): set k and clear fellBack before each evaluation, exactly as
+// wireScope is reused across a row scan.
+type colScope struct {
+	blk *columnarBlock
+	k   int
+	bc  *blockCache
+	c   *Collection
+	// fellBack means this record needs the ordinary evaluator: an attribute's stored value is an
+	// EXPRESSION, whose value depends on the rest of the ad. The caller re-evaluates that one record
+	// rather than abandoning the query.
+	fellBack bool
+
+	// bind caches name -> schema field index for the schema in bindFor: -1 means "not a schema field"
+	// (it lives in the cold tail), -2 means the table has never seen the name. A query's references
+	// are fixed, so resolving them per RECORD would pay InternTable.LookupID's mutex and possible
+	// case-fold on every value.
+	bind    map[string]int
+	bindFor *adSchema
+
+	strScratch []byte // decompressed string region, cached per block by the block cache
+}
+
+const (
+	bindColdTail = -1 // not a schema field: look in the cold tail
+	bindUnknown  = -2 // the table has never interned this name: no record can have it
+)
+
+// bindField resolves name against the current block's schema, caching the answer.
+func (cs *colScope) bindField(name string) int {
+	if cs.bindFor != cs.blk.schema {
+		cs.bind, cs.bindFor = make(map[string]int, 8), cs.blk.schema
+	}
+	if v, ok := cs.bind[name]; ok {
+		return v
+	}
+	v := bindColdTail
+	id, ok := cs.c.intern.LookupID(name)
+	if !ok {
+		v = bindUnknown
+	} else if i, ok := cs.blk.schema.byID[id]; ok {
+		v = i
+	}
+	cs.bind[name] = v
+	return v
+}
+
+// resolve is the attribute resolver handed to vm.Matcher.EvalResolved.
+func (cs *colScope) resolve(name string, scope ast.AttributeScope) classad.Value {
+	if scope != ast.NoScope && scope != ast.MyScope {
+		// TARGET/PARENT: a collection scan has no match target, and a chained parent lives in another
+		// record. wireScope returns undefined for TARGET; do the same rather than fall back, since
+		// falling back would not find one either.
+		return classad.NewUndefinedValue()
+	}
+	idx := cs.bindField(name)
+	if idx == bindUnknown {
+		// The table never interned this name, so no record defines it. Exact, no fallback.
+		return classad.NewUndefinedValue()
+	}
+	if idx == bindColdTail {
+		id, ok := cs.c.intern.LookupID(name)
+		if !ok {
+			return classad.NewUndefinedValue()
+		}
+		return cs.fromColdTail(id)
+	}
+	if testBit(cs.blk.escapeAt(cs.k), idx) {
+		// Escaped: missing, or present but not storable in its slot. Both live in the cold tail.
+		return cs.fromColdTail(cs.blk.schema.fields[idx].id)
+	}
+	f := cs.blk.schema.fields[idx]
+	switch f.kind {
+	case akInt:
+		v, ok := cs.slotInt(idx, f)
+		if !ok {
+			cs.fellBack = true
+			return classad.NewUndefinedValue()
+		}
+		return classad.NewIntValue(v)
+	case akReal:
+		v, ok := cs.slotInt(idx, f)
+		if !ok {
+			cs.fellBack = true
+			return classad.NewUndefinedValue()
+		}
+		return classad.NewRealValue(math.Float64frombits(uint64(v)))
+	case akBool:
+		return classad.NewBoolValue(cs.slotBool(f))
+	case akString:
+		s, ok := cs.slotString(idx)
+		if !ok {
+			cs.fellBack = true
+			return classad.NewUndefinedValue()
+		}
+		return classad.NewStringValue(s)
+	}
+	cs.fellBack = true
+	return classad.NewUndefinedValue()
+}
+
+// fromColdTail reads an attribute the block stores in its cold tail: a non-schema attribute, or a
+// schema field whose value escaped. An expression there sets fellBack, since only the ordinary
+// evaluator can resolve it against the rest of the ad.
+func (cs *colScope) fromColdTail(id uint32) classad.Value {
+	node, found, err := cs.blk.escapedNode(cs.k, id, cs.bc)
+	if err != nil {
+		cs.fellBack = true
+		return classad.NewUndefinedValue()
+	}
+	if !found {
+		return classad.NewUndefinedValue() // genuinely absent from this record
+	}
+	lit, ok := wire.LiteralValue(node)
+	if !ok {
+		cs.fellBack = true
+		return classad.NewUndefinedValue()
+	}
+	return litToValue(lit)
+}
+
+// slotInt reads a numeric field's raw slot value (a real's slot holds math.Float64bits).
+func (cs *colScope) slotInt(idx int, f adField) (int64, bool) {
+	b := cs.blk
+	base := cs.k * b.hotStride
+	if off, hot := b.hotFieldOff[idx]; hot {
+		return readIntLE(b.hot[base+off:], f.width, f.unsigned), true
+	}
+	start, ok := b.coldFieldStart[idx]
+	if !ok {
+		return 0, false
+	}
+	coldNum, err := cs.bc.stream(b, kindColdNum)
+	if err != nil {
+		return 0, false
+	}
+	return readIntLE(coldNum[start+cs.k*f.width:], f.width, f.unsigned), true
+}
+
+// slotBool reads a bit-packed boolean. The bool bitset sits immediately after the escape bitmap in
+// each record's hot region, so it is an uncompressed strided read like a hot numeric.
+func (cs *colScope) slotBool(f adField) bool {
+	b := cs.blk
+	base := cs.k*b.hotStride + b.schema.escBytes
+	return testBit(b.hot[base:base+b.schema.boolBytes], f.boolBit)
+}
+
+// slotString reads a string field from the record's string region.
+//
+// The region is POSITIONAL -- uvarint(len)+bytes for each non-escaped string field in schema order --
+// so reaching field idx means walking the string fields before it; there is no fixed offset to jump
+// to as there is for a numeric slot. The region itself decompresses once per block (cached), not once
+// per record.
+//
+// The walk is not what costs. Copying was: returning string(region[...]) allocated once per record and
+// made a string predicate SLOWER here (6.95ms) than in the row path (6.68ms) over 60k records.
+// Aliasing the region instead brings it to 6.09ms with 111KB allocated against the row path's 3.5MB.
+// A comparison never needed the copy.
+func (cs *colScope) slotString(idx int) (string, bool) {
+	b := cs.blk
+	if cs.strScratch == nil {
+		raw, err := cs.bc.stream(b, kindStr)
+		if err != nil {
+			return "", false
+		}
+		cs.strScratch = raw
+	}
+	region := cs.strScratch[b.strOff[cs.k]:b.strOff[cs.k+1]]
+	esc := b.escapeAt(cs.k)
+	for i := range b.schema.fields {
+		if b.schema.fields[i].kind != akString || testBit(esc, i) {
+			continue
+		}
+		l, n := binary.Uvarint(region)
+		if n <= 0 || int(l)+n > len(region) {
+			return "", false
+		}
+		if i == idx {
+			// ZERO COPY: alias the decompressed region instead of copying it. A comparison needs no
+			// copy, and the copy was the cost -- one Go string allocation per record, which is what
+			// made a string predicate slower here than in the row path.
+			//
+			// Safe unconditionally, not just for the scan's duration: the region is an immutable
+			// decompressed buffer that nothing mutates, and the returned string's header keeps the
+			// underlying array alive through the GC even if a caller retains the value.
+			if l == 0 {
+				return "", true
+			}
+			return unsafe.String(&region[n], int(l)), true
+		}
+		region = region[n+int(l):]
+	}
+	return "", false
+}
+
+// setBlock rebinds the scope to a new block, dropping per-block caches.
+func (cs *colScope) setBlock(blk *columnarBlock) {
+	cs.blk = blk
+	cs.strScratch = nil
+}
+
+// zonePrunableTests extracts the query's probes that a block zone can reason about: scalar numeric
+// comparisons on numeric fields of THIS schema, as (field index, tests).
+//
+// A SUBSET is sound, and Probes (not ExactProbes) is the right input here: pruning only skips a block
+// when some NECESSARY condition cannot hold in it, so omitting conjuncts costs selectivity and never
+// correctness. That is the opposite of answering from probes, which needs them to cover the query --
+// colScope answers by evaluating the query itself, so it is exact regardless.
+func (c *Collection) zonePrunableTests(q *vm.Query, s *adSchema) ([]int, []fieldPred) {
+	var idxs []int
+	var preds []fieldPred
+	for _, p := range q.Probes() {
+		id, ok := c.intern.LookupID(p.Attr)
+		if !ok {
+			continue
+		}
+		idx, ok := s.byID[id]
+		if !ok || !numericKind(s.fields[idx].kind) {
+			continue
+		}
+		up, ok := valUsable(id, p)
+		if !ok || len(up.fvals) != 1 {
+			continue
+		}
+		if _, ok := numCmp(up.op, up.fvals[0]); !ok {
+			continue
+		}
+		idxs = append(idxs, idx)
+		preds = append(preds, fieldPred{fieldID: id, tests: []zoneTest{{op: up.op, vals: up.fvals}}})
+	}
+	return idxs, preds
+}
+
+// indexCanPrune reports whether any of q's probes names an INDEXED attribute, i.e. whether the
+// ordinary row path could narrow to a candidate set instead of scanning everything.
+//
+// This gates the routing, and the gate is not theoretical: an archive's constrained COUNT(*) was
+// measured 2.9x SLOWER than the scan when the scan had an index to prune with and the columnar path
+// read every value. Block zones fixed that for numeric ranges, but they cannot help a string equality
+// -- there are no numeric zones for a string column -- so an indexed `Owner == "x"` is still better
+// served by the posting list than by evaluating 60k records.
+func (c *Collection) indexCanPrune(q *vm.Query) bool {
+	spec := c.spec.Load()
+	if spec == nil || !spec.any() {
+		return false
+	}
+	for _, p := range q.Probes() {
+		id, ok := c.intern.LookupID(p.Attr)
+		if !ok {
+			continue
+		}
+		if spec.catHas(id) || spec.valHas(id) {
+			return true
+		}
+	}
+	return false
+}
+
+// ColumnarEvalCount counts the records matching q by evaluating q itself against each record's
+// columns, for any NATIVE query.
+//
+// ok=false when it cannot serve the query at all: the accelerator is off, or the query is not native
+// (a delegated subtree needs a real ClassAd scope). Individual records whose stored value is an
+// expression are re-evaluated the ordinary way; that never fails the query.
+//
+// Because it evaluates the query rather than a summary of it, it is exact by construction -- the class
+// of bug that required ExactProbes cannot arise here.
+func (c *Collection) ColumnarEvalCount(q *vm.Query) (int, bool) {
+	st := c.schemaScan.Load()
+	if st == nil || c.intern == nil || q == nil || !q.Native() {
+		return 0, false
+	}
+	m := q.Matcher()
+	cs := &colScope{bc: st.cache, c: c}
+	resolver := cs.resolve // hoisted: a method value expression allocates
+	fallbackM := q.Matcher()
+	count := 0
+	for _, sh := range c.shards {
+		s0, wins := sh.snapshot()
+		for _, w := range wins {
+			seg := w.seg.colblk.Load()
+			if seg == nil || seg.schema() == nil {
+				count += c.rowEvalWindow(w, s0, fallbackM)
+				continue
+			}
+			pruneIdxs, prunePreds := c.zonePrunableTests(q, seg.schema())
+			base := 0
+			for _, blk := range seg.blocks {
+				if len(prunePreds) > 0 && !blockMayMatch(blk, pruneIdxs, prunePreds) {
+					base += blk.n
+					continue
+				}
+				cs.setBlock(blk)
+				for k := 0; k < blk.n; k++ {
+					gk := base + k
+					if gk >= len(seg.offs) {
+						break
+					}
+					o := seg.offs[gk]
+					if !(recSeq(w.data, o) <= s0 && recSuperseded(w.data, o) > s0) {
+						continue
+					}
+					cs.k, cs.fellBack = k, false
+					v := m.EvalResolved(resolver)
+					if cs.fellBack {
+						// One record needs the ordinary evaluator; the rest of the scan is unaffected.
+						if c.evalOneRecord(w, o, fallbackM) {
+							count++
+						}
+						continue
+					}
+					if isTrueValue(v) {
+						count++
+					}
+				}
+				base += blk.n
+			}
+		}
+		releaseWindows(wins)
+	}
+	return count, true
+}
+
+// evalOneRecord decodes a single arena record and evaluates the query against it the ordinary way.
+func (c *Collection) evalOneRecord(w segWindow, off uint32, m *vm.Matcher) bool {
+	ww, err := w.codec.Decompress(nil, recAd(w.data, off))
+	if err != nil {
+		return false
+	}
+	node, err := c.decodeWireDict(w.dict(), ww)
+	if err != nil {
+		return false
+	}
+	return m.Matches(classad.FromAST(node))
+}
+
+// rowEvalWindow counts matches in a window with no columnar block (the active segment, or one the
+// accelerator has not reached) by evaluating each visible record the ordinary way.
+func (c *Collection) rowEvalWindow(w segWindow, s0 uint64, m *vm.Matcher) int {
+	count := 0
+	for off := 0; off < w.used; {
+		o := uint32(off)
+		total := recTotalLen(w.data, o)
+		if total == 0 {
+			break
+		}
+		if !recIsMarker(w.data, o) && recSeq(w.data, o) <= s0 && recSuperseded(w.data, o) > s0 {
+			if c.evalOneRecord(w, o, m) {
+				count++
+			}
+		}
+		off += int(total)
+	}
+	return count
+}

--- a/collections/colscope_test.go
+++ b/collections/colscope_test.go
@@ -1,0 +1,211 @@
+package collections
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/collections/vm"
+)
+
+// colScope evaluates the query itself against columns, so the risk is not "does it prune correctly"
+// but "does it read every value type correctly" -- strings are positional, bools are bit-packed,
+// non-schema attributes live in the cold tail, and an expression cannot be judged from its node.
+
+// scopeFixture2 exercises every read path: numeric slots, a bool, a string, a NON-schema attribute
+// (present in too few records to become a field), an escaped too-wide number, and an expression.
+func scopeFixture2(tb testing.TB, n int) *Collection {
+	tb.Helper()
+	c := New(Options{Shards: 1, SegmentSize: 1 << 16})
+	for i := 0; i < n; i++ {
+		src := fmt.Sprintf("ClusterId = %d\nProcId = %d\nJobStatus = %d\nRequestMemory = %d\n"+
+			"RequestCpus = %d\nOwner = \"user%d\"\nCmd = \"/home/user%d/run.sh\"\nWantCheckpoint = %t",
+			i, i%10, 1+i%5, 1024+(i%32)*512, 1+i%8, i%512, i%512, i%3 == 0)
+		switch {
+		case i%997 == 11:
+			src += "\nRareAttr = 42" // present in ~0.1%: never a schema field, lives in the cold tail
+		case i%991 == 13:
+			src = fmt.Sprintf("ClusterId = %d\nProcId = %d\nJobStatus = %d\nRequestMemory = %d\n"+
+				"RequestCpus = %d\nOwner = \"user%d\"\nCmd = \"/home/user%d/run.sh\"\nWantCheckpoint = false",
+				1<<40+i, i%10, 1+i%5, 1024+(i%32)*512, 1+i%8, i%512, i%512) // too-wide ClusterId: escapes
+		case i%983 == 17:
+			src += "\nDerived = RequestCpus * 2" // an expression: forces the per-record fallback
+		}
+		if err := c.Put([]byte(fmt.Sprintf("k%d", i)), mustAdOld(tb, src)); err != nil {
+			tb.Fatal(err)
+		}
+	}
+	for _, e := range []string{"ProcId >= 0", "JobStatus >= 0", "RequestMemory >= 0", "RequestCpus >= 0"} {
+		q, err := vm.Parse(e)
+		if err != nil {
+			tb.Fatal(err)
+		}
+		for i := 0; i < 20; i++ {
+			for range c.Query(q) {
+			}
+		}
+	}
+	if !c.BuildAndEnableSchemaScan(4000, 8) {
+		tb.Skip("no sealed segments")
+	}
+	return c
+}
+
+// scopeQueries2 are the shapes NO hand-written column scan serves.
+var scopeQueries2 = []string{
+	`Owner == "user3"`,                           // string equality
+	`Owner != "user3"`,                           // string inequality
+	`Owner == "user3" && RequestMemory > 4096`,   // string + numeric (numeric part is prunable)
+	"RequestMemory > RequestCpus * 512",          // arithmetic between attributes
+	"ProcId >= 5 && ClusterId != ProcId",         // attribute to attribute
+	"RequestMemory > 4096 || RequestCpus >= 7",   // disjunction
+	"WantCheckpoint",                             // a bare bool field
+	"!WantCheckpoint && RequestCpus >= 4",        // negated bool
+	"RareAttr == 42",                             // a NON-schema attribute, only in the cold tail
+	"Derived > 4",                                // an EXPRESSION value: per-record fallback
+	`Cmd == "/home/user3/run.sh" && ProcId == 3`, // two strings, one numeric
+}
+
+// TestColScopeMatchesRowPath is the equivalence gate for every newly-served shape.
+func TestColScopeMatchesRowPath(t *testing.T) {
+	c := scopeFixture2(t, 5000)
+	defer c.Close()
+	for _, expr := range scopeQueries2 {
+		q, err := vm.Parse(expr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := 0
+		for range c.Query(q) {
+			want++
+		}
+		got, served := c.ColumnarEvalCount(q)
+		if !served {
+			t.Errorf("%s: declined; it is native and should be servable", expr)
+			continue
+		}
+		if got != want {
+			t.Errorf("%s: colScope %d != row %d", expr, got, want)
+		}
+		t.Logf("%-48s colScope=%-6d row=%d", expr, got, want)
+	}
+	// The fixture must contain the exceptional records, or several rows above prove nothing.
+	for _, expr := range []string{"RareAttr == 42", "Derived > 4", "ClusterId > 1000000000000"} {
+		if n := rowTruth(t, c, expr); n == 0 {
+			t.Errorf("fixture has no records matching %q; that shape is untested", expr)
+		}
+	}
+}
+
+// TestColScopeRoutedOnlyWithoutIndex pins the gate. colScope evaluates EVERY visible record, so a
+// selective constraint on an indexed attribute is better served by the row path's posting list --
+// routing without checking that was measured 2.9x slower on an archive.
+func TestColScopeRoutedOnlyWithoutIndex(t *testing.T) {
+	c := scopeFixture2(t, 3000)
+	defer c.Close()
+	// A string comparison is served: zero-copy region reads made it competitive with the row path
+	// (6.09ms vs 6.68ms over 60k records) at a twentieth of the allocations.
+	sq, err := vm.Parse(`Owner == "user3"`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, served := c.CountQuery(sq)
+	if !served {
+		t.Error("a string comparison should be served")
+	} else if want := rowTruth(t, c, `Owner == "user3"`); got != want {
+		t.Errorf("string comparison: %d != row %d", got, want)
+	}
+
+	// A shape colScope serves that ALSO has an index-usable probe. The attr-to-attr conjunct is
+	// omitted from Probes, so the RequestMemory probe is what an index could prune with.
+	const mixed = "RequestMemory > 4096 && ClusterId != ProcId"
+	q, err := vm.Parse(mixed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, served := c.CountQuery(q); !served {
+		t.Error("with no index, this should fall through to colScope")
+	}
+	// Index RequestMemory, and the routing must step aside for the posting list.
+	if !c.AddIndex(nil, []string{"RequestMemory"}) {
+		t.Skip("AddIndex declined")
+	}
+	c.Reindex()
+	if _, served := c.CountQuery(q); served {
+		t.Error("with RequestMemory indexed, CountQuery should decline so the row path can prune")
+	}
+	// An arithmetic query has NO index-usable probe, so an index cannot prune it and colScope stays
+	// the right choice even now -- the gate asks whether the index helps THIS query, not whether one
+	// exists.
+	aq, err := vm.Parse("RequestMemory > RequestCpus * 512")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, served := c.CountQuery(aq); !served {
+		t.Error("an arithmetic query has no prunable probe; colScope should still serve it")
+	}
+	if got, _ := c.ColumnarEvalCount(q); got != rowTruth(t, c, mixed) {
+		t.Error("the answer changed after indexing")
+	}
+}
+
+// TestColScopeMVCC checks visibility through the evaluator path.
+func TestColScopeMVCC(t *testing.T) {
+	c := scopeFixture2(t, 3000)
+	defer c.Close()
+	for i := 0; i < 300; i++ {
+		if err := c.Put([]byte(fmt.Sprintf("k%d", i)), mustAdOld(t, fmt.Sprintf(
+			"ClusterId = %d\nProcId = %d\nJobStatus = 4\nRequestMemory = 65536\nRequestCpus = 1\n"+
+				"Owner = \"replaced\"\nCmd = \"/x\"\nWantCheckpoint = false", i, i%10))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, expr := range []string{`Owner == "replaced"`, `Owner == "user3"`, "RequestMemory > RequestCpus * 512"} {
+		q, err := vm.Parse(expr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got, served := c.ColumnarEvalCount(q)
+		if !served {
+			t.Fatalf("%s: declined", expr)
+		}
+		if want := rowTruth(t, c, expr); got != want {
+			t.Errorf("%s after supersession: colScope %d != row %d", expr, got, want)
+		}
+	}
+}
+
+// BenchmarkColScopeShapes measures what the newly-served shapes cost against the row scan.
+func BenchmarkColScopeShapes(b *testing.B) {
+	c := scopeFixture2(b, 60000)
+	defer c.Close()
+	for _, expr := range []string{
+		`Owner == "user3"`,
+		`Owner == "user3" && RequestMemory > 4096`,
+		"RequestMemory > RequestCpus * 512",
+		"RequestMemory > 4096 || RequestCpus >= 7",
+		"WantCheckpoint",
+	} {
+		q, err := vm.Parse(expr)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if _, ok := c.ColumnarEvalCount(q); !ok {
+			b.Fatalf("%s declined", expr)
+		}
+		b.Run("colScope/"+expr, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				c.ColumnarEvalCount(q)
+			}
+		})
+		b.Run("rowScan/"+expr, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				n := 0
+				for range c.Query(q) {
+					n++
+				}
+			}
+		})
+	}
+}

--- a/collections/colscope_test.go
+++ b/collections/colscope_test.go
@@ -209,3 +209,74 @@ func BenchmarkColScopeShapes(b *testing.B) {
 		})
 	}
 }
+
+// scopeFixtureCodec is scopeFixture2 with a real codec, which is what a db-created store uses
+// (db.chooseBaseCodec gives new stores plain ZSTD). It matters for the comparison: with compression
+// OFF the row path decompresses nothing per record, so it is far cheaper than in production and the
+// columnar advantage is understated.
+func scopeFixtureCodec(tb testing.TB, n int) *Collection {
+	tb.Helper()
+	cd, err := NewZSTDCodec(nil)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	c := New(Options{Shards: 1, SegmentSize: 1 << 16, Codec: cd})
+	for i := 0; i < n; i++ {
+		src := fmt.Sprintf("ClusterId = %d\nProcId = %d\nJobStatus = %d\nRequestMemory = %d\n"+
+			"RequestCpus = %d\nOwner = \"user%d\"\nCmd = \"/home/user%d/run.sh\"\nWantCheckpoint = %t\n"+
+			"Args = \"--input in%d.dat --output out%d.dat\"\nIwd = \"/scratch/user%d/run%d\"",
+			i, i%10, 1+i%5, 1024+(i%32)*512, 1+i%8, i%512, i%512, i%3 == 0, i, i, i%512, i)
+		if err := c.Put([]byte(fmt.Sprintf("k%d", i)), mustAdOld(tb, src)); err != nil {
+			tb.Fatal(err)
+		}
+	}
+	for _, e := range []string{"ProcId >= 0", "JobStatus >= 0", "RequestMemory >= 0", "RequestCpus >= 0"} {
+		q, err := vm.Parse(e)
+		if err != nil {
+			tb.Fatal(err)
+		}
+		for i := 0; i < 20; i++ {
+			for range c.Query(q) {
+			}
+		}
+	}
+	if !c.BuildAndEnableSchemaScan(4000, 8) {
+		tb.Skip("no sealed segments")
+	}
+	return c
+}
+
+// BenchmarkColScopeCompressed is the production-shaped comparison: records ZSTD-compressed, so the
+// row path pays a decompress PER RECORD while colScope pays one per block region.
+func BenchmarkColScopeCompressed(b *testing.B) {
+	c := scopeFixtureCodec(b, 60000)
+	defer c.Close()
+	for _, expr := range []string{
+		`Owner == "user3"`,
+		"RequestMemory > RequestCpus * 512",
+		"WantCheckpoint",
+	} {
+		q, err := vm.Parse(expr)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if _, ok := c.ColumnarEvalCount(q); !ok {
+			b.Fatalf("%s declined", expr)
+		}
+		b.Run("colScope/"+expr, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				c.ColumnarEvalCount(q)
+			}
+		})
+		b.Run("rowScan/"+expr, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				n := 0
+				for range c.Query(q) {
+					n++
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Finishes the #172 prototype. The hand-written column scans serve `Attr OP literal` conjunctions on numeric fields at 10–500x; everything else decoded whole ads, even though it all compiles to **native** instructions:

| shape | before |
|---|---|
| `Owner == "user3"` | not served |
| `RequestMemory > RequestCpus * 512` | not served |
| `ProcId >= 5 && ClusterId != ProcId` | not served |
| `RequestMemory > 4096 \|\| RequestCpus >= 7` | not served |
| `WantCheckpoint` (bare bool) | not served |
| `RareAttr == 42` (not a schema field) | not served |

Five different shapes, and **disjunction doesn't fit a narrowing design at any price**. One resolver covers them: `EvalResolved` is already backing-agnostic and `wireScope` is the same idea over an ad's wire bytes. `colScope` reads numerics and bools from fixed slots, strings from the positional string region, and everything else — non-schema attributes, escaped values — from the cold tail, which stores both keyed by interned id.

## Measured, 60k records, records ZSTD-compressed (what a db-created store uses)

| query | colScope | row scan | gain |
|---|---|---|---|
| `WantCheckpoint` | **3.68 ms** | 48.7 ms | **13.2x** |
| `RequestMemory > RequestCpus * 512` | **9.46 ms** | 66.0 ms | **7.0x** |
| `Owner == "user3"` | **6.91 ms** | 36.0 ms | **5.2x** |

**My first numbers were 2–5x too flat**, and it is worth saying why. The fixture was an in-memory `Collection` with no `Options.Codec`, which defaults to **identity** — so the row path decompressed nothing per record, which no deployment does. The same three queries measured 2.7x, 2.4x and 1.1x that way.

colScope's own times barely move between the two fixtures. That is the mechanism: it decompresses **nothing** for a numeric or bool (the hot region is stored uncompressed) and **one string region per block** for a string, cached. The row path's time triples-to-sixfolds because it decompresses every **record**.

And to be precise about what the row path does, since the flat numbers looked plausible to me at first: it is **not** decoding whole ads. For a native query it looks the referenced attributes up directly in the wire bytes (`wireScope`, gated on `plan.PartialSafe`), so it reads only what the query needs — it just has to decompress each record before it can see any of it. With compression off, that leaves almost nothing to beat.

| with compression OFF (not a deployment shape) | colScope | row scan |
|---|---|---|
| `RequestMemory > 4096 \|\| RequestCpus >= 7` | 7.71 ms | 16.0 ms |
| `RequestMemory > RequestCpus * 512` | 9.13 ms | 22.2 ms |
| `WantCheckpoint` | 3.54 ms | 9.40 ms |
| `Owner == "user3"` | 6.09 ms | 6.68 ms |

## Strings almost lost, and the fault was mine

Returning `string(region[...])` allocated a Go string **per record**, which made a string predicate *slower* columnar (6.95 ms) than row (6.68 ms). A comparison never needed the copy. Aliasing the decompressed region with `unsafe.String` gives **6.09 ms and 111 KB allocated**, against the row path's 3.5 MB.

That's safe unconditionally, not just for the scan: the region is immutable and GC-managed, and the returned string's header keeps its array alive even if a caller retains the value. (`unsafe` already has precedent in this package — `segment.go`.)

I had briefly gated string queries out on the strength of the pre-fix numbers. The gate is gone; the measurement was of my allocation, not of the layout — and once the fixture was compression-enabled, strings turned out to be a **5.2x win**, not the wash the flat numbers suggested.

## Design points

- **Expression values**: an expression can't be judged from its stored node, so that *one record* is re-evaluated the ordinary way rather than the query being abandoned — `matchWire`'s `fellBack` contract, per record.
- **Routed last, and only when an index can't prune.** It evaluates every visible record, so a selective constraint on an indexed attribute belongs to the posting list — routing without that check was measured 2.9x slower on an archive (#176). The gate asks whether the index helps *this query*: an arithmetic comparison has no index-usable probe, so colScope still serves it even on an indexed column.
- **Zone pruning still applies** to whichever conjuncts *are* `Attr OP literal`, using `Probes` rather than `ExactProbes` — pruning needs only *necessary* conditions, so a lossy subset is sound, where answering from probes would not be.
- Because it evaluates the query rather than a summary of it, it **cannot reproduce the class of wrong answer** that made `ExactProbes` necessary (#171).

## Test changes worth reading

Four existing tests asserted these shapes must be **declined**. Each already reported the answer it got, and each was **correct** — so they now require that whatever answers is *right*, rather than that nothing answers. That's the property that keeps holding as more shapes become servable, and it's the third time this pattern has come up (#174, #177, here).

The bitmap-specific declines are still asserted directly against `PresenceCountQuery`, since those are real limits of that path rather than of the router.

Equivalence covers all 11 shapes against the row path, plus MVCC supersession and the routing gate. The fixture asserts its own exceptional records exist (non-schema attribute, expression value, escaped too-wide value), so those rows can't pass vacuously.

`collections` (including `-race` over the concurrent subset, since blocks are shared across goroutines), `db`, `dbrpc` green.
