### PR TITLE
collections: batch + width-typed column loads (12-31% off every columnar scan)

### DIFF
--- a/collections/colblock.go
+++ b/collections/colblock.go
@@ -353,6 +353,98 @@ func (b *columnarBlock) mayMatch(idx int, tests []zoneTest) bool {
 	return true
 }
 
+// escapeFree reports whether NO record in this block escaped fieldIdx, so a reader can skip the
+// per-record escape test entirely.
+//
+// The answer is already recorded: numericZones sets blockZone.escaped while encoding, for the zone
+// pruning that came with row groups. Spending it here costs nothing and removes a slice construction
+// plus a bit test from every value read. Only numeric fields carry a zone, which is where the hot
+// scans are.
+func (b *columnarBlock) escapeFree(fieldIdx int) bool {
+	z, ok := b.zones[fieldIdx]
+	return ok && !z.escaped
+}
+
+// loadIntBatch fills dst[0:b.n] with a column's raw slot values, or reports false when the field is
+// not a numeric column here.
+//
+// It does NOT require the block to be escape-free, and that is deliberate. An earlier version bailed
+// when any record had escaped, which sounds cheap and is not: with ~1000-record row groups, even a
+// 0.1% escape rate leaves only about a third of blocks eligible, and 1% leaves almost none -- so the
+// fast path would essentially never fire on real data. Instead the load runs unconditionally and the
+// CALLER checks the escape bit as it walks, reading those few records from the cold tail. Escaped
+// slots hold undefined bytes, so a caller must not use dst[k] without that check (see escapeFree,
+// which lets it skip the check entirely when the block has none).
+//
+// This is the batch form of scanInt, and it is where the measured cost actually was. Removing the
+// per-record escape test and readIntLE's byte-at-a-time read left the callback itself as the
+// bottleneck: a closure call per record. Separating "load the column" from "apply the predicate" lets
+// both be tight loops over contiguous memory, which is what the vectorization spike measured as the
+// win -- applied to the paths that already exist rather than to a new engine.
+func (b *columnarBlock) loadIntBatch(fieldIdx int, bc *blockCache, dst []int64) bool {
+	f := b.schema.fields[fieldIdx]
+	if !numericKind(f.kind) {
+		return false
+	}
+	if off, hot := b.hotFieldOff[fieldIdx]; hot {
+		loadIntsTyped(dst, b.hot, b.hotStride, off, f.width, f.unsigned, b.n)
+		return true
+	}
+	start, ok := b.coldFieldStart[fieldIdx]
+	if !ok {
+		return false
+	}
+	coldNum, err := bc.stream(b, kindColdNum)
+	if err != nil {
+		return false
+	}
+	loadIntsTyped(dst, coldNum[start:], f.width, 0, f.width, f.unsigned, b.n)
+	return true
+}
+
+// loadIntsTyped fills dst from a strided column with the width decision hoisted OUT of the loop.
+//
+// readIntLE reads a value byte at a time and then branches to sign-extend, so a generic loop pays a
+// loop and a branch per VALUE. A column has one width for the whole block by construction -- widths
+// are per-field and fitted by chooseIntWidth -- so the switch belongs outside, and each case is a
+// single machine load.
+func loadIntsTyped(dst []int64, src []byte, stride, off, width int, unsigned bool, n int) {
+	switch {
+	case width == 1 && unsigned:
+		for k := 0; k < n; k++ {
+			dst[k] = int64(src[k*stride+off])
+		}
+	case width == 1:
+		for k := 0; k < n; k++ {
+			dst[k] = int64(int8(src[k*stride+off]))
+		}
+	case width == 2 && unsigned:
+		for k := 0; k < n; k++ {
+			dst[k] = int64(binary.LittleEndian.Uint16(src[k*stride+off:]))
+		}
+	case width == 2:
+		for k := 0; k < n; k++ {
+			dst[k] = int64(int16(binary.LittleEndian.Uint16(src[k*stride+off:])))
+		}
+	case width == 4 && unsigned:
+		for k := 0; k < n; k++ {
+			dst[k] = int64(binary.LittleEndian.Uint32(src[k*stride+off:]))
+		}
+	case width == 4:
+		for k := 0; k < n; k++ {
+			dst[k] = int64(int32(binary.LittleEndian.Uint32(src[k*stride+off:])))
+		}
+	case width == 8:
+		for k := 0; k < n; k++ {
+			dst[k] = int64(binary.LittleEndian.Uint64(src[k*stride+off:]))
+		}
+	default: // a 6-byte or otherwise unusual fitted width
+		for k := 0; k < n; k++ {
+			dst[k] = readIntLE(src[k*stride+off:], width, unsigned)
+		}
+	}
+}
+
 // scanInt calls fn for each record's value of a numeric (int/real read as int bits) field: a
 // hot field reads the uncompressed region directly (no decode); a cold field decompresses its
 // column group once (via bc, nil for no cache). present is false for a missing/exceptional

--- a/collections/colmulti.go
+++ b/collections/colmulti.go
@@ -119,6 +119,7 @@ func (c *Collection) schemaScanCountMulti(preds []fieldPred, bc *blockCache) int
 	}
 	count := 0
 	var keep []bool
+	var scratch []int64
 	for _, sh := range c.shards {
 		s0, wins := sh.snapshot()
 		for _, w := range wins {
@@ -139,8 +140,9 @@ func (c *Collection) schemaScanCountMulti(preds []fieldPred, bc *blockCache) int
 				}
 				if cap(keep) < blk.n {
 					keep = make([]bool, blk.n)
+					scratch = make([]int64, blk.n)
 				}
-				keep = keep[:blk.n]
+				keep, scratch = keep[:blk.n], scratch[:blk.n]
 				// Pass 0 establishes visibility, so later passes never touch a record no
 				// snapshot can see.
 				live := 0
@@ -160,7 +162,7 @@ func (c *Collection) schemaScanCountMulti(preds []fieldPred, bc *blockCache) int
 					if live == 0 {
 						break // nothing left in this block; later columns would be read for nothing
 					}
-					live = narrowByField(blk, idxs[i], preds[i], bc, keep)
+					live = narrowByField(blk, idxs[i], preds[i], bc, keep, scratch)
 				}
 				count += live
 				base += blk.n
@@ -202,9 +204,40 @@ func resolveFields(cs *colSegment, preds []fieldPred) ([]int, bool) {
 // narrowByField clears keep[k] for every still-candidate record failing this field's predicate, and
 // returns how many survive. A real field's slot holds math.Float64bits, so the raw value is
 // converted by kind -- reading a real as an integer would silently produce astronomical values.
-func narrowByField(blk *columnarBlock, idx int, p fieldPred, bc *blockCache, keep []bool) int {
+func narrowByField(blk *columnarBlock, idx int, p fieldPred, bc *blockCache, keep []bool, scratch []int64) int {
 	isReal := blk.schema.fields[idx].kind == akReal
 	live := 0
+	// Batch form: one tight typed load of the whole column, then one predicate loop. Escaped records
+	// are read from the cold tail as they come up, so the batch load is unconditional -- gating it on
+	// an escape-free block made it fire almost never (see loadIntBatch).
+	if len(scratch) >= blk.n && blk.loadIntBatch(idx, bc, scratch) {
+		escFree := blk.escapeFree(idx)
+		for k := 0; k < blk.n; k++ {
+			if !keep[k] {
+				continue
+			}
+			var v float64
+			if !escFree && testBit(blk.escapeAt(k), idx) {
+				// The value is not in the column: missing, wrong kind, or too wide for the slot.
+				nv, ok := blk.escapedNumVal(k, p.fieldID, bc)
+				if !ok {
+					keep[k] = false
+					continue
+				}
+				v = nv.f
+			} else if isReal {
+				v = math.Float64frombits(uint64(scratch[k]))
+			} else {
+				v = float64(scratch[k])
+			}
+			if !p.eval(v) {
+				keep[k] = false
+				continue
+			}
+			live++
+		}
+		return live
+	}
 	_ = blk.scanInt(idx, bc, func(k int, present bool, v int64) {
 		if !keep[k] {
 			return

--- a/collections/colstatsmulti.go
+++ b/collections/colstatsmulti.go
@@ -172,6 +172,7 @@ func (c *Collection) schemaScanStatsMulti(aggID uint32, preds []fieldPred, bc *b
 	aggLookup := c.attrLookup(aggID)
 
 	var keep []bool
+	var scratch []int64
 	for _, sh := range c.shards {
 		s0, wins := sh.snapshot()
 		for _, w := range wins {
@@ -222,8 +223,9 @@ func (c *Collection) schemaScanStatsMulti(aggID uint32, preds []fieldPred, bc *b
 				}
 				if cap(keep) < blk.n {
 					keep = make([]bool, blk.n)
+					scratch = make([]int64, blk.n)
 				}
-				keep = keep[:blk.n]
+				keep, scratch = keep[:blk.n], scratch[:blk.n]
 				live := 0
 				for k := 0; k < blk.n; k++ {
 					gk := base + k
@@ -241,7 +243,7 @@ func (c *Collection) schemaScanStatsMulti(aggID uint32, preds []fieldPred, bc *b
 					if live == 0 {
 						break
 					}
-					live = narrowByField(blk, otherIdxs[i], otherPreds[i], bc, keep)
+					live = narrowByField(blk, otherIdxs[i], otherPreds[i], bc, keep, scratch)
 				}
 				if live > 0 {
 					for k := 0; k < blk.n; k++ {


### PR DESCRIPTION
The vectorization spike (#179) attributed the cost: **loading the columns was ~50% of a columnar scan** — more than the expression evaluation in either interpreted or fused form. So the load is what to optimize, and it had two avoidable costs per value: a slice construction plus a bit test for the escape check, and `readIntLE` reading a value **a byte at a time** before branching to sign-extend.

## Three changes, in the order the measurements demanded

1. **`loadIntsTyped` hoists the width decision out of the loop.** A column is one width for the whole block *by construction* — widths are per-field and fitted by `chooseIntWidth` — so each case becomes a single machine load instead of a byte loop plus a branch.
2. **`escapeFree` spends something already recorded.** `numericZones` sets `blockZone.escaped` while encoding, for the zone pruning that came with row groups, so a block with no escapes for a field skips the escape test entirely. Free.
3. **`narrowByField` batch-loads the column and applies the predicate in a second tight loop**, instead of taking a callback per record. This was the actual lever — with the escape test and byte-loop gone, the **per-record closure call** was the bottleneck. Separating "load the column" from "apply the predicate" is the spike's finding applied to the paths that already exist.

## Measured, 60k records

| path | before | after | |
|---|---|---|---|
| count, 1 field | 797 µs | **700 µs** | −12% |
| count, 2 fields | 1066 µs | **935 µs** | −12% |
| count, 3 fields | 1074 µs | **748 µs** | **−30%** |
| stats, other attr | 491 µs | **415 µs** | −15% |
| stats, multi-field | 766 µs | **525 µs** | **−31%** |

## Two things I got wrong on the way

Both caught by measuring rather than reasoning, and both worth recording because they're the kind of mistake that looks like a success:

**The first version filled a `[]int64` per block.** It was the fastest of all — and turned 37 KB of scan garbage into **544 KB**. The buffer is now owned by the scan and reused across blocks.

**The second version only batch-loaded when the block was escape-*free*.** That sounds cheap and isn't: with ~1000-record row groups, even a **0.1%** escape rate leaves about a third of blocks eligible, and 1% leaves almost none — so the fast path would essentially never fire on real data. It showed up as a single-field count that didn't improve *at all* while the multi-field ones did, because the fixture injects escapes into exactly that column. The load is now unconditional and the caller reads the few escaped records from the cold tail as it walks.

Note the second mistake is the same shape as the first `blockZone` design question: a block-level flag is only useful if blocks are small enough for it to be *true* sometimes, and at 1 MiB they aren't for escape-freedom (they are for value ranges, which is why pruning works).

An aggregate whose only predicate is on the aggregated attribute takes the fused single pass and never touches the scratch buffer, so it isn't allocated for it.

## Next

This clears the way for the vectorized interpreter — the batch-load-then-apply shape here *is* the executor's inner loop, just hard-coded to one predicate. Per your steer, that interpreter should execute the **existing `vm.Program`** rather than a new IR: same compiler, same constant/ref pools, a second executor with a vector stack. `OpLoadRef` becomes a column load, `OpBinop` a kernel, `OpPushConst` a broadcast; short-circuit jumps become bitmap combines.

`collections`, `db`, `dbrpc` green.
