### PR TITLE
collections: vectorized evaluation over the interpreter's own program, with mask planes

### DIFF
--- a/collections/colscan.go
+++ b/collections/colscan.go
@@ -558,17 +558,22 @@ func (c *Collection) CountQuery(q *vm.Query) (int, bool) {
 		if n, served := c.PresenceCountQuery(q); served {
 			return n, true
 		}
-		// Last tier: evaluate the query itself against the columns (see ColumnarEvalCount). It serves
-		// any NATIVE query -- string comparisons, attribute-to-attribute, arithmetic, disjunctions --
-		// at roughly an order of magnitude less than the hand-written scans but several times better
-		// than decoding ads.
+		// Last tier: evaluate the query itself against the columns, a COLUMN at a time where the
+		// expression allows it (VectorEvalCount) and per record where it does not. It serves any
+		// NATIVE query -- string comparisons, attribute-to-attribute, arithmetic, disjunctions.
+		//
+		// VectorEvalCount rather than ColumnarEvalCount because it cannot be worse: a block it cannot
+		// vectorize is served by exactly the per-record path ColumnarEvalCount would have used, and a
+		// block that is mostly superseded is too. Where it does vectorize -- the arithmetic,
+		// disjunction and boolean shapes the hand-written scans above refuse -- it is ~10x, which is
+		// the hand-written scans' speed generalized to expressions nobody hand-wrote.
 		//
 		// Skipped when an index could prune the row path instead: this evaluates EVERY visible record,
 		// so against a selective indexed constraint the scan wins, and a routing that ignored that was
 		// measured 2.9x slower on exactly such a query.
 		// Skipped only when an index could prune the row path instead.
 		if !c.indexCanPrune(q) {
-			return c.ColumnarEvalCount(q)
+			return c.VectorEvalCount(q)
 		}
 		return 0, false
 	}

--- a/collections/colscope.go
+++ b/collections/colscope.go
@@ -328,34 +328,44 @@ func (c *Collection) ColumnarEvalCount(q *vm.Query) (int, bool) {
 					continue
 				}
 				cs.setBlock(blk)
-				for k := 0; k < blk.n; k++ {
-					gk := base + k
-					if gk >= len(seg.offs) {
-						break
-					}
-					o := seg.offs[gk]
-					if !(recSeq(w.data, o) <= s0 && recSuperseded(w.data, o) > s0) {
-						continue
-					}
-					cs.k, cs.fellBack = k, false
-					v := m.EvalResolved(resolver)
-					if cs.fellBack {
-						// One record needs the ordinary evaluator; the rest of the scan is unaffected.
-						if c.evalOneRecord(w, o, fallbackM) {
-							count++
-						}
-						continue
-					}
-					if isTrueValue(v) {
-						count++
-					}
-				}
+				count += c.countBlockScoped(cs, resolver, m, fallbackM, w, seg, blk, base, s0)
 				base += blk.n
 			}
 		}
 		releaseWindows(wins)
 	}
 	return count, true
+}
+
+// countBlockScoped counts one block's visible matching records with the per-record resolver. Extracted
+// so the vectorized scan can fall back to it for a single block it cannot serve, rather than abandoning
+// the whole query.
+func (c *Collection) countBlockScoped(cs *colScope, resolver func(name string, scope ast.AttributeScope) classad.Value,
+	m, fallbackM *vm.Matcher, w segWindow, seg *colSegment, blk *columnarBlock, base int, s0 uint64) int {
+	count := 0
+	for k := 0; k < blk.n; k++ {
+		gk := base + k
+		if gk >= len(seg.offs) {
+			break
+		}
+		o := seg.offs[gk]
+		if !(recSeq(w.data, o) <= s0 && recSuperseded(w.data, o) > s0) {
+			continue
+		}
+		cs.k, cs.fellBack = k, false
+		v := m.EvalResolved(resolver)
+		if cs.fellBack {
+			// One record needs the ordinary evaluator; the rest of the scan is unaffected.
+			if c.evalOneRecord(w, o, fallbackM) {
+				count++
+			}
+			continue
+		}
+		if isTrueValue(v) {
+			count++
+		}
+	}
+	return count
 }
 
 // evalOneRecord decodes a single arena record and evaluates the query against it the ordinary way.

--- a/collections/colvec.go
+++ b/collections/colvec.go
@@ -1,0 +1,251 @@
+package collections
+
+import (
+	"sync"
+	"sync/atomic"
+
+	"github.com/PelicanPlatform/classad/ast"
+	"github.com/PelicanPlatform/classad/collections/vm"
+)
+
+// Vectorized evaluation of an arbitrary constraint over columnar blocks.
+//
+// colScope made any native expression columnar, but per RECORD: one interpreter dispatch per operator
+// per record, each producing a boxed value. The hand-written scans (colmulti/colstatsmulti) are ~10x
+// that, and the reason is not that they are hand-written -- it is that they work a COLUMN at a time, so
+// dispatch is amortized over a block and the inner loops are contiguous. vm's vector executor
+// generalizes that to any expression it can lower; this file is the bridge that feeds it columns.
+//
+// The two pieces divide as: vm.VecEval knows the expression and nothing about storage, blockVecSource
+// knows the storage and nothing about the expression. So the column reads here are the only place that
+// touches block layout, and they reduce to loadIntBatch -- the width-typed batch load -- plus the
+// escape flag.
+//
+// NO FLOAT MATERIALIZATION. A real's slot already holds math.Float64bits and vm.Vec stores a real as
+// those same bits, so loading a real column is a copy, not a conversion. That was the spike's specific
+// recommendation and it is why LoadColumn hands loadIntBatch the vector's payload slice directly.
+//
+// DECLINING IS PER BLOCK, not per query. A block whose schema lacks the attribute, or holds it as a
+// string, or has an escaped value that is an expression, falls back to colScope for THAT BLOCK; every
+// other block still vectorizes. A schema change or a handful of odd records therefore costs a slope
+// rather than a cliff.
+
+// vecSplit records how the last VectorEvalCount divided its work: blocks served as vectors, blocks that
+// declined to colScope, and windows with no block at all.
+//
+// Tests and benchmarks assert against it because a scan that silently declined every block would look
+// exactly like a correct vectorized scan that is mysteriously no faster -- which is how three earlier
+// measurements in this package produced plausible and wrong conclusions.
+type vecSplit struct {
+	vecBlocks   int
+	scopeBlocks int // the executor declined: a string column, an expression in the cold tail, Elvis
+	churnBlocks int // mostly-superseded: colScope is cheaper than evaluating records nobody can see
+	rowWindows  int
+}
+
+// vecScratchPool reuses the vector stack across queries. Without it each call allocated its own stack
+// -- about as much as colScope allocates in total, which at a millisecond per query is real GC pressure
+// on a busy table.
+var vecScratchPool = sync.Pool{New: func() any { return new(vm.VecScratch) }}
+
+// minLiveNum/minLiveDen is the visible fraction below which a block goes to colScope instead. The vector
+// executor evaluates EVERY record in a block, including superseded ones, while colScope evaluates only
+// the visible ones -- so on a heavily updated table the vectorized scan can do mostly wasted work. It is
+// worth roughly 8x per record, so it stays ahead while more than an eighth of a block is visible; the
+// guard trips at a quarter, leaving margin rather than sitting on the crossover.
+const (
+	minLiveNum = 1
+	minLiveDen = 4
+)
+
+var lastVecSplit atomic.Pointer[vecSplit]
+
+// blockVecSource feeds one columnar block's columns to the vector executor.
+type blockVecSource struct {
+	c   *Collection
+	blk *columnarBlock
+	bc  *blockCache
+}
+
+// LoadColumn resolves an attribute to a field of this block's schema and loads it as a vector.
+//
+// ok=false declines the block. An attribute the schema does not carry lives in the cold tail, which is
+// a per-record read with a decompression behind it -- exactly what a vector load is meant to avoid --
+// so it declines rather than pretending to be fast.
+func (s *blockVecSource) LoadColumn(name string, scope ast.AttributeScope, dst vm.Vec) bool {
+	if scope != ast.NoScope && scope != ast.MyScope {
+		return false
+	}
+	id, ok := s.c.intern.LookupID(name)
+	if !ok {
+		return false
+	}
+	idx, ok := s.blk.schema.byID[id]
+	if !ok {
+		return false
+	}
+	f := s.blk.schema.fields[idx]
+	switch {
+	case f.kind == akBool:
+		return s.loadBool(idx, f, id, dst)
+	case numericKind(f.kind):
+		return s.loadNum(idx, f, id, dst)
+	}
+	return false // akString: colScope reads these zero-copy; a vector has no string payload yet
+}
+
+// loadNum loads a numeric column, then repairs the escaped elements from the cold tail.
+func (s *blockVecSource) loadNum(idx int, f adField, id uint32, dst vm.Vec) bool {
+	if !s.blk.loadIntBatch(idx, s.bc, dst.I) {
+		return false
+	}
+	st := vm.VsInt
+	if f.kind == akReal {
+		st = vm.VsReal
+	}
+	for k := 0; k < s.blk.n; k++ {
+		dst.St[k] = st
+	}
+	if s.blk.escapeFree(idx) {
+		return true
+	}
+	return s.fixEscapes(idx, id, dst)
+}
+
+// loadBool loads a bit-packed boolean column. The bool bitset sits immediately after the escape bitmap
+// in each record's hot region, so this is a strided read of uncompressed memory.
+func (s *blockVecSource) loadBool(idx int, f adField, id uint32, dst vm.Vec) bool {
+	b := s.blk
+	for k := 0; k < b.n; k++ {
+		base := k*b.hotStride + b.schema.escBytes
+		dst.SetBool(k, testBit(b.hot[base:base+b.schema.boolBytes], f.boolBit))
+	}
+	if b.escapeFree(idx) {
+		return true
+	}
+	return s.fixEscapes(idx, id, dst)
+}
+
+// fixEscapes overwrites the elements whose value did not fit its slot. An escape means the value is
+// MISSING or UNSTORABLE: missing is UNDEFINED, a scalar is read from the cold tail, and anything else
+// -- a string, a computed expression -- declines the block, because only the ordinary evaluator can
+// give the right answer for it.
+func (s *blockVecSource) fixEscapes(idx int, id uint32, dst vm.Vec) bool {
+	for k := 0; k < s.blk.n; k++ {
+		if !testBit(s.blk.escapeAt(k), idx) {
+			continue
+		}
+		node, found, err := s.blk.escapedNode(k, id, s.bc)
+		if err != nil {
+			return false
+		}
+		if !found {
+			dst.St[k] = vm.VsUndef
+			continue
+		}
+		nv, ok := nodeColVal(node)
+		if !ok {
+			return false
+		}
+		switch nv.kind {
+		case akReal:
+			dst.SetReal(k, nv.f)
+		case akBool:
+			dst.SetBool(k, nv.i != 0)
+		default:
+			dst.SetInt(k, nv.i)
+		}
+	}
+	return true
+}
+
+// VectorEvalCount counts records satisfying q, evaluating it a column at a time.
+//
+// ok=false only when there is no columnar state at all; individual blocks that cannot be vectorized
+// are served by colScope, and segments without a block by a row walk, so the answer is always complete.
+func (c *Collection) VectorEvalCount(q *vm.Query) (int, bool) {
+	st := c.schemaScan.Load()
+	if st == nil || c.intern == nil || q == nil || !q.Native() {
+		return 0, false
+	}
+	m := q.Matcher()
+	fallbackM := q.Matcher()
+	cs := &colScope{bc: st.cache, c: c}
+	resolver := cs.resolve
+	src := &blockVecSource{c: c, bc: st.cache}
+	scratch := vecScratchPool.Get().(*vm.VecScratch)
+	defer vecScratchPool.Put(scratch)
+	var live []bool
+	var split vecSplit
+	defer func() { lastVecSplit.Store(&split) }()
+	count := 0
+	for _, sh := range c.shards {
+		s0, wins := sh.snapshot()
+		for _, w := range wins {
+			seg := w.seg.colblk.Load()
+			if seg == nil || seg.schema() == nil {
+				split.rowWindows++
+				count += c.rowEvalWindow(w, s0, fallbackM)
+				continue
+			}
+			pruneIdxs, prunePreds := c.zonePrunableTests(q, seg.schema())
+			base := 0
+			for _, blk := range seg.blocks {
+				if len(prunePreds) > 0 && !blockMayMatch(blk, pruneIdxs, prunePreds) {
+					base += blk.n
+					continue
+				}
+				// Visibility first, once. The vectorized path needs the mask anyway to count, and
+				// knowing how much of the block is live is what decides whether vectorizing it is
+				// worth doing at all.
+				if cap(live) < blk.n {
+					live = make([]bool, blk.n)
+				}
+				live = live[:blk.n]
+				nLive := 0
+				for k := 0; k < blk.n; k++ {
+					gk := base + k
+					vis := gk < len(seg.offs)
+					if vis {
+						o := seg.offs[gk]
+						vis = recSeq(w.data, o) <= s0 && recSuperseded(w.data, o) > s0
+					}
+					live[k] = vis
+					if vis {
+						nLive++
+					}
+				}
+				if nLive == 0 {
+					base += blk.n
+					continue
+				}
+				if nLive*minLiveDen < blk.n*minLiveNum {
+					split.churnBlocks++
+					cs.setBlock(blk)
+					count += c.countBlockScoped(cs, resolver, m, fallbackM, w, seg, blk, base, s0)
+					base += blk.n
+					continue
+				}
+				src.blk = blk
+				vec, ok := q.VecEval(src, blk.n, scratch)
+				if !ok {
+					// This block only. Every other block still vectorizes.
+					split.scopeBlocks++
+					cs.setBlock(blk)
+					count += c.countBlockScoped(cs, resolver, m, fallbackM, w, seg, blk, base, s0)
+					base += blk.n
+					continue
+				}
+				split.vecBlocks++
+				for k := 0; k < blk.n; k++ {
+					if live[k] && vec.IsTrue(k) {
+						count++
+					}
+				}
+				base += blk.n
+			}
+		}
+		releaseWindows(wins)
+	}
+	return count, true
+}

--- a/collections/colvec_test.go
+++ b/collections/colvec_test.go
@@ -1,0 +1,245 @@
+package collections
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/collections/vm"
+)
+
+// vecExprs are the expressions the vectorized scan is expected to SERVE, spanning the kernels that have
+// fast paths (comparison, +-*, logical combines, unary) and ones that route to the parity hook per
+// element (division, modulo, identity), so a regression in either shows up here.
+var vecExprs = []string{
+	"RequestMemory > 4096",
+	"RequestMemory <= 4096",
+	"RequestCpus == 4",
+	"JobStatus != 1",
+	"RequestMemory > 4096 && RequestCpus >= 4",
+	"RequestMemory > 4096 || RequestCpus >= 4",
+	"JobStatus == 1 || JobStatus == 4",
+	"RequestMemory > 4096 && RequestCpus >= 4 && JobStatus == 1",
+	"RequestMemory > 4096 && (JobStatus == 1 || JobStatus == 4)",
+	"RequestMemory > RequestCpus * 512",
+	"ProcId + ClusterId > 100",
+	"RequestMemory - 1024 > RequestCpus * 256",
+	"RequestMemory / 1024 > 4", // division: hook per element
+	"ProcId % 3 == 0",          // modulo: hook per element
+	"RequestMemory =?= 4096",   // identity: hook per element
+	"!(JobStatus == 1)",
+	"-ProcId < 0",
+	"WantCheckpoint",
+	"WantCheckpoint && RequestCpus > 2",
+	"WantCheckpoint || JobStatus == 4",
+	"!WantCheckpoint",
+	"RequestMemory > 4096 && WantCheckpoint",
+	"true",
+	"ProcId >= 0 && ProcId < 10",
+}
+
+// rowCount is the independent reference: the ordinary row path, which decodes ads and evaluates the
+// expression the ordinary way.
+func rowCount(tb testing.TB, c *Collection, expr string) int {
+	tb.Helper()
+	q, err := vm.Parse(expr)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	n := 0
+	for range c.Query(q) {
+		n++
+	}
+	return n
+}
+
+// TestVectorEvalCountAgrees is the correctness gate: for every expression, the vectorized count equals
+// the row path's count, AND the vectorized path actually served the blocks.
+//
+// The second half matters as much as the first. A scan that declined every block would agree perfectly
+// -- because it would be colScope -- and prove nothing about the vector executor.
+func TestVectorEvalCountAgrees(t *testing.T) {
+	c := scopeFixtureCodec(t, 20000)
+	defer c.Close()
+
+	for _, expr := range vecExprs {
+		q, err := vm.Parse(expr)
+		if err != nil {
+			t.Fatalf("parse %q: %v", expr, err)
+		}
+		got, ok := c.VectorEvalCount(q)
+		if !ok {
+			t.Fatalf("%q: no columnar state", expr)
+		}
+		if want := rowCount(t, c, expr); got != want {
+			t.Errorf("%q: vectorized %d != row %d", expr, got, want)
+		}
+		split := lastVecSplit.Load()
+		if split.vecBlocks == 0 {
+			t.Errorf("%q: no block was vectorized (%d declined to colScope); the comparison is vacuous",
+				expr, split.scopeBlocks)
+		}
+		if split.scopeBlocks != 0 {
+			t.Logf("%q: %d/%d blocks vectorized, %d declined",
+				expr, split.vecBlocks, split.vecBlocks+split.scopeBlocks, split.scopeBlocks)
+		}
+	}
+}
+
+// TestVectorEvalDeclinesGracefully checks the per-block fallback is a slope, not a cliff: an expression
+// the executor cannot vectorize at all must still produce the right answer, via colScope.
+func TestVectorEvalDeclinesGracefully(t *testing.T) {
+	c := scopeFixtureCodec(t, 20000)
+	defer c.Close()
+
+	for _, expr := range []string{
+		`Owner == "user3"`, // string column
+		`Owner == "user3" || ProcId == 1`,
+		`RequestMemory > 4096 ?: false`, // Elvis
+		`size(Args) > 0`,                // delegated subtree
+	} {
+		q, err := vm.Parse(expr)
+		if err != nil {
+			t.Fatalf("parse %q: %v", expr, err)
+		}
+		got, ok := c.VectorEvalCount(q)
+		if !ok {
+			continue // a non-native query is legitimately refused outright
+		}
+		if want := rowCount(t, c, expr); got != want {
+			t.Errorf("%q: %d != row %d", expr, got, want)
+		}
+		if split := lastVecSplit.Load(); split.vecBlocks != 0 {
+			t.Logf("%q: unexpectedly vectorized %d blocks", expr, split.vecBlocks)
+		}
+	}
+}
+
+// TestVectorEvalSeesUpdates checks the vector path honours snapshot visibility -- it evaluates every
+// record in a block including superseded ones, and must not count them.
+func TestVectorEvalSeesUpdates(t *testing.T) {
+	c := scopeFixtureCodec(t, 20000)
+	defer c.Close()
+
+	q, err := vm.Parse("RequestMemory > 4096")
+	if err != nil {
+		t.Fatal(err)
+	}
+	before, _ := c.VectorEvalCount(q)
+	if before != rowCount(t, c, "RequestMemory > 4096") {
+		t.Fatal("baseline disagrees")
+	}
+	// Rewrite 500 records to a value that fails the predicate.
+	for i := 0; i < 500; i++ {
+		src := "ClusterId = 1\nProcId = 0\nJobStatus = 1\nRequestMemory = 1\nRequestCpus = 1\n" +
+			"Owner = \"user0\"\nCmd = \"/x\"\nWantCheckpoint = false\nArgs = \"\"\nIwd = \"/x\""
+		if err := c.Put([]byte(fmt.Sprintf("k%d", i)), mustAdOld(t, src)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	got, ok := c.VectorEvalCount(q)
+	if !ok {
+		t.Fatal("declined after update")
+	}
+	if want := rowCount(t, c, "RequestMemory > 4096"); got != want {
+		t.Errorf("after update: vectorized %d != row %d", got, want)
+	}
+	if got >= before {
+		t.Errorf("count did not drop after superseding 500 matching records: %d -> %d", before, got)
+	}
+}
+
+// BenchmarkVectorEval sizes the win against every path that can serve the same expression: the
+// per-record columnar evaluator (colScope), the hand-written column scan where its shape applies, and
+// the row scan.
+func BenchmarkVectorEval(b *testing.B) {
+	c := scopeFixtureCodec(b, 60000)
+	defer c.Close()
+
+	for _, expr := range []string{
+		"RequestMemory > 4096",
+		"RequestMemory > 4096 && RequestCpus >= 4",
+		"RequestMemory > RequestCpus * 512",
+		"RequestMemory > 4096 && (JobStatus == 1 || JobStatus == 4)",
+		"WantCheckpoint && RequestCpus > 2",
+		"ProcId + ClusterId > 100",
+	} {
+		q, err := vm.Parse(expr)
+		if err != nil {
+			b.Fatal(err)
+		}
+		// Assert the vectorized path serves this shape before timing it.
+		if _, ok := c.VectorEvalCount(q); !ok {
+			b.Fatalf("%q: declined", expr)
+		}
+		if split := lastVecSplit.Load(); split.vecBlocks == 0 {
+			b.Fatalf("%q: nothing vectorized; the timing would be colScope's", expr)
+		}
+		b.Run("vector/"+expr, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				c.VectorEvalCount(q)
+			}
+		})
+		b.Run("colScope/"+expr, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				c.ColumnarEvalCount(q)
+			}
+		})
+		b.Run("handwritten/"+expr, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				c.CountQuery(q)
+			}
+		})
+		b.Run("rowScan/"+expr, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				n := 0
+				for range c.Query(q) {
+					n++
+				}
+			}
+		})
+	}
+}
+
+// TestVectorEvalChurnGuard checks the mostly-superseded guard: the vectorized executor evaluates every
+// record in a block including ones no snapshot can see, so a block that is almost entirely superseded
+// must be handed to the per-record path instead of vectorized for nothing.
+func TestVectorEvalChurnGuard(t *testing.T) {
+	c := scopeFixtureCodec(t, 20000)
+	defer c.Close()
+
+	q, err := vm.Parse("RequestMemory > RequestCpus * 512")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := c.VectorEvalCount(q); !ok {
+		t.Fatal("declined")
+	}
+	if split := lastVecSplit.Load(); split.churnBlocks != 0 {
+		t.Fatalf("a freshly built fixture should have no churned blocks, got %d", split.churnBlocks)
+	}
+	// Supersede nearly everything, then rebuild so the sealed blocks hold mostly-dead records.
+	for i := 0; i < 19000; i++ {
+		src := fmt.Sprintf("ClusterId = %d\nProcId = 0\nJobStatus = 1\nRequestMemory = 8192\n"+
+			"RequestCpus = 1\nOwner = \"u\"\nCmd = \"/x\"\nWantCheckpoint = false\nArgs = \"\"\nIwd = \"/x\"", i)
+		if err := c.Put([]byte(fmt.Sprintf("k%d", i)), mustAdOld(t, src)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	got, ok := c.VectorEvalCount(q)
+	if !ok {
+		t.Fatal("declined after churn")
+	}
+	if want := rowCount(t, c, "RequestMemory > RequestCpus * 512"); got != want {
+		t.Errorf("after churn: %d != row %d", got, want)
+	}
+	split := lastVecSplit.Load()
+	t.Logf("after superseding 19000/20000: %d vectorized, %d churn-guarded, %d declined, %d row windows",
+		split.vecBlocks, split.churnBlocks, split.scopeBlocks, split.rowWindows)
+	if split.churnBlocks == 0 {
+		t.Error("no block tripped the churn guard; either the guard is dead or the fixture did not churn")
+	}
+}

--- a/collections/vm/vecexec.go
+++ b/collections/vm/vecexec.go
@@ -1,0 +1,495 @@
+package vm
+
+import (
+	"math"
+
+	"github.com/PelicanPlatform/classad/ast"
+	"github.com/PelicanPlatform/classad/classad"
+)
+
+// A VECTORIZED executor for the same compiled Program the scalar interpreter runs.
+//
+// The scalar interpreter dispatches once per instruction per RECORD. This one dispatches once per
+// instruction per BATCH: a ref becomes a column load, a binop becomes a kernel over two vectors, a
+// logical combine becomes a three-valued elementwise merge. Dispatch is amortized over the batch and
+// the inner loops are contiguous, which is why the hand-written column scans are ~10x the per-record
+// evaluator for the one shape they support. This generalizes that to arbitrary expressions.
+//
+// It executes the EXISTING Program rather than a second IR. The compiler, the constant pool, the ref
+// table and the operator strings are shared, so an expression is lowered in exactly one place -- and
+// the scalar executor becomes a per-record reference to test this one against on the same Program.
+// That mirrors how EvalResolved reuses a Program with a different resolver.
+//
+// PARITY. The package's overriding requirement is that it cannot diverge from classad.Eval, which the
+// scalar interpreter achieves by routing every value operation through the ApplyBinaryOp/ApplyUnaryOp
+// hooks. Hand-writing vector kernels for the full semantics would abandon that. So each kernel has a
+// fast loop for the ONE state combination that is unambiguous and dominant -- number OP number,
+// bool AND bool -- and routes every other element, per element, through the same hook the scalar
+// interpreter uses. Undefined, error, division by zero, mixed types and non-boolean logical operands
+// are therefore computed by the reference implementation, not reproduced here. The fast paths cover
+// the values real data is made of; the hook covers the ones semantics arguments are about.
+//
+// SHORT-CIRCUIT. OpShortAnd/OpShortOr are NO-OPS here. They exist to skip evaluating the right
+// operand, which a vector cannot do per record, and the compiler always emits the matching
+// OpCombineAnd/OpCombineOr anyway (emitLogical). Skipping the jump leaves the left operand on the
+// stack, the right operand is evaluated, and the combine merges them -- safe rather than merely
+// convenient because ClassAd's && and || are total, so `false && ERROR` is false whether or not the
+// right side ran. The cost is that both sides are always evaluated; the benefit is that both are
+// evaluated as vectors.
+//
+// NOT HANDLED, returning ok=false so the caller falls back rather than guessing: string values
+// (constants or columns), the Elvis operator (a per-record select with no combine opcode to hang it
+// on), and delegated subtrees (OpEvalNode, which Native() already excludes).
+
+// Element states. A vector carries one per element, which is how three-valued logic and ERROR survive
+// vectorization, and how int and real stay distinguishable -- 7/2 is not 7.0/2.0.
+const (
+	VsInt   uint8 = iota // I[i] is the integer
+	VsReal               // I[i] is math.Float64bits of the real
+	VsBool               // I[i] is 0 or 1
+	VsUndef              // UNDEFINED
+	VsError              // ERROR
+)
+
+// Vec is one batch of values. The payload is a single int64 slice because that is how both
+// classad.Value and the columnar block already store a real (as IEEE-754 bits), so loading a column
+// into a vector is a copy rather than a conversion, and no precision is lost for integers above 2^53.
+type Vec struct {
+	I  []int64
+	St []uint8
+}
+
+func newVec(n int) Vec { return Vec{I: make([]int64, n), St: make([]uint8, n)} }
+
+// Float returns element i as a float64 whatever its numeric state.
+func (v Vec) Float(i int) float64 {
+	if v.St[i] == VsReal {
+		return math.Float64frombits(uint64(v.I[i]))
+	}
+	return float64(v.I[i])
+}
+
+// SetReal/SetInt/SetBool write one element.
+func (v Vec) SetReal(i int, f float64) { v.St[i], v.I[i] = VsReal, int64(math.Float64bits(f)) }
+func (v Vec) SetInt(i int, x int64)    { v.St[i], v.I[i] = VsInt, x }
+func (v Vec) SetBool(i int, b bool) {
+	v.St[i] = VsBool
+	if b {
+		v.I[i] = 1
+	} else {
+		v.I[i] = 0
+	}
+}
+
+// value boxes element i for the parity hook.
+func (v Vec) value(i int) classad.Value {
+	switch v.St[i] {
+	case VsInt:
+		return classad.NewIntValue(v.I[i])
+	case VsReal:
+		return classad.NewRealValue(math.Float64frombits(uint64(v.I[i])))
+	case VsBool:
+		return classad.NewBoolValue(v.I[i] != 0)
+	case VsUndef:
+		return classad.NewUndefinedValue()
+	default:
+		return classad.NewErrorValue()
+	}
+}
+
+// setValue unboxes a hook result back into element i. ok=false for a value a vector cannot hold (a
+// string, list or nested ad), which makes the whole evaluation decline rather than truncate.
+func (v Vec) setValue(i int, val classad.Value) bool {
+	switch val.Type() {
+	case classad.IntegerValue:
+		x, err := val.IntValue()
+		if err != nil {
+			return false
+		}
+		v.SetInt(i, x)
+	case classad.RealValue:
+		f, err := val.RealValue()
+		if err != nil {
+			return false
+		}
+		v.SetReal(i, f)
+	case classad.BooleanValue:
+		b, err := val.BoolValue()
+		if err != nil {
+			return false
+		}
+		v.SetBool(i, b)
+	case classad.UndefinedValue:
+		v.St[i] = VsUndef
+	case classad.ErrorValue:
+		v.St[i] = VsError
+	default:
+		return false
+	}
+	return true
+}
+
+// ColumnSource supplies a batch of values for an attribute reference. The collections package
+// implements it over a columnar block; anything that can produce n values per attribute can.
+//
+// ok=false means the reference cannot be served as a vector -- a string column, or an attribute whose
+// values are expressions -- and the evaluation declines as a whole.
+type ColumnSource interface {
+	LoadColumn(name string, scope ast.AttributeScope, dst Vec) bool
+}
+
+// VecEval executes the query over a batch of n records and returns the result vector. A record matches
+// a constraint when its element is VsBool with I == 1; see Vec.IsTrue.
+//
+// ok=false when the program uses something this executor does not implement. It never returns a
+// partial answer.
+func (q *Query) VecEval(src ColumnSource, n int, scratch *VecScratch) (Vec, bool) {
+	if q == nil || q.prog == nil {
+		return Vec{}, false
+	}
+	if len(q.prog.nodes) != 0 {
+		return Vec{}, false // a delegated subtree needs a real per-record scope
+	}
+	if scratch == nil {
+		scratch = &VecScratch{}
+	}
+	return execVec(q.prog, scratch.evaluator(), src, n, scratch)
+}
+
+func execVec(p *Program, ev *classad.Evaluator, src ColumnSource, n int, s *VecScratch) (Vec, bool) {
+	s.reset(n)
+	for ip := 0; ip < len(p.code); {
+		in := p.code[ip]
+		switch in.Op {
+		case OpPushConst:
+			if !broadcast(s.push(), p.consts[in.A]) {
+				return Vec{}, false
+			}
+		case OpPushTrue:
+			fillBool(s.push(), true)
+		case OpPushFalse:
+			fillBool(s.push(), false)
+		case OpPushUndef:
+			fillState(s.push(), VsUndef)
+		case OpPushError:
+			fillState(s.push(), VsError)
+		case OpLoadRef:
+			r := p.refs[in.A]
+			if !src.LoadColumn(r.name, r.scope, s.push()) {
+				return Vec{}, false
+			}
+		case OpBinop:
+			right, left := s.pop(), s.top()
+			if !binopVec(ev, p.ops[in.A], left, right) {
+				return Vec{}, false
+			}
+		case OpUnop:
+			if !unopVec(ev, p.ops[in.A], s.top()) {
+				return Vec{}, false
+			}
+		case OpShortAnd, OpShortOr:
+			// No-op: see the file comment. The combine below does the work.
+		case OpCombineAnd:
+			right, left := s.pop(), s.top()
+			if !logicalVec(ev, "&&", left, right) {
+				return Vec{}, false
+			}
+		case OpCombineOr:
+			right, left := s.pop(), s.top()
+			if !logicalVec(ev, "||", left, right) {
+				return Vec{}, false
+			}
+		default:
+			return Vec{}, false // OpJmpIfNotUndef (Elvis), OpEvalNode, anything added later
+		}
+		ip++
+	}
+	if s.depth != 1 {
+		return Vec{}, false
+	}
+	return s.top(), true
+}
+
+// VecScratch holds the vector stack and the evaluator so a scan reuses both across batches instead of
+// allocating per block.
+type VecScratch struct {
+	stack []Vec
+	depth int
+	n     int
+	ev    *classad.Evaluator
+}
+
+func (s *VecScratch) evaluator() *classad.Evaluator {
+	if s.ev == nil {
+		// The vector executor never resolves a reference through the evaluator -- refs come from the
+		// ColumnSource -- so an empty scope is enough for the value-operation hooks.
+		s.ev = classad.NewEvaluator(nil)
+	}
+	return s.ev
+}
+
+func (s *VecScratch) reset(n int) {
+	s.depth, s.n = 0, n
+}
+
+func (s *VecScratch) push() Vec {
+	if s.depth == len(s.stack) {
+		s.stack = append(s.stack, newVec(s.n))
+	}
+	v := s.stack[s.depth]
+	if cap(v.I) < s.n {
+		v = newVec(s.n)
+		s.stack[s.depth] = v
+	}
+	v.I, v.St = v.I[:s.n], v.St[:s.n]
+	s.stack[s.depth] = v
+	s.depth++
+	return v
+}
+
+func (s *VecScratch) pop() Vec { s.depth--; return s.stack[s.depth] }
+func (s *VecScratch) top() Vec { return s.stack[s.depth-1] }
+
+func fillBool(v Vec, b bool) {
+	x := int64(0)
+	if b {
+		x = 1
+	}
+	for i := range v.St {
+		v.St[i], v.I[i] = VsBool, x
+	}
+}
+
+func fillState(v Vec, st uint8) {
+	for i := range v.St {
+		v.St[i] = st
+	}
+}
+
+// broadcast fills a vector with one constant. A string constant declines: `Name == "x"` is a real
+// query shape, just not one this executor serves yet.
+func broadcast(v Vec, c classad.Value) bool {
+	switch c.Type() {
+	case classad.IntegerValue:
+		x, err := c.IntValue()
+		if err != nil {
+			return false
+		}
+		for i := range v.St {
+			v.St[i], v.I[i] = VsInt, x
+		}
+	case classad.RealValue:
+		f, err := c.RealValue()
+		if err != nil {
+			return false
+		}
+		bits := int64(math.Float64bits(f))
+		for i := range v.St {
+			v.St[i], v.I[i] = VsReal, bits
+		}
+	case classad.BooleanValue:
+		b, err := c.BoolValue()
+		if err != nil {
+			return false
+		}
+		fillBool(v, b)
+	case classad.UndefinedValue:
+		fillState(v, VsUndef)
+	case classad.ErrorValue:
+		fillState(v, VsError)
+	default:
+		return false
+	}
+	return true
+}
+
+// numeric reports whether an element is a number this executor's fast paths can use.
+func numeric(st uint8) bool { return st == VsInt || st == VsReal }
+
+// binopVec applies a binary operator elementwise, in place on l.
+//
+// Only comparisons and the three exact arithmetic operators have fast loops, and only for
+// number-OP-number. Division, modulo, the identity operators and every mixed or exceptional element go
+// to the hook, so their semantics come from the reference rather than from this file.
+func binopVec(ev *classad.Evaluator, op string, l, r Vec) bool {
+	switch op {
+	case "<", "<=", ">", ">=", "==", "!=":
+		return compareVec(ev, op, l, r)
+	case "+", "-", "*":
+		return arithVec(ev, op, l, r)
+	default:
+		return hookAll(ev, op, l, r)
+	}
+}
+
+// compareVec: both integers compare exactly as int64; any real involved compares as float64; anything
+// else goes to the hook.
+func compareVec(ev *classad.Evaluator, op string, l, r Vec) bool {
+	for i := range l.St {
+		ls, rs := l.St[i], r.St[i]
+		if !numeric(ls) || !numeric(rs) {
+			if !hookOne(ev, op, l, r, i) {
+				return false
+			}
+			continue
+		}
+		var res bool
+		if ls == VsInt && rs == VsInt {
+			a, b := l.I[i], r.I[i]
+			switch op {
+			case "<":
+				res = a < b
+			case "<=":
+				res = a <= b
+			case ">":
+				res = a > b
+			case ">=":
+				res = a >= b
+			case "==":
+				res = a == b
+			case "!=":
+				res = a != b
+			}
+		} else {
+			a, b := l.Float(i), r.Float(i)
+			switch op {
+			case "<":
+				res = a < b
+			case "<=":
+				res = a <= b
+			case ">":
+				res = a > b
+			case ">=":
+				res = a >= b
+			case "==":
+				res = a == b
+			case "!=":
+				res = a != b
+			}
+		}
+		l.SetBool(i, res)
+	}
+	return true
+}
+
+// arithVec handles +, -, * for number-OP-number. Integer pairs stay integral, which keeps values above
+// 2^53 exact and keeps the result's TYPE right for whatever consumes it. Overflow is delegated so the
+// reference decides what it means.
+func arithVec(ev *classad.Evaluator, op string, l, r Vec) bool {
+	for i := range l.St {
+		ls, rs := l.St[i], r.St[i]
+		if !numeric(ls) || !numeric(rs) {
+			if !hookOne(ev, op, l, r, i) {
+				return false
+			}
+			continue
+		}
+		if ls == VsInt && rs == VsInt {
+			a, b := l.I[i], r.I[i]
+			var x int64
+			var over bool
+			switch op {
+			case "+":
+				x = a + b
+				over = (x > a) != (b > 0)
+			case "-":
+				x = a - b
+				over = (x < a) != (b > 0)
+			case "*":
+				x = a * b
+				over = a != 0 && (x/a != b || (a == -1 && b == math.MinInt64))
+			}
+			if over {
+				if !hookOne(ev, op, l, r, i) {
+					return false
+				}
+				continue
+			}
+			l.SetInt(i, x)
+			continue
+		}
+		a, b := l.Float(i), r.Float(i)
+		var f float64
+		switch op {
+		case "+":
+			f = a + b
+		case "-":
+			f = a - b
+		case "*":
+			f = a * b
+		}
+		l.SetReal(i, f)
+	}
+	return true
+}
+
+func unopVec(ev *classad.Evaluator, op string, v Vec) bool {
+	for i := range v.St {
+		switch {
+		case op == "!" && v.St[i] == VsBool:
+			v.SetBool(i, v.I[i] == 0)
+		case op == "-" && v.St[i] == VsInt:
+			if v.I[i] == math.MinInt64 {
+				if !hookOneUn(ev, op, v, i) {
+					return false
+				}
+				continue
+			}
+			v.SetInt(i, -v.I[i])
+		case op == "-" && v.St[i] == VsReal:
+			v.SetReal(i, -v.Float(i))
+		default:
+			if !hookOneUn(ev, op, v, i) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// logicalVec is && / ||. Both operands boolean is the dominant case and the only one with a fast path;
+// everything else -- FALSE dominating an ERROR, UNDEFINED propagation, a non-boolean operand -- is the
+// reference's answer, via the same hook the scalar interpreter calls for these opcodes.
+func logicalVec(ev *classad.Evaluator, op string, l, r Vec) bool {
+	and := op == "&&"
+	for i := range l.St {
+		if l.St[i] != VsBool || r.St[i] != VsBool {
+			if !hookOne(ev, op, l, r, i) {
+				return false
+			}
+			continue
+		}
+		a, b := l.I[i] != 0, r.I[i] != 0
+		if and {
+			l.SetBool(i, a && b)
+		} else {
+			l.SetBool(i, a || b)
+		}
+	}
+	return true
+}
+
+// hookOne computes element i through the parity hook.
+func hookOne(ev *classad.Evaluator, op string, l, r Vec, i int) bool {
+	return l.setValue(i, ev.ApplyBinaryOp(op, l.value(i), r.value(i)))
+}
+
+func hookOneUn(ev *classad.Evaluator, op string, v Vec, i int) bool {
+	return v.setValue(i, ev.ApplyUnaryOp(op, v.value(i)))
+}
+
+// hookAll routes an entire operator through the hook: correct for anything, fast for nothing. Division,
+// modulo and the identity operators land here, so adding a fast path for one later is an optimization
+// rather than a semantics change.
+func hookAll(ev *classad.Evaluator, op string, l, r Vec) bool {
+	for i := range l.St {
+		if !hookOne(ev, op, l, r, i) {
+			return false
+		}
+	}
+	return true
+}
+
+// IsTrue reports whether element i is TRUE, which is what counting matches needs. UNDEFINED and ERROR
+// are not matches.
+func (v Vec) IsTrue(i int) bool { return v.St[i] == VsBool && v.I[i] == 1 }

--- a/collections/vm/vecexec_test.go
+++ b/collections/vm/vecexec_test.go
@@ -1,0 +1,315 @@
+package vm
+
+import (
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/ast"
+	"github.com/PelicanPlatform/classad/classad"
+)
+
+// The vector executor's correctness argument is differential: it runs the SAME Program as the scalar
+// interpreter, so the scalar interpreter is the reference, per record. Any expression the vector
+// executor accepts must produce, for every record, exactly the value Query.Eval produces for that
+// record's ad -- same type, same payload, same UNDEFINED, same ERROR.
+//
+// That is a stronger check than comparing match counts. A count hides a record whose result went from
+// UNDEFINED to FALSE, which is the mistake three-valued logic invites and the one a vectorized combine
+// is most likely to make.
+
+// testSource is a ColumnSource over explicit per-record attribute EXPRESSIONS, so a test can put an
+// UNDEFINED, an ERROR, a string, or a real in one column and see what the executor does with it.
+//
+// Both sides of the comparison are derived from the same source text: the vector side by evaluating
+// each attribute's literal into a Vec element, the scalar side by inserting the same parsed expression
+// into a ClassAd. Neither side is derived from the other, so the test cannot be circular.
+type testSource struct {
+	recs []map[string]string
+	// vals caches each attribute's evaluated literal. LoadColumn must not allocate, or an allocation
+	// test of the executor would be measuring the fixture.
+	vals []map[string]classad.Value
+}
+
+func newTestSource(recs []map[string]string) *testSource {
+	s := &testSource{recs: recs, vals: make([]map[string]classad.Value, len(recs))}
+	for i, r := range recs {
+		s.vals[i] = make(map[string]classad.Value, len(r))
+		for k, src := range r {
+			q, err := Parse(src)
+			if err != nil {
+				panic(err)
+			}
+			s.vals[i][k] = q.Eval(classad.New())
+		}
+	}
+	return s
+}
+
+func (s *testSource) LoadColumn(name string, scope ast.AttributeScope, dst Vec) bool {
+	if scope != ast.NoScope && scope != ast.MyScope {
+		return false
+	}
+	for i := range s.recs {
+		v, ok := s.vals[i][name]
+		if !ok {
+			dst.St[i] = VsUndef
+			continue
+		}
+		if !dst.setValue(i, v) {
+			return false // a string column: decline, exactly as a real source would
+		}
+	}
+	return true
+}
+
+func (s *testSource) ad(i int) *classad.ClassAd {
+	ad := classad.New()
+	for k, src := range s.recs[i] {
+		q, err := Parse(src)
+		if err != nil {
+			panic(err)
+		}
+		ad.Insert(k, q.Expr())
+	}
+	return ad
+}
+
+func sameValue(a, b classad.Value) bool {
+	if a.Type() != b.Type() {
+		return false
+	}
+	switch a.Type() {
+	case classad.IntegerValue:
+		x, _ := a.IntValue()
+		y, _ := b.IntValue()
+		return x == y
+	case classad.RealValue:
+		x, _ := a.RealValue()
+		y, _ := b.RealValue()
+		return x == y || (math.IsNaN(x) && math.IsNaN(y))
+	case classad.BooleanValue:
+		x, _ := a.BoolValue()
+		y, _ := b.BoolValue()
+		return x == y
+	}
+	return true // undefined / error carry no payload
+}
+
+// vecCorpus is a record set built to exercise the states, not just the happy path: integers, reals,
+// negatives, zero (for division), a missing attribute, an explicit UNDEFINED, a string in a numeric
+// position, and a boolean.
+func vecCorpus() *testSource {
+	return newTestSource([]map[string]string{
+		{"A": "10", "B": "3", "F": "true"},
+		{"A": "0", "B": "0", "F": "false"},
+		{"A": "2.5", "B": "2", "F": "true"},
+		{"A": "-7", "B": "0.5", "F": "false"},
+		{"B": "4", "F": "true"}, // A missing
+		{"A": "5"},              // B and F missing
+		{"A": "undefined", "B": "1"},
+		{"A": "9223372036854775807", "B": "2"}, // MaxInt64: + and * must overflow-check
+		{"A": "-9223372036854775808", "B": "-1"},
+		{"A": "error", "B": "1"},
+		{"A": "1152921504606846976", "B": "1152921504606846976"}, // 2^60: beyond float64 exactness
+		{"A": "1.5", "B": "0"},                                   // real division by zero
+	})
+}
+
+var vecExprs = []string{
+	// comparisons, the dominant shape
+	"A > 4", "A >= 4", "A < 4", "A <= 4", "A == 4", "A != 4",
+	"A > B", "A == B", "A >= B",
+	// arithmetic with the fast paths
+	"A + B > 8", "A - B < 0", "A * B > 20", "A + B", "A * B", "A - B",
+	// arithmetic routed to the hook
+	"A / B > 2", "A % B == 0", "A / B", "A % B",
+	// integers that must not become float64
+	"A + B == 2305843009213693952",
+	// logical combines, including operands that are not boolean
+	"A > 4 && B < 4", "A > 4 || B < 4", "A > 4 && B < 4 && A != 0",
+	"A > 4 || B < 4 || A == 0", "!(A > 4)", "A > 4 && !(B < 2)",
+	"F && A > 4", "F || A > 4", "!F",
+	"A && B",     // non-boolean logical operands: the hook's problem
+	"F && 1 / 0", // a FALSE that must dominate an ERROR the vector executor computed anyway
+	// unary
+	"-A > 0", "-A", "-(A + B)",
+	// identity operators, hook-routed
+	"A =?= B", "A =!= B", "A =?= undefined", "A =!= undefined",
+	// mixed nesting
+	"(A + B) * 2 > A", "(A > B) == (B < A)", "A > 4 && (B == 3 || B == 4)",
+	// constants
+	"true", "false", "1 > 0", "A > 4 && true",
+}
+
+// TestVecMatchesScalarPerRecord is the executor's core test: same Program, per-record equality.
+func TestVecMatchesScalarPerRecord(t *testing.T) {
+	src := vecCorpus()
+	n := len(src.recs)
+	var scratch VecScratch
+	declined := 0
+	for _, expr := range vecExprs {
+		q, err := Parse(expr)
+		if err != nil {
+			t.Fatalf("parse %q: %v", expr, err)
+		}
+		got, ok := q.VecEval(src, n, &scratch)
+		if !ok {
+			declined++
+			t.Logf("declined: %s", expr)
+			continue
+		}
+		for i := 0; i < n; i++ {
+			want := q.Eval(src.ad(i))
+			if !sameValue(got.value(i), want) {
+				t.Errorf("%q record %d: vector %s (state %d) != scalar %s",
+					expr, i, got.value(i), got.St[i], want)
+			}
+		}
+	}
+	if declined > 3 {
+		t.Errorf("%d/%d expressions declined; the corpus is meant to be mostly servable",
+			declined, len(vecExprs))
+	}
+	t.Logf("%d expressions x %d records verified against the scalar interpreter (%d declined)",
+		len(vecExprs)-declined, n, declined)
+}
+
+// TestVecDeclinesUnsupported pins what the executor refuses, so a future change that starts silently
+// serving one of these has to update the test and say so.
+func TestVecDeclinesUnsupported(t *testing.T) {
+	src := newTestSource([]map[string]string{
+		{"A": "1", "S": `"x"`},
+	})
+	for _, expr := range []string{
+		`S == "x"`,        // string column
+		`A == "x"`,        // string constant
+		`A ?: 5`,          // Elvis: a per-record select, no combine opcode
+		`size({1,2,3})`,   // delegated subtree (OpEvalNode)
+		`strcat("a","b")`, // function returning a string
+	} {
+		q, err := Parse(expr)
+		if err != nil {
+			t.Fatalf("parse %q: %v", expr, err)
+		}
+		if _, ok := q.VecEval(src, 1, nil); ok {
+			t.Errorf("%q: expected the vector executor to decline", expr)
+		}
+	}
+}
+
+// TestVecShortCircuitNoOpIsSafe is the specific claim that lets && vectorize: OpShortAnd is skipped, so
+// the right operand is ALWAYS evaluated, and the answer must still match. `false && (1/0)` is the case
+// that would break if the combine got the truth table wrong -- short-circuit would never have computed
+// the ERROR, and the vector executor always does.
+func TestVecShortCircuitNoOpIsSafe(t *testing.T) {
+	src := newTestSource([]map[string]string{
+		{"A": "0"},  // A > 5 is FALSE
+		{"A": "10"}, // A > 5 is TRUE
+		{},          // A missing: A > 5 is UNDEFINED
+	})
+	for _, expr := range []string{
+		"A > 5 && 1 / 0 > 0", // FALSE && ERROR
+		"A > 5 || 1 / 0 > 0", // TRUE || ERROR
+		"A > 5 && B > 1",     // ... && UNDEFINED
+		"A > 5 || B > 1",     // ... || UNDEFINED
+	} {
+		q, err := Parse(expr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got, ok := q.VecEval(src, len(src.recs), nil)
+		if !ok {
+			t.Fatalf("%q declined; this shape must vectorize", expr)
+		}
+		for i := range src.recs {
+			want := q.Eval(src.ad(i))
+			if !sameValue(got.value(i), want) {
+				t.Errorf("%q record %d: vector %s != scalar %s", expr, i, got.value(i), want)
+			}
+		}
+	}
+}
+
+// TestVecScratchReuse checks the stack is actually reused: a second batch through the same scratch must
+// not allocate, or a per-block scan pays for its stack per block.
+func TestVecScratchReuse(t *testing.T) {
+	src := vecCorpus()
+	q, err := Parse("A > 4 && B < 4 && A + B > 2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var scratch VecScratch
+	if _, ok := q.VecEval(src, len(src.recs), &scratch); !ok {
+		t.Fatal("declined")
+	}
+	before := testing.AllocsPerRun(20, func() { q.VecEval(src, len(src.recs), &scratch) })
+	if before > 0 {
+		t.Errorf("steady-state VecEval allocates %.1f times per call; the scratch should absorb it", before)
+	}
+}
+
+// TestVecStackDepth guards the no-op short-circuit's stack discipline. Skipping OpShortAnd relies on it
+// PEEKING rather than popping; if that ever changes, the stack would be unbalanced and this catches it
+// as a decline rather than as a wrong answer.
+func TestVecStackDepth(t *testing.T) {
+	src := vecCorpus()
+	for _, expr := range []string{
+		"A > 1 && B > 1", "A > 1 || B > 1",
+		"A > 1 && B > 1 && A > 2 && B > 2",
+		"(A > 1 || B > 1) && (A > 2 || B > 2)",
+		"A > 1 && (B > 1 || (A > 2 && B > 2))",
+	} {
+		q, err := Parse(expr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var s VecScratch
+		if _, ok := q.VecEval(src, len(src.recs), &s); !ok {
+			t.Fatalf("%q declined", expr)
+		}
+		if s.depth != 1 {
+			t.Errorf("%q left stack depth %d, want 1", expr, s.depth)
+		}
+	}
+}
+
+func TestVecBatchInvariantToSize(t *testing.T) {
+	// The same records split into different batch sizes must give the same answers, or a scan that
+	// batches per block gets a different result than one that batches per segment.
+	big := vecCorpus()
+	q, err := Parse("A > 4 && B < 4")
+	if err != nil {
+		t.Fatal(err)
+	}
+	whole, ok := q.VecEval(big, len(big.recs), nil)
+	if !ok {
+		t.Fatal("declined")
+	}
+	var want []string
+	for i := range big.recs {
+		want = append(want, fmt.Sprint(whole.value(i)))
+	}
+	for _, batch := range []int{1, 2, 3, 5, 7} {
+		var got []string
+		for start := 0; start < len(big.recs); start += batch {
+			end := start + batch
+			if end > len(big.recs) {
+				end = len(big.recs)
+			}
+			sub := newTestSource(big.recs[start:end])
+			v, ok := q.VecEval(sub, end-start, nil)
+			if !ok {
+				t.Fatalf("batch %d declined", batch)
+			}
+			for i := 0; i < end-start; i++ {
+				got = append(got, fmt.Sprint(v.value(i)))
+			}
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Errorf("batch=%d record %d: %s != %s", batch, i, got[i], want[i])
+			}
+		}
+	}
+}


### PR DESCRIPTION
Six commits, reviewable in order. The first is the executor; the rest are the follow-ons it made possible.

| | |
|---|---|
| `9f41281` | vectorized evaluation over the existing `vm.Program` |
| `d93ca3a` | strings in the executor |
| `89e1b40` | row groups sealed on multiples of eight |
| `28abc87` | SPIKE: attribute the scan before reaching for SIMD |
| `ea1b853` | SPIKE: masks unify the combine and the comparison |
| `02cbc14` | booleans as mask planes — SIMD-shaped, scalar inside |

## 1. The executor runs the interpreter's own program

The spike (#179) concluded *a vectorized bytecode interpreter, not per-shape generated code*. This is that — and it executes **the existing `vm.Program`**. The compiler, constant pool, ref table, operator strings and opcodes are **unchanged**; this is a second *executor*, exactly as `EvalResolved` is a second resolver. Two consequences matter more than the speed:

1. An expression is lowered in **one place**. A lowering bug can't exist in one executor and not the other.
2. **The scalar interpreter becomes the reference.** The core test runs both over the same Program and compares **per record** — 63 expressions × 12 records, every value's type and payload. A match-count comparison would hide a record going UNDEFINED → FALSE, which is the mistake three-valued logic invites.

**Parity by construction, not by care.** Each kernel has a fast loop for the one unambiguous dominant state combination and routes every *other element, per element,* through the same `ApplyBinaryOp` hook the scalar interpreter uses. Division and modulo have no fast path at all and still work.

**Short-circuit doesn't vectorize and doesn't need to.** `OpShortAnd`/`OpShortOr` are no-ops: the compiler always emits the matching `OpCombineAnd`/`OpCombineOr`, and they *peek* rather than pop, so skipping the jump leaves the stack correct. Verified exhaustively — see below, because this turned out to be less obvious than it looked.

**Declining is per block.** A block holding the attribute as a string, or with an expression in its cold tail, or that is mostly superseded, falls back to exactly the per-record path `ColumnarEvalCount` would have used. `CountQuery`'s last tier routes here because it cannot be worse.

The churn guard is worth calling out: the executor evaluates **every record in a block, including ones no snapshot can see**, and colScope doesn't. On a heavily-updated table that's mostly wasted work. It's worth ~8x per record, so the guard trips at a quarter live, leaving margin rather than sitting on the crossover. A test supersedes 19000/20000 records and asserts it fires.

## 2. Strings

`Owner == "user3"` declined, because a vector had no string payload. Now 3.5x colScope, 15x row.

Parity came from **sharing the comparison, not reimplementing it**: all six of `< <= > >= == !=` fold case via `compareStringsFold`, while `=?=`/`=!=` are case-**sensitive**. classad exports `CompareStringsFold` and the kernel calls it. The load aliases the region rather than copying — one alloc per record previously made strings *slower* than the row path. Both codecs' `Decompress` copies (identity's included), so aliasing can't outlive its backing; it can *pin* it, so pooled stacks clear string payloads on release.

Well short of the numeric gains, structurally: the string region is **positional**, so reaching a field means walking the string fields before it, per record. A per-block string dictionary would turn equality into an integer compare — the real lever there, not vectorization.

## 3. Row groups on multiples of eight

Eight int64s are one cache line and one AVX-512 vector; eight booleans are one byte of the bool bitset. The value isn't the records it shifts — it's that a kernel's tail handling runs once per *segment*, since only a segment's final group is short.

Two wrong turns, both caught by tests rather than reasoning:

**Rounding up** is the obvious implementation and it's wrong — it puts blocks *over* the byte budget by up to 7 records. `TestRowGroupsBoundedByBytes` caught it at 1075680 vs 1048576 B. Ordinary ads overshoot a couple of percent; one pathological half-MB ad overshoots several times over, defeating the budget's purpose. So it seals at the last aligned **prefix** that fits and carries the remainder forward.

**Backing off needs a floor**, or it invents a different pathology: 8 small ads then one enormous one trips the budget just past a boundary, and sealing the prefix emits a **132-byte block** while the ad that filled the budget carries forward. Below half the budget the back-off is skipped. Verified load-bearing by disabling it.

That runt test was vacuous *twice* first — one fixture produced no multi-block segment at all, the next used a repetitive blob ZSTD shrank 600 KB → 140 B so every block looked like a runt regardless.

## 4–5. Two spikes, kept for the reasoning

**Don't reach for SIMD yet.** Go 1.26's `simd/archsimd` is **amd64-only** (every op file is `_amd64.go`), needs `GOEXPERIMENT=simd`, and is outside the Go 1 compatibility promise. Decomposing the scan: eval is 28–62%, so even a *free* eval band is 1.4–2.6x by Amdahl.

And the eval band wasn't what I expected. Adding conjuncts so each step adds one comparison and one combine showed **a combine cost as much as a comparison that loads and compares int64s** — for an operation that only merges booleans. That's a representation problem, not an arithmetic one, and no instruction set fixes it.

**Roaring is the wrong layer here.** A row group is ≤8192 records — a dense bitmap is 1 KB, cache-resident in 16 cache lines; container dispatch would be pure overhead. And `math/bits.OnesCount64` already lowers to one instruction at ~0.5 ns per *word*, so there's nothing for VPOPCNTDQ or Harley-Seal to fix at this scale. Roaring is worth asking about one layer down — value/categorical index postings across a whole table.

## 6. Booleans as mask planes

Two bitplanes, 2 bits per record (`00` F, `01` T, `10` U, `11` E). A comparison *produces* a mask; logical operators consume and produce masks; arithmetic stays on data.

**Shaped for SIMD, scalar inside.** Comparisons build each output word in a register and store it once, so the inner loop over 64 records is exactly what eight `Int64x8.Greater` calls replace — `Greater` *returns* `Mask64x8`, `Mask64x8.And` is the combine, `ToBits` feeds the popcount, `Int64x8.Compress` is the pushdown primitive. Nothing above the kernels moves when that lands, and everything here is ordinary `uint64` that runs everywhere today.

| | kernels before | after | |
|---|---|---|---|
| 1 cmp, 0 combine | 0.213 ms | **0.159** | 1.34x |
| 2 cmp, 1 combine | 0.578 ms | **0.347** | 1.66x |
| 3 cmp, 2 combine | 0.998 ms | **0.501** | 1.99x |
| 4 cmp, 3 combine | 1.462 ms | **0.686** | 2.13x |

The slope is the result: marginal cost per conjunct fell ~0.42 → ~0.175 ms, so a **combine went ~0.207 → ~0.016 ms, about 13x**. Comparisons got 1.34x on their own from writing two bits instead of nine bytes.

**End-to-end the scan is 1.06–1.31x** — Amdahl, as predicted before the work. Against colScope: numerics 7.1–12.4x, strings 3.5x. It also *raised* SIMD's ceiling, the other reason to go first: combines were ~40% of the eval band and SIMD couldn't help them; they're now ~5%, so the band is nearly all comparisons.

A bool column skips the data form entirely — a stored bit becomes a result bit — but only where the column is escape-free, since an escaped value need not be a boolean and a mask can't hold a number. Visibility is a bitmap, so counting survivors is a popcount against the result mask. Both plane operators take a per-word shortcut when neither operand has an UNDEFINED or ERROR in those 64 records: one well-predicted branch per 64 records, and it's the common case.

## Two semantics findings, established rather than assumed

**`&&` does not commute.** `ERROR && FALSE` is ERROR; `FALSE && ERROR` is FALSE. Short-circuit semantics made total — the left operand decides where it can. My first bitplane tables assumed FALSE dominates everything and the agreement test caught it immediately.

That prompted dumping all 16 state pairs of both operators three ways — the parity hook, the full scalar path (which short-circuits), the vector path (which doesn't). **All 32 agree**, which upgrades the short-circuit no-op from "verified over whatever pairs a 12-record corpus produced" to exhaustive. That matters *because* the table is left-biased: a combine that quietly symmetrised it would still pass a corpus with no ERROR on the left.

**Numbers are truthy as logical operands** — `1 && true` TRUE, `0.0 && true` FALSE, `!42` FALSE — while a *string* is an ERROR. So **two notions of truth coexist**, and conflating them is a silent wrong-answer bug: `Vec.IsTrue` is strict (a constraint valued `42` does not match, per the store's `isTrueValue`), `dataStateToMask` is operand truthiness. Separate functions, comments saying why.

Tables are verified against the **reference evaluator**, not the kernels built on them — that would be circular.

## Not handled (declines, doesn't guess)

Elvis (`?:`) and delegated subtrees (`OpEvalNode`, already excluded by `Native()`).

Block accounting now covers vectorized / declined / churn-guarded / pruned / empty, which caught `!RequestMemory` being **zone-pruned outright** rather than evaluated — correct, but it meant that assertion proved nothing until pruning was counted separately.

`collections`, `vm`, `db`, `dbrpc`, `changefeed`, root all green.

## Next

Per-query overhead is now 12–43% of a scan (two `Matcher()` allocations plus colScope setup per call — per-query constant work). Then selection pushdown (loads 11–55%; 55% for strings). Then SIMD comparison kernels when 1.27 makes the package portable, re-measuring rather than assuming these shares hold.
