### PR TITLE
collections: mask planes for booleans, strings in the executor, 8-aligned row groups

### DIFF
--- a/classad/vm_support.go
+++ b/classad/vm_support.go
@@ -145,3 +145,12 @@ func FoldConstants(e ast.Expr) ast.Expr {
 func RecoverCyclic(result *Value) {
 	recoverCyclic(result)
 }
+
+// CompareStringsFold compares two strings the way every ClassAd string comparison operator does:
+// case-insensitively. All six of <, <=, >, >=, == and != route through it, while the identity
+// operators =?= and =!= deliberately do not -- they are case SENSITIVE.
+//
+// Exported for the vectorized executor, which compares a whole column at a time and so cannot afford
+// to box each element and re-dispatch on the operator, but must still produce exactly what the
+// tree-walking evaluator produces. Sharing the function is what makes that a fact rather than a hope.
+func CompareStringsFold(a, b string) int { return compareStringsFold(a, b) }

--- a/collections/colblock.go
+++ b/collections/colblock.go
@@ -79,6 +79,20 @@ const (
 	// default. Well above the byte budget's reach for any ad fat enough for the byte rule to bind.
 	colGroupMaxRows = 8192
 
+	// colGroupAlign is the row-count multiple a byte-sealed row group is rounded UP to.
+	//
+	// Eight int64s are one cache line and one AVX-512 vector, and eight booleans are one byte of the
+	// bool bitset, so an aligned block lets a column kernel run whole vectors with no tail. The value of
+	// aligning is not the handful of records it shifts between blocks -- it is that a kernel's tail
+	// handling then runs once per SEGMENT rather than once per block, because only a segment's FINAL
+	// group is short. That last group cannot be aligned: it holds whatever records remain, and padding it
+	// would mean storing records that do not exist.
+	//
+	// Applied to the byte rule only. An explicit maxRows policy seals exactly, so a test sweeping group
+	// sizes still gets the size it asked for, and neither does an ad so large that the budget trips
+	// within the first colGroupAlign records.
+	colGroupAlign = 8
+
 	// colGroupRows is the reference point the measurements above were taken at: what
 	// colGroupTargetBytes works out to for OSPool slot ads (~8867 B/ad of regions). Kept as the
 	// documented equivalence, and used by tests that need an exact row-count grouping.
@@ -86,7 +100,8 @@ const (
 )
 
 // colGrouping is the row-group sealing policy: seal a group once its records reach targetBytes of
-// uncompressed row form, or maxRows records, whichever comes first.
+// uncompressed row form, or maxRows records, whichever comes first. Where the byte rule trips, the block
+// is sealed at the last colGroupAlign boundary that still fits the budget (see sealAt).
 //
 // A zero targetBytes means "no byte rule" -- group purely by row count, which is what a test
 // sweeping exact group sizes wants. A zero maxRows means colGroupMaxRows.
@@ -114,6 +129,41 @@ func (g colGrouping) full(rows, bytes int) bool {
 	}
 	return g.targetBytes > 0 && bytes >= g.targetBytes
 }
+
+// sealAt returns how many of the group's rows to seal into a block now, given the row count and bytes
+// that tripped full(), plus the row count and bytes as of the last colGroupAlign boundary.
+//
+// Alignment is a choice of SEAL POINT, not of when to notice the budget. Rounding UP to the next
+// boundary would be simpler and is wrong: it puts the block OVER the byte budget by up to
+// colGroupAlign-1 records, which for a 1 MiB budget and ordinary ads is a couple of percent but for a
+// single pathological half-megabyte ad is several times over -- and the budget exists precisely so that
+// no block is too big to cache. Sealing the last aligned PREFIX and carrying the remainder into the next
+// group keeps both properties.
+//
+// Returns len(rows) when there is no aligned prefix to fall back to: an explicit maxRows policy (which
+// seals exactly, so a test gets the group size it asked for), and ads so large that the budget trips
+// within the first colGroupAlign records.
+func (g colGrouping) sealAt(rows, bytes, alignedRows, alignedBytes int) (seal, sealBytes int) {
+	if g.targetBytes <= 0 || bytes <= g.targetBytes {
+		return rows, bytes // the row cap tripped, or the byte rule tripped exactly on budget
+	}
+	if alignedRows <= 0 || alignedRows >= rows {
+		return rows, bytes
+	}
+	// Backing off to the aligned prefix must not produce a runt. Record sizes vary by orders of
+	// magnitude -- a few small ads followed by one enormous one will trip the budget a record or two past
+	// a boundary, and sealing the prefix would then emit a block holding almost nothing while the ad that
+	// actually filled the budget carries forward. Below the floor, take the aligned-but-over block
+	// instead: the overshoot is one record's worth and is caused by that record, which no split avoids.
+	if alignedBytes < g.minGroupBytes() {
+		return rows, bytes
+	}
+	return alignedRows, alignedBytes
+}
+
+// minGroupBytes is the smallest block the aligned-prefix back-off may produce, as a fraction of the byte
+// budget rather than an absolute, so a test configuring a small budget still gets a proportionate floor.
+func (g colGrouping) minGroupBytes() int { return g.targetBytes / 2 }
 
 // columnarBlock is the PAX layout for a row-group of adSchema records (see adschema.go): the
 // schema's popular ("hot") numeric fields plus the escape and bool bitsets stay uncompressed
@@ -264,6 +314,9 @@ func buildColumnarFromSegment(data []byte, upto int, arenaCodec, regionCodec Cod
 	var offs []uint32
 	var buf []byte
 	groupBytes := 0
+	// The group's extent as of the last colGroupAlign boundary, so an over-budget group can be sealed
+	// there rather than past it. See sealAt.
+	alignedRows, alignedBytes := 0, 0
 	for off := 0; off < upto; {
 		o := uint32(off)
 		total := recTotalLen(data, o)
@@ -278,9 +331,21 @@ func buildColumnarFromSegment(data []byte, upto int, arenaCodec, regionCodec Cod
 					recs = append(recs, rec)
 					offs = append(offs, o)
 					groupBytes += len(rec)
+					if len(recs)%colGroupAlign == 0 {
+						alignedRows, alignedBytes = len(recs), groupBytes
+					}
 					if g.full(len(recs), groupBytes) {
-						blocks = append(blocks, encodeColumnarBlock(s, recs, hot, regionCodec))
-						recs, groupBytes = recs[:0], 0
+						seal, sealBytes := g.sealAt(len(recs), groupBytes, alignedRows, alignedBytes)
+						blocks = append(blocks, encodeColumnarBlock(s, recs[:seal], hot, regionCodec))
+						// Carry the records past the seal point into the next group. encodeColumnarBlock
+						// has already copied what it needs out of the record slices, so moving their
+						// headers down is safe; offs is per SEGMENT and is not reset.
+						n := copy(recs, recs[seal:])
+						recs, groupBytes = recs[:n], groupBytes-sealBytes
+						alignedRows, alignedBytes = 0, 0
+						if n > 0 && n%colGroupAlign == 0 {
+							alignedRows, alignedBytes = n, groupBytes
+						}
 					}
 				}
 			}

--- a/collections/colblock_segment_test.go
+++ b/collections/colblock_segment_test.go
@@ -2,8 +2,10 @@ package collections
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
+	"github.com/PelicanPlatform/classad/collections/vm"
 	"github.com/PelicanPlatform/classad/collections/wire"
 )
 
@@ -151,4 +153,71 @@ func TestBuildColumnarFromSegmentRowGroups(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestColGroupsAlignedToEight checks the byte-driven sealing policy produces row groups whose row counts
+// are multiples of colGroupAlign, so a column kernel can run whole vectors and handle a tail once per
+// segment rather than once per block.
+//
+// A segment's FINAL group is exempt and must be: it holds whatever records remain.
+func TestColGroupsAlignedToEight(t *testing.T) {
+	// Ads fat enough that the BYTE rule binds, which is the rule alignment applies to. If the row cap
+	// bound instead, every block would be colGroupMaxRows and the test would pass without testing
+	// anything.
+	c := New(Options{Shards: 1, SegmentSize: 1 << 22})
+	defer c.Close()
+	pad := strings.Repeat("x", 4096)
+	for i := 0; i < 4000; i++ {
+		src := fmt.Sprintf("ClusterId = %d\nProcId = %d\nRequestMemory = %d\nOwner = \"user%d\"\nBlob = \"%s\"",
+			i, i%10, 1024+(i%32)*512, i%512, pad)
+		if err := c.Put([]byte(fmt.Sprintf("k%d", i)), mustAdOld(t, src)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, e := range []string{"ProcId >= 0", "RequestMemory >= 0"} {
+		q, err := vm.Parse(e)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i := 0; i < 20; i++ {
+			for range c.Query(q) {
+			}
+		}
+	}
+	if !c.BuildAndEnableSchemaScan(4000, 8) {
+		t.Fatal("no sealed segments")
+	}
+	st := c.schemaScan.Load()
+	if st == nil {
+		t.Fatal("no schema scan state")
+	}
+	checked, multi := 0, 0
+	for _, sh := range c.shards {
+		_, wins := sh.snapshot()
+		for _, w := range wins {
+			seg := w.seg.colblk.Load()
+			if seg == nil || len(seg.blocks) == 0 {
+				continue
+			}
+			if len(seg.blocks) > 1 {
+				multi++
+			}
+			for i, blk := range seg.blocks {
+				if i == len(seg.blocks)-1 {
+					continue // the short final group
+				}
+				checked++
+				if blk.n%colGroupAlign != 0 {
+					t.Errorf("block %d of %d holds %d rows, not a multiple of %d",
+						i, len(seg.blocks), blk.n, colGroupAlign)
+				}
+			}
+		}
+		releaseWindows(wins)
+	}
+	if multi == 0 || checked == 0 {
+		t.Fatalf("no segment held more than one row group (%d multi-block segments, %d non-final blocks); "+
+			"the fixture never exercised the byte rule, so alignment was not tested", multi, checked)
+	}
+	t.Logf("%d non-final row groups across %d multi-block segments, all %d-aligned", checked, multi, colGroupAlign)
 }

--- a/collections/colgroup_test.go
+++ b/collections/colgroup_test.go
@@ -3,6 +3,8 @@ package collections
 import (
 	"fmt"
 	"testing"
+
+	"github.com/PelicanPlatform/classad/collections/vm"
 )
 
 // Row groups (see colGroupRows): a segment's columnar accelerator is a SERIES of blocks, not one
@@ -376,4 +378,107 @@ func TestColSegmentRejectsGroupOffsMismatch(t *testing.T) {
 		t.Error("a blob whose block counts do not sum to its offs length was accepted; a scan " +
 			"would read the wrong record's MVCC header")
 	}
+}
+
+// TestRowGroupsNoRunts covers the pathological mix the aligned-prefix back-off invites: several small
+// records followed by one enormous one, so the byte budget trips a record or two past an alignment
+// boundary and the prefix holds almost nothing.
+//
+// Sealing that prefix would emit a runt block while the ad that actually filled the budget carries into
+// the next group. Below the floor the back-off is skipped, so blocks stay reasonably sized even where
+// that costs alignment.
+func TestRowGroupsNoRunts(t *testing.T) {
+	c := New(Options{Shards: 1, SegmentSize: 1 << 23})
+	defer c.Close()
+	// Incompressible, deterministically. The block's size is only observable through its compressed
+	// regions, so a repetitive blob would shrink to a few hundred bytes and every block would look like a
+	// runt whether or not it was one -- measuring the codec instead of the grouping.
+	small := incompressible(64, 1)
+	huge := incompressible(colGroupTargetBytes+128*1024, 2) // crosses the byte budget on its own
+	n := 0
+	for round := 0; round < 16; round++ {
+		// Exactly colGroupAlign small ads -- so the last alignment boundary holds almost nothing -- then
+		// one ad that crosses the whole budget by itself. That is the shape that makes the aligned-prefix
+		// back-off emit a runt, and the only shape that exercises the floor.
+		for i := 0; i < colGroupAlign; i++ {
+			src := fmt.Sprintf("ClusterId = %d\nProcId = %d\nBlob = \"%s\"", n, n%10, small)
+			if err := c.Put([]byte(fmt.Sprintf("k%d", n)), mustAdOld(t, src)); err != nil {
+				t.Fatal(err)
+			}
+			n++
+		}
+		src := fmt.Sprintf("ClusterId = %d\nProcId = %d\nBlob = \"%s\"", n, n%10, huge)
+		if err := c.Put([]byte(fmt.Sprintf("k%d", n)), mustAdOld(t, src)); err != nil {
+			t.Fatal(err)
+		}
+		n++
+	}
+	for _, e := range []string{"ProcId >= 0", "ClusterId >= 0"} {
+		q, err := vm.Parse(e)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i := 0; i < 20; i++ {
+			for range c.Query(q) {
+			}
+		}
+	}
+	if !c.BuildAndEnableSchemaScan(4000, 8) {
+		t.Fatal("no sealed segments; the fixture did not seal, so nothing was tested")
+	}
+	floor := colGroupTargetBytes / 2
+	blocks, runts := 0, 0
+	for _, sh := range c.shards {
+		_, wins := sh.snapshot()
+		for _, w := range wins {
+			seg := w.seg.colblk.Load()
+			if seg == nil {
+				continue
+			}
+			for i, blk := range seg.blocks {
+				if i == len(seg.blocks)-1 || blk.n == 0 {
+					continue // the short final group is exempt by construction
+				}
+				blocks++
+				// A non-final block should either be alignment-driven and substantial, or contain one of
+				// the enormous records. Either way it must not be a runt.
+				bytes := blk.n * blk.hotStride
+				if r, ok := blockRegionBytes(blk); ok {
+					bytes += r
+				}
+				if bytes < floor/8 {
+					runts++
+					t.Errorf("non-final block %d/%d holds %d records / ~%d B, far below the %d B floor",
+						i, len(seg.blocks), blk.n, bytes, floor)
+				}
+			}
+		}
+		releaseWindows(wins)
+	}
+	if blocks == 0 {
+		t.Fatal("no segment held more than one row group, so the aligned-prefix back-off never ran " +
+			"and this test asserted nothing")
+	}
+	t.Logf("%d non-final blocks, %d runts", blocks, runts)
+}
+
+// blockRegionBytes reports a block's compressed region bytes, as a stand-in for its record content size.
+// Only meaningful for incompressible content; see incompressible.
+func blockRegionBytes(b *columnarBlock) (int, bool) {
+	return len(b.coldNumComp) + len(b.strComp) + len(b.coldComp), true
+}
+
+// incompressible builds a deterministic n-byte string a compressor cannot shrink, from a simple LCG so
+// no test depends on a seeded RNG or on Math.random.
+func incompressible(n int, seed uint32) string {
+	const alpha = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	b := make([]byte, n)
+	x := seed*2654435761 + 1
+	for i := range b {
+		x = x*1664525 + 1013904223
+		// Alphanumeric only: a quote or a backslash would have to be escaped, and the point is the
+		// bytes' entropy, which 62 symbols carry plenty of for a compressor to make no progress.
+		b[i] = alpha[(x>>16)%uint32(len(alpha))]
+	}
+	return string(b)
 }

--- a/collections/colscope.go
+++ b/collections/colscope.go
@@ -3,6 +3,7 @@ package collections
 import (
 	"encoding/binary"
 	"math"
+	"sync/atomic"
 	"unsafe"
 
 	"github.com/PelicanPlatform/classad/ast"
@@ -236,6 +237,33 @@ func (cs *colScope) setBlock(blk *columnarBlock) {
 	cs.strScratch = nil
 }
 
+// prunePlan caches the zone-prunable probe analysis, which depends only on the query and the SCHEMA.
+//
+// A scan visits one window per segment -- 162 of them on a 60k-record table -- and they almost always
+// share a single schema OBJECT, so recomputing the analysis per window repeated identical work 161 times:
+// measured at 11% of a scan's time and 44% of its allocations, for an answer that never changed. Keyed on
+// pointer identity, so two equal-but-distinct schemas merely recompute rather than answer wrongly.
+// zonePruneAnalyses counts how many times the probe analysis actually ran, so a test can hold the line
+// that it runs once per query rather than once per segment. One atomic add per query is free; the
+// alternative is a regression that only shows up as a query being mysteriously slower on a table with
+// many segments, which is how this cost went unnoticed in the first place.
+var zonePruneAnalyses atomic.Int64
+
+type prunePlan struct {
+	schema *adSchema
+	idxs   []int
+	preds  []fieldPred
+	valid  bool
+}
+
+func (p *prunePlan) tests(c *Collection, q *vm.Query, s *adSchema) ([]int, []fieldPred) {
+	if !p.valid || s != p.schema {
+		p.idxs, p.preds = c.zonePrunableTests(q, s)
+		p.schema, p.valid = s, true
+	}
+	return p.idxs, p.preds
+}
+
 // zonePrunableTests extracts the query's probes that a block zone can reason about: scalar numeric
 // comparisons on numeric fields of THIS schema, as (field index, tests).
 //
@@ -244,6 +272,7 @@ func (cs *colScope) setBlock(blk *columnarBlock) {
 // correctness. That is the opposite of answering from probes, which needs them to cover the query --
 // colScope answers by evaluating the query itself, so it is exact regardless.
 func (c *Collection) zonePrunableTests(q *vm.Query, s *adSchema) ([]int, []fieldPred) {
+	zonePruneAnalyses.Add(1)
 	var idxs []int
 	var preds []fieldPred
 	for _, p := range q.Probes() {
@@ -312,6 +341,7 @@ func (c *Collection) ColumnarEvalCount(q *vm.Query) (int, bool) {
 	resolver := cs.resolve // hoisted: a method value expression allocates
 	fallbackM := q.Matcher()
 	count := 0
+	var plan prunePlan
 	for _, sh := range c.shards {
 		s0, wins := sh.snapshot()
 		for _, w := range wins {
@@ -320,7 +350,7 @@ func (c *Collection) ColumnarEvalCount(q *vm.Query) (int, bool) {
 				count += c.rowEvalWindow(w, s0, fallbackM)
 				continue
 			}
-			pruneIdxs, prunePreds := c.zonePrunableTests(q, seg.schema())
+			pruneIdxs, prunePreds := plan.tests(c, q, seg.schema())
 			base := 0
 			for _, blk := range seg.blocks {
 				if len(prunePreds) > 0 && !blockMayMatch(blk, pruneIdxs, prunePreds) {

--- a/collections/colvec.go
+++ b/collections/colvec.go
@@ -40,10 +40,12 @@ import (
 // exactly like a correct vectorized scan that is mysteriously no faster -- which is how three earlier
 // measurements in this package produced plausible and wrong conclusions.
 type vecSplit struct {
-	vecBlocks   int
-	scopeBlocks int // the executor declined: a string column, an expression in the cold tail, Elvis
-	churnBlocks int // mostly-superseded: colScope is cheaper than evaluating records nobody can see
-	rowWindows  int
+	vecBlocks    int
+	scopeBlocks  int // the executor declined: a string column, an expression in the cold tail, Elvis
+	churnBlocks  int // mostly-superseded: colScope is cheaper than evaluating records nobody can see
+	prunedBlocks int // a zone ruled the block out; no records were examined at all
+	emptyBlocks  int // nothing in the block was visible to this snapshot
+	rowWindows   int
 }
 
 // vecScratchPool reuses the vector stack across queries. Without it each call allocated its own stack
@@ -75,7 +77,7 @@ type blockVecSource struct {
 // ok=false declines the block. An attribute the schema does not carry lives in the cold tail, which is
 // a per-record read with a decompression behind it -- exactly what a vector load is meant to avoid --
 // so it declines rather than pretending to be fast.
-func (s *blockVecSource) LoadColumn(name string, scope ast.AttributeScope, dst vm.Vec) bool {
+func (s *blockVecSource) LoadColumn(name string, scope ast.AttributeScope, dst *vm.Vec) bool {
 	if scope != ast.NoScope && scope != ast.MyScope {
 		return false
 	}
@@ -109,8 +111,9 @@ func (s *blockVecSource) LoadColumn(name string, scope ast.AttributeScope, dst v
 // Copying is what a string predicate cannot afford: one allocation per record made a string comparison
 // slower in the columnar path than in the row path, which is why this aliases and why Vec's elements are
 // released back to the pool (see VecScratch.Release).
-func (s *blockVecSource) loadStr(idx int, id uint32, dst vm.Vec) bool {
+func (s *blockVecSource) loadStr(idx int, id uint32, dst *vm.Vec) bool {
 	b := s.blk
+	dst.Mask = false
 	region, err := s.bc.stream(b, kindStr)
 	if err != nil {
 		return false
@@ -154,7 +157,8 @@ func (s *blockVecSource) loadStr(idx int, id uint32, dst vm.Vec) bool {
 }
 
 // loadNum loads a numeric column, then repairs the escaped elements from the cold tail.
-func (s *blockVecSource) loadNum(idx int, f adField, id uint32, dst vm.Vec) bool {
+func (s *blockVecSource) loadNum(idx int, f adField, id uint32, dst *vm.Vec) bool {
+	dst.Mask = false
 	if !s.blk.loadIntBatch(idx, s.bc, dst.I) {
 		return false
 	}
@@ -171,16 +175,40 @@ func (s *blockVecSource) loadNum(idx int, f adField, id uint32, dst vm.Vec) bool
 	return s.fixEscapes(idx, id, dst)
 }
 
-// loadBool loads a bit-packed boolean column. The bool bitset sits immediately after the escape bitmap
-// in each record's hot region, so this is a strided read of uncompressed memory.
-func (s *blockVecSource) loadBool(idx int, f adField, id uint32, dst vm.Vec) bool {
+// loadBool loads a bit-packed boolean column. The bool bitset sits immediately after the escape bitmap in
+// each record's hot region, so this is a strided read of uncompressed memory.
+//
+// Where the column has no escape it is delivered as a MASK, built a word at a time: a stored bit becomes a
+// result bit with no per-element state byte in between, which is the shortest path storage-to-kernel in the
+// whole executor. A column WITH escapes goes to the data form instead, because an escaped value need not be
+// a boolean at all -- the attribute may hold a number or a string on some records -- and a mask cannot
+// represent that. Converting later, if a logical operator wants one, then applies the operand truthiness
+// the reference applies.
+func (s *blockVecSource) loadBool(idx int, f adField, id uint32, dst *vm.Vec) bool {
 	b := s.blk
+	if b.escapeFree(idx) {
+		for w := range dst.Hi {
+			start := w * 64
+			end := start + 64
+			if end > b.n {
+				end = b.n
+			}
+			var lo uint64
+			for k := start; k < end; k++ {
+				base := k*b.hotStride + b.schema.escBytes
+				if testBit(b.hot[base:base+b.schema.boolBytes], f.boolBit) {
+					lo |= 1 << uint(k-start)
+				}
+			}
+			dst.Hi[w], dst.Lo[w] = 0, lo
+		}
+		dst.Mask = true
+		return true
+	}
+	dst.Mask = false
 	for k := 0; k < b.n; k++ {
 		base := k*b.hotStride + b.schema.escBytes
 		dst.SetBool(k, testBit(b.hot[base:base+b.schema.boolBytes], f.boolBit))
-	}
-	if b.escapeFree(idx) {
-		return true
 	}
 	return s.fixEscapes(idx, id, dst)
 }
@@ -194,7 +222,7 @@ func (s *blockVecSource) loadBool(idx int, f adField, id uint32, dst vm.Vec) boo
 // Reading the value as whatever type it actually is, rather than insisting it match the column, is what
 // keeps a handful of odd records from declining a whole block: the kernels route a mismatched type
 // through the parity hook and get the reference's answer for it.
-func (s *blockVecSource) fixEscapes(idx int, id uint32, dst vm.Vec) bool {
+func (s *blockVecSource) fixEscapes(idx int, id uint32, dst *vm.Vec) bool {
 	for k := 0; k < s.blk.n; k++ {
 		if !testBit(s.blk.escapeAt(k), idx) {
 			continue
@@ -248,7 +276,7 @@ func (c *Collection) VectorEvalCount(q *vm.Query) (int, bool) {
 		scratch.Release()
 		vecScratchPool.Put(scratch)
 	}()
-	var live []bool
+	var live []uint64
 	var split vecSplit
 	defer func() { lastVecSplit.Store(&split) }()
 	count := 0
@@ -265,30 +293,38 @@ func (c *Collection) VectorEvalCount(q *vm.Query) (int, bool) {
 			base := 0
 			for _, blk := range seg.blocks {
 				if len(prunePreds) > 0 && !blockMayMatch(blk, pruneIdxs, prunePreds) {
+					split.prunedBlocks++
 					base += blk.n
 					continue
 				}
 				// Visibility first, once. The vectorized path needs the mask anyway to count, and
 				// knowing how much of the block is live is what decides whether vectorizing it is
 				// worth doing at all.
-				if cap(live) < blk.n {
-					live = make([]bool, blk.n)
+				// Visibility as a BITMAP, so counting the survivors is a popcount per 64 records
+				// rather than a branch per record, and so the result mask can be ANDed with it
+				// directly instead of consulted element by element.
+				words := vm.MaskWords(blk.n)
+				if cap(live) < words {
+					live = make([]uint64, words)
 				}
-				live = live[:blk.n]
+				live = live[:words]
+				for i := range live {
+					live[i] = 0
+				}
 				nLive := 0
 				for k := 0; k < blk.n; k++ {
 					gk := base + k
-					vis := gk < len(seg.offs)
-					if vis {
-						o := seg.offs[gk]
-						vis = recSeq(w.data, o) <= s0 && recSuperseded(w.data, o) > s0
+					if gk >= len(seg.offs) {
+						break
 					}
-					live[k] = vis
-					if vis {
+					o := seg.offs[gk]
+					if recSeq(w.data, o) <= s0 && recSuperseded(w.data, o) > s0 {
+						live[k/64] |= 1 << uint(k%64)
 						nLive++
 					}
 				}
 				if nLive == 0 {
+					split.emptyBlocks++
 					base += blk.n
 					continue
 				}
@@ -310,11 +346,7 @@ func (c *Collection) VectorEvalCount(q *vm.Query) (int, bool) {
 					continue
 				}
 				split.vecBlocks++
-				for k := 0; k < blk.n; k++ {
-					if live[k] && vec.IsTrue(k) {
-						count++
-					}
-				}
+				count += vec.CountTrue(live)
 				base += blk.n
 			}
 		}

--- a/collections/colvec.go
+++ b/collections/colvec.go
@@ -277,6 +277,7 @@ func (c *Collection) VectorEvalCount(q *vm.Query) (int, bool) {
 		vecScratchPool.Put(scratch)
 	}()
 	var live []uint64
+	var plan prunePlan
 	var split vecSplit
 	defer func() { lastVecSplit.Store(&split) }()
 	count := 0
@@ -289,7 +290,7 @@ func (c *Collection) VectorEvalCount(q *vm.Query) (int, bool) {
 				count += c.rowEvalWindow(w, s0, fallbackM)
 				continue
 			}
-			pruneIdxs, prunePreds := c.zonePrunableTests(q, seg.schema())
+			pruneIdxs, prunePreds := plan.tests(c, q, seg.schema())
 			base := 0
 			for _, blk := range seg.blocks {
 				if len(prunePreds) > 0 && !blockMayMatch(blk, pruneIdxs, prunePreds) {

--- a/collections/colvec.go
+++ b/collections/colvec.go
@@ -1,11 +1,14 @@
 package collections
 
 import (
+	"encoding/binary"
 	"sync"
 	"sync/atomic"
+	"unsafe"
 
 	"github.com/PelicanPlatform/classad/ast"
 	"github.com/PelicanPlatform/classad/collections/vm"
+	"github.com/PelicanPlatform/classad/collections/wire"
 )
 
 // Vectorized evaluation of an arbitrary constraint over columnar blocks.
@@ -88,10 +91,66 @@ func (s *blockVecSource) LoadColumn(name string, scope ast.AttributeScope, dst v
 	switch {
 	case f.kind == akBool:
 		return s.loadBool(idx, f, id, dst)
+	case f.kind == akString:
+		return s.loadStr(idx, id, dst)
 	case numericKind(f.kind):
 		return s.loadNum(idx, f, id, dst)
 	}
-	return false // akString: colScope reads these zero-copy; a vector has no string payload yet
+	return false
+}
+
+// loadStr loads a string column, aliasing the block's decompressed string region rather than copying.
+//
+// The region is POSITIONAL -- uvarint(len)+bytes per non-escaped string field in schema order -- so
+// reaching a field means walking the string fields before it, per record. That walk is the same one
+// colScope does; what the vector path removes is the per-operator resolver call and the boxed value
+// around it, not the walk.
+//
+// Copying is what a string predicate cannot afford: one allocation per record made a string comparison
+// slower in the columnar path than in the row path, which is why this aliases and why Vec's elements are
+// released back to the pool (see VecScratch.Release).
+func (s *blockVecSource) loadStr(idx int, id uint32, dst vm.Vec) bool {
+	b := s.blk
+	region, err := s.bc.stream(b, kindStr)
+	if err != nil {
+		return false
+	}
+	escFree := b.escapeFree(idx)
+	for k := 0; k < b.n; k++ {
+		esc := b.escapeAt(k)
+		if !escFree && testBit(esc, idx) {
+			dst.St[k] = vm.VsUndef // repaired from the cold tail below
+			continue
+		}
+		rec := region[b.strOff[k]:b.strOff[k+1]]
+		found := false
+		for i := range b.schema.fields {
+			if b.schema.fields[i].kind != akString || testBit(esc, i) {
+				continue
+			}
+			l, n := binary.Uvarint(rec)
+			if n <= 0 || int(l)+n > len(rec) {
+				return false
+			}
+			if i == idx {
+				if l == 0 {
+					dst.SetString(k, "")
+				} else {
+					dst.SetString(k, unsafe.String(&rec[n], int(l)))
+				}
+				found = true
+				break
+			}
+			rec = rec[n+int(l):]
+		}
+		if !found {
+			return false
+		}
+	}
+	if escFree {
+		return true
+	}
+	return s.fixEscapes(idx, id, dst)
 }
 
 // loadNum loads a numeric column, then repairs the escaped elements from the cold tail.
@@ -127,9 +186,14 @@ func (s *blockVecSource) loadBool(idx int, f adField, id uint32, dst vm.Vec) boo
 }
 
 // fixEscapes overwrites the elements whose value did not fit its slot. An escape means the value is
-// MISSING or UNSTORABLE: missing is UNDEFINED, a scalar is read from the cold tail, and anything else
-// -- a string, a computed expression -- declines the block, because only the ordinary evaluator can
-// give the right answer for it.
+// MISSING or UNSTORABLE: missing is UNDEFINED, and any scalar literal is read from the cold tail --
+// including one of the wrong type for the column, since a number where the schema expects a string is
+// exactly what escaping is for. Only a computed expression declines, because only the ordinary
+// evaluator can resolve one against the rest of the ad.
+//
+// Reading the value as whatever type it actually is, rather than insisting it match the column, is what
+// keeps a handful of odd records from declining a whole block: the kernels route a mismatched type
+// through the parity hook and get the reference's answer for it.
 func (s *blockVecSource) fixEscapes(idx int, id uint32, dst vm.Vec) bool {
 	for k := 0; k < s.blk.n; k++ {
 		if !testBit(s.blk.escapeAt(k), idx) {
@@ -143,17 +207,23 @@ func (s *blockVecSource) fixEscapes(idx int, id uint32, dst vm.Vec) bool {
 			dst.St[k] = vm.VsUndef
 			continue
 		}
-		nv, ok := nodeColVal(node)
+		lit, ok := wire.LiteralValue(node)
 		if !ok {
-			return false
+			return false // a computed expression
 		}
-		switch nv.kind {
-		case akReal:
-			dst.SetReal(k, nv.f)
-		case akBool:
-			dst.SetBool(k, nv.i != 0)
+		switch lit.Kind {
+		case wire.LitInt:
+			dst.SetInt(k, lit.Int)
+		case wire.LitReal:
+			dst.SetReal(k, lit.Real)
+		case wire.LitBool:
+			dst.SetBool(k, lit.Bool)
+		case wire.LitString:
+			dst.SetString(k, lit.Str)
+		case wire.LitUndef:
+			dst.St[k] = vm.VsUndef
 		default:
-			dst.SetInt(k, nv.i)
+			dst.St[k] = vm.VsError
 		}
 	}
 	return true
@@ -174,7 +244,10 @@ func (c *Collection) VectorEvalCount(q *vm.Query) (int, bool) {
 	resolver := cs.resolve
 	src := &blockVecSource{c: c, bc: st.cache}
 	scratch := vecScratchPool.Get().(*vm.VecScratch)
-	defer vecScratchPool.Put(scratch)
+	defer func() {
+		scratch.Release()
+		vecScratchPool.Put(scratch)
+	}()
 	var live []bool
 	var split vecSplit
 	defer func() { lastVecSplit.Store(&split) }()

--- a/collections/colvec_test.go
+++ b/collections/colvec_test.go
@@ -35,6 +35,17 @@ var vecExprs = []string{
 	"RequestMemory > 4096 && WantCheckpoint",
 	"true",
 	"ProcId >= 0 && ProcId < 10",
+	// strings: the shape colScope already served zero-copy, now a column at a time
+	`Owner == "user3"`,
+	`Owner == "USER3"`, // == folds case
+	`Owner != "user3"`,
+	`Owner =?= "user3"`,
+	`Owner =!= "USER3"`, // =?= / =!= do not fold
+	`Owner < "user5"`,
+	`Owner == "user3" || Owner == "user10"`,
+	`Owner == "user3" && RequestCpus > 2`,
+	`Cmd == "/home/user3/run.sh"`,
+	`Owner == "user3" || RequestMemory > 8192`,
 }
 
 // rowCount is the independent reference: the ordinary row path, which decodes ads and evaluates the
@@ -92,8 +103,6 @@ func TestVectorEvalDeclinesGracefully(t *testing.T) {
 	defer c.Close()
 
 	for _, expr := range []string{
-		`Owner == "user3"`, // string column
-		`Owner == "user3" || ProcId == 1`,
 		`RequestMemory > 4096 ?: false`, // Elvis
 		`size(Args) > 0`,                // delegated subtree
 	} {
@@ -162,6 +171,8 @@ func BenchmarkVectorEval(b *testing.B) {
 		"RequestMemory > 4096 && (JobStatus == 1 || JobStatus == 4)",
 		"WantCheckpoint && RequestCpus > 2",
 		"ProcId + ClusterId > 100",
+		`Owner == "user3"`,
+		`Owner == "user3" || Owner == "user10"`,
 	} {
 		q, err := vm.Parse(expr)
 		if err != nil {

--- a/collections/colvec_test.go
+++ b/collections/colvec_test.go
@@ -46,6 +46,16 @@ var vecExprs = []string{
 	`Owner == "user3" && RequestCpus > 2`,
 	`Cmd == "/home/user3/run.sh"`,
 	`Owner == "user3" || RequestMemory > 8192`,
+	// Results that are NOT boolean. A constraint whose value is a number never matches -- the store takes a
+	// boolean or nothing -- which is a different rule from the truthiness a logical OPERAND gets, and the
+	// two live in different places now (Vec.IsTrue vs dataStateToMask). These pin both.
+	"RequestMemory",  // data-form result: no match, ever
+	"ProcId + 1",     // likewise
+	"!RequestMemory", // truthy operand, boolean result: 42 is true, so this is false
+	"!ProcId",        // ProcId is 0 for a tenth of records, where !0 is TRUE
+	"WantCheckpoint", // a bool column, delivered as a mask with no data form in between
+	"!WantCheckpoint && RequestCpus > 1",
+	"RequestMemory > 0 && WantCheckpoint",
 }
 
 // rowCount is the independent reference: the ordinary row path, which decodes ads and evaluates the
@@ -84,10 +94,15 @@ func TestVectorEvalCountAgrees(t *testing.T) {
 		if want := rowCount(t, c, expr); got != want {
 			t.Errorf("%q: vectorized %d != row %d", expr, got, want)
 		}
+		// Every block must be accounted for, and at least one must have been vectorized OR pruned. A
+		// fully pruned query is a legitimate outcome -- `!RequestMemory` is prunable because the fixture
+		// never stores a zero there -- but "nothing was vectorized and nothing was pruned" means the
+		// comparison ran entirely on the fallback and proves nothing about this executor.
 		split := lastVecSplit.Load()
-		if split.vecBlocks == 0 {
-			t.Errorf("%q: no block was vectorized (%d declined to colScope); the comparison is vacuous",
-				expr, split.scopeBlocks)
+		if split.vecBlocks == 0 && split.prunedBlocks == 0 {
+			t.Errorf("%q: nothing vectorized and nothing pruned (%d declined, %d churn, %d empty, %d row "+
+				"windows); the comparison is vacuous", expr, split.scopeBlocks, split.churnBlocks,
+				split.emptyBlocks, split.rowWindows)
 		}
 		if split.scopeBlocks != 0 {
 			t.Logf("%q: %d/%d blocks vectorized, %d declined",

--- a/collections/vecphase_test.go
+++ b/collections/vecphase_test.go
@@ -40,9 +40,8 @@ func (c *Collection) vecScanPhase(q *vm.Query, phase int) int {
 	src := &blockVecSource{c: c, bc: st.cache}
 	scratch := &vm.VecScratch{}
 	attrs := q.ReadAttrs()
-	var probe vm.Vec
+	var probe *vm.Vec
 	touched := 0
-	var live []bool
 	for _, sh := range c.shards {
 		s0, wins := sh.snapshot()
 		for _, w := range wins {
@@ -52,20 +51,14 @@ func (c *Collection) vecScanPhase(q *vm.Query, phase int) int {
 			}
 			base := 0
 			for _, blk := range seg.blocks {
-				if cap(live) < blk.n {
-					live = make([]bool, blk.n)
-				}
-				live = live[:blk.n]
 				nLive := 0
 				for k := 0; k < blk.n; k++ {
 					gk := base + k
-					vis := gk < len(seg.offs)
-					if vis {
-						o := seg.offs[gk]
-						vis = recSeq(w.data, o) <= s0 && recSuperseded(w.data, o) > s0
+					if gk >= len(seg.offs) {
+						break
 					}
-					live[k] = vis
-					if vis {
+					o := seg.offs[gk]
+					if recSeq(w.data, o) <= s0 && recSuperseded(w.data, o) > s0 {
 						nLive++
 					}
 				}
@@ -75,10 +68,12 @@ func (c *Collection) vecScanPhase(q *vm.Query, phase int) int {
 					continue
 				}
 				src.blk = blk
-				if cap(probe.I) < blk.n {
-					probe = vm.Vec{I: make([]int64, blk.n), S: make([]string, blk.n), St: make([]uint8, blk.n)}
+				if probe == nil || cap(probe.I) < blk.n {
+					probe = &vm.Vec{
+						I: make([]int64, blk.n), S: make([]string, blk.n), St: make([]uint8, blk.n),
+						Hi: make([]uint64, vm.MaskWords(blk.n)), Lo: make([]uint64, vm.MaskWords(blk.n)),
+					}
 				}
-				probe.I, probe.S, probe.St = probe.I[:blk.n], probe.S[:blk.n], probe.St[:blk.n]
 				if phase == phaseLoads {
 					for _, a := range attrs {
 						src.LoadColumn(a, ast.NoScope, probe)

--- a/collections/vecphase_test.go
+++ b/collections/vecphase_test.go
@@ -1,0 +1,181 @@
+package collections
+
+import (
+	"testing"
+
+	"github.com/PelicanPlatform/classad/ast"
+	"github.com/PelicanPlatform/classad/collections/vm"
+)
+
+// SPIKE: is there anything for SIMD to do?
+//
+// Go 1.26 has simd/archsimd (GOEXPERIMENT=simd) and it is AMD64-ONLY -- every operation file is
+// _amd64.go -- with an architecture-agnostic package expected in 1.27. So before anyone writes an
+// intrinsic, the question worth answering is whether the vectorized scan is even limited by the
+// arithmetic SIMD would widen.
+//
+// This decomposes the scan into the phases it actually runs, over identical data, so the answer is a
+// measurement rather than an argument:
+//
+//	visibility  -- establish which records a snapshot can see (recSeq/recSuperseded per record)
+//	+loads      -- and load each referenced column into a vector
+//	+eval       -- and run the expression kernels over those vectors
+//	full        -- and count, which is what VectorEvalCount does
+//
+// SIMD can only touch the arithmetic inside +eval. If that band is a small share of the total, widening
+// it eight ways cannot matter, and the profitable work is wherever the time actually is.
+
+const (
+	phaseVisibility = iota
+	phaseLoads
+	phaseEval
+)
+
+// vecScanPhase runs the vectorized scan but stops after the named phase, so the phases' costs subtract.
+func (c *Collection) vecScanPhase(q *vm.Query, phase int) int {
+	st := c.schemaScan.Load()
+	if st == nil {
+		return -1
+	}
+	src := &blockVecSource{c: c, bc: st.cache}
+	scratch := &vm.VecScratch{}
+	attrs := q.ReadAttrs()
+	var probe vm.Vec
+	touched := 0
+	var live []bool
+	for _, sh := range c.shards {
+		s0, wins := sh.snapshot()
+		for _, w := range wins {
+			seg := w.seg.colblk.Load()
+			if seg == nil || seg.schema() == nil {
+				continue
+			}
+			base := 0
+			for _, blk := range seg.blocks {
+				if cap(live) < blk.n {
+					live = make([]bool, blk.n)
+				}
+				live = live[:blk.n]
+				nLive := 0
+				for k := 0; k < blk.n; k++ {
+					gk := base + k
+					vis := gk < len(seg.offs)
+					if vis {
+						o := seg.offs[gk]
+						vis = recSeq(w.data, o) <= s0 && recSuperseded(w.data, o) > s0
+					}
+					live[k] = vis
+					if vis {
+						nLive++
+					}
+				}
+				touched += nLive
+				if phase == phaseVisibility || nLive == 0 {
+					base += blk.n
+					continue
+				}
+				src.blk = blk
+				if cap(probe.I) < blk.n {
+					probe = vm.Vec{I: make([]int64, blk.n), S: make([]string, blk.n), St: make([]uint8, blk.n)}
+				}
+				probe.I, probe.S, probe.St = probe.I[:blk.n], probe.S[:blk.n], probe.St[:blk.n]
+				if phase == phaseLoads {
+					for _, a := range attrs {
+						src.LoadColumn(a, ast.NoScope, probe)
+					}
+					base += blk.n
+					continue
+				}
+				vec, ok := q.VecEval(src, blk.n, scratch)
+				if !ok {
+					base += blk.n
+					continue
+				}
+				_ = vec
+				base += blk.n
+			}
+		}
+		releaseWindows(wins)
+	}
+	return touched
+}
+
+// BenchmarkVecPhases attributes the vectorized scan's time to visibility, column loads, expression
+// evaluation and counting. The evaluation band is the only one SIMD could widen.
+func BenchmarkVecPhases(b *testing.B) {
+	c := scopeFixtureCodec(b, 60000)
+	defer c.Close()
+	for _, expr := range []string{
+		"RequestMemory > 4096",
+		"RequestMemory > 4096 && RequestCpus >= 4",
+		"RequestMemory > RequestCpus * 512",
+		"RequestMemory > 4096 && (JobStatus == 1 || JobStatus == 4)",
+		`Owner == "user3"`,
+	} {
+		q, err := vm.Parse(expr)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if n := c.vecScanPhase(q, phaseVisibility); n <= 0 {
+			b.Fatalf("%q: visibility pass saw %d records", expr, n)
+		}
+		b.Run("1visibility/"+expr, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				c.vecScanPhase(q, phaseVisibility)
+			}
+		})
+		b.Run("2loads/"+expr, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				c.vecScanPhase(q, phaseLoads)
+			}
+		})
+		b.Run("3eval/"+expr, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				c.vecScanPhase(q, phaseEval)
+			}
+		})
+		b.Run("4full/"+expr, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				c.VectorEvalCount(q)
+			}
+		})
+	}
+}
+
+// BenchmarkVecEvalScaling separates the cost of a COMPARISON from the cost of a logical COMBINE, by
+// measuring the eval phase as conjuncts are added. Each extra conjunct adds one comparison and one
+// combine, so the slope says what a combine costs.
+//
+// It matters for deciding whether SIMD is the right lever. A comparison is arithmetic over loaded
+// columns, which is what SIMD widens. A combine is pure three-valued logic over the executor's boolean
+// representation -- one state byte plus an eight-byte payload per element -- which no instruction set
+// fixes: it is a representation problem, and a bitmap would collapse it to a word-wise AND over 64
+// records at a time in ordinary Go.
+func BenchmarkVecEvalScaling(b *testing.B) {
+	c := scopeFixtureCodec(b, 60000)
+	defer c.Close()
+	for _, tc := range []struct {
+		name string
+		expr string
+	}{
+		{"1cmp_0combine", "RequestMemory > 0"},
+		{"2cmp_1combine", "RequestMemory > 0 && RequestCpus > 0"},
+		{"3cmp_2combine", "RequestMemory > 0 && RequestCpus > 0 && JobStatus > 0"},
+		{"4cmp_3combine", "RequestMemory > 0 && RequestCpus > 0 && JobStatus > 0 && ProcId >= 0"},
+	} {
+		q, err := vm.Parse(tc.expr)
+		if err != nil {
+			b.Fatal(err)
+		}
+		b.Run("loads/"+tc.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				c.vecScanPhase(q, phaseLoads)
+			}
+		})
+		b.Run("eval/"+tc.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				c.vecScanPhase(q, phaseEval)
+			}
+		})
+	}
+}

--- a/collections/vecprune_test.go
+++ b/collections/vecprune_test.go
@@ -1,0 +1,111 @@
+package collections
+
+import (
+	"testing"
+
+	"github.com/PelicanPlatform/classad/collections/vm"
+)
+
+// The zone-prunable probe analysis depends only on the query and the schema, and a scan visits one window
+// per SEGMENT -- 162 on a 60k-record table -- which all share a single schema object. Recomputing it per
+// window repeated identical work 161 times: 11% of a scan's time and 44% of its allocations, for an answer
+// that never changed.
+//
+// This holds that line for both scans. It counts the analyses rather than timing them, because the failure
+// mode is invisible: an un-hoisted analysis is still CORRECT, and only shows up as a query that got slower
+// on a table with many segments -- which is precisely why the cost went unnoticed until the scan was
+// attributed phase by phase.
+func TestZonePruneAnalyzedOncePerQuery(t *testing.T) {
+	c := scopeFixtureCodec(t, 60000)
+	defer c.Close()
+
+	segments := 0
+	for _, sh := range c.shards {
+		_, ws := sh.snapshot()
+		for _, w := range ws {
+			if seg := w.seg.colblk.Load(); seg != nil && seg.schema() != nil {
+				segments++
+			}
+		}
+		releaseWindows(ws)
+	}
+	if segments < 10 {
+		t.Fatalf("fixture has only %d columnar segments; with so few, a per-window analysis would cost "+
+			"nothing and this test would pass without testing anything", segments)
+	}
+
+	for _, tc := range []struct {
+		name string
+		run  func(*vm.Query)
+	}{
+		{"VectorEvalCount", func(q *vm.Query) { c.VectorEvalCount(q) }},
+		{"ColumnarEvalCount", func(q *vm.Query) { c.ColumnarEvalCount(q) }},
+	} {
+		for _, expr := range []string{
+			"RequestMemory > 4096",
+			"RequestMemory > 4096 && RequestCpus >= 4",
+			`Owner == "user3"`, // no prunable probe at all: must still analyze only once
+		} {
+			q, err := vm.Parse(expr)
+			if err != nil {
+				t.Fatal(err)
+			}
+			tc.run(q) // warm any lazily built state
+			before := zonePruneAnalyses.Load()
+			tc.run(q)
+			got := zonePruneAnalyses.Load() - before
+			if got > 1 {
+				t.Errorf("%s(%q): analyzed the probes %d times across %d segments; it depends only on the "+
+					"query and the schema, so once is enough", tc.name, expr, got, segments)
+			}
+		}
+	}
+}
+
+// TestPrunePlanRecomputesOnSchemaChange checks the cache is keyed on the schema and not merely on being
+// warm: segments sealed under different schemas coexist, and answering one segment's question with
+// another's analysis would prune the wrong blocks.
+func TestPrunePlanRecomputesOnSchemaChange(t *testing.T) {
+	c := scopeFixtureCodec(t, 20000)
+	defer c.Close()
+	q, err := vm.Parse("RequestMemory > 4096")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var sch *adSchema
+	for _, sh := range c.shards {
+		_, ws := sh.snapshot()
+		for _, w := range ws {
+			if seg := w.seg.colblk.Load(); seg != nil && seg.schema() != nil {
+				sch = seg.schema()
+			}
+		}
+		releaseWindows(ws)
+	}
+	if sch == nil {
+		t.Fatal("no schema")
+	}
+	other := &adSchema{byID: map[uint32]int{}}
+
+	var plan prunePlan
+	before := zonePruneAnalyses.Load()
+	plan.tests(c, q, sch)
+	plan.tests(c, q, sch) // same schema: cached
+	if n := zonePruneAnalyses.Load() - before; n != 1 {
+		t.Errorf("same schema twice ran %d analyses, want 1", n)
+	}
+	before = zonePruneAnalyses.Load()
+	plan.tests(c, q, other)
+	if n := zonePruneAnalyses.Load() - before; n != 1 {
+		t.Errorf("a different schema ran %d analyses, want 1", n)
+	}
+	// And back, which must not silently keep the other schema's answer.
+	before = zonePruneAnalyses.Load()
+	idxs, _ := plan.tests(c, q, sch)
+	if n := zonePruneAnalyses.Load() - before; n != 1 {
+		t.Errorf("returning to the first schema ran %d analyses, want 1", n)
+	}
+	if len(idxs) == 0 {
+		t.Error("the first schema's analysis found no prunable probe for a numeric range on a numeric field")
+	}
+}

--- a/collections/vecselectivity_test.go
+++ b/collections/vecselectivity_test.go
@@ -1,0 +1,64 @@
+package collections
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/collections/vm"
+)
+
+// WHY THERE IS NO SELECTION PUSHDOWN YET.
+//
+// Is the remaining gap to the hand-written scan caused by SELECTION -- the executor loading a second
+// column for records the first predicate already excluded -- or by fixed per-block overhead?
+//
+// The two predict different things. If it is selection, the gap widens as the first predicate gets more
+// selective, because the hand-written scan skips more and the executor skips nothing. If it is fixed
+// overhead, the gap stays flat. Building pushdown before knowing which would be building on a guess.
+//
+// The answer was FIXED OVERHEAD, mostly. The gap was 1.50x at 62% selectivity, where there is essentially
+// nothing to skip, and 1.74x at 6%, where there is almost everything to skip -- so selection was worth
+// about 0.24x and the other 1.50x was per-block work. Removing the literal broadcast (see
+// compareVecConst) then took the gap to 1.21-1.42x, leaving selection worth ~0.18x on a highly selective
+// conjunction and nothing on an unselective one.
+//
+// Pushdown is therefore real but small, and it is not free: restricting a load per record adds a branch
+// per record to a loop that costs one or two cycles, so it can only pay where the skipped work is
+// expensive -- a string region walk or a cold-tail read, not a hot numeric compare. That is the shape to
+// build if this is revisited, and this benchmark is how to tell whether it worked.
+//
+// RequestMemory is 1024+(i%32)*512, so the thresholds below select ~100%, ~78%, ~53% and ~6%.
+func BenchmarkSelectivityGap(b *testing.B) {
+	c := scopeFixtureCodec(b, 60000)
+	defer c.Close()
+	for _, thr := range []int{0, 4096, 8192, 16000} {
+		expr := fmt.Sprintf("RequestMemory > %d && RequestCpus >= 4", thr)
+		q, err := vm.Parse(expr)
+		if err != nil {
+			b.Fatal(err)
+		}
+		// Both paths must actually serve it, or the comparison is meaningless.
+		hw, okHW := c.CountQuery(q)
+		vec, okV := c.VectorEvalCount(q)
+		if !okHW || !okV {
+			b.Fatalf("%s: handwritten=%v vector=%v", expr, okHW, okV)
+		}
+		if hw != vec {
+			b.Fatalf("%s: handwritten %d != vector %d", expr, hw, vec)
+		}
+		if sp := lastVecSplit.Load(); sp.vecBlocks == 0 {
+			b.Fatalf("%s: nothing vectorized", expr)
+		}
+		name := fmt.Sprintf("thr%05d_sel%d", thr, hw*100/60000)
+		b.Run("vector/"+name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				c.VectorEvalCount(q)
+			}
+		})
+		b.Run("handwritten/"+name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				c.CountQuery(q)
+			}
+		})
+	}
+}

--- a/collections/vm/vecexec.go
+++ b/collections/vm/vecexec.go
@@ -66,6 +66,16 @@ type Vec struct {
 	// MASK form: three-valued logic as two bitplanes, two bits per record. See vecmask.go.
 	Hi, Lo []uint64
 
+	// Const marks a vector every record of which holds the SAME value, kept once in element 0 with the
+	// rest left as garbage. A literal in an expression is the dominant case, and materializing one across
+	// a block cost 9.8% of a scan in the profile -- nine bytes per record written per block, to say the
+	// same thing 1000 times.
+	//
+	// Every consumer must either specialize on it (compareVec does, which also tightens its loop by
+	// reading a scalar instead of a second array) or call materialize first. valueData and IsTrue read
+	// element 0 when it is set, so the parity-hook path and the counters are safe without either.
+	Const bool
+
 	// Mask selects which form holds this vector's value. A comparison consumes data and produces a
 	// mask; a logical operator consumes and produces masks; arithmetic consumes and produces data.
 	// Conversion in either direction is available (toMask/toData) but only happens where an operator
@@ -128,6 +138,9 @@ func (v *Vec) value(i int) classad.Value {
 // mask form of the same vector: the two forms occupy different arrays, so a comparison can read its left
 // operand's values while filling its planes.
 func (v *Vec) valueData(i int) classad.Value {
+	if v.Const {
+		i = 0
+	}
 	switch v.St[i] {
 	case VsInt:
 		return classad.NewIntValue(v.I[i])
@@ -297,7 +310,7 @@ func (s *VecScratch) push() *Vec {
 	v.n = s.n
 	v.I, v.S, v.St = v.I[:s.n], v.S[:s.n], v.St[:s.n]
 	v.Hi, v.Lo = v.Hi[:maskWords(s.n)], v.Lo[:maskWords(s.n)]
-	v.Mask = false
+	v.Mask, v.Const = false, false
 	s.depth++
 	return v
 }
@@ -310,38 +323,30 @@ func fillBool(v *Vec, b bool) {
 	if b {
 		x = 1
 	}
-	for i := range v.St {
-		v.St[i], v.I[i] = VsBool, x
-	}
+	v.St[0], v.I[0], v.Const, v.Mask = VsBool, x, true, false
 }
 
 func fillState(v *Vec, st uint8) {
-	for i := range v.St {
-		v.St[i] = st
-	}
+	v.St[0], v.Const, v.Mask = st, true, false
 }
 
 // broadcast fills a vector with one constant. A string constant declines: `Name == "x"` is a real
 // query shape, just not one this executor serves yet.
 func broadcast(v *Vec, c classad.Value) bool {
+	v.Const, v.Mask = true, false
 	switch c.Type() {
 	case classad.IntegerValue:
 		x, err := c.IntValue()
 		if err != nil {
 			return false
 		}
-		for i := range v.St {
-			v.St[i], v.I[i] = VsInt, x
-		}
+		v.St[0], v.I[0] = VsInt, x
 	case classad.RealValue:
 		f, err := c.RealValue()
 		if err != nil {
 			return false
 		}
-		bits := int64(math.Float64bits(f))
-		for i := range v.St {
-			v.St[i], v.I[i] = VsReal, bits
-		}
+		v.St[0], v.I[0] = VsReal, int64(math.Float64bits(f))
 	case classad.BooleanValue:
 		b, err := c.BoolValue()
 		if err != nil {
@@ -353,9 +358,7 @@ func broadcast(v *Vec, c classad.Value) bool {
 		if err != nil {
 			return false
 		}
-		for i := range v.St {
-			v.St[i], v.S[i] = VsString, str
-		}
+		v.St[0], v.S[0] = VsString, str
 	case classad.UndefinedValue:
 		fillState(v, VsUndef)
 	case classad.ErrorValue:
@@ -389,6 +392,8 @@ func binopVec(ev *classad.Evaluator, op string, l, r *Vec) bool {
 func arithVec(ev *classad.Evaluator, op string, l, r *Vec) bool {
 	l.toData()
 	r.toData()
+	l.materialize()
+	r.materialize()
 	for i := range l.St {
 		ls, rs := l.St[i], r.St[i]
 		if !numeric(ls) || !numeric(rs) {
@@ -445,6 +450,7 @@ func unopVec(ev *classad.Evaluator, op string, v *Vec) bool {
 		return true
 	}
 	v.toData()
+	v.materialize()
 	for i := 0; i < v.n; i++ {
 		switch {
 		case op == "-" && v.St[i] == VsInt:
@@ -479,6 +485,8 @@ func hookOneUn(ev *classad.Evaluator, op string, v *Vec, i int) bool {
 func hookAll(ev *classad.Evaluator, op string, l, r *Vec) bool {
 	l.toData()
 	r.toData()
+	l.materialize()
+	r.materialize()
 	for i := range l.St {
 		if !hookOne(ev, op, l, r, i) {
 			return false
@@ -498,6 +506,9 @@ func hookAll(ev *classad.Evaluator, op string, l, r *Vec) bool {
 func (v *Vec) IsTrue(i int) bool {
 	if v.Mask {
 		return maskStateAt(v.Hi, v.Lo, i) == mTrue
+	}
+	if v.Const {
+		i = 0
 	}
 	return v.St[i] == VsBool && v.I[i] == 1
 }
@@ -520,10 +531,45 @@ func (v *Vec) CountTrue(live []uint64) int {
 	return n
 }
 
+// materialize expands a Const vector so every element carries the value, for a kernel that does not
+// specialize on it.
+func (v *Vec) materialize() {
+	if !v.Const {
+		return
+	}
+	v.Const = false
+	st, i0, s0 := v.St[0], v.I[0], v.S[0]
+	for k := 1; k < v.n; k++ {
+		v.St[k], v.I[k], v.S[k] = st, i0, s0
+	}
+}
+
 // toMask converts the vector in place to mask form, applying ClassAd's logical-operand truthiness. A
 // no-op when it is already a mask.
 func (v *Vec) toMask() {
 	if v.Mask {
+		return
+	}
+	if v.Const {
+		// One state repeated: the planes are all-ones or all-zeros words, so there is nothing to walk.
+		st := dataStateToMask(v.St[0], v.I[0])
+		hi, lo := uint64(0), uint64(0)
+		if st&2 != 0 {
+			hi = ^uint64(0)
+		}
+		if st&1 != 0 {
+			lo = ^uint64(0)
+		}
+		for w := range v.Hi {
+			v.Hi[w], v.Lo[w] = hi, lo
+		}
+		// Bits past n must be clear, or a popcount over the tail counts records that do not exist.
+		if tail := uint(v.n % 64); tail != 0 && len(v.Hi) > 0 {
+			m := (uint64(1) << tail) - 1
+			v.Hi[len(v.Hi)-1] &= m
+			v.Lo[len(v.Lo)-1] &= m
+		}
+		v.Const, v.Mask = false, true
 		return
 	}
 	for w := range v.Hi {
@@ -544,8 +590,10 @@ func (v *Vec) toMask() {
 	v.Mask = true
 }
 
-// toData converts the vector in place to data form, so an arithmetic or comparison kernel can consume a
-// boolean produced upstream. A no-op when it is already data.
+// toData converts the vector in place to data form. It deliberately does NOT materialize a Const vector:
+// compareVec calls this and then specializes on Const, so materializing here would silently disable that
+// specialization -- which it did, and cost the whole optimization until the benchmark showed no gain.
+// Kernels that index elements call materialize themselves.
 func (v *Vec) toData() {
 	if !v.Mask {
 		return
@@ -562,7 +610,7 @@ func (v *Vec) toData() {
 			v.St[i] = VsError
 		}
 	}
-	v.Mask = false
+	v.Mask, v.Const = false, false
 }
 
 // Comparison opcodes, resolved from the operator string ONCE per batch rather than per element. The
@@ -687,6 +735,10 @@ func compareVec(ev *classad.Evaluator, op string, l, r *Vec) bool {
 	}
 	l.toData()
 	r.toData()
+	l.materialize()
+	if r.Const {
+		return compareVecConst(ev, op, c, l, r)
+	}
 	for w := range l.Hi {
 		base := w * 64
 		end := base + 64
@@ -723,6 +775,54 @@ func compareVec(ev *classad.Evaluator, op string, l, r *Vec) bool {
 	return true
 }
 
+// compareVecConst compares a column against a LITERAL -- `Attr OP constant`, the shape most constraints
+// are made of.
+//
+// Two things it avoids. The literal is never materialized across the block, which the profile put at 9.8%
+// of a scan: nine bytes per record written per block to repeat one value. And the loop reads a scalar held
+// in registers rather than a second array, so the comparison touches one column's memory instead of two.
+// Both are also what a SIMD version wants -- a literal becomes one broadcast into a vector register, not a
+// memory fill.
+func compareVecConst(ev *classad.Evaluator, op string, c cmpOp, l, r *Vec) bool {
+	rst := r.St[0]
+	rInt, rFloat, rStr := r.I[0], r.Float(0), r.S[0]
+	rIsInt := rst == VsInt
+	rIsNum := numeric(rst)
+	rIsStr := rst == VsString
+	for w := range l.Hi {
+		base := w * 64
+		end := base + 64
+		if end > l.n {
+			end = l.n
+		}
+		var hi, lo uint64
+		for i := base; i < end; i++ {
+			ls := l.St[i]
+			var st int
+			switch {
+			case rIsInt && ls == VsInt:
+				st = boolMask(cmpInt(c, l.I[i], rInt))
+			case rIsStr && ls == VsString:
+				st = boolMask(cmpOrder(c, classad.CompareStringsFold(l.S[i], rStr)))
+			case rIsNum && numeric(ls):
+				st = boolMask(cmpFloat(c, l.Float(i), rFloat))
+			default:
+				var ok bool
+				st, ok = valueToMaskState(ev.ApplyBinaryOp(op, l.valueData(i), r.valueData(i)))
+				if !ok {
+					return false
+				}
+			}
+			b := uint(i - base)
+			hi |= uint64(st>>1) << b
+			lo |= uint64(st&1) << b
+		}
+		l.Hi[w], l.Lo[w] = hi, lo
+	}
+	l.Mask = true
+	return true
+}
+
 // identicalVec is =?= / =!=: total, never undefined, and case SENSITIVE for strings. Two elements are
 // identical when their ClassAd TYPES match and their payloads match -- so 1 =?= 1.0 is false, which is why
 // int and real are distinct states rather than one numeric state.
@@ -734,6 +834,8 @@ func identicalVec(op string, l, r *Vec) bool {
 	negate := op == "=!="
 	l.toData()
 	r.toData()
+	l.materialize()
+	r.materialize()
 	for w := range l.Hi {
 		base := w * 64
 		end := base + 64
@@ -774,33 +876,6 @@ func logicalVec(op string, l, r *Vec) bool {
 		planeAnd(l.Hi, l.Lo, r.Hi, r.Lo, l.Hi, l.Lo)
 	} else {
 		planeOr(l.Hi, l.Lo, r.Hi, r.Lo, l.Hi, l.Lo)
-	}
-	return true
-}
-
-// identicalVec is =?= / =!=: total, never undefined, and case SENSITIVE for strings. Two elements are
-// identical when their ClassAd TYPES match and their payloads match -- so 1 =?= 1.0 is false, which is
-// why int and real are distinct states rather than one numeric state.
-//
-// Hand-written rather than hooked because the rule is a type check plus a payload compare, with no
-// coercion to get wrong, and because a Vec cannot hold the values (lists, nested ads) whose identity
-// the reference treats as an error.
-func identicalVecOLD(op string, l, r *Vec) bool {
-	negate := op == "=!="
-	for i := range l.St {
-		same := l.St[i] == r.St[i]
-		if same {
-			switch l.St[i] {
-			case VsInt, VsReal, VsBool:
-				same = l.I[i] == r.I[i]
-			case VsString:
-				same = l.S[i] == r.S[i]
-			}
-		}
-		if negate {
-			same = !same
-		}
-		l.SetBool(i, same)
 	}
 	return true
 }

--- a/collections/vm/vecexec.go
+++ b/collections/vm/vecexec.go
@@ -56,21 +56,37 @@ const (
 // classad.Value and the columnar block already store a real (as IEEE-754 bits), so loading a column
 // into a vector is a copy rather than a conversion, and no precision is lost for integers above 2^53.
 type Vec struct {
+	n int
+
+	// DATA form: one element per record.
 	I  []int64
 	S  []string
 	St []uint8
+
+	// MASK form: three-valued logic as two bitplanes, two bits per record. See vecmask.go.
+	Hi, Lo []uint64
+
+	// Mask selects which form holds this vector's value. A comparison consumes data and produces a
+	// mask; a logical operator consumes and produces masks; arithmetic consumes and produces data.
+	// Conversion in either direction is available (toMask/toData) but only happens where an operator
+	// genuinely needs the other form.
+	Mask bool
 }
 
 // newVec allocates the string payload unconditionally rather than on first use. A numeric-only program
 // pays 16 bytes per element for a slice it never reads, which is worth not having a Vec whose payload
 // can be missing: LoadColumn receives a Vec by value and could not allocate into its caller's.
 // The stacks are pooled across queries, so this is paid once, not per query.
-func newVec(n int) Vec {
-	return Vec{I: make([]int64, n), S: make([]string, n), St: make([]uint8, n)}
+func newVec(n int) *Vec {
+	return &Vec{
+		n: n,
+		I: make([]int64, n), S: make([]string, n), St: make([]uint8, n),
+		Hi: make([]uint64, maskWords(n)), Lo: make([]uint64, maskWords(n)),
+	}
 }
 
 // Float returns element i as a float64 whatever its numeric state.
-func (v Vec) Float(i int) float64 {
+func (v *Vec) Float(i int) float64 {
 	if v.St[i] == VsReal {
 		return math.Float64frombits(uint64(v.I[i]))
 	}
@@ -78,11 +94,11 @@ func (v Vec) Float(i int) float64 {
 }
 
 // SetReal/SetInt/SetBool write one element.
-func (v Vec) SetReal(i int, f float64)  { v.St[i], v.I[i] = VsReal, int64(math.Float64bits(f)) }
-func (v Vec) SetInt(i int, x int64)     { v.St[i], v.I[i] = VsInt, x }
-func (v Vec) SetString(i int, s string) { v.St[i], v.S[i] = VsString, s }
+func (v Vec) SetReal(i int, f float64)   { v.St[i], v.I[i] = VsReal, int64(math.Float64bits(f)) }
+func (v Vec) SetInt(i int, x int64)      { v.St[i], v.I[i] = VsInt, x }
+func (v *Vec) SetString(i int, s string) { v.St[i], v.S[i] = VsString, s }
 
-func (v Vec) SetBool(i int, b bool) {
+func (v *Vec) SetBool(i int, b bool) {
 	v.St[i] = VsBool
 	if b {
 		v.I[i] = 1
@@ -91,8 +107,27 @@ func (v Vec) SetBool(i int, b bool) {
 	}
 }
 
-// value boxes element i for the parity hook.
-func (v Vec) value(i int) classad.Value {
+// value boxes element i for the parity hook or a caller, in whichever form the vector holds.
+func (v *Vec) value(i int) classad.Value {
+	if v.Mask {
+		switch maskStateAt(v.Hi, v.Lo, i) {
+		case mTrue:
+			return classad.NewBoolValue(true)
+		case mFalse:
+			return classad.NewBoolValue(false)
+		case mUndef:
+			return classad.NewUndefinedValue()
+		default:
+			return classad.NewErrorValue()
+		}
+	}
+	return v.valueData(i)
+}
+
+// valueData boxes element i from the DATA form, which is what a kernel reads while it is writing the
+// mask form of the same vector: the two forms occupy different arrays, so a comparison can read its left
+// operand's values while filling its planes.
+func (v *Vec) valueData(i int) classad.Value {
 	switch v.St[i] {
 	case VsInt:
 		return classad.NewIntValue(v.I[i])
@@ -111,7 +146,7 @@ func (v Vec) value(i int) classad.Value {
 
 // setValue unboxes a hook result back into element i. ok=false for a value a vector cannot hold (a
 // string, list or nested ad), which makes the whole evaluation decline rather than truncate.
-func (v Vec) setValue(i int, val classad.Value) bool {
+func (v *Vec) setValueData(i int, val classad.Value) bool {
 	switch val.Type() {
 	case classad.IntegerValue:
 		x, err := val.IntValue()
@@ -153,7 +188,7 @@ func (v Vec) setValue(i int, val classad.Value) bool {
 // ok=false means the reference cannot be served as a vector -- a string column, or an attribute whose
 // values are expressions -- and the evaluation declines as a whole.
 type ColumnSource interface {
-	LoadColumn(name string, scope ast.AttributeScope, dst Vec) bool
+	LoadColumn(name string, scope ast.AttributeScope, dst *Vec) bool
 }
 
 // VecEval executes the query over a batch of n records and returns the result vector. A record matches
@@ -161,12 +196,12 @@ type ColumnSource interface {
 //
 // ok=false when the program uses something this executor does not implement. It never returns a
 // partial answer.
-func (q *Query) VecEval(src ColumnSource, n int, scratch *VecScratch) (Vec, bool) {
+func (q *Query) VecEval(src ColumnSource, n int, scratch *VecScratch) (*Vec, bool) {
 	if q == nil || q.prog == nil {
-		return Vec{}, false
+		return nil, false
 	}
 	if len(q.prog.nodes) != 0 {
-		return Vec{}, false // a delegated subtree needs a real per-record scope
+		return nil, false // a delegated subtree needs a real per-record scope
 	}
 	if scratch == nil {
 		scratch = &VecScratch{}
@@ -174,14 +209,14 @@ func (q *Query) VecEval(src ColumnSource, n int, scratch *VecScratch) (Vec, bool
 	return execVec(q.prog, scratch.evaluator(), src, n, scratch)
 }
 
-func execVec(p *Program, ev *classad.Evaluator, src ColumnSource, n int, s *VecScratch) (Vec, bool) {
+func execVec(p *Program, ev *classad.Evaluator, src ColumnSource, n int, s *VecScratch) (*Vec, bool) {
 	s.reset(n)
 	for ip := 0; ip < len(p.code); {
 		in := p.code[ip]
 		switch in.Op {
 		case OpPushConst:
 			if !broadcast(s.push(), p.consts[in.A]) {
-				return Vec{}, false
+				return nil, false
 			}
 		case OpPushTrue:
 			fillBool(s.push(), true)
@@ -194,36 +229,36 @@ func execVec(p *Program, ev *classad.Evaluator, src ColumnSource, n int, s *VecS
 		case OpLoadRef:
 			r := p.refs[in.A]
 			if !src.LoadColumn(r.name, r.scope, s.push()) {
-				return Vec{}, false
+				return nil, false
 			}
 		case OpBinop:
 			right, left := s.pop(), s.top()
 			if !binopVec(ev, p.ops[in.A], left, right) {
-				return Vec{}, false
+				return nil, false
 			}
 		case OpUnop:
 			if !unopVec(ev, p.ops[in.A], s.top()) {
-				return Vec{}, false
+				return nil, false
 			}
 		case OpShortAnd, OpShortOr:
 			// No-op: see the file comment. The combine below does the work.
 		case OpCombineAnd:
 			right, left := s.pop(), s.top()
-			if !logicalVec(ev, "&&", left, right) {
-				return Vec{}, false
+			if !logicalVec("&&", left, right) {
+				return nil, false
 			}
 		case OpCombineOr:
 			right, left := s.pop(), s.top()
-			if !logicalVec(ev, "||", left, right) {
-				return Vec{}, false
+			if !logicalVec("||", left, right) {
+				return nil, false
 			}
 		default:
-			return Vec{}, false // OpJmpIfNotUndef (Elvis), OpEvalNode, anything added later
+			return nil, false // OpJmpIfNotUndef (Elvis), OpEvalNode, anything added later
 		}
 		ip++
 	}
 	if s.depth != 1 {
-		return Vec{}, false
+		return nil, false
 	}
 	return s.top(), true
 }
@@ -231,7 +266,7 @@ func execVec(p *Program, ev *classad.Evaluator, src ColumnSource, n int, s *VecS
 // VecScratch holds the vector stack and the evaluator so a scan reuses both across batches instead of
 // allocating per block.
 type VecScratch struct {
-	stack []Vec
+	stack []*Vec
 	depth int
 	n     int
 	ev    *classad.Evaluator
@@ -250,25 +285,27 @@ func (s *VecScratch) reset(n int) {
 	s.depth, s.n = 0, n
 }
 
-func (s *VecScratch) push() Vec {
+func (s *VecScratch) push() *Vec {
 	if s.depth == len(s.stack) {
 		s.stack = append(s.stack, newVec(s.n))
 	}
 	v := s.stack[s.depth]
-	if cap(v.I) < s.n {
+	if cap(v.I) < s.n || cap(v.Hi) < maskWords(s.n) {
 		v = newVec(s.n)
 		s.stack[s.depth] = v
 	}
-	v.I, v.St = v.I[:s.n], v.St[:s.n]
-	s.stack[s.depth] = v
+	v.n = s.n
+	v.I, v.S, v.St = v.I[:s.n], v.S[:s.n], v.St[:s.n]
+	v.Hi, v.Lo = v.Hi[:maskWords(s.n)], v.Lo[:maskWords(s.n)]
+	v.Mask = false
 	s.depth++
 	return v
 }
 
-func (s *VecScratch) pop() Vec { s.depth--; return s.stack[s.depth] }
-func (s *VecScratch) top() Vec { return s.stack[s.depth-1] }
+func (s *VecScratch) pop() *Vec { s.depth--; return s.stack[s.depth] }
+func (s *VecScratch) top() *Vec { return s.stack[s.depth-1] }
 
-func fillBool(v Vec, b bool) {
+func fillBool(v *Vec, b bool) {
 	x := int64(0)
 	if b {
 		x = 1
@@ -278,7 +315,7 @@ func fillBool(v Vec, b bool) {
 	}
 }
 
-func fillState(v Vec, st uint8) {
+func fillState(v *Vec, st uint8) {
 	for i := range v.St {
 		v.St[i] = st
 	}
@@ -286,7 +323,7 @@ func fillState(v Vec, st uint8) {
 
 // broadcast fills a vector with one constant. A string constant declines: `Name == "x"` is a real
 // query shape, just not one this executor serves yet.
-func broadcast(v Vec, c classad.Value) bool {
+func broadcast(v *Vec, c classad.Value) bool {
 	switch c.Type() {
 	case classad.IntegerValue:
 		x, err := c.IntValue()
@@ -337,7 +374,7 @@ func numeric(st uint8) bool { return st == VsInt || st == VsReal }
 // Only comparisons and the three exact arithmetic operators have fast loops, and only for
 // number-OP-number. Division, modulo, the identity operators and every mixed or exceptional element go
 // to the hook, so their semantics come from the reference rather than from this file.
-func binopVec(ev *classad.Evaluator, op string, l, r Vec) bool {
+func binopVec(ev *classad.Evaluator, op string, l, r *Vec) bool {
 	switch op {
 	case "<", "<=", ">", ">=", "==", "!=":
 		return compareVec(ev, op, l, r)
@@ -349,68 +386,9 @@ func binopVec(ev *classad.Evaluator, op string, l, r Vec) bool {
 		return hookAll(ev, op, l, r)
 	}
 }
-
-// compareVec: both integers compare exactly as int64; any real involved compares as float64; anything
-// else goes to the hook.
-func compareVec(ev *classad.Evaluator, op string, l, r Vec) bool {
-	for i := range l.St {
-		ls, rs := l.St[i], r.St[i]
-		if ls == VsString && rs == VsString {
-			// Case-INSENSITIVE, via the evaluator's own comparison function. Every ClassAd comparison
-			// operator folds case; only the identity operators =?= and =!= do not. Sharing the function
-			// is what makes matching the reference a fact rather than a hope.
-			l.SetBool(i, cmpResult(op, classad.CompareStringsFold(l.S[i], r.S[i])))
-			continue
-		}
-		if !numeric(ls) || !numeric(rs) {
-			if !hookOne(ev, op, l, r, i) {
-				return false
-			}
-			continue
-		}
-		var res bool
-		if ls == VsInt && rs == VsInt {
-			a, b := l.I[i], r.I[i]
-			switch op {
-			case "<":
-				res = a < b
-			case "<=":
-				res = a <= b
-			case ">":
-				res = a > b
-			case ">=":
-				res = a >= b
-			case "==":
-				res = a == b
-			case "!=":
-				res = a != b
-			}
-		} else {
-			a, b := l.Float(i), r.Float(i)
-			switch op {
-			case "<":
-				res = a < b
-			case "<=":
-				res = a <= b
-			case ">":
-				res = a > b
-			case ">=":
-				res = a >= b
-			case "==":
-				res = a == b
-			case "!=":
-				res = a != b
-			}
-		}
-		l.SetBool(i, res)
-	}
-	return true
-}
-
-// arithVec handles +, -, * for number-OP-number. Integer pairs stay integral, which keeps values above
-// 2^53 exact and keeps the result's TYPE right for whatever consumes it. Overflow is delegated so the
-// reference decides what it means.
-func arithVec(ev *classad.Evaluator, op string, l, r Vec) bool {
+func arithVec(ev *classad.Evaluator, op string, l, r *Vec) bool {
+	l.toData()
+	r.toData()
 	for i := range l.St {
 		ls, rs := l.St[i], r.St[i]
 		if !numeric(ls) || !numeric(rs) {
@@ -458,11 +436,17 @@ func arithVec(ev *classad.Evaluator, op string, l, r Vec) bool {
 	return true
 }
 
-func unopVec(ev *classad.Evaluator, op string, v Vec) bool {
-	for i := range v.St {
+func unopVec(ev *classad.Evaluator, op string, v *Vec) bool {
+	if op == "!" {
+		// Truthiness first -- !42 is FALSE and !"x" is an ERROR -- then TRUE and FALSE swap while
+		// UNDEFINED and ERROR pass through, which is two operations per 64 records.
+		v.toMask()
+		planeNot(v.Hi, v.Lo, v.Hi, v.Lo)
+		return true
+	}
+	v.toData()
+	for i := 0; i < v.n; i++ {
 		switch {
-		case op == "!" && v.St[i] == VsBool:
-			v.SetBool(i, v.I[i] == 0)
 		case op == "-" && v.St[i] == VsInt:
 			if v.I[i] == math.MinInt64 {
 				if !hookOneUn(ev, op, v, i) {
@@ -481,42 +465,20 @@ func unopVec(ev *classad.Evaluator, op string, v Vec) bool {
 	}
 	return true
 }
-
-// logicalVec is && / ||. Both operands boolean is the dominant case and the only one with a fast path;
-// everything else -- FALSE dominating an ERROR, UNDEFINED propagation, a non-boolean operand -- is the
-// reference's answer, via the same hook the scalar interpreter calls for these opcodes.
-func logicalVec(ev *classad.Evaluator, op string, l, r Vec) bool {
-	and := op == "&&"
-	for i := range l.St {
-		if l.St[i] != VsBool || r.St[i] != VsBool {
-			if !hookOne(ev, op, l, r, i) {
-				return false
-			}
-			continue
-		}
-		a, b := l.I[i] != 0, r.I[i] != 0
-		if and {
-			l.SetBool(i, a && b)
-		} else {
-			l.SetBool(i, a || b)
-		}
-	}
-	return true
+func hookOne(ev *classad.Evaluator, op string, l, r *Vec, i int) bool {
+	return l.setValueData(i, ev.ApplyBinaryOp(op, l.valueData(i), r.valueData(i)))
 }
 
-// hookOne computes element i through the parity hook.
-func hookOne(ev *classad.Evaluator, op string, l, r Vec, i int) bool {
-	return l.setValue(i, ev.ApplyBinaryOp(op, l.value(i), r.value(i)))
-}
-
-func hookOneUn(ev *classad.Evaluator, op string, v Vec, i int) bool {
-	return v.setValue(i, ev.ApplyUnaryOp(op, v.value(i)))
+func hookOneUn(ev *classad.Evaluator, op string, v *Vec, i int) bool {
+	return v.setValueData(i, ev.ApplyUnaryOp(op, v.valueData(i)))
 }
 
 // hookAll routes an entire operator through the hook: correct for anything, fast for nothing. Division,
 // modulo and the identity operators land here, so adding a fast path for one later is an optimization
 // rather than a semantics change.
-func hookAll(ev *classad.Evaluator, op string, l, r Vec) bool {
+func hookAll(ev *classad.Evaluator, op string, l, r *Vec) bool {
+	l.toData()
+	r.toData()
 	for i := range l.St {
 		if !hookOne(ev, op, l, r, i) {
 			return false
@@ -527,25 +489,293 @@ func hookAll(ev *classad.Evaluator, op string, l, r Vec) bool {
 
 // IsTrue reports whether element i is TRUE, which is what counting matches needs. UNDEFINED and ERROR
 // are not matches.
-func (v Vec) IsTrue(i int) bool { return v.St[i] == VsBool && v.I[i] == 1 }
+// IsTrue reports whether element i is strictly boolean TRUE, which is what counting matches needs.
+//
+// This is NOT the truthiness used for a logical OPERAND. A constraint whose value is the number 42 does
+// not match -- the store's isTrueValue takes a boolean or nothing -- while `42 && true` is TRUE because
+// numbers are truthy as operands. Two different notions of truth, and conflating them is a silent
+// wrong-answer bug, so they are separate functions: this one, and dataStateToMask.
+func (v *Vec) IsTrue(i int) bool {
+	if v.Mask {
+		return maskStateAt(v.Hi, v.Lo, i) == mTrue
+	}
+	return v.St[i] == VsBool && v.I[i] == 1
+}
 
-// cmpResult turns a three-way comparison into the operator's boolean.
-func cmpResult(op string, c int) bool {
+// CountTrue counts records that are TRUE and whose bit is set in live.
+//
+// In mask form that is one popcount per 64 records. In data form -- a constraint whose value is a number
+// or a string, which never matches -- it walks elements, because such a constraint is rare and being
+// right about it matters more than being quick.
+func (v *Vec) CountTrue(live []uint64) int {
+	if v.Mask {
+		return planeCountTrue(v.Hi, v.Lo, live)
+	}
+	n := 0
+	for i := 0; i < v.n; i++ {
+		if live[i/64]&(1<<uint(i%64)) != 0 && v.IsTrue(i) {
+			n++
+		}
+	}
+	return n
+}
+
+// toMask converts the vector in place to mask form, applying ClassAd's logical-operand truthiness. A
+// no-op when it is already a mask.
+func (v *Vec) toMask() {
+	if v.Mask {
+		return
+	}
+	for w := range v.Hi {
+		var hi, lo uint64
+		base := w * 64
+		end := base + 64
+		if end > v.n {
+			end = v.n
+		}
+		for i := base; i < end; i++ {
+			st := dataStateToMask(v.St[i], v.I[i])
+			b := uint(i - base)
+			hi |= uint64(st>>1) << b
+			lo |= uint64(st&1) << b
+		}
+		v.Hi[w], v.Lo[w] = hi, lo
+	}
+	v.Mask = true
+}
+
+// toData converts the vector in place to data form, so an arithmetic or comparison kernel can consume a
+// boolean produced upstream. A no-op when it is already data.
+func (v *Vec) toData() {
+	if !v.Mask {
+		return
+	}
+	for i := 0; i < v.n; i++ {
+		switch maskStateAt(v.Hi, v.Lo, i) {
+		case mTrue:
+			v.St[i], v.I[i] = VsBool, 1
+		case mFalse:
+			v.St[i], v.I[i] = VsBool, 0
+		case mUndef:
+			v.St[i] = VsUndef
+		default:
+			v.St[i] = VsError
+		}
+	}
+	v.Mask = false
+}
+
+// Comparison opcodes, resolved from the operator string ONCE per batch rather than per element. The
+// string switch was per-element work that the word loops below would otherwise repeat 8192 times, and
+// resolving it up front is also what a SIMD version needs: one kernel selected, then a uniform loop.
+type cmpOp uint8
+
+const (
+	cmpLT cmpOp = iota
+	cmpLE
+	cmpGT
+	cmpGE
+	cmpEQ
+	cmpNE
+)
+
+func parseCmpOp(op string) (cmpOp, bool) {
 	switch op {
 	case "<":
-		return c < 0
+		return cmpLT, true
 	case "<=":
-		return c <= 0
+		return cmpLE, true
 	case ">":
-		return c > 0
+		return cmpGT, true
 	case ">=":
-		return c >= 0
+		return cmpGE, true
 	case "==":
-		return c == 0
+		return cmpEQ, true
 	case "!=":
-		return c != 0
+		return cmpNE, true
 	}
-	return false
+	return 0, false
+}
+
+func cmpInt(c cmpOp, a, b int64) bool {
+	switch c {
+	case cmpLT:
+		return a < b
+	case cmpLE:
+		return a <= b
+	case cmpGT:
+		return a > b
+	case cmpGE:
+		return a >= b
+	case cmpEQ:
+		return a == b
+	}
+	return a != b
+}
+
+func cmpFloat(c cmpOp, a, b float64) bool {
+	switch c {
+	case cmpLT:
+		return a < b
+	case cmpLE:
+		return a <= b
+	case cmpGT:
+		return a > b
+	case cmpGE:
+		return a >= b
+	case cmpEQ:
+		return a == b
+	}
+	return a != b
+}
+
+func cmpOrder(c cmpOp, o int) bool {
+	switch c {
+	case cmpLT:
+		return o < 0
+	case cmpLE:
+		return o <= 0
+	case cmpGT:
+		return o > 0
+	case cmpGE:
+		return o >= 0
+	case cmpEQ:
+		return o == 0
+	}
+	return o != 0
+}
+
+func boolMask(b bool) int {
+	if b {
+		return mTrue
+	}
+	return mFalse
+}
+
+// valueToMaskState maps a hook result to a mask state. ok=false for a value a mask cannot hold, which
+// declines the evaluation rather than truncating it -- a comparison never yields a number, so this only
+// fires if the reference grows a case this executor has not been taught.
+func valueToMaskState(v classad.Value) (int, bool) {
+	switch v.Type() {
+	case classad.BooleanValue:
+		b, err := v.BoolValue()
+		if err != nil {
+			return 0, false
+		}
+		return boolMask(b), true
+	case classad.UndefinedValue:
+		return mUndef, true
+	case classad.ErrorValue:
+		return mError, true
+	}
+	return 0, false
+}
+
+// compareVec applies a comparison elementwise and writes the result as a MASK, a word at a time.
+//
+// WORD AT A TIME is the point, not a detail. Each output word is built in a register and stored once, so
+// there is no read-modify-write per element and no stale tail; the inner loop over 64 records is exactly
+// what a SIMD version replaces with eight Int64x8.Greater calls whose masks concatenate into the same
+// word. Writing the result as two bits rather than nine bytes also removes most of the memory traffic a
+// boolean intermediate used to cost.
+//
+// Reading l's DATA form while writing l's MASK form is safe because they are different arrays.
+func compareVec(ev *classad.Evaluator, op string, l, r *Vec) bool {
+	c, ok := parseCmpOp(op)
+	if !ok {
+		return false
+	}
+	l.toData()
+	r.toData()
+	for w := range l.Hi {
+		base := w * 64
+		end := base + 64
+		if end > l.n {
+			end = l.n
+		}
+		var hi, lo uint64
+		for i := base; i < end; i++ {
+			ls, rs := l.St[i], r.St[i]
+			var st int
+			switch {
+			case ls == VsString && rs == VsString:
+				// Case-INSENSITIVE, via the evaluator's own comparison function. Every ClassAd
+				// comparison operator folds case; only =?= and =!= do not.
+				st = boolMask(cmpOrder(c, classad.CompareStringsFold(l.S[i], r.S[i])))
+			case ls == VsInt && rs == VsInt:
+				st = boolMask(cmpInt(c, l.I[i], r.I[i]))
+			case numeric(ls) && numeric(rs):
+				st = boolMask(cmpFloat(c, l.Float(i), r.Float(i)))
+			default:
+				var ok bool
+				st, ok = valueToMaskState(ev.ApplyBinaryOp(op, l.valueData(i), r.valueData(i)))
+				if !ok {
+					return false
+				}
+			}
+			b := uint(i - base)
+			hi |= uint64(st>>1) << b
+			lo |= uint64(st&1) << b
+		}
+		l.Hi[w], l.Lo[w] = hi, lo
+	}
+	l.Mask = true
+	return true
+}
+
+// identicalVec is =?= / =!=: total, never undefined, and case SENSITIVE for strings. Two elements are
+// identical when their ClassAd TYPES match and their payloads match -- so 1 =?= 1.0 is false, which is why
+// int and real are distinct states rather than one numeric state.
+//
+// Hand-written rather than hooked because the rule is a type check plus a payload compare with no coercion
+// to get wrong, and because a vector cannot hold the values (lists, nested ads) whose identity the
+// reference treats as an error.
+func identicalVec(op string, l, r *Vec) bool {
+	negate := op == "=!="
+	l.toData()
+	r.toData()
+	for w := range l.Hi {
+		base := w * 64
+		end := base + 64
+		if end > l.n {
+			end = l.n
+		}
+		var lo uint64
+		for i := base; i < end; i++ {
+			same := l.St[i] == r.St[i]
+			if same {
+				switch l.St[i] {
+				case VsInt, VsReal, VsBool:
+					same = l.I[i] == r.I[i]
+				case VsString:
+					same = l.S[i] == r.S[i]
+				}
+			}
+			if same != negate {
+				lo |= 1 << uint(i-base)
+			}
+		}
+		l.Hi[w], l.Lo[w] = 0, lo
+	}
+	l.Mask = true
+	return true
+}
+
+// logicalVec is && / ||, over mask planes: a fixed sequence of word-wise ANDs and ORs per 64 records,
+// with no branch and no dependence on how many records were UNDEFINED or ERROR.
+//
+// Operands arrive as masks when they came from a comparison, which is the common case, and are converted
+// with ClassAd's operand truthiness otherwise -- numbers are truthy, strings are an error. See
+// dataStateToMask, and note that is a DIFFERENT notion of truth from IsTrue.
+func logicalVec(op string, l, r *Vec) bool {
+	l.toMask()
+	r.toMask()
+	if op == "&&" {
+		planeAnd(l.Hi, l.Lo, r.Hi, r.Lo, l.Hi, l.Lo)
+	} else {
+		planeOr(l.Hi, l.Lo, r.Hi, r.Lo, l.Hi, l.Lo)
+	}
+	return true
 }
 
 // identicalVec is =?= / =!=: total, never undefined, and case SENSITIVE for strings. Two elements are
@@ -555,7 +785,7 @@ func cmpResult(op string, c int) bool {
 // Hand-written rather than hooked because the rule is a type check plus a payload compare, with no
 // coercion to get wrong, and because a Vec cannot hold the values (lists, nested ads) whose identity
 // the reference treats as an error.
-func identicalVec(op string, l, r Vec) bool {
+func identicalVecOLD(op string, l, r *Vec) bool {
 	negate := op == "=!="
 	for i := range l.St {
 		same := l.St[i] == r.St[i]

--- a/collections/vm/vecexec.go
+++ b/collections/vm/vecexec.go
@@ -44,11 +44,12 @@ import (
 // Element states. A vector carries one per element, which is how three-valued logic and ERROR survive
 // vectorization, and how int and real stay distinguishable -- 7/2 is not 7.0/2.0.
 const (
-	VsInt   uint8 = iota // I[i] is the integer
-	VsReal               // I[i] is math.Float64bits of the real
-	VsBool               // I[i] is 0 or 1
-	VsUndef              // UNDEFINED
-	VsError              // ERROR
+	VsInt    uint8 = iota // I[i] is the integer
+	VsReal                // I[i] is math.Float64bits of the real
+	VsBool                // I[i] is 0 or 1
+	VsUndef               // UNDEFINED
+	VsError               // ERROR
+	VsString              // S[i] is the string
 )
 
 // Vec is one batch of values. The payload is a single int64 slice because that is how both
@@ -56,10 +57,17 @@ const (
 // into a vector is a copy rather than a conversion, and no precision is lost for integers above 2^53.
 type Vec struct {
 	I  []int64
+	S  []string
 	St []uint8
 }
 
-func newVec(n int) Vec { return Vec{I: make([]int64, n), St: make([]uint8, n)} }
+// newVec allocates the string payload unconditionally rather than on first use. A numeric-only program
+// pays 16 bytes per element for a slice it never reads, which is worth not having a Vec whose payload
+// can be missing: LoadColumn receives a Vec by value and could not allocate into its caller's.
+// The stacks are pooled across queries, so this is paid once, not per query.
+func newVec(n int) Vec {
+	return Vec{I: make([]int64, n), S: make([]string, n), St: make([]uint8, n)}
+}
 
 // Float returns element i as a float64 whatever its numeric state.
 func (v Vec) Float(i int) float64 {
@@ -70,8 +78,10 @@ func (v Vec) Float(i int) float64 {
 }
 
 // SetReal/SetInt/SetBool write one element.
-func (v Vec) SetReal(i int, f float64) { v.St[i], v.I[i] = VsReal, int64(math.Float64bits(f)) }
-func (v Vec) SetInt(i int, x int64)    { v.St[i], v.I[i] = VsInt, x }
+func (v Vec) SetReal(i int, f float64)  { v.St[i], v.I[i] = VsReal, int64(math.Float64bits(f)) }
+func (v Vec) SetInt(i int, x int64)     { v.St[i], v.I[i] = VsInt, x }
+func (v Vec) SetString(i int, s string) { v.St[i], v.S[i] = VsString, s }
+
 func (v Vec) SetBool(i int, b bool) {
 	v.St[i] = VsBool
 	if b {
@@ -90,6 +100,8 @@ func (v Vec) value(i int) classad.Value {
 		return classad.NewRealValue(math.Float64frombits(uint64(v.I[i])))
 	case VsBool:
 		return classad.NewBoolValue(v.I[i] != 0)
+	case VsString:
+		return classad.NewStringValue(v.S[i])
 	case VsUndef:
 		return classad.NewUndefinedValue()
 	default:
@@ -119,6 +131,12 @@ func (v Vec) setValue(i int, val classad.Value) bool {
 			return false
 		}
 		v.SetBool(i, b)
+	case classad.StringValue:
+		str, err := val.StringValue()
+		if err != nil {
+			return false
+		}
+		v.SetString(i, str)
 	case classad.UndefinedValue:
 		v.St[i] = VsUndef
 	case classad.ErrorValue:
@@ -293,6 +311,14 @@ func broadcast(v Vec, c classad.Value) bool {
 			return false
 		}
 		fillBool(v, b)
+	case classad.StringValue:
+		str, err := c.StringValue()
+		if err != nil {
+			return false
+		}
+		for i := range v.St {
+			v.St[i], v.S[i] = VsString, str
+		}
 	case classad.UndefinedValue:
 		fillState(v, VsUndef)
 	case classad.ErrorValue:
@@ -317,6 +343,8 @@ func binopVec(ev *classad.Evaluator, op string, l, r Vec) bool {
 		return compareVec(ev, op, l, r)
 	case "+", "-", "*":
 		return arithVec(ev, op, l, r)
+	case "=?=", "=!=":
+		return identicalVec(op, l, r)
 	default:
 		return hookAll(ev, op, l, r)
 	}
@@ -327,6 +355,13 @@ func binopVec(ev *classad.Evaluator, op string, l, r Vec) bool {
 func compareVec(ev *classad.Evaluator, op string, l, r Vec) bool {
 	for i := range l.St {
 		ls, rs := l.St[i], r.St[i]
+		if ls == VsString && rs == VsString {
+			// Case-INSENSITIVE, via the evaluator's own comparison function. Every ClassAd comparison
+			// operator folds case; only the identity operators =?= and =!= do not. Sharing the function
+			// is what makes matching the reference a fact rather than a hope.
+			l.SetBool(i, cmpResult(op, classad.CompareStringsFold(l.S[i], r.S[i])))
+			continue
+		}
 		if !numeric(ls) || !numeric(rs) {
 			if !hookOne(ev, op, l, r, i) {
 				return false
@@ -493,3 +528,63 @@ func hookAll(ev *classad.Evaluator, op string, l, r Vec) bool {
 // IsTrue reports whether element i is TRUE, which is what counting matches needs. UNDEFINED and ERROR
 // are not matches.
 func (v Vec) IsTrue(i int) bool { return v.St[i] == VsBool && v.I[i] == 1 }
+
+// cmpResult turns a three-way comparison into the operator's boolean.
+func cmpResult(op string, c int) bool {
+	switch op {
+	case "<":
+		return c < 0
+	case "<=":
+		return c <= 0
+	case ">":
+		return c > 0
+	case ">=":
+		return c >= 0
+	case "==":
+		return c == 0
+	case "!=":
+		return c != 0
+	}
+	return false
+}
+
+// identicalVec is =?= / =!=: total, never undefined, and case SENSITIVE for strings. Two elements are
+// identical when their ClassAd TYPES match and their payloads match -- so 1 =?= 1.0 is false, which is
+// why int and real are distinct states rather than one numeric state.
+//
+// Hand-written rather than hooked because the rule is a type check plus a payload compare, with no
+// coercion to get wrong, and because a Vec cannot hold the values (lists, nested ads) whose identity
+// the reference treats as an error.
+func identicalVec(op string, l, r Vec) bool {
+	negate := op == "=!="
+	for i := range l.St {
+		same := l.St[i] == r.St[i]
+		if same {
+			switch l.St[i] {
+			case VsInt, VsReal, VsBool:
+				same = l.I[i] == r.I[i]
+			case VsString:
+				same = l.S[i] == r.S[i]
+			}
+		}
+		if negate {
+			same = !same
+		}
+		l.SetBool(i, same)
+	}
+	return true
+}
+
+// Release drops the vector stack's references to string payloads and returns the scratch to a state
+// safe to keep in a pool.
+//
+// A string element aliases a block's decompressed string region rather than copying it, so a pooled
+// stack would otherwise pin whichever region it last read -- for as long as the pool holds it, and even
+// if the table it came from has since been dropped. The regions are heap buffers, so this is a retention
+// question rather than the use-after-munmap hazard aliasing mmap'd memory would create, but a few
+// thousand pointer writes per query is a cheap way not to have the question at all.
+func (s *VecScratch) Release() {
+	for i := range s.stack {
+		clear(s.stack[i].S)
+	}
+}

--- a/collections/vm/vecexec_test.go
+++ b/collections/vm/vecexec_test.go
@@ -101,12 +101,12 @@ func sameValue(a, b classad.Value) bool {
 // position, and a boolean.
 func vecCorpus() *testSource {
 	return newTestSource([]map[string]string{
-		{"A": "10", "B": "3", "F": "true"},
-		{"A": "0", "B": "0", "F": "false"},
-		{"A": "2.5", "B": "2", "F": "true"},
-		{"A": "-7", "B": "0.5", "F": "false"},
-		{"B": "4", "F": "true"}, // A missing
-		{"A": "5"},              // B and F missing
+		{"A": "10", "B": "3", "F": "true", "S": `"user3"`},
+		{"A": "0", "B": "0", "F": "false", "S": `"USER3"`}, // same string, different case
+		{"A": "2.5", "B": "2", "F": "true", "S": `"user10"`},
+		{"A": "-7", "B": "0.5", "F": "false", "S": `""`}, // empty string
+		{"B": "4", "F": "true"},                          // A and S missing
+		{"A": "5"},                                       // B and F missing
 		{"A": "undefined", "B": "1"},
 		{"A": "9223372036854775807", "B": "2"}, // MaxInt64: + and * must overflow-check
 		{"A": "-9223372036854775808", "B": "-1"},
@@ -140,6 +140,15 @@ var vecExprs = []string{
 	"(A + B) * 2 > A", "(A > B) == (B < A)", "A > 4 && (B == 3 || B == 4)",
 	// constants
 	"true", "false", "1 > 0", "A > 4 && true",
+	// strings: every comparison operator folds case, the identity operators do not
+	`S == "user3"`, `S == "USER3"`, `S != "user3"`, `S < "user5"`, `S > "user5"`,
+	`S <= "user3"`, `S >= "USER3"`,
+	`S =?= "user3"`, `S =!= "user3"`, `S =?= "USER3"`, `S =!= "USER3"`,
+	`S == ""`, `S =?= undefined`,
+	`S == "user3" || S == "user10"`, `S == "user3" && A > 4`,
+	`S == A`,    // string against a number: the hook's problem
+	`S < A`,     // likewise, ordered
+	`S && true`, // a string as a logical operand
 }
 
 // TestVecMatchesScalarPerRecord is the executor's core test: same Program, per-record equality.
@@ -167,7 +176,7 @@ func TestVecMatchesScalarPerRecord(t *testing.T) {
 			}
 		}
 	}
-	if declined > 3 {
+	if declined > 0 {
 		t.Errorf("%d/%d expressions declined; the corpus is meant to be mostly servable",
 			declined, len(vecExprs))
 	}
@@ -182,8 +191,6 @@ func TestVecDeclinesUnsupported(t *testing.T) {
 		{"A": "1", "S": `"x"`},
 	})
 	for _, expr := range []string{
-		`S == "x"`,        // string column
-		`A == "x"`,        // string constant
 		`A ?: 5`,          // Elvis: a per-record select, no combine opcode
 		`size({1,2,3})`,   // delegated subtree (OpEvalNode)
 		`strcat("a","b")`, // function returning a string

--- a/collections/vm/vecexec_test.go
+++ b/collections/vm/vecexec_test.go
@@ -46,7 +46,7 @@ func newTestSource(recs []map[string]string) *testSource {
 	return s
 }
 
-func (s *testSource) LoadColumn(name string, scope ast.AttributeScope, dst Vec) bool {
+func (s *testSource) LoadColumn(name string, scope ast.AttributeScope, dst *Vec) bool {
 	if scope != ast.NoScope && scope != ast.MyScope {
 		return false
 	}
@@ -56,7 +56,7 @@ func (s *testSource) LoadColumn(name string, scope ast.AttributeScope, dst Vec) 
 			dst.St[i] = VsUndef
 			continue
 		}
-		if !dst.setValue(i, v) {
+		if !dst.setValueData(i, v) {
 			return false // a string column: decline, exactly as a real source would
 		}
 	}

--- a/collections/vm/vecmask.go
+++ b/collections/vm/vecmask.go
@@ -1,0 +1,178 @@
+package vm
+
+import (
+	"math"
+	"math/bits"
+)
+
+// The MASK form of a vector: three-valued logic as two bitplanes, two bits per record.
+//
+//	hi lo
+//	 0  0  FALSE      0  1  TRUE      1  0  UNDEFINED      1  1  ERROR
+//
+// A boolean element cost nine bytes in the data form (a state byte plus an eight-byte payload) and every
+// logical operator walked it with a branch per record, which measured as expensive as a comparison that
+// loads and compares int64s -- for an operation that only merges booleans. In this form a combine is a
+// fixed sequence of word-wise ANDs and ORs over 64 records at a time, with no branch, and its cost no
+// longer depends on how many records were missing an attribute.
+//
+// SHAPED FOR SIMD, SCALAR INSIDE. These are the operations AVX-512 performs natively -- a comparison
+// RETURNS a mask (Int64x8.Greater gives Mask64x8), Mask64x8.And is the combine, ToBits feeds a popcount,
+// and Int64x8.Compress is the selection-pushdown primitive -- so widening these loops later replaces
+// their bodies and nothing above them. Everything here is ordinary uint64 arithmetic and runs on every
+// architecture today; simd/archsimd in Go 1.26 is amd64-only and behind GOEXPERIMENT.
+//
+// The tables are LEFT-BIASED, not symmetric: `ERROR && FALSE` is ERROR while `FALSE && ERROR` is FALSE.
+// That is short-circuit semantics made total -- the left operand decides where it can -- and asymmetry
+// costs a few word operations and nothing else. Every table here is verified against the tree-walking
+// evaluator over all sixteen state pairs, because a combine that quietly symmetrised them would still
+// pass any corpus that never put an ERROR on the left.
+
+// Mask state encodings, as (hi, lo) bit pairs.
+const (
+	mFalse = 0 // 00
+	mTrue  = 1 // 01
+	mUndef = 2 // 10
+	mError = 3 // 11
+)
+
+func maskWords(n int) int { return (n + 63) / 64 }
+
+// planeAnd is ClassAd &&:
+//
+//	ERROR && anything = ERROR      FALSE && anything = FALSE
+//	TRUE  && y        = y          UNDEF && FALSE    = FALSE
+//	                               UNDEF && ERROR    = ERROR, else UNDEFINED
+//
+// FALSE is 00, so it needs no term: whatever is none of ERROR, TRUE or UNDEFINED falls out as zero in
+// both planes.
+func planeAnd(xhi, xlo, yhi, ylo, ohi, olo []uint64) {
+	for w := range ohi {
+		xh, xl, yh, yl := xhi[w], xlo[w], yhi[w], ylo[w]
+		if xh|yh == 0 {
+			// Neither operand has an UNDEFINED or ERROR anywhere in these 64 records, so the whole
+			// three-valued apparatus collapses to one AND. One branch per 64 records, and it is the
+			// common case: a comparison over an escape-free column yields only TRUE or FALSE.
+			ohi[w], olo[w] = 0, xl&yl
+			continue
+		}
+		isTx, isUx, isEx := ^xh&xl, xh&^xl, xh&xl
+		isTy, isUy, isEy := ^yh&yl, yh&^yl, yh&yl
+		hands := isTx | isUx // the left operand does not settle it alone
+		resE := isEx | (hands & isEy)
+		resT := isTx & isTy
+		resU := (isTx & isUy) | (isUx & (isTy | isUy))
+		ohi[w], olo[w] = resU|resE, resT|resE
+	}
+}
+
+// planeOr is ClassAd ||, left-biased the same way:
+//
+//	ERROR || anything = ERROR      TRUE  || anything = TRUE
+//	FALSE || y        = y          UNDEF || TRUE     = TRUE
+//	                               UNDEF || ERROR    = ERROR, else UNDEFINED
+func planeOr(xhi, xlo, yhi, ylo, ohi, olo []uint64) {
+	for w := range ohi {
+		xh, xl, yh, yl := xhi[w], xlo[w], yhi[w], ylo[w]
+		if xh|yh == 0 {
+			ohi[w], olo[w] = 0, xl|yl
+			continue
+		}
+		isFx, isTx, isUx, isEx := ^xh&^xl, ^xh&xl, xh&^xl, xh&xl
+		isFy, isTy, isUy, isEy := ^yh&^yl, ^yh&yl, yh&^yl, yh&yl
+		hands := isFx | isUx
+		resE := isEx | (hands & isEy)
+		resT := isTx | (hands & isTy)
+		resU := (isFx & isUy) | (isUx & (isFy | isUy))
+		ohi[w], olo[w] = resU|resE, resT|resE
+	}
+}
+
+// planeNot is ClassAd !: TRUE and FALSE swap, UNDEFINED and ERROR pass through. The hi plane is
+// unchanged, which is what makes it two operations per word.
+func planeNot(hi, lo, ohi, olo []uint64) {
+	for w := range ohi {
+		h, l := hi[w], lo[w]
+		ohi[w], olo[w] = h, (^h&^l)|(h&l)
+	}
+}
+
+// planeCountTrue counts records whose result is TRUE and that live has set: one popcount per 64 records.
+//
+// math/bits.OnesCount64 already lowers to a single instruction on both amd64 and arm64 and measures about
+// half a nanosecond per WORD, so there is nothing here for a vectorized popcount to improve at row-group
+// scale.
+func planeCountTrue(hi, lo, live []uint64) int {
+	n := 0
+	for w := range hi {
+		n += bits.OnesCount64(^hi[w] & lo[w] & live[w])
+	}
+	return n
+}
+
+// maskStateAt reads one record's two bits.
+func maskStateAt(hi, lo []uint64, i int) int {
+	w, b := i/64, uint(i%64)
+	return int((hi[w]>>b)&1)<<1 | int((lo[w]>>b)&1)
+}
+
+// setMaskStateAt writes one record's two bits, clearing whatever was there.
+func setMaskStateAt(hi, lo []uint64, i, st int) {
+	w, b := i/64, uint(i%64)
+	m := uint64(1) << b
+	if st&2 != 0 {
+		hi[w] |= m
+	} else {
+		hi[w] &^= m
+	}
+	if st&1 != 0 {
+		lo[w] |= m
+	} else {
+		lo[w] &^= m
+	}
+}
+
+// dataStateToMask maps one DATA element to its mask state as a logical operand.
+//
+// Numbers are TRUTHY in ClassAd's logical operators -- `1 && true` is TRUE, `0 && true` is FALSE, `0.0` is
+// FALSE, `!42` is FALSE -- while a STRING is an ERROR. That asymmetry is the whole reason this function
+// exists rather than a rule like "not a boolean means error", which is what it looks like it should be and
+// which TestMaskConversionMatchesReference would have caught.
+func dataStateToMask(st uint8, payload int64) int {
+	switch st {
+	case VsBool:
+		if payload != 0 {
+			return mTrue
+		}
+		return mFalse
+	case VsInt:
+		if payload != 0 {
+			return mTrue
+		}
+		return mFalse
+	case VsReal:
+		f := math.Float64frombits(uint64(payload))
+		if f != 0 {
+			return mTrue
+		}
+		return mFalse
+	case VsUndef:
+		return mUndef
+	default:
+		// A string, and anything a vector cannot hold, is an error in a logical position.
+		return mError
+	}
+}
+
+// MaskWords returns the number of uint64 words a mask plane needs for n records. Exported so a caller
+// that builds its own visibility mask sizes it the same way the executor does.
+func MaskWords(n int) int { return maskWords(n) }
+
+// PopCountMasked counts set bits of a & b, for a caller combining its own bitmaps.
+func PopCountMasked(a, b []uint64) int {
+	n := 0
+	for w := range a {
+		n += bits.OnesCount64(a[w] & b[w])
+	}
+	return n
+}

--- a/collections/vm/vecmask_test.go
+++ b/collections/vm/vecmask_test.go
@@ -2,165 +2,156 @@ package vm
 
 import (
 	"fmt"
-	"math/bits"
 	"testing"
 
 	"github.com/PelicanPlatform/classad/classad"
 )
 
-// SPIKE: three-valued logic as BITPLANES, which is the representation both the combine and the
-// comparison want.
+// The mask form's tables are verified against the REFERENCE evaluator, not against the executor that uses
+// them -- comparing plane operations to the kernels built on plane operations would be circular.
 //
-// The phase spike found a logical combine costs about as much as a comparison that loads and compares
-// int64s, which makes no sense for an operation that only merges booleans -- until you look at the
-// representation. A boolean element is nine bytes here (a state byte plus an eight-byte payload) and the
-// combine walks it with a four-way branch per record.
+// The spike that chose this representation recorded its numbers in its own commit; what stays here is the
+// correctness, because the tables are where this can silently diverge. Two ways it nearly did:
 //
-// Two bitplanes hold the same four states in two BITS per record:
+//	ERROR && FALSE = ERROR   but   FALSE && ERROR = FALSE     -- && does not commute
+//	1 && true = TRUE, 0 && true = FALSE, "x" && true = ERROR  -- numbers are TRUTHY, strings are not
 //
-//	hi lo
-//	 0  0  FALSE      0  1  TRUE      1  0  UNDEFINED      1  1  ERROR
-//
-// which makes a combine a fixed sequence of word-wise ANDs and ORs over 64 records at a time, branch
-// free, in ordinary Go. It is also exactly what SIMD wants: Int64x8.Greater RETURNS a Mask64x8 rather
-// than a vector, Mask64x8.And is the combine, ToBits feeds a popcount, and Int64x8.Compress is the
-// selection-pushdown primitive. So bitplanes are not a detour to take before SIMD -- they are the layout
-// SIMD plugs into, and they carry most of the win to every architecture without the experiment flag.
+// Both look like rules a reasonable person would state the other way, and a corpus that never puts an
+// ERROR on the left, or never puts a bare number in a logical position, passes either way.
 
+// The spike's names for the mask states, kept so these tests read as tables.
 const (
-	stF = 0 // hi=0 lo=0
-	stT = 1 // hi=0 lo=1
-	stU = 2 // hi=1 lo=0
-	stE = 3 // hi=1 lo=1
+	stF = mFalse
+	stT = mTrue
+	stU = mUndef
+	stE = mError
 )
 
-// planeAnd is ClassAd &&, and the table is LEFT-BIASED rather than symmetric:
-//
-//	ERROR && anything  = ERROR        FALSE && ERROR = FALSE
-//	TRUE  && y         = y            UNDEF && FALSE = FALSE
-//	FALSE && anything  = FALSE        UNDEF && ERROR = ERROR, else UNDEF
-//
-// So && does not commute: `ERROR && FALSE` is ERROR while `FALSE && ERROR` is FALSE. That is
-// short-circuit semantics made total -- the left operand decides where it can -- and it is exactly what
-// this spike's first version got wrong by assuming FALSE dominates everything, which is what the
-// agreement test against the executor caught. Asymmetry costs a few more word operations and nothing
-// else; it is still branch-free over 64 records at a time.
-func planeAnd(xhi, xlo, yhi, ylo, ohi, olo []uint64) {
-	for w := range ohi {
-		xh, xl, yh, yl := xhi[w], xlo[w], yhi[w], ylo[w]
-		isTx, isUx, isEx := ^xh&xl, xh&^xl, xh&xl
-		isTy, isUy, isEy := ^yh&yl, yh&^yl, yh&yl
-		// FALSE is 00, so it needs no term: whatever is neither ERROR, TRUE nor UNDEFINED falls out of
-		// both planes as zero.
-		resE := isEx | ((isTx | isUx) & isEy)
-		resT := isTx & isTy
-		resU := (isTx & isUy) | (isUx & (isTy | isUy))
-		ohi[w], olo[w] = resU|resE, resT|resE
+func setPlaneState(v *Vec, i, st int) {
+	switch st {
+	case stF:
+		v.SetBool(i, false)
+	case stT:
+		v.SetBool(i, true)
+	case stU:
+		v.St[i] = VsUndef
+	case stE:
+		v.St[i] = VsError
 	}
 }
 
-// planeOr is ClassAd ||, left-biased in the same way:
-//
-//	ERROR || anything = ERROR        TRUE  || ERROR = TRUE
-//	FALSE || y        = y            UNDEF || TRUE  = TRUE
-//	TRUE  || anything = TRUE         UNDEF || ERROR = ERROR, else UNDEF
-func planeOr(xhi, xlo, yhi, ylo, ohi, olo []uint64) {
-	for w := range ohi {
-		xh, xl, yh, yl := xhi[w], xlo[w], yhi[w], ylo[w]
-		isFx, isTx, isUx, isEx := ^xh&^xl, ^xh&xl, xh&^xl, xh&xl
-		isFy, isTy, isUy, isEy := ^yh&^yl, ^yh&yl, yh&^yl, yh&yl
-		hands := isFx | isUx // the left operand hands the decision to the right
-		resE := isEx | (hands & isEy)
-		resT := isTx | (hands & isTy)
-		resU := (isFx & isUy) | (isUx & (isFy | isUy))
-		ohi[w], olo[w] = resU|resE, resT|resE
-	}
+func maskName(st int) string {
+	return map[int]string{stF: "FALSE", stT: "TRUE", stU: "UNDEF", stE: "ERROR"}[st]
 }
 
-// planeAndDefined is the same operator when neither side can be UNDEFINED or ERROR: one AND per 64
-// records. The block already knows when that holds -- escapeFree(field) says a column has no missing or
-// unstorable value, so a comparison over it yields only TRUE or FALSE -- which is the common case on
-// real data and the reason to carry the flag at all.
-func planeAndDefined(xlo, ylo, olo []uint64) {
-	for w := range olo {
-		olo[w] = xlo[w] & ylo[w]
-	}
-}
-
-// planeCountTrue counts records whose result is TRUE and which the snapshot can see: one popcount per 64
-// records, against a per-record branch today.
-func planeCountTrue(hi, lo, live []uint64) int {
-	n := 0
-	for w := range hi {
-		n += bits.OnesCount64(^hi[w] & lo[w] & live[w])
-	}
-	return n
-}
-
-func packPlanes(states []uint8, hi, lo []uint64) {
-	for i, s := range states {
-		w, b := i/64, uint(i%64)
-		if s == stU || s == stE {
-			hi[w] |= 1 << b
-		}
-		if s == stT || s == stE {
-			lo[w] |= 1 << b
-		}
-	}
-}
-
-// TestPlaneLogicMatchesExecutor is the precondition for any timing: the bitplane operators must agree
-// with the executor's combine -- which is itself verified per record against the tree-walking evaluator
-// -- for every one of the sixteen state pairs.
-func TestPlaneLogicMatchesExecutor(t *testing.T) {
-	names := map[int]string{stF: "FALSE", stT: "TRUE", stU: "UNDEF", stE: "ERROR"}
+// TestPlaneLogicMatchesReference checks planeAnd and planeOr against ApplyBinaryOp for all sixteen state
+// pairs of both operators -- every entry of the truth table the whole representation rests on.
+func TestPlaneLogicMatchesReference(t *testing.T) {
 	ev := classad.NewEvaluator(nil)
+	box := func(st int) classad.Value {
+		switch st {
+		case stF:
+			return classad.NewBoolValue(false)
+		case stT:
+			return classad.NewBoolValue(true)
+		case stU:
+			return classad.NewUndefinedValue()
+		default:
+			return classad.NewErrorValue()
+		}
+	}
 	for _, op := range []string{"&&", "||"} {
 		for x := 0; x < 4; x++ {
 			for y := 0; y < 4; y++ {
-				// The executor's answer, in its own representation.
-				l, r := newVec(1), newVec(1)
-				setPlaneState(l, 0, x)
-				setPlaneState(r, 0, y)
-				if !logicalVec(ev, op, l, r) {
-					t.Fatalf("%s %s %s: executor declined", names[x], op, names[y])
-				}
-				want := stateOf(l, 0)
-
-				// The bitplane answer.
-				xhi, xlo := make([]uint64, 1), make([]uint64, 1)
-				yhi, ylo := make([]uint64, 1), make([]uint64, 1)
+				xhi, xlo := []uint64{uint64(x >> 1)}, []uint64{uint64(x & 1)}
+				yhi, ylo := []uint64{uint64(y >> 1)}, []uint64{uint64(y & 1)}
 				ohi, olo := make([]uint64, 1), make([]uint64, 1)
-				packPlanes([]uint8{uint8(x)}, xhi, xlo)
-				packPlanes([]uint8{uint8(y)}, yhi, ylo)
 				if op == "&&" {
 					planeAnd(xhi, xlo, yhi, ylo, ohi, olo)
 				} else {
 					planeOr(xhi, xlo, yhi, ylo, ohi, olo)
 				}
-				got := int(ohi[0]&1)<<1 | int(olo[0]&1)
+				got := maskStateAt(ohi, olo, 0)
+				want, ok := valueToMaskState(ev.ApplyBinaryOp(op, box(x), box(y)))
+				if !ok {
+					t.Fatalf("%s %s %s: reference produced a value a mask cannot hold",
+						maskName(x), op, maskName(y))
+				}
 				if got != want {
-					t.Errorf("%s %s %s: bitplanes say %s, executor says %s",
-						names[x], op, names[y], names[got], names[want])
+					t.Errorf("%s %s %s: planes say %s, reference says %s",
+						maskName(x), op, maskName(y), maskName(got), maskName(want))
 				}
 			}
 		}
 	}
 }
 
-// TestShortCircuitNoOpExhaustive is the strong form of the claim that lets && and || vectorize at all:
-// the vector executor SKIPS the short-circuit jump and always evaluates both operands, so for every one
-// of the sixteen state pairs of both operators its answer must equal the scalar path's -- which does
-// short-circuit, and therefore never even evaluates a right operand the left one settles.
+// TestPlaneNotMatchesReference checks planeNot against ApplyUnaryOp for all four states.
+func TestPlaneNotMatchesReference(t *testing.T) {
+	ev := classad.NewEvaluator(nil)
+	for _, src := range []struct {
+		st  int
+		val classad.Value
+	}{
+		{stF, classad.NewBoolValue(false)},
+		{stT, classad.NewBoolValue(true)},
+		{stU, classad.NewUndefinedValue()},
+		{stE, classad.NewErrorValue()},
+	} {
+		hi, lo := []uint64{uint64(src.st >> 1)}, []uint64{uint64(src.st & 1)}
+		ohi, olo := make([]uint64, 1), make([]uint64, 1)
+		planeNot(hi, lo, ohi, olo)
+		got := maskStateAt(ohi, olo, 0)
+		want, _ := valueToMaskState(ev.ApplyUnaryOp("!", src.val))
+		if got != want {
+			t.Errorf("!%s: planes say %s, reference says %s", maskName(src.st), maskName(got), maskName(want))
+		}
+	}
+}
+
+// TestAllDefinedFastPathMatchesGeneral checks the per-word shortcut planeAnd and planeOr take when neither
+// operand has an UNDEFINED or ERROR in those 64 records -- the common case, since a comparison over an
+// escape-free column yields only TRUE or FALSE. It must produce what the general path would.
+func TestAllDefinedFastPathMatchesGeneral(t *testing.T) {
+	const words = 64
+	xhi, xlo := make([]uint64, words), make([]uint64, words)
+	yhi, ylo := make([]uint64, words), make([]uint64, words)
+	for w := 0; w < words; w++ {
+		xlo[w] = uint64(w)*0x9e3779b97f4a7c15 | 1
+		ylo[w] = uint64(w)*0xc2b2ae3d27d4eb4f | 3
+	}
+	for _, tc := range []struct {
+		name string
+		fast func(ohi, olo []uint64)
+		want func(w int) uint64
+	}{
+		{"and", func(ohi, olo []uint64) { planeAnd(xhi, xlo, yhi, ylo, ohi, olo) }, func(w int) uint64 { return xlo[w] & ylo[w] }},
+		{"or", func(ohi, olo []uint64) { planeOr(xhi, xlo, yhi, ylo, ohi, olo) }, func(w int) uint64 { return xlo[w] | ylo[w] }},
+	} {
+		ohi, olo := make([]uint64, words), make([]uint64, words)
+		tc.fast(ohi, olo)
+		for w := 0; w < words; w++ {
+			if ohi[w] != 0 {
+				t.Fatalf("%s word %d: defined inputs produced undefined/error", tc.name, w)
+			}
+			if olo[w] != tc.want(w) {
+				t.Errorf("%s word %d: %#x != %#x", tc.name, w, olo[w], tc.want(w))
+			}
+		}
+	}
+}
+
+// TestShortCircuitNoOpExhaustive is the strong form of the claim that lets && and || vectorize at all: the
+// vector executor SKIPS the short-circuit jump and always evaluates both operands, so for every one of the
+// sixteen state pairs of both operators its answer must equal the scalar path's -- which does
+// short-circuit, and therefore never evaluates a right operand the left one settles.
 //
-// The executor's own differential test covers this incidentally, over whatever state pairs a
-// twelve-record corpus happens to produce. This covers all thirty-two deliberately, which matters more
-// than it looks: the table is left-biased, so `ERROR && FALSE` and `FALSE && ERROR` differ, and a
-// combine that quietly symmetrised them would still pass a corpus that never put an ERROR on the left.
+// The executor's differential test covers this incidentally, over whatever pairs a twelve-record corpus
+// happens to produce. This covers all thirty-two deliberately, which matters because the table is
+// left-biased: a combine that quietly symmetrised it would still pass a corpus with no ERROR on the left.
 func TestShortCircuitNoOpExhaustive(t *testing.T) {
 	src := map[int]string{stF: "false", stT: "true", stU: "undefined", stE: "error"}
-	names := map[int]string{stF: "FALSE", stT: "TRUE", stU: "UNDEF", stE: "ERROR"}
-	empty := &testSource{recs: []map[string]string{{}}, vals: []map[string]classad.Value{{}}}
+	empty := newTestSource([]map[string]string{{}})
 	for _, op := range []string{"&&", "||"} {
 		for x := 0; x < 4; x++ {
 			for y := 0; y < 4; y++ {
@@ -174,194 +165,36 @@ func TestShortCircuitNoOpExhaustive(t *testing.T) {
 					t.Fatalf("%s: vector executor declined", expr)
 				}
 				if !sameValue(got.value(0), q.Eval(classad.New())) {
-					t.Errorf("%s %s %s: vector %s != scalar %s",
-						names[x], op, names[y], got.value(0), q.Eval(classad.New()))
+					t.Errorf("%s %s %s: vector %s != scalar %s", maskName(x), op, maskName(y),
+						got.value(0), q.Eval(classad.New()))
 				}
 			}
 		}
 	}
 }
 
-// TestPlaneAndDefinedMatchesGeneral checks the fast path agrees with the general one wherever it is
-// allowed to run: both operands defined.
-func TestPlaneAndDefinedMatchesGeneral(t *testing.T) {
-	const n = 4096
-	words := n / 64
-	xhi, xlo := make([]uint64, words), make([]uint64, words)
-	yhi, ylo := make([]uint64, words), make([]uint64, words)
-	for w := 0; w < words; w++ {
-		xlo[w] = uint64(w)*0x9e3779b97f4a7c15 | 1
-		ylo[w] = uint64(w)*0xc2b2ae3d27d4eb4f | 3
-	}
-	gh, gl := make([]uint64, words), make([]uint64, words)
-	planeAnd(xhi, xlo, yhi, ylo, gh, gl)
-	fl := make([]uint64, words)
-	planeAndDefined(xlo, ylo, fl)
-	for w := 0; w < words; w++ {
-		if gh[w] != 0 {
-			t.Fatalf("word %d: general path produced undefined/error from defined inputs", w)
-		}
-		if gl[w] != fl[w] {
-			t.Errorf("word %d: fast %#x != general %#x", w, fl[w], gl[w])
-		}
-	}
-}
-
-func setPlaneState(v Vec, i, st int) {
-	switch st {
-	case stF:
-		v.SetBool(i, false)
-	case stT:
-		v.SetBool(i, true)
-	case stU:
-		v.St[i] = VsUndef
-	case stE:
-		v.St[i] = VsError
-	}
-}
-
-func stateOf(v Vec, i int) int {
-	switch v.St[i] {
-	case VsBool:
-		if v.I[i] != 0 {
-			return stT
-		}
-		return stF
-	case VsUndef:
-		return stU
-	default:
-		return stE
-	}
-}
-
-// BenchmarkCombineRepresentation compares the executor's nine-bytes-per-element combine against the
-// bitplane combine over a full-sized row group, across three input distributions.
+// TestMaskConversionMatchesReference pins the DATA-to-mask conversion, which is where the truthiness rule
+// lives: numbers are truthy in a logical position, strings are an error, and a real zero is false.
 //
-// The distributions are the point. The executor's combine has a fast path for both-operands-boolean and
-// falls to the per-element parity hook otherwise, so its cost depends entirely on how many UNDEFINED and
-// ERROR values a block contains -- which is a property of the DATA, not the query. The bitplane combine
-// is word-wise arithmetic that cannot branch, so its cost is identical in all three. A representation
-// whose speed does not depend on how many records were missing an attribute is worth something beyond
-// the raw multiple.
-//
-// The executor's combine writes into its left operand, so it needs its input restored each iteration.
-// That restore is reported separately rather than hidden: needing it is a real property of a mutating
-// byte-per-element representation, but the reader should be able to subtract it.
-func BenchmarkCombineRepresentation(b *testing.B) {
-	const n = 8192 // colGroupMaxRows: the largest row group
-	words := n / 64
-	ev := classad.NewEvaluator(nil)
-
-	for _, dist := range []struct {
-		name string
-		// state returns the left and right operand states for record i.
-		state func(i int) (int, int)
-	}{
-		// An escape-free column compared to a literal yields only TRUE or FALSE, which is what the block
-		// already knows via escapeFree. The common case on real data.
-		{"allboolean", func(i int) (int, int) {
-			l, r := stF, stF
-			if i%3 == 0 {
-				l = stT
+// The rule that looks right and is wrong is "anything that is not a boolean is an ERROR". It holds for
+// strings and fails for every number.
+func TestMaskConversionMatchesReference(t *testing.T) {
+	operands := []string{"0", "1", "42", "-1", "0.0", "1.5", "-0.0", `""`, `"x"`, "true", "false", "undefined", "error"}
+	empty := newTestSource([]map[string]string{{}})
+	for _, l := range operands {
+		for _, form := range []string{"(%s) && true", "(%s) && false", "(%s) || false", "(%s) || true", "!(%s)"} {
+			expr := fmt.Sprintf(form, l)
+			q, err := Parse(expr)
+			if err != nil {
+				t.Fatalf("parse %q: %v", expr, err)
 			}
-			if i%5 == 0 {
-				r = stT
+			got, ok := q.VecEval(empty, 1, nil)
+			if !ok {
+				t.Fatalf("%s: declined", expr)
 			}
-			return l, r
-		}},
-		// A few records missing the attribute.
-		{"1pct_undefined", func(i int) (int, int) {
-			l, r := stF, stF
-			if i%3 == 0 {
-				l = stT
+			if want := q.Eval(classad.New()); !sameValue(got.value(0), want) {
+				t.Errorf("%s: vector %s != scalar %s", expr, got.value(0), want)
 			}
-			if i%5 == 0 {
-				r = stT
-			}
-			if i%97 == 0 {
-				l = stU
-			}
-			if i%101 == 0 {
-				r = stU
-			}
-			return l, r
-		}},
-		// A third of records not boolean: the shape that makes the executor's fast path miss constantly.
-		{"33pct_mixed", func(i int) (int, int) {
-			l := stF
-			if i%3 == 0 {
-				l = stT
-			}
-			if i%97 == 0 {
-				l = stU
-			}
-			if i%991 == 0 {
-				l = stE
-			}
-			return l, (l + 1) % 4
-		}},
-	} {
-		srcL, srcR := newVec(n), newVec(n)
-		lStates, rStates := make([]uint8, n), make([]uint8, n)
-		for i := 0; i < n; i++ {
-			ls, rs := dist.state(i)
-			lStates[i], rStates[i] = uint8(ls), uint8(rs)
-			setPlaneState(srcL, i, ls)
-			setPlaneState(srcR, i, rs)
 		}
-		l, r := newVec(n), newVec(n)
-		copy(r.St, srcR.St)
-		copy(r.I, srcR.I)
-
-		b.Run("executor+restore/"+dist.name, func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
-				copy(l.St, srcL.St)
-				copy(l.I, srcL.I)
-				logicalVec(ev, "&&", l, r)
-			}
-		})
-		b.Run("restoreonly/"+dist.name, func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
-				copy(l.St, srcL.St)
-				copy(l.I, srcL.I)
-			}
-		})
-
-		xhi, xlo := make([]uint64, words), make([]uint64, words)
-		yhi, ylo := make([]uint64, words), make([]uint64, words)
-		ohi, olo := make([]uint64, words), make([]uint64, words)
-		packPlanes(lStates, xhi, xlo)
-		packPlanes(rStates, yhi, ylo)
-		b.Run("bitplane/"+dist.name, func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
-				planeAnd(xhi, xlo, yhi, ylo, ohi, olo)
-			}
-		})
-		b.Run("bitplanefast/"+dist.name, func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
-				planeAndDefined(xlo, ylo, olo)
-			}
-		})
-
-		live := make([]uint64, words)
-		for w := range live {
-			live[w] = ^uint64(0)
-		}
-		b.Run("countbranch/"+dist.name, func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
-				c := 0
-				for k := 0; k < n; k++ {
-					if l.IsTrue(k) {
-						c++
-					}
-				}
-				_ = c
-			}
-		})
-		b.Run("countpopcount/"+dist.name, func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
-				_ = planeCountTrue(ohi, olo, live)
-			}
-		})
 	}
 }

--- a/collections/vm/vecmask_test.go
+++ b/collections/vm/vecmask_test.go
@@ -1,0 +1,367 @@
+package vm
+
+import (
+	"fmt"
+	"math/bits"
+	"testing"
+
+	"github.com/PelicanPlatform/classad/classad"
+)
+
+// SPIKE: three-valued logic as BITPLANES, which is the representation both the combine and the
+// comparison want.
+//
+// The phase spike found a logical combine costs about as much as a comparison that loads and compares
+// int64s, which makes no sense for an operation that only merges booleans -- until you look at the
+// representation. A boolean element is nine bytes here (a state byte plus an eight-byte payload) and the
+// combine walks it with a four-way branch per record.
+//
+// Two bitplanes hold the same four states in two BITS per record:
+//
+//	hi lo
+//	 0  0  FALSE      0  1  TRUE      1  0  UNDEFINED      1  1  ERROR
+//
+// which makes a combine a fixed sequence of word-wise ANDs and ORs over 64 records at a time, branch
+// free, in ordinary Go. It is also exactly what SIMD wants: Int64x8.Greater RETURNS a Mask64x8 rather
+// than a vector, Mask64x8.And is the combine, ToBits feeds a popcount, and Int64x8.Compress is the
+// selection-pushdown primitive. So bitplanes are not a detour to take before SIMD -- they are the layout
+// SIMD plugs into, and they carry most of the win to every architecture without the experiment flag.
+
+const (
+	stF = 0 // hi=0 lo=0
+	stT = 1 // hi=0 lo=1
+	stU = 2 // hi=1 lo=0
+	stE = 3 // hi=1 lo=1
+)
+
+// planeAnd is ClassAd &&, and the table is LEFT-BIASED rather than symmetric:
+//
+//	ERROR && anything  = ERROR        FALSE && ERROR = FALSE
+//	TRUE  && y         = y            UNDEF && FALSE = FALSE
+//	FALSE && anything  = FALSE        UNDEF && ERROR = ERROR, else UNDEF
+//
+// So && does not commute: `ERROR && FALSE` is ERROR while `FALSE && ERROR` is FALSE. That is
+// short-circuit semantics made total -- the left operand decides where it can -- and it is exactly what
+// this spike's first version got wrong by assuming FALSE dominates everything, which is what the
+// agreement test against the executor caught. Asymmetry costs a few more word operations and nothing
+// else; it is still branch-free over 64 records at a time.
+func planeAnd(xhi, xlo, yhi, ylo, ohi, olo []uint64) {
+	for w := range ohi {
+		xh, xl, yh, yl := xhi[w], xlo[w], yhi[w], ylo[w]
+		isTx, isUx, isEx := ^xh&xl, xh&^xl, xh&xl
+		isTy, isUy, isEy := ^yh&yl, yh&^yl, yh&yl
+		// FALSE is 00, so it needs no term: whatever is neither ERROR, TRUE nor UNDEFINED falls out of
+		// both planes as zero.
+		resE := isEx | ((isTx | isUx) & isEy)
+		resT := isTx & isTy
+		resU := (isTx & isUy) | (isUx & (isTy | isUy))
+		ohi[w], olo[w] = resU|resE, resT|resE
+	}
+}
+
+// planeOr is ClassAd ||, left-biased in the same way:
+//
+//	ERROR || anything = ERROR        TRUE  || ERROR = TRUE
+//	FALSE || y        = y            UNDEF || TRUE  = TRUE
+//	TRUE  || anything = TRUE         UNDEF || ERROR = ERROR, else UNDEF
+func planeOr(xhi, xlo, yhi, ylo, ohi, olo []uint64) {
+	for w := range ohi {
+		xh, xl, yh, yl := xhi[w], xlo[w], yhi[w], ylo[w]
+		isFx, isTx, isUx, isEx := ^xh&^xl, ^xh&xl, xh&^xl, xh&xl
+		isFy, isTy, isUy, isEy := ^yh&^yl, ^yh&yl, yh&^yl, yh&yl
+		hands := isFx | isUx // the left operand hands the decision to the right
+		resE := isEx | (hands & isEy)
+		resT := isTx | (hands & isTy)
+		resU := (isFx & isUy) | (isUx & (isFy | isUy))
+		ohi[w], olo[w] = resU|resE, resT|resE
+	}
+}
+
+// planeAndDefined is the same operator when neither side can be UNDEFINED or ERROR: one AND per 64
+// records. The block already knows when that holds -- escapeFree(field) says a column has no missing or
+// unstorable value, so a comparison over it yields only TRUE or FALSE -- which is the common case on
+// real data and the reason to carry the flag at all.
+func planeAndDefined(xlo, ylo, olo []uint64) {
+	for w := range olo {
+		olo[w] = xlo[w] & ylo[w]
+	}
+}
+
+// planeCountTrue counts records whose result is TRUE and which the snapshot can see: one popcount per 64
+// records, against a per-record branch today.
+func planeCountTrue(hi, lo, live []uint64) int {
+	n := 0
+	for w := range hi {
+		n += bits.OnesCount64(^hi[w] & lo[w] & live[w])
+	}
+	return n
+}
+
+func packPlanes(states []uint8, hi, lo []uint64) {
+	for i, s := range states {
+		w, b := i/64, uint(i%64)
+		if s == stU || s == stE {
+			hi[w] |= 1 << b
+		}
+		if s == stT || s == stE {
+			lo[w] |= 1 << b
+		}
+	}
+}
+
+// TestPlaneLogicMatchesExecutor is the precondition for any timing: the bitplane operators must agree
+// with the executor's combine -- which is itself verified per record against the tree-walking evaluator
+// -- for every one of the sixteen state pairs.
+func TestPlaneLogicMatchesExecutor(t *testing.T) {
+	names := map[int]string{stF: "FALSE", stT: "TRUE", stU: "UNDEF", stE: "ERROR"}
+	ev := classad.NewEvaluator(nil)
+	for _, op := range []string{"&&", "||"} {
+		for x := 0; x < 4; x++ {
+			for y := 0; y < 4; y++ {
+				// The executor's answer, in its own representation.
+				l, r := newVec(1), newVec(1)
+				setPlaneState(l, 0, x)
+				setPlaneState(r, 0, y)
+				if !logicalVec(ev, op, l, r) {
+					t.Fatalf("%s %s %s: executor declined", names[x], op, names[y])
+				}
+				want := stateOf(l, 0)
+
+				// The bitplane answer.
+				xhi, xlo := make([]uint64, 1), make([]uint64, 1)
+				yhi, ylo := make([]uint64, 1), make([]uint64, 1)
+				ohi, olo := make([]uint64, 1), make([]uint64, 1)
+				packPlanes([]uint8{uint8(x)}, xhi, xlo)
+				packPlanes([]uint8{uint8(y)}, yhi, ylo)
+				if op == "&&" {
+					planeAnd(xhi, xlo, yhi, ylo, ohi, olo)
+				} else {
+					planeOr(xhi, xlo, yhi, ylo, ohi, olo)
+				}
+				got := int(ohi[0]&1)<<1 | int(olo[0]&1)
+				if got != want {
+					t.Errorf("%s %s %s: bitplanes say %s, executor says %s",
+						names[x], op, names[y], names[got], names[want])
+				}
+			}
+		}
+	}
+}
+
+// TestShortCircuitNoOpExhaustive is the strong form of the claim that lets && and || vectorize at all:
+// the vector executor SKIPS the short-circuit jump and always evaluates both operands, so for every one
+// of the sixteen state pairs of both operators its answer must equal the scalar path's -- which does
+// short-circuit, and therefore never even evaluates a right operand the left one settles.
+//
+// The executor's own differential test covers this incidentally, over whatever state pairs a
+// twelve-record corpus happens to produce. This covers all thirty-two deliberately, which matters more
+// than it looks: the table is left-biased, so `ERROR && FALSE` and `FALSE && ERROR` differ, and a
+// combine that quietly symmetrised them would still pass a corpus that never put an ERROR on the left.
+func TestShortCircuitNoOpExhaustive(t *testing.T) {
+	src := map[int]string{stF: "false", stT: "true", stU: "undefined", stE: "error"}
+	names := map[int]string{stF: "FALSE", stT: "TRUE", stU: "UNDEF", stE: "ERROR"}
+	empty := &testSource{recs: []map[string]string{{}}, vals: []map[string]classad.Value{{}}}
+	for _, op := range []string{"&&", "||"} {
+		for x := 0; x < 4; x++ {
+			for y := 0; y < 4; y++ {
+				expr := fmt.Sprintf("(%s) %s (%s)", src[x], op, src[y])
+				q, err := Parse(expr)
+				if err != nil {
+					t.Fatal(err)
+				}
+				got, ok := q.VecEval(empty, 1, nil)
+				if !ok {
+					t.Fatalf("%s: vector executor declined", expr)
+				}
+				if !sameValue(got.value(0), q.Eval(classad.New())) {
+					t.Errorf("%s %s %s: vector %s != scalar %s",
+						names[x], op, names[y], got.value(0), q.Eval(classad.New()))
+				}
+			}
+		}
+	}
+}
+
+// TestPlaneAndDefinedMatchesGeneral checks the fast path agrees with the general one wherever it is
+// allowed to run: both operands defined.
+func TestPlaneAndDefinedMatchesGeneral(t *testing.T) {
+	const n = 4096
+	words := n / 64
+	xhi, xlo := make([]uint64, words), make([]uint64, words)
+	yhi, ylo := make([]uint64, words), make([]uint64, words)
+	for w := 0; w < words; w++ {
+		xlo[w] = uint64(w)*0x9e3779b97f4a7c15 | 1
+		ylo[w] = uint64(w)*0xc2b2ae3d27d4eb4f | 3
+	}
+	gh, gl := make([]uint64, words), make([]uint64, words)
+	planeAnd(xhi, xlo, yhi, ylo, gh, gl)
+	fl := make([]uint64, words)
+	planeAndDefined(xlo, ylo, fl)
+	for w := 0; w < words; w++ {
+		if gh[w] != 0 {
+			t.Fatalf("word %d: general path produced undefined/error from defined inputs", w)
+		}
+		if gl[w] != fl[w] {
+			t.Errorf("word %d: fast %#x != general %#x", w, fl[w], gl[w])
+		}
+	}
+}
+
+func setPlaneState(v Vec, i, st int) {
+	switch st {
+	case stF:
+		v.SetBool(i, false)
+	case stT:
+		v.SetBool(i, true)
+	case stU:
+		v.St[i] = VsUndef
+	case stE:
+		v.St[i] = VsError
+	}
+}
+
+func stateOf(v Vec, i int) int {
+	switch v.St[i] {
+	case VsBool:
+		if v.I[i] != 0 {
+			return stT
+		}
+		return stF
+	case VsUndef:
+		return stU
+	default:
+		return stE
+	}
+}
+
+// BenchmarkCombineRepresentation compares the executor's nine-bytes-per-element combine against the
+// bitplane combine over a full-sized row group, across three input distributions.
+//
+// The distributions are the point. The executor's combine has a fast path for both-operands-boolean and
+// falls to the per-element parity hook otherwise, so its cost depends entirely on how many UNDEFINED and
+// ERROR values a block contains -- which is a property of the DATA, not the query. The bitplane combine
+// is word-wise arithmetic that cannot branch, so its cost is identical in all three. A representation
+// whose speed does not depend on how many records were missing an attribute is worth something beyond
+// the raw multiple.
+//
+// The executor's combine writes into its left operand, so it needs its input restored each iteration.
+// That restore is reported separately rather than hidden: needing it is a real property of a mutating
+// byte-per-element representation, but the reader should be able to subtract it.
+func BenchmarkCombineRepresentation(b *testing.B) {
+	const n = 8192 // colGroupMaxRows: the largest row group
+	words := n / 64
+	ev := classad.NewEvaluator(nil)
+
+	for _, dist := range []struct {
+		name string
+		// state returns the left and right operand states for record i.
+		state func(i int) (int, int)
+	}{
+		// An escape-free column compared to a literal yields only TRUE or FALSE, which is what the block
+		// already knows via escapeFree. The common case on real data.
+		{"allboolean", func(i int) (int, int) {
+			l, r := stF, stF
+			if i%3 == 0 {
+				l = stT
+			}
+			if i%5 == 0 {
+				r = stT
+			}
+			return l, r
+		}},
+		// A few records missing the attribute.
+		{"1pct_undefined", func(i int) (int, int) {
+			l, r := stF, stF
+			if i%3 == 0 {
+				l = stT
+			}
+			if i%5 == 0 {
+				r = stT
+			}
+			if i%97 == 0 {
+				l = stU
+			}
+			if i%101 == 0 {
+				r = stU
+			}
+			return l, r
+		}},
+		// A third of records not boolean: the shape that makes the executor's fast path miss constantly.
+		{"33pct_mixed", func(i int) (int, int) {
+			l := stF
+			if i%3 == 0 {
+				l = stT
+			}
+			if i%97 == 0 {
+				l = stU
+			}
+			if i%991 == 0 {
+				l = stE
+			}
+			return l, (l + 1) % 4
+		}},
+	} {
+		srcL, srcR := newVec(n), newVec(n)
+		lStates, rStates := make([]uint8, n), make([]uint8, n)
+		for i := 0; i < n; i++ {
+			ls, rs := dist.state(i)
+			lStates[i], rStates[i] = uint8(ls), uint8(rs)
+			setPlaneState(srcL, i, ls)
+			setPlaneState(srcR, i, rs)
+		}
+		l, r := newVec(n), newVec(n)
+		copy(r.St, srcR.St)
+		copy(r.I, srcR.I)
+
+		b.Run("executor+restore/"+dist.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				copy(l.St, srcL.St)
+				copy(l.I, srcL.I)
+				logicalVec(ev, "&&", l, r)
+			}
+		})
+		b.Run("restoreonly/"+dist.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				copy(l.St, srcL.St)
+				copy(l.I, srcL.I)
+			}
+		})
+
+		xhi, xlo := make([]uint64, words), make([]uint64, words)
+		yhi, ylo := make([]uint64, words), make([]uint64, words)
+		ohi, olo := make([]uint64, words), make([]uint64, words)
+		packPlanes(lStates, xhi, xlo)
+		packPlanes(rStates, yhi, ylo)
+		b.Run("bitplane/"+dist.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				planeAnd(xhi, xlo, yhi, ylo, ohi, olo)
+			}
+		})
+		b.Run("bitplanefast/"+dist.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				planeAndDefined(xlo, ylo, olo)
+			}
+		})
+
+		live := make([]uint64, words)
+		for w := range live {
+			live[w] = ^uint64(0)
+		}
+		b.Run("countbranch/"+dist.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				c := 0
+				for k := 0; k < n; k++ {
+					if l.IsTrue(k) {
+						c++
+					}
+				}
+				_ = c
+			}
+		})
+		b.Run("countpopcount/"+dist.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = planeCountTrue(ohi, olo, live)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Follows #182 (merged). Seven commits, reviewable in order.

| | |
|---|---|
| `66e5c1c` | strings in the executor |
| `dfa9ebd` | row groups sealed on multiples of eight |
| `c550f0c` | SPIKE: attribute the scan before reaching for SIMD |
| `68b39b6` | SPIKE: masks unify the combine and the comparison |
| `f051412` | booleans as mask planes — SIMD-shaped, scalar inside |
| `e546a05` | analyze the prunable probes once per query, not once per segment |
| `6d38ce6` | keep a literal scalar instead of repeating it per record |

## 1. Strings

`Owner == "user3"` declined, because a vector had no string payload. Now 3.5x colScope, 15x row.

Parity came from **sharing the comparison, not reimplementing it**: all six of `< <= > >= == !=` fold case via `compareStringsFold`, while `=?=`/`=!=` are case-**sensitive**. classad exports `CompareStringsFold` and the kernel calls it. The load aliases the region rather than copying — one alloc per record previously made strings *slower* than the row path. Both codecs' `Decompress` copies (identity's included), so aliasing can't outlive its backing; it can *pin* it, so pooled stacks clear string payloads on release.

Well short of the numeric gains, structurally: the string region is **positional**, so reaching a field means walking the string fields before it, per record. A per-block string dictionary would turn equality into an integer compare — the real lever there, not vectorization.

## 2. Row groups on multiples of eight

Eight int64s are one cache line and one AVX-512 vector; eight booleans are one byte of the bool bitset. The value isn't the records it shifts — it's that a kernel's tail handling runs once per *segment*, since only a segment's final group is short.

Two wrong turns, both caught by tests rather than reasoning:

**Rounding up** is the obvious implementation and it's wrong — it puts blocks *over* the byte budget by up to 7 records. `TestRowGroupsBoundedByBytes` caught it at 1075680 vs 1048576 B. Ordinary ads overshoot a couple of percent; one pathological half-MB ad overshoots several times over, defeating the budget's purpose. So it seals at the last aligned **prefix** that fits and carries the remainder forward.

**Backing off needs a floor**, or it invents a different pathology: 8 small ads then one enormous one trips the budget just past a boundary, and sealing the prefix emits a **132-byte block** while the ad that filled the budget carries forward. Below half the budget the back-off is skipped. Verified load-bearing by disabling it.

That runt test was vacuous *twice* first — one fixture produced no multi-block segment at all, the next used a repetitive blob ZSTD shrank 600 KB → 140 B so every block looked like a runt regardless.

## 3–4. Two spikes, kept for the reasoning

**Don't reach for SIMD yet.** Go 1.26's `simd/archsimd` is **amd64-only** (every op file is `_amd64.go`), needs `GOEXPERIMENT=simd`, and is outside the Go 1 compatibility promise. Decomposing the scan: eval is 28–62%, so even a *free* eval band is 1.4–2.6x by Amdahl.

And the eval band wasn't what I expected. Adding conjuncts so each step adds one comparison and one combine showed **a combine cost as much as a comparison that loads and compares int64s** — for an operation that only merges booleans. That's a representation problem, not an arithmetic one, and no instruction set fixes it.

**Roaring is the wrong layer here.** A row group is ≤8192 records — a dense bitmap is 1 KB, cache-resident in 16 cache lines; container dispatch would be pure overhead. And `math/bits.OnesCount64` already lowers to one instruction at ~0.5 ns per *word*, so there's nothing for VPOPCNTDQ or Harley-Seal to fix at this scale. Roaring is worth asking about one layer down — value/categorical index postings across a whole table.

## 5. Booleans as mask planes

Two bitplanes, 2 bits per record (`00` F, `01` T, `10` U, `11` E). A comparison *produces* a mask; logical operators consume and produce masks; arithmetic stays on data.

**Shaped for SIMD, scalar inside.** Comparisons build each output word in a register and store it once, so the inner loop over 64 records is exactly what eight `Int64x8.Greater` calls replace — `Greater` *returns* `Mask64x8`, `Mask64x8.And` is the combine, `ToBits` feeds the popcount, `Int64x8.Compress` is the pushdown primitive. Nothing above the kernels moves when that lands, and everything here is ordinary `uint64` that runs everywhere today.

| | kernels before | after | |
|---|---|---|---|
| 1 cmp, 0 combine | 0.213 ms | **0.159** | 1.34x |
| 2 cmp, 1 combine | 0.578 ms | **0.347** | 1.66x |
| 3 cmp, 2 combine | 0.998 ms | **0.501** | 1.99x |
| 4 cmp, 3 combine | 1.462 ms | **0.686** | 2.13x |

The slope is the result: marginal cost per conjunct fell ~0.42 → ~0.175 ms, so a **combine went ~0.207 → ~0.016 ms, about 13x**. Comparisons got 1.34x on their own from writing two bits instead of nine bytes.

**End-to-end the scan is 1.06–1.31x** — Amdahl, as predicted before the work. Against colScope: numerics 7.1–12.4x, strings 3.5x. It also *raised* SIMD's ceiling, the other reason to go first: combines were ~40% of the eval band and SIMD couldn't help them; they're now ~5%, so the band is nearly all comparisons.

A bool column skips the data form entirely — a stored bit becomes a result bit — but only where the column is escape-free, since an escaped value need not be a boolean and a mask can't hold a number. Visibility is a bitmap, so counting survivors is a popcount against the result mask. Both plane operators take a per-word shortcut when neither operand has an UNDEFINED or ERROR in those 64 records: one well-predicted branch per 64 records, and it's the common case.

## Two semantics findings, established rather than assumed

**`&&` does not commute.** `ERROR && FALSE` is ERROR; `FALSE && ERROR` is FALSE. Short-circuit semantics made total — the left operand decides where it can. My first bitplane tables assumed FALSE dominates everything and the agreement test caught it immediately.

That prompted dumping all 16 state pairs of both operators three ways — the parity hook, the full scalar path (which short-circuits), the vector path (which doesn't). **All 32 agree**, which upgrades the short-circuit no-op from "verified over whatever pairs a 12-record corpus produced" to exhaustive. That matters *because* the table is left-biased: a combine that quietly symmetrised it would still pass a corpus with no ERROR on the left.

**Numbers are truthy as logical operands** — `1 && true` TRUE, `0.0 && true` FALSE, `!42` FALSE — while a *string* is an ERROR. So **two notions of truth coexist**, and conflating them is a silent wrong-answer bug: `Vec.IsTrue` is strict (a constraint valued `42` does not match, per the store's `isTrueValue`), `dataStateToMask` is operand truthiness. Separate functions, comments saying why.

Tables are verified against the **reference evaluator**, not the kernels built on them — that would be circular.

## Not handled (declines, doesn't guess)

Elvis (`?:`) and delegated subtrees (`OpEvalNode`, already excluded by `Native()`).

Block accounting now covers vectorized / declined / churn-guarded / pruned / empty, which caught `!RequestMemory` being **zone-pruned outright** rather than evaluated — correct, but it meant that assertion proved nothing until pruning was counted separately.

`collections`, `vm`, `db`, `dbrpc`, `changefeed`, root all green.

## 6. Analyze the prunable probes once per query

The zone-prunable probe analysis depends only on the query and the **schema**, and both columnar scans ran it inside the window loop. A scan visits one window per segment — **162** on a 60k-record table — and they all share a **single schema object**, so it repeated identical work 161 times.

Priced before touching it, which corrected my own guess about what that band was:

| | | |
|---|---|---|
| `zonePrunableTests` | 402 ns, 440 B, 13 allocs | ×161 = **11.2% of a scan** |
| `Matcher` | 13 ns, 0 B, **0 allocs** | not a factor at all |
| `snapshot`+release | 1578 ns | ×1 = 0.3% |

So the two `Matcher()` calls I had blamed cost nothing, and the analysis was 11% of the time and **44% of the allocations**.

| expression | before | after | |
|---|---|---|---|
| `RequestMemory > 4096` | 0.641 ms | **0.493** | 1.30x |
| `... && RequestCpus >= 4` | 1.092 | **0.806** | 1.36x |
| `WantCheckpoint && RequestCpus > 2` | 0.990 | **0.789** | 1.25x |
| `ProcId + ClusterId > 100` | 0.952 | **0.830** | 1.15x |
| `... && (JobStatus == 1 \|\| == 4)` | 1.283 | **1.113** | 1.15x |
| `RequestMemory > RequestCpus * 512` | 0.954 | **0.866** | 1.10x |
| `Owner == "user3"` | 1.940 | 2.012 | flat |
| **allocations** | 182 KB / 4769 | **110 KB / 2689** | −40% / −44% |

Keyed on schema **pointer identity**, so two equal-but-distinct schemas merely recompute rather than answer wrongly, and segments sealed under different schemas each get their own analysis.

The string shapes are flat, which is this fix's expected shape rather than a disappointment: a string constraint has no prunable numeric probe, so there was less repeated work to remove. Their first measurements read 0.92x, which seven samples resolved to noise inside a 1.897–2.101 range — the same benchmark-artifact trap that produced three wrong conclusions earlier in this work, so single-sample deltas near 1x now get re-run rather than reported.

`TestZonePruneAnalyzedOncePerQuery` **counts** the analyses rather than timing them, because the failure mode is invisible: a per-window analysis is still *correct* and only shows up as a query that got slower on a table with many segments — which is exactly why this went unnoticed until the scan was attributed phase by phase. It fails at 161 analyses when the cache is defeated, and refuses to run on a fixture with too few segments to make the difference observable.

## 7. Keep a literal scalar instead of repeating it per record

Profiling attributed **9.8%** of the scan to `broadcast` — writing nine bytes per record, per block, to say the same thing a thousand times. A literal is one value. It's now kept once in element 0 with the vector marked `Const`, and the comparison kernel specializes on it, which also lets the loop read a scalar in registers instead of a second array.

| expression | before | after | |
|---|---|---|---|
| `... && (JobStatus == 1 \|\| == 4)` | 1.113 ms | **0.851** | 1.31x |
| `RequestMemory > 4096 && RequestCpus >= 4` | 0.806 | **0.636** | 1.27x |
| `WantCheckpoint && RequestCpus > 2` | 0.789 | **0.694** | 1.14x |
| `ProcId + ClusterId > 100` | 0.830 | **0.770** | 1.08x |
| `RequestMemory > 4096` | 0.493 | **0.466** | 1.06x |
| `RequestMemory > RequestCpus * 512` | 0.866 | **0.815** | 1.06x |
| `Owner == "user3"` | 2.012 | **1.909** | 1.05x |
| **total** | 10.532 | **9.550** | **1.10x** |

The gain scales with how many literals an expression has, which is the shape that confirms it does what it claims.

**It first measured as a 0.89x regression** — because `compareVec` calls `toData` before checking `Const`, and I'd made `toData` materialize, so the specialization was disabled by its own prologue and all that remained was the extra bookkeeping. The profile said 9.8%; the benchmark said nothing changed; the benchmark was right about the code as written. `toData` no longer materializes and says why, because the next conversion added there would re-disable this silently.

A `Const` vector's other elements are garbage, so every consumer either specializes or calls `materialize`. `valueData` and `IsTrue` read element 0 when it's set, which makes the parity-hook path and the counters safe without either. `toMask` handles it directly, since one repeated state is all-ones or all-zeros words — masking the tail past `n`, or a popcount would count records that don't exist.

## Why there is still no selection pushdown

Asked before building: is the hand-written scan's remaining lead caused by selection, or by fixed per-block work? Those predict different things — selection widens the gap as the first predicate gets more selective, fixed overhead keeps it flat.

| threshold / final selectivity | vector | hand-written | gap | gap before #7 |
|---|---|---|---|---|
| `> 0` / 62% | 0.701 ms | 0.566 | **1.24x** | 1.50x |
| `> 4096` / 50% | 0.712 | 0.589 | 1.21x | 1.37x |
| `> 8192` / 34% | 0.655 | 0.526 | 1.25x | 1.37x |
| `> 16000` / 6% | 0.638 | 0.450 | **1.42x** | 1.74x |

It was mostly **fixed overhead**: 1.50x at 62% selectivity where there's essentially nothing to skip. So selection was worth ~0.24x and the rest was per-block work — which is what commits 6 and 7 went after. Pushdown is now worth ~0.18x on a highly selective conjunction and nothing on an unselective one.

It's also not free: restricting a load per record adds a branch per record to a loop costing one or two cycles, so it can only pay where the skipped work is *expensive* — a string region walk or a cold-tail read, not a hot numeric compare. That's the shape to build if it's revisited, and the benchmark stays as the way to tell whether it worked.

## Next

Selection pushdown, narrowly: loads are 11–55% of a scan, and for strings that 55% is the positional region walk, where a per-block string dictionary would turn equality into an integer compare. Then SIMD comparison kernels when 1.27 makes the package portable, re-measuring rather than assuming these shares hold.
