### PR TITLE
db: assert the archive count's answer, not which tier produced it (main is red)

### DIFF
--- a/db/archive_count_test.go
+++ b/db/archive_count_test.go
@@ -94,15 +94,25 @@ func TestArchiveConstrainedCountMatchesScan(t *testing.T) {
 	}
 }
 
-// TestArchiveCountConstraintDeclinesGracefully pins that a declined constraint still produces the
-// right answer through the scan, since the whole design rests on falling back rather than guessing.
-func TestArchiveCountConstraintDeclinesGracefully(t *testing.T) {
+// TestArchiveCountConstraintFallsBackGracefully pins the property the design actually rests on: however
+// a constraint is served -- from the stored count, the hand-written column scan, the general columnar
+// evaluator, or a full row scan -- the answer matches the scan.
+//
+// It used to assert that `Owner == "user3"` and `RequestMemory > RequestCpus` DECLINE. That was true when
+// the columnar count served only numeric comparisons against a literal, and stopped being true when the
+// general columnar evaluator landed and made both servable. Asserting which TIER answers a query pins an
+// implementation detail that improvements are supposed to change; asserting the ANSWER pins the contract.
+// So the tier is logged, not checked, and the decline path is exercised by a constraint that cannot be
+// lowered at all rather than by one that merely could not be lowered yet.
+func TestArchiveCountConstraintFallsBackGracefully(t *testing.T) {
 	cat, a := archiveCountFixture(t, 2000)
 	defer cat.Close()
-	for _, constraint := range []string{`Owner == "user3"`, "RequestMemory > RequestCpus"} {
-		if _, served := a.CountConstraint(constraint); served {
-			t.Errorf("%s: expected the columnar count to decline", constraint)
-		}
+	for _, constraint := range []string{
+		`Owner == "user3"`,            // a string field
+		"RequestMemory > RequestCpus", // attribute to attribute, no literal
+		`regexp("user3", Owner)`,      // a function call: not lowerable, so this must decline
+		`size(Owner) > 4`,             // likewise
+	} {
 		rows, err := a.AggregateCols(constraint, nil, []AggSpec{{Func: AggCount, Arg: "*"}})
 		if err != nil {
 			t.Fatal(err)
@@ -110,8 +120,15 @@ func TestArchiveCountConstraintDeclinesGracefully(t *testing.T) {
 		var got int
 		fmt.Sscanf(rows[0].Values[0], "%d", &got)
 		if want := scanCount(t, a, constraint); got != want {
-			t.Errorf("%s: fell back to the scan and got %d, want %d", constraint, got, want)
+			t.Errorf("%s: COUNT(*) = %d, scan = %d", constraint, got, want)
 		}
+		_, served := a.CountConstraint(constraint)
+		t.Logf("%-30s count=%-6d columnar=%v", constraint, got, served)
+	}
+	// The fallback must still be reachable, or this test would pass by serving everything columnar and
+	// would no longer be testing a fallback at all.
+	if _, served := a.CountConstraint(`regexp("user3", Owner)`); served {
+		t.Error(`regexp(...) was served columnar; it cannot be lowered, so something is answering it wrongly`)
 	}
 }
 


### PR DESCRIPTION
**`origin/main` is currently red**, and neither PR that caused it was wrong on its own.

#176 added `TestArchiveCountConstraintDeclinesGracefully`, asserting that `Owner == "user3"` and `RequestMemory > RequestCpus` **decline** the columnar count. True at the time — the columnar count served only numeric comparisons against a literal. #178 then landed colScope, which evaluates *any* native query against the columns, and both became servable. Each branch was green; the merge is not. No CI run could have caught it, because each PR was tested against a main that lacked the other.

## The fix

The test's stated intent is *"a declined constraint still produces the right answer."* Asserting **which tier** answers pins an implementation detail that improvements are specifically meant to change. So:

- the tier is **logged**, and the **answer** is checked against the scan
- the decline path now uses constraints that **cannot be lowered at all** (`regexp(...)`, `size(...)`) rather than ones that merely hadn't been lowered yet
- a closing check fails if even those are served — which would mean something is answering a constraint it cannot evaluate

Renamed to `...FallsBackGracefully`, since falling back is the property, not declining.

```
Owner == "user3"               count=4      columnar=true
RequestMemory > RequestCpus    count=2000   columnar=true
regexp("user3", Owner)         count=444    columnar=false
size(Owner) > 4                count=2000   columnar=false
```

`db` green.

## Worth noting

This is the second time a test here asserted a limitation and then broke when the limitation was lifted. A test that says "this shape is not served" is one a later PR is *supposed* to falsify — so where the intent is really "the answer is right regardless", it should say that instead.
